### PR TITLE
Any Option to allow additional detail input

### DIFF
--- a/app/forms/custom_fields.py
+++ b/app/forms/custom_fields.py
@@ -1,7 +1,7 @@
 from decimal import Decimal, InvalidOperation
 
 from babel import numbers
-from wtforms import TextAreaField, IntegerField, DecimalField
+from wtforms import TextAreaField, IntegerField, DecimalField, SelectMultipleField, SelectField
 
 from app.settings import DEFAULT_LOCALE
 
@@ -54,3 +54,55 @@ class CustomDecimalField(DecimalField):
                 self.data = Decimal(valuelist[0].replace(numbers.get_group_symbol(DEFAULT_LOCALE), ''))
             except (ValueError, TypeError, InvalidOperation):
                 pass
+
+
+class CustomSelectMultipleField(SelectMultipleField):
+    """
+    This custom field allows us to add the additional detail_answer_id to choices/options.
+    This saves us having to later map options with their detail_answer.
+    """
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def __iter__(self):
+        opts = dict(widget=self.option_widget, _name=self.name, _form=None, _meta=self.meta)
+        for i, (value, label, checked, detail_answer_id) in enumerate(self.iter_choices()):
+            opt = self._Option(label=label, id='%s-%d' % (self.id, i), **opts)
+            opt.process(None, value)
+            opt.detail_answer_id = detail_answer_id
+            opt.checked = checked
+            yield opt
+
+    def iter_choices(self):
+        for value, label, detail_answer_id in self.choices:
+            selected = self.data is not None and self.coerce(value) in self.data
+            yield (value, label, selected, detail_answer_id)
+
+
+class CustomSelectField(SelectField):
+    """
+    This custom field allows us to add the additional detail_answer_id to choices/options.
+    This saves us having to later map options with their detail_answer.
+    """
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def __iter__(self):
+        opts = dict(widget=self.option_widget, _name=self.name, _form=None, _meta=self.meta)
+        for i, (value, label, checked, detail_answer_id) in enumerate(self.iter_choices()):
+            opt = self._Option(label=label, id='%s-%d' % (self.id, i), **opts)
+            opt.process(None, value)
+            opt.detail_answer_id = detail_answer_id
+            opt.checked = checked
+            yield opt
+
+    def iter_choices(self):
+        for value, label, detail_answer_id in self.choices:
+            yield (value, label, self.coerce(value) == self.data, detail_answer_id)
+
+    def pre_validate(self, form):
+        for value, _, _ in self.choices:
+            if value == self.data:
+                break
+        else:
+            raise ValueError(self.gettext('Not a valid choice'))

--- a/app/forms/fields.py
+++ b/app/forms/fields.py
@@ -1,10 +1,11 @@
 from decimal import Decimal
 from flask_babel import gettext as _
 from structlog import get_logger
-from wtforms import FormField, SelectField, SelectMultipleField, StringField
+from wtforms import FormField, SelectField, StringField
 from wtforms import validators
 
-from app.forms.custom_fields import MaxTextAreaField, CustomIntegerField, CustomDecimalField
+from app.forms.custom_fields import MaxTextAreaField, CustomIntegerField, CustomDecimalField, \
+    CustomSelectMultipleField, CustomSelectField
 from app.forms.date_form import MonthYearField, YearField, \
     DateField
 from app.forms.duration_form import get_duration_form
@@ -17,27 +18,27 @@ MAX_DECIMAL_PLACES = 6
 logger = get_logger()
 
 
-def get_field(answer, label, error_messages, answer_store, metadata, group_instance=0):
+def get_field(answer, label, error_messages, answer_store, metadata, group_instance=0, disable_validation=False):
     guidance = answer.get('guidance', '')
 
     if answer['type'] in ['Number', 'Currency', 'Percentage', 'Unit']:
-        field = get_number_field(answer, label, guidance, error_messages, answer_store)
+        field = get_number_field(answer, label, guidance, error_messages, answer_store, disable_validation)
     elif answer['type'] == 'Date':
         field = get_date_field(answer, label, guidance, error_messages, answer_store, metadata)
     elif answer['type'] == 'MonthYearDate':
         field = get_month_year_field(answer, label, guidance, error_messages, answer_store, metadata, group_instance=group_instance)
     elif answer['type'] == 'YearDate':
         field = get_year_field(answer, label, guidance, error_messages, answer_store, metadata, group_instance=group_instance)
-    elif answer['type'] == 'Checkbox':
-        field = get_select_multiple_field(answer, label, guidance, error_messages)
+    elif answer['type'] == 'Duration':
+        field = get_duration_field(answer, label, guidance, error_messages)
     else:
         field = {
+            'Checkbox': get_select_multiple_field,
             'Radio': get_select_field,
             'TextArea': get_text_area_field,
             'TextField': get_string_field,
             'Dropdown': get_dropdown_field,
-            'Duration': get_duration_field,
-        }[answer['type']](answer, label, guidance, error_messages)
+        }[answer['type']](answer, label, guidance, error_messages, disable_validation)
 
     return field
 
@@ -46,6 +47,14 @@ def build_choices(options):
     choices = []
     for option in options:
         choices.append((option['value'], option['label']))
+    return choices
+
+
+def build_choices_with_detail_answer_ids(options):
+    choices = []
+    for option in options:
+        detail_answer_id = option['detail_answer']['id'] if option.get('detail_answer') else None
+        choices.append((option['value'], option['label'], detail_answer_id))
     return choices
 
 
@@ -69,7 +78,7 @@ def get_length_validator(answer, error_messages):
 
 
 def get_mandatory_validator(answer, error_messages, mandatory_message_key):
-    validate_with = [validators.Optional()]
+    validate_with = validators.Optional()
 
     if answer['mandatory'] is True:
         mandatory_message = error_messages[mandatory_message_key]
@@ -78,16 +87,15 @@ def get_mandatory_validator(answer, error_messages, mandatory_message_key):
                 mandatory_message_key in answer['validation']['messages']:
             mandatory_message = answer['validation']['messages'][mandatory_message_key]
 
-        validate_with = [
-            ResponseRequired(
-                message=mandatory_message,
-            ),
-        ]
-    return validate_with
+        validate_with = ResponseRequired(message=mandatory_message)
+
+    return [validate_with]
 
 
-def get_string_field(answer, label, guidance, error_messages):
-    validate_with = get_mandatory_validator(answer, error_messages, 'MANDATORY_TEXTFIELD')
+def get_string_field(answer, label, guidance, error_messages, disable_validation=False):
+    validate_with = []
+    if disable_validation is False:
+        validate_with = get_mandatory_validator(answer, error_messages, 'MANDATORY_TEXTFIELD')
 
     return StringField(
         label=label,
@@ -96,9 +104,11 @@ def get_string_field(answer, label, guidance, error_messages):
     )
 
 
-def get_text_area_field(answer, label, guidance, error_messages):
-    validate_with = get_mandatory_validator(answer, error_messages, 'MANDATORY_TEXTAREA')
-    validate_with.extend(get_length_validator(answer, error_messages))
+def get_text_area_field(answer, label, guidance, error_messages, disable_validation=False):
+    validate_with = []
+    if disable_validation is False:
+        validate_with = get_mandatory_validator(answer, error_messages, 'MANDATORY_TEXTAREA')
+        validate_with.extend(get_length_validator(answer, error_messages))
 
     return MaxTextAreaField(
         label=label,
@@ -151,13 +161,15 @@ def get_duration_field(answer, label, guidance, error_messages):
     )
 
 
-def get_select_multiple_field(answer, label, guidance, error_messages):
-    validate_with = get_mandatory_validator(answer, error_messages, 'MANDATORY_CHECKBOX')
+def get_select_multiple_field(answer, label, guidance, error_messages, disable_validation=False):
+    validate_with = []
+    if disable_validation is False:
+        validate_with = get_mandatory_validator(answer, error_messages, 'MANDATORY_CHECKBOX')
 
-    return SelectMultipleField(
+    return CustomSelectMultipleField(
         label=label,
         description=guidance,
-        choices=build_choices(answer['options']),
+        choices=build_choices_with_detail_answer_ids(answer['options']),
         validators=validate_with,
     )
 
@@ -171,8 +183,10 @@ def _coerce_str_unless_none(value):
     return str(value) if value is not None else None
 
 
-def get_dropdown_field(answer, label, guidance, error_messages):
-    validate_with = get_mandatory_validator(answer, error_messages, 'MANDATORY_DROPDOWN')
+def get_dropdown_field(answer, label, guidance, error_messages, disable_validation=False):
+    validate_with = []
+    if disable_validation is False:
+        validate_with = get_mandatory_validator(answer, error_messages, 'MANDATORY_DROPDOWN')
 
     return SelectField(
         label=label,
@@ -183,8 +197,10 @@ def get_dropdown_field(answer, label, guidance, error_messages):
     )
 
 
-def get_select_field(answer, label, guidance, error_messages):
-    validate_with = get_mandatory_validator(answer, error_messages, 'MANDATORY_RADIO')
+def get_select_field(answer, label, guidance, error_messages, disable_validation=False):
+    validate_with = []
+    if disable_validation is False:
+        validate_with = get_mandatory_validator(answer, error_messages, 'MANDATORY_RADIO')
 
     # We use a custom coerce function to avoid a defect where Python NoneType
     # is coerced to the string 'None' which clashes with legitimate Radio field
@@ -193,23 +209,35 @@ def get_select_field(answer, label, guidance, error_messages):
     # https://github.com/ONSdigital/eq-survey-runner/issues/1013
     # See related WTForms PR: https://github.com/wtforms/wtforms/pull/288
 
-    return SelectField(
+    return CustomSelectField(
         label=label,
         description=guidance,
-        choices=build_choices(answer['options']),
+        choices=build_choices_with_detail_answer_ids(answer['options']),
         validators=validate_with,
         coerce=_coerce_str_unless_none,
     )
 
 
-def get_number_field(answer, label, guidance, error_messages, answer_store):
-    answer_errors = error_messages.copy()
+def get_number_field(answer, label, guidance, error_messages, answer_store, disable_validation=False):
+    validate_with = []
 
-    if 'validation' in answer and 'messages' in answer['validation']:
-        for error_key, error_message in answer['validation']['messages'].items():
-            answer_errors[error_key] = error_message
+    if disable_validation is False:
+        validate_with = _get_number_field_validators(answer, error_messages, answer_store)
 
-    mandatory_or_optional = get_mandatory_validator(answer, answer_errors, 'MANDATORY_NUMBER')
+    if answer.get('decimal_places', 0) > 0:
+        return CustomDecimalField(
+            label=label,
+            validators=validate_with,
+            description=guidance,
+        )
+    return CustomIntegerField(
+        label=label,
+        validators=validate_with,
+        description=guidance,
+    )
+
+
+def _get_number_field_validators(answer, error_messages, answer_store):
 
     max_decimals = answer.get('decimal_places', 0)
     if max_decimals > MAX_DECIMAL_PLACES:
@@ -232,27 +260,23 @@ def get_number_field(answer, label, guidance, error_messages, answer_store):
                         .format(max_value, MAX_NUMBER, answer['id']))
 
     if min_value > max_value:
-        raise Exception('min_value: {} > max_value: {} for answer id: {}'.format(min_value, max_value, answer['id']))
+        raise Exception(
+            'min_value: {} > max_value: {} for answer id: {}'.format(min_value, max_value, answer['id']))
 
-    validate_with = mandatory_or_optional + [
+    answer_errors = error_messages.copy()
+    if 'validation' in answer and 'messages' in answer['validation']:
+        for error_key, error_message in answer['validation']['messages'].items():
+            answer_errors[error_key] = error_message
+
+    mandatory_or_optional = get_mandatory_validator(answer, answer_errors, 'MANDATORY_NUMBER')
+
+    return mandatory_or_optional + [
         NumberCheck(answer_errors['INVALID_NUMBER']),
         NumberRange(minimum=min_value, minimum_exclusive=minimum_exclusive,
                     maximum=max_value, maximum_exclusive=maximum_exclusive,
                     messages=answer_errors, currency=answer.get('currency')),
         DecimalPlaces(max_decimals=max_decimals, messages=answer_errors),
     ]
-
-    if max_decimals > 0:
-        return CustomDecimalField(
-            label=label,
-            validators=validate_with,
-            description=guidance,
-        )
-    return CustomIntegerField(
-        label=label,
-        validators=validate_with,
-        description=guidance,
-    )
 
 
 def get_schema_defined_limit(answer_id, definition, answer_store):

--- a/app/helpers/form_helper.py
+++ b/app/helpers/form_helper.py
@@ -111,7 +111,7 @@ def post_form_for_location(schema, block_json, location, answer_store, metadata,
 
         return form
 
-    data = clear_other_text_field(request_form, schema.get_questions_for_block(block_json))
+    data = clear_detail_answer_field(request_form, schema.get_questions_for_block(block_json))
     return generate_form(schema, block_json, answer_store, metadata, location.group_instance, group_instance_id, formdata=data)
 
 
@@ -123,10 +123,10 @@ def disable_mandatory_answers(block_json):
     return block_json
 
 
-def clear_other_text_field(data, questions_for_block):
+def clear_detail_answer_field(data, questions_for_block):
     """
     Checks the submitted answers and in the case of both checkboxes and radios,
-    removes the text entered into the other text field if the Other option is not
+    removes the text entered into the detail answer field if the associated option is not
     selected.
     :param data: the submitted form data.
     :param questions_for_block: a list of questions from the block schema.
@@ -135,12 +135,10 @@ def clear_other_text_field(data, questions_for_block):
     form_data = MultiDict(data)
     for question in questions_for_block:
         for answer in question.get('answers', []):
-            if 'parent_answer_id' in answer and \
-                    answer['parent_answer_id'] in data and \
-                    'Other' not in form_data.getlist(answer['parent_answer_id']) and \
-                    form_data.get(answer['id']):
-
-                form_data[answer['id']] = ''
+            for option in answer.get('options', []):
+                if 'detail_answer' in option:
+                    if option['value'] not in form_data.getlist(answer['id']):
+                        form_data[option['detail_answer']['id']] = ''
 
     return form_data
 

--- a/app/submitter/convert_payload_0_0_1.py
+++ b/app/submitter/convert_payload_0_0_1.py
@@ -25,7 +25,7 @@ def convert_answers_to_payload_0_0_1(answer_store, schema, routing_path):
 
             value = answer['value']
 
-            if answer_schema is not None and value is not None and 'parent_answer_id' not in answer_schema:
+            if answer_schema is not None and value is not None:
                 if answer_schema['type'] == 'Checkbox':
                     data.update(_get_checkbox_answer_data(answer_store, answer_schema, value))
                 elif 'q_code' in answer_schema:
@@ -64,14 +64,14 @@ def _get_checkbox_answer_data(answer_store, answer_schema, value):
         option = next((option for option in answer_schema['options'] if option['value'] == user_answer), None)
 
         if option:
-            if 'child_answer_id' in option:
-                filtered = answer_store.filter(answer_ids=[option['child_answer_id']])
+            if 'detail_answer' in option:
+                filtered = answer_store.filter(answer_ids=[option['detail_answer']['id']])
 
                 if filtered.count() > 1:
-                    raise Exception('Multiple answers found for {}'.format(option['child_answer_id']))
+                    raise Exception('Multiple answers found for {}'.format(option['detail_answer']['id']))
 
-                # if the user has selected 'other' we need to find the child value it refers to.
-                # the child value can be empty, in this case we just use the main value (e.g. other)
+                # if the user has selected an option with a detail answer we need to find the detail answer value it refers to.
+                # the detail answer value can be empty, in this case we just use the main value (e.g. other)
                 user_answer = filtered.values()[0] or user_answer
 
             qcodes_and_values.append((option.get('q_code'), user_answer))

--- a/app/templates/partials/questions/general.html
+++ b/app/templates/partials/questions/general.html
@@ -2,11 +2,9 @@
   {% set question_answers %}
     <div class="question__answers">
       {%- for answer in question.answers -%}
-        {% if not answer.parent_answer_id %}
-          <div class="question__answer">
-            {% include theme('partials/answer.html') %}
-          </div>
-        {% endif %}
+        <div class="question__answer">
+          {% include theme('partials/answer.html') %}
+        </div>
       {%- endfor -%}
     </div>
   {% endset %}

--- a/app/templates/partials/questions/mutuallyexclusive.html
+++ b/app/templates/partials/questions/mutuallyexclusive.html
@@ -3,8 +3,6 @@
 <div class="question__answers">
   <fieldset class="field field--exclusive">
     {%- for answer in question.answers -%}
-      {% if not answer.parent_answer_id %}
-
         <div class="question__answer">
           {% set exclusive_class = "js-exclusive-group" %}
           {% if loop.last %}
@@ -14,8 +12,6 @@
 
           {% include theme('partials/answer.html') %}
         </div>
-
-      {% endif%}
     {%- endfor -%}
   </fieldset>
 </div>

--- a/app/templates/partials/summary/checkbox.html
+++ b/app/templates/partials/summary/checkbox.html
@@ -1,13 +1,9 @@
-{% macro answer_with_child(selected_answer) %}
+{% macro answer_with_detail_answer(selected_answer) %}
     {{selected_answer.label}}
-    {%- if answer.child_answer_value is not none and selected_answer.should_display_other %}
-    <ul>
+    {%- if selected_answer.detail_answer_value -%}
+    <ul class="u-m-no">
         <li>
-            {%- if answer.child_answer_value == ''  -%}
-                {{ _("No answer provided") }}
-            {%- else -%}
-                {{ answer.child_answer_value }}
-            {%- endif -%}
+          {{ selected_answer.detail_answer_value }}
         </li>
     </ul>
     {%- endif -%}
@@ -16,9 +12,9 @@
 {%- if answer.value|length > 1 -%}
     <ul class="u-m-no">
         {% for selected_answer in answer.value %}
-            <li>{{ answer_with_child(selected_answer) }}</li>
+            <li>{{ answer_with_detail_answer(selected_answer) }}</li>
         {% endfor %}
     </ul>
 {%- else -%}
-    {{ answer_with_child(answer.value[0]) }}
+    {{ answer_with_detail_answer(answer.value[0]) }}
 {%- endif -%}

--- a/app/templates/partials/summary/radio.html
+++ b/app/templates/partials/summary/radio.html
@@ -1,12 +1,8 @@
-{{answer.value}}
-{%- if answer.child_answer_value is not none -%}
+{{answer.value.label}}
+{%- if answer.value.detail_answer_value -%}
     <ul>
         <li>
-            {%- if answer.child_answer_value == ''  -%}
-                {{ _("No answer provided") }}
-            {%- else -%}
-                {{ answer.child_answer_value }}
-            {%- endif -%}
+          {{ answer.value.detail_answer_value }}
         </li>
     </ul>
 {%- endif -%}

--- a/app/templates/partials/widgets/multiple_choice_widget.html
+++ b/app/templates/partials/widgets/multiple_choice_widget.html
@@ -22,8 +22,7 @@
       "value": option.data,
       "name": option.name,
       "id": option.id,
-      "checked": "checked" if option['checked'],
-      "data-qa": "has-other-option" if answer.id in form.other_answer and form.other_answer[answer.id][loop.index0] != None
+      "checked": "checked" if option['checked']
     } %}
 
     {% set label = {
@@ -44,25 +43,24 @@
       </label>
         <span class="js-exclusive-alert u-vh" role="alert" aria-live="polite" data-adjective='{{ _("deselected") }}'></span>
 
-      {% if answer.id in form.other_answer and form.other_answer[answer.id][loop.index0] != None %}
-        {% set other_answer = form.other_answer[answer.id][loop.index0] %}
+      {% if option.detail_answer_id %}
+        {% set detail_answer = form.fields[option.detail_answer_id] %}
 
         {% set other_label = {
           "class": "label mercury",
-          "for": other_answer.id
+          "for": detail_answer.id
         } %}
 
         {% set other_input = {
           "class": "input js-focusable " ~ exclusive_class,
           "type": "text",
-          "name": other_answer.name,
-          "id": other_answer.id,
-          "value": other_answer.data,
-          "data-qa": "other-option"
+          "name": detail_answer.name,
+          "id": detail_answer.id,
+          "value": detail_answer.data
         } %}
 
         <div class="field__other">
-          <label {{other_label|xmlattr}}>{{other_answer.label.text}}</label>
+          <label {{other_label|xmlattr}}>{{detail_answer.label.text}}</label>
           <input {{other_input|xmlattr}}>
         </div>
 

--- a/app/templating/summary/answer.py
+++ b/app/templating/summary/answer.py
@@ -1,14 +1,12 @@
 class Answer:
 
-    def __init__(self, answer_schema, answer, group_instance, child_answer_value=None):
+    def __init__(self, answer_schema, answer, group_instance):
         self.id = answer_schema['id'] + '-' + str(group_instance)
         self.label = answer_schema.get('label')
         self.value = answer
         self.type = answer_schema['type'].lower()
         self.unit = answer_schema.get('unit')
         self.unit_length = answer_schema.get('unit_length')
-        self.parent_answer_id = answer_schema.get('parent_answer_id')
-        self.child_answer_value = child_answer_value
         self.currency = answer_schema.get('currency')
 
     def serialize(self):
@@ -19,7 +17,5 @@ class Answer:
             'type': self.type,
             'unit': self.unit,
             'unit_length': self.unit_length,
-            'parent_answer_id': self.parent_answer_id,
-            'child_answer_value': self.child_answer_value,
             'currency': self.currency,
         }

--- a/app/templating/view_context.py
+++ b/app/templating/view_context.py
@@ -44,7 +44,7 @@ def build_view_context_for_non_question(variables, rendered_block):
     }
 
 
-def build_view_context_for_question(metadata, schema, answer_store, current_location, variables, rendered_block, form):  # noqa: C901, E501  pylint: disable=too-complex,line-too-long,too-many-locals
+def build_view_context_for_question(metadata, schema, answer_store, current_location, variables, rendered_block, form):  # noqa: C901, E501  pylint: disable=too-complex,line-too-long,too-many-locals,too-many-branches
 
     context = {
         'variables': variables,
@@ -56,7 +56,6 @@ def build_view_context_for_question(metadata, schema, answer_store, current_loca
             'mapped_errors': form.map_errors(),
             'answer_errors': {},
             'data': {},
-            'other_answer': {},
             'fields': {},
         },
     }
@@ -77,10 +76,9 @@ def build_view_context_for_question(metadata, schema, answer_store, current_loca
                 answer_ids.append(answer['id'])
 
             if answer['type'] in ('Checkbox', 'Radio'):
-                options = answer['options']
-                context['form']['other_answer'][answer['id']] = []
-                for index in range(len(options)):
-                    context['form']['other_answer'][answer['id']].append(form.get_other_answer(answer['id'], index))
+                for option in answer['options']:
+                    if 'detail_answer' in option:
+                        answer_ids.append(option['detail_answer']['id'])
 
     for answer_id in answer_ids:
         context['form']['answer_errors'][answer_id] = form.answer_errors(answer_id)

--- a/app/translations/messages.pot
+++ b/app/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-11-30 12:40+0000\n"
+"POT-Creation-Date: 2018-12-06 10:14+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -42,11 +42,15 @@ msgstr ""
 msgid "%(from_date)s to %(to_date)s"
 msgstr ""
 
+#: app/forms/custom_fields.py:108
+msgid "Not a valid choice"
+msgstr ""
+
 #: app/forms/date_form.py:216
 msgid "Select month"
 msgstr ""
 
-#: app/forms/fields.py:180
+#: app/forms/fields.py:194
 msgid "Select an answer"
 msgstr ""
 
@@ -597,8 +601,6 @@ msgid "Add"
 msgstr ""
 
 #: app/templates/partials/summary/answer.html:2
-#: app/templates/partials/summary/checkbox.html:7
-#: app/templates/partials/summary/radio.html:6
 msgid "No answer provided"
 msgstr ""
 

--- a/data/cy/lms_2.json
+++ b/data/cy/lms_2.json
@@ -282,48 +282,46 @@
                                 "title": "Fe ddywedoch nad  {{ metadata['display_address'] }} yw eich prif breswylfa. Pa fath o gyfeiriad yw hyn?",
                                 "type": "General",
                                 "answers": [{
-                                        "id": "address-type-answer-no-primary",
-                                        "mandatory": true,
-                                        "type": "Radio",
-                                        "options": [{
-                                                "label": "Cyfeiriad blaenorol y mae post wedi ei ailgyfeirio ohono",
-                                                "value": "A previous address from which mail has been redirected"
-                                            },
-                                            {
-                                                "label": "Llety i fyfyrwyr wedi ei rentu trwy landlord preifat",
-                                                "value": "Student accommodation rented through a private landlord"
-                                            },
-                                            {
-                                                "label": "Fy ail gartref",
-                                                "value": "My second home",
-                                                "description": "Er enghraifft, rhywle i aros tra’n gweithio i ffwrdd o’ch prif breswylfa"
-                                            },
-                                            {
-                                                "label": "Cyfeiriad busnes neu nad yw’n breswyl",
-                                                "value": "A business or non-residential address"
-                                            },
-                                            {
-                                                "label": "Sefydliad cymunedol",
-                                                "value": "A communal establishment"
-                                            },
-                                            {
-                                                "label": "Nid yw’r cyfeiriad yn gyfarwydd i mi",
-                                                "value": "This address is not familiar to me"
-                                            },
-                                            {
-                                                "label": "Arall, disgrifiad",
-                                                "value": "Other, please describe",
-                                                "child_answer_id": "address-type-answer-other-no-primary"
+                                    "id": "address-type-answer-no-primary",
+                                    "mandatory": true,
+                                    "type": "Radio",
+                                    "options": [{
+                                            "label": "Cyfeiriad blaenorol y mae post wedi ei ailgyfeirio ohono",
+                                            "value": "A previous address from which mail has been redirected"
+                                        },
+                                        {
+                                            "label": "Llety i fyfyrwyr wedi ei rentu trwy landlord preifat",
+                                            "value": "Student accommodation rented through a private landlord"
+                                        },
+                                        {
+                                            "label": "Fy ail gartref",
+                                            "value": "My second home",
+                                            "description": "Er enghraifft, rhywle i aros tra’n gweithio i ffwrdd o’ch prif breswylfa"
+                                        },
+                                        {
+                                            "label": "Cyfeiriad busnes neu nad yw’n breswyl",
+                                            "value": "A business or non-residential address"
+                                        },
+                                        {
+                                            "label": "Sefydliad cymunedol",
+                                            "value": "A communal establishment"
+                                        },
+                                        {
+                                            "label": "Nid yw’r cyfeiriad yn gyfarwydd i mi",
+                                            "value": "This address is not familiar to me"
+                                        },
+                                        {
+                                            "label": "Arall",
+                                            "value": "Other, please describe",
+                                            "detail_answer": {
+                                                "id": "address-type-answer-other-no-primary",
+                                                "label": "Disgrifiad",
+                                                "mandatory": false,
+                                                "type": "TextField"
                                             }
-                                        ]
-                                    },
-                                    {
-                                        "parent_answer_id": "address-type-answer-no-primary",
-                                        "id": "address-type-answer-other-no-primary",
-                                        "mandatory": false,
-                                        "type": "TextField"
-                                    }
-                                ]
+                                        }
+                                    ]
+                                }]
                             }]
                         },
                         {
@@ -1297,6 +1295,7 @@
                             "type": "General",
                             "answers": [{
                                 "id": "dob-age-answer",
+                                "label": "Oedran",
                                 "unit": "duration-year",
                                 "type": "Unit",
                                 "unit_length": "long",
@@ -1438,44 +1437,41 @@
                                 }
                             ],
                             "answers": [{
-                                    "id": "nationality-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "Prydeinig",
-                                            "value": "British"
-                                        },
-                                        {
-                                            "label": "Gwyddelig",
-                                            "value": "Irish"
-                                        },
-                                        {
-                                            "label": "Indiaidd",
-                                            "value": "Indian"
-                                        },
-                                        {
-                                            "label": "Pacistanaidd",
-                                            "value": "Pakistani"
-                                        },
-                                        {
-                                            "label": "Pwylaidd",
-                                            "value": "Polish"
-                                        },
-                                        {
-                                            "label": "Arall",
-                                            "value": "Other",
-                                            "child_answer_id": "nationality-answer-other"
+                                "id": "nationality-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Prydeinig",
+                                        "value": "British"
+                                    },
+                                    {
+                                        "label": "Gwyddelig",
+                                        "value": "Irish"
+                                    },
+                                    {
+                                        "label": "Indiaidd",
+                                        "value": "Indian"
+                                    },
+                                    {
+                                        "label": "Pacistanaidd",
+                                        "value": "Pakistani"
+                                    },
+                                    {
+                                        "label": "Pwylaidd",
+                                        "value": "Polish"
+                                    },
+                                    {
+                                        "label": "Arall",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "nationality-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Rhowch eich cenedligrwydd"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "nationality-answer-other",
-                                    "parent_answer_id": "nationality-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Rhowch eich cenedligrwydd"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }]
                     },
                     {
@@ -1504,60 +1500,57 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "country-of-birth-wales-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "Cymru",
-                                            "value": "Wales"
-                                        },
-                                        {
-                                            "label": "Lloegr",
-                                            "value": "England"
-                                        },
-                                        {
-                                            "label": "Yr Alban",
-                                            "value": "Scotland"
-                                        },
-                                        {
-                                            "label": "Gogledd Iwerddon",
-                                            "value": "Northern Ireland"
-                                        },
-                                        {
-                                            "label": "Gweriniaeth Iwerddon",
-                                            "value": "Republic of Ireland"
-                                        },
-                                        {
-                                            "label": "Ynys Manaw neu Ynysoedd y Sianel",
-                                            "value": "Isle of Man or Channel Islands"
-                                        },
-                                        {
-                                            "label": "India",
-                                            "value": "India"
-                                        },
-                                        {
-                                            "label": "Pacistan",
-                                            "value": "Pakistan"
-                                        },
-                                        {
-                                            "label": "Gwlad Pwyl",
-                                            "value": "Poland"
-                                        },
-                                        {
-                                            "label": "Arall",
-                                            "value": "Other",
-                                            "child_answer_id": "country-of-birth-wales-answer-other"
+                                "id": "country-of-birth-wales-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Cymru",
+                                        "value": "Wales"
+                                    },
+                                    {
+                                        "label": "Lloegr",
+                                        "value": "England"
+                                    },
+                                    {
+                                        "label": "Yr Alban",
+                                        "value": "Scotland"
+                                    },
+                                    {
+                                        "label": "Gogledd Iwerddon",
+                                        "value": "Northern Ireland"
+                                    },
+                                    {
+                                        "label": "Gweriniaeth Iwerddon",
+                                        "value": "Republic of Ireland"
+                                    },
+                                    {
+                                        "label": "Ynys Manaw neu Ynysoedd y Sianel",
+                                        "value": "Isle of Man or Channel Islands"
+                                    },
+                                    {
+                                        "label": "India",
+                                        "value": "India"
+                                    },
+                                    {
+                                        "label": "Pacistan",
+                                        "value": "Pakistan"
+                                    },
+                                    {
+                                        "label": "Gwlad Pwyl",
+                                        "value": "Poland"
+                                    },
+                                    {
+                                        "label": "Arall",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "country-of-birth-wales-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Nodwch gwlad lle y’ch ganwyd"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "country-of-birth-wales-answer-other",
-                                    "parent_answer_id": "country-of-birth-wales-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Nodwch gwlad lle y’ch ganwyd"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -1647,60 +1640,57 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "country-of-birth-scotland-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "Yr Alban",
-                                            "value": "Scotland"
-                                        },
-                                        {
-                                            "label": "Lloegr",
-                                            "value": "England"
-                                        },
-                                        {
-                                            "label": "Cymru",
-                                            "value": "Wales"
-                                        },
-                                        {
-                                            "label": "Gogledd Iwerddon",
-                                            "value": "Northern Ireland"
-                                        },
-                                        {
-                                            "label": "Gweriniaeth Iwerddon",
-                                            "value": "Republic of Ireland"
-                                        },
-                                        {
-                                            "label": "Ynys Manaw neu Ynysoedd y Sianel",
-                                            "value": "Isle of Man or Channel Islands"
-                                        },
-                                        {
-                                            "label": "India",
-                                            "value": "India"
-                                        },
-                                        {
-                                            "label": "Pacistan",
-                                            "value": "Pakistan"
-                                        },
-                                        {
-                                            "label": "Gwlad Pwyl",
-                                            "value": "Poland"
-                                        },
-                                        {
-                                            "label": "Arall",
-                                            "value": "Other",
-                                            "child_answer_id": "country-of-birth-scotland-answer-other"
+                                "id": "country-of-birth-scotland-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Yr Alban",
+                                        "value": "Scotland"
+                                    },
+                                    {
+                                        "label": "Lloegr",
+                                        "value": "England"
+                                    },
+                                    {
+                                        "label": "Cymru",
+                                        "value": "Wales"
+                                    },
+                                    {
+                                        "label": "Gogledd Iwerddon",
+                                        "value": "Northern Ireland"
+                                    },
+                                    {
+                                        "label": "Gweriniaeth Iwerddon",
+                                        "value": "Republic of Ireland"
+                                    },
+                                    {
+                                        "label": "Ynys Manaw neu Ynysoedd y Sianel",
+                                        "value": "Isle of Man or Channel Islands"
+                                    },
+                                    {
+                                        "label": "India",
+                                        "value": "India"
+                                    },
+                                    {
+                                        "label": "Pacistan",
+                                        "value": "Pakistan"
+                                    },
+                                    {
+                                        "label": "Gwlad Pwyl",
+                                        "value": "Poland"
+                                    },
+                                    {
+                                        "label": "Arall",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "country-of-birth-scotland-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Nodwch gwlad lle y’ch ganwyd"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "country-of-birth-scotland-answer-other",
-                                    "parent_answer_id": "country-of-birth-scotland-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Nodwch gwlad lle y’ch ganwyd"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -1784,60 +1774,57 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "country-of-birth-england-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "Lloegr",
-                                            "value": "England"
-                                        },
-                                        {
-                                            "label": "Cymru",
-                                            "value": "Wales"
-                                        },
-                                        {
-                                            "label": "Yr Alban",
-                                            "value": "Scotland"
-                                        },
-                                        {
-                                            "label": "Gogledd Iwerddon",
-                                            "value": "Northern Ireland"
-                                        },
-                                        {
-                                            "label": "Gweriniaeth Iwerddon",
-                                            "value": "Republic of Ireland"
-                                        },
-                                        {
-                                            "label": "Ynys Manaw neu Ynysoedd y Sianel",
-                                            "value": "Isle of Man or Channel Islands"
-                                        },
-                                        {
-                                            "label": "India",
-                                            "value": "India"
-                                        },
-                                        {
-                                            "label": "Pacistan",
-                                            "value": "Pakistan"
-                                        },
-                                        {
-                                            "label": "Gwlad Pwyl",
-                                            "value": "Poland"
-                                        },
-                                        {
-                                            "label": "Arall",
-                                            "value": "Other",
-                                            "child_answer_id": "country-of-birth-england-answer-other"
+                                "id": "country-of-birth-england-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Lloegr",
+                                        "value": "England"
+                                    },
+                                    {
+                                        "label": "Cymru",
+                                        "value": "Wales"
+                                    },
+                                    {
+                                        "label": "Yr Alban",
+                                        "value": "Scotland"
+                                    },
+                                    {
+                                        "label": "Gogledd Iwerddon",
+                                        "value": "Northern Ireland"
+                                    },
+                                    {
+                                        "label": "Gweriniaeth Iwerddon",
+                                        "value": "Republic of Ireland"
+                                    },
+                                    {
+                                        "label": "Ynys Manaw neu Ynysoedd y Sianel",
+                                        "value": "Isle of Man or Channel Islands"
+                                    },
+                                    {
+                                        "label": "India",
+                                        "value": "India"
+                                    },
+                                    {
+                                        "label": "Pacistan",
+                                        "value": "Pakistan"
+                                    },
+                                    {
+                                        "label": "Gwlad Pwyl",
+                                        "value": "Poland"
+                                    },
+                                    {
+                                        "label": "Arall",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "country-of-birth-england-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Nodwch gwlad lle y’ch ganwyd"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "country-of-birth-england-answer-other",
-                                    "parent_answer_id": "country-of-birth-england-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Nodwch gwlad lle y’ch ganwyd"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -2229,52 +2216,49 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "why-uk-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "Ar gyfer gwaith",
-                                            "value": "For employment"
-                                        },
-                                        {
-                                            "label": "I astudio",
-                                            "value": "For study"
-                                        },
-                                        {
-                                            "label": "Fel cymar neu ddibynnydd i ddinesydd neu berson wedi setlo yn y Deyrnas Unedig",
-                                            "value": "As a spouse or dependent of a UK citizen or settled person"
-                                        },
-                                        {
-                                            "label": "Fel cymar neu ddibynnydd i rywun sy’n dod i neu sydd eisoes yn y Deyrnas Unedig i ddibenion gwaith neu astudio",
-                                            "value": "As a spouse or dependent of someone who is coming to or is already in the UK for work or study reasons"
-                                        },
-                                        {
-                                            "label": "I briodi neu ffurfio partneriaeth sifil yn y Deyrnas Unedig gyda rhywun nad yw’n ddinesydd o’r Deyrnas Unedig",
-                                            "value": "To get married or form a civil partnership in the UK with a non-UK citizen"
-                                        },
-                                        {
-                                            "label": "I geisio lloches",
-                                            "value": "Seeking asylum"
-                                        },
-                                        {
-                                            "label": "Fel ymwelydd",
-                                            "value": "As a visitor"
-                                        },
-                                        {
-                                            "label": "Rheswm arall",
-                                            "value": "Another reason",
-                                            "child_answer_id": "why-uk-answer-other"
+                                "id": "why-uk-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Ar gyfer gwaith",
+                                        "value": "For employment"
+                                    },
+                                    {
+                                        "label": "I astudio",
+                                        "value": "For study"
+                                    },
+                                    {
+                                        "label": "Fel cymar neu ddibynnydd i ddinesydd neu berson wedi setlo yn y Deyrnas Unedig",
+                                        "value": "As a spouse or dependent of a UK citizen or settled person"
+                                    },
+                                    {
+                                        "label": "Fel cymar neu ddibynnydd i rywun sy’n dod i neu sydd eisoes yn y Deyrnas Unedig i ddibenion gwaith neu astudio",
+                                        "value": "As a spouse or dependent of someone who is coming to or is already in the UK for work or study reasons"
+                                    },
+                                    {
+                                        "label": "I briodi neu ffurfio partneriaeth sifil yn y Deyrnas Unedig gyda rhywun nad yw’n ddinesydd o’r Deyrnas Unedig",
+                                        "value": "To get married or form a civil partnership in the UK with a non-UK citizen"
+                                    },
+                                    {
+                                        "label": "I geisio lloches",
+                                        "value": "Seeking asylum"
+                                    },
+                                    {
+                                        "label": "Fel ymwelydd",
+                                        "value": "As a visitor"
+                                    },
+                                    {
+                                        "label": "Rheswm arall",
+                                        "value": "Another reason",
+                                        "detail_answer": {
+                                            "id": "why-uk-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Nodwch"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "why-uk-answer-other",
-                                    "parent_answer_id": "why-uk-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Nodwch"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }],
                         "routing_rules": [{
                             "goto": {
@@ -2301,52 +2285,49 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "why-uk-continuous-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "Ar gyfer gwaith",
-                                            "value": "For employment"
-                                        },
-                                        {
-                                            "label": "I astudio",
-                                            "value": "For study"
-                                        },
-                                        {
-                                            "label": "Fel cymar neu ddibynnydd i ddinesydd neu berson wedi setlo yn y Deyrnas Unedig",
-                                            "value": "As a spouse or dependent of a UK citizen or settled person"
-                                        },
-                                        {
-                                            "label": "Fel cymar neu ddibynnydd i rywun sy’n dod i neu sydd eisoes yn y Deyrnas Unedig i ddibenion gwaith neu astudio",
-                                            "value": "As a spouse or dependent of someone who is coming to or is already in the UK for work or study reasons"
-                                        },
-                                        {
-                                            "label": "I briodi neu ffurfio partneriaeth sifil yn y Deyrnas Unedig gyda rhywun nad yw’n ddinesydd o’r Deyrnas Unedig",
-                                            "value": "To get married or form a civil partnership in the UK with a non-UK citizen"
-                                        },
-                                        {
-                                            "label": "I geisio lloches",
-                                            "value": "Seeking asylum"
-                                        },
-                                        {
-                                            "label": "Fel ymwelydd",
-                                            "value": "As a visitor"
-                                        },
-                                        {
-                                            "label": "Rheswm arall",
-                                            "value": "Another reason",
-                                            "child_answer_id": "why-uk-continuous-answer-other"
+                                "id": "why-uk-continuous-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Ar gyfer gwaith",
+                                        "value": "For employment"
+                                    },
+                                    {
+                                        "label": "I astudio",
+                                        "value": "For study"
+                                    },
+                                    {
+                                        "label": "Fel cymar neu ddibynnydd i ddinesydd neu berson wedi setlo yn y Deyrnas Unedig",
+                                        "value": "As a spouse or dependent of a UK citizen or settled person"
+                                    },
+                                    {
+                                        "label": "Fel cymar neu ddibynnydd i rywun sy’n dod i neu sydd eisoes yn y Deyrnas Unedig i ddibenion gwaith neu astudio",
+                                        "value": "As a spouse or dependent of someone who is coming to or is already in the UK for work or study reasons"
+                                    },
+                                    {
+                                        "label": "I briodi neu ffurfio partneriaeth sifil yn y Deyrnas Unedig gyda rhywun nad yw’n ddinesydd o’r Deyrnas Unedig",
+                                        "value": "To get married or form a civil partnership in the UK with a non-UK citizen"
+                                    },
+                                    {
+                                        "label": "I geisio lloches",
+                                        "value": "Seeking asylum"
+                                    },
+                                    {
+                                        "label": "Fel ymwelydd",
+                                        "value": "As a visitor"
+                                    },
+                                    {
+                                        "label": "Rheswm arall",
+                                        "value": "Another reason",
+                                        "detail_answer": {
+                                            "id": "why-uk-continuous-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Nodwch"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "why-uk-continuous-answer-other",
-                                    "parent_answer_id": "why-uk-continuous-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Nodwch"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }],
                         "routing_rules": [{
                             "goto": {
@@ -2373,44 +2354,41 @@
                                 ],
                                 "type": "General",
                                 "answers": [{
-                                        "id": "national-identity-england-answer",
-                                        "mandatory": false,
-                                        "type": "Checkbox",
-                                        "options": [{
-                                                "label": "Saesneg",
-                                                "value": "English"
-                                            },
-                                            {
-                                                "label": "Cymraeg",
-                                                "value": "Welsh"
-                                            },
-                                            {
-                                                "label": "Albanaidd",
-                                                "value": "Scottish"
-                                            },
-                                            {
-                                                "label": "Gogledd Iwerddon",
-                                                "value": "Northern Irish"
-                                            },
-                                            {
-                                                "label": "Prydeinig",
-                                                "value": "British"
-                                            },
-                                            {
-                                                "label": "Arall",
-                                                "value": "Other",
-                                                "child_answer_id": "national-identity-england-answer-other"
+                                    "id": "national-identity-england-answer",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "options": [{
+                                            "label": "Saesneg",
+                                            "value": "English"
+                                        },
+                                        {
+                                            "label": "Cymraeg",
+                                            "value": "Welsh"
+                                        },
+                                        {
+                                            "label": "Albanaidd",
+                                            "value": "Scottish"
+                                        },
+                                        {
+                                            "label": "Gogledd Iwerddon",
+                                            "value": "Northern Irish"
+                                        },
+                                        {
+                                            "label": "Prydeinig",
+                                            "value": "British"
+                                        },
+                                        {
+                                            "label": "Arall",
+                                            "value": "Other",
+                                            "detail_answer": {
+                                                "id": "national-identity-england-answer-other",
+                                                "type": "TextField",
+                                                "mandatory": false,
+                                                "label": "Rhowch eich hunaniaeth genedlaethol"
                                             }
-                                        ]
-                                    },
-                                    {
-                                        "id": "national-identity-england-answer-other",
-                                        "parent_answer_id": "national-identity-england-answer",
-                                        "type": "TextField",
-                                        "mandatory": false,
-                                        "label": "Rhowch eich hunaniaeth genedlaethol"
-                                    }
-                                ],
+                                        }
+                                    ]
+                                }],
                                 "skip_conditions": [{
                                     "when": [{
                                         "meta": "country",
@@ -2435,44 +2413,41 @@
                                 ],
                                 "type": "General",
                                 "answers": [{
-                                        "id": "national-identity-wales-answer",
-                                        "mandatory": false,
-                                        "type": "Checkbox",
-                                        "options": [{
-                                                "label": "Cymraeg",
-                                                "value": "Welsh"
-                                            },
-                                            {
-                                                "label": "Saesneg",
-                                                "value": "English"
-                                            },
-                                            {
-                                                "label": "Albanaidd",
-                                                "value": "Scottish"
-                                            },
-                                            {
-                                                "label": "Gogledd Iwerddon",
-                                                "value": "Northern Irish"
-                                            },
-                                            {
-                                                "label": "Prydeinig",
-                                                "value": "British"
-                                            },
-                                            {
-                                                "label": "Arall",
-                                                "value": "Other",
-                                                "child_answer_id": "national-identity-wales-answer-other"
+                                    "id": "national-identity-wales-answer",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "options": [{
+                                            "label": "Cymraeg",
+                                            "value": "Welsh"
+                                        },
+                                        {
+                                            "label": "Saesneg",
+                                            "value": "English"
+                                        },
+                                        {
+                                            "label": "Albanaidd",
+                                            "value": "Scottish"
+                                        },
+                                        {
+                                            "label": "Gogledd Iwerddon",
+                                            "value": "Northern Irish"
+                                        },
+                                        {
+                                            "label": "Prydeinig",
+                                            "value": "British"
+                                        },
+                                        {
+                                            "label": "Arall",
+                                            "value": "Other",
+                                            "detail_answer": {
+                                                "id": "national-identity-wales-answer-other",
+                                                "type": "TextField",
+                                                "mandatory": false,
+                                                "label": "Rhowch eich hunaniaeth genedlaethol"
                                             }
-                                        ]
-                                    },
-                                    {
-                                        "id": "national-identity-wales-answer-other",
-                                        "parent_answer_id": "national-identity-wales-answer",
-                                        "type": "TextField",
-                                        "mandatory": false,
-                                        "label": "Rhowch eich hunaniaeth genedlaethol"
-                                    }
-                                ],
+                                        }
+                                    ]
+                                }],
                                 "skip_conditions": [{
                                     "when": [{
                                         "meta": "country",
@@ -2497,44 +2472,41 @@
                                 ],
                                 "type": "General",
                                 "answers": [{
-                                        "id": "national-identity-scotland-answer",
-                                        "mandatory": false,
-                                        "type": "Checkbox",
-                                        "options": [{
-                                                "label": "Albanaidd",
-                                                "value": "Scottish"
-                                            },
-                                            {
-                                                "label": "Saesneg",
-                                                "value": "English"
-                                            },
-                                            {
-                                                "label": "Cymraeg",
-                                                "value": "Welsh"
-                                            },
-                                            {
-                                                "label": "Gogledd Iwerddon",
-                                                "value": "Northern Irish"
-                                            },
-                                            {
-                                                "label": "Prydeinig",
-                                                "value": "British"
-                                            },
-                                            {
-                                                "label": "Arall",
-                                                "value": "Other",
-                                                "child_answer_id": "national-identity-scotland-answer-other"
+                                    "id": "national-identity-scotland-answer",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "options": [{
+                                            "label": "Albanaidd",
+                                            "value": "Scottish"
+                                        },
+                                        {
+                                            "label": "Saesneg",
+                                            "value": "English"
+                                        },
+                                        {
+                                            "label": "Cymraeg",
+                                            "value": "Welsh"
+                                        },
+                                        {
+                                            "label": "Gogledd Iwerddon",
+                                            "value": "Northern Irish"
+                                        },
+                                        {
+                                            "label": "Prydeinig",
+                                            "value": "British"
+                                        },
+                                        {
+                                            "label": "Arall",
+                                            "value": "Other",
+                                            "detail_answer": {
+                                                "id": "national-identity-scotland-answer-other",
+                                                "type": "TextField",
+                                                "mandatory": false,
+                                                "label": "Rhowch eich hunaniaeth genedlaethol"
                                             }
-                                        ]
-                                    },
-                                    {
-                                        "id": "national-identity-scotland-answer-other",
-                                        "parent_answer_id": "national-identity-scotland-answer",
-                                        "type": "TextField",
-                                        "mandatory": false,
-                                        "label": "Rhowch eich hunaniaeth genedlaethol"
-                                    }
-                                ],
+                                        }
+                                    ]
+                                }],
                                 "skip_conditions": [{
                                     "when": [{
                                             "meta": "country",
@@ -2866,36 +2838,33 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "white-ethnic-group-answer",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "Saesneg, Cymraeg, Albanaidd, Gogledd Iwerddon neu Brydeinig",
-                                            "value": "English, Welsh, Scottish, Northern Irish or British"
-                                        },
-                                        {
-                                            "label": "Gwyddelig",
-                                            "value": "Irish"
-                                        },
-                                        {
-                                            "label": "Sipsi neu Deithiwr Gwyddelig",
-                                            "value": "Gypsy or Irish Traveller"
-                                        },
-                                        {
-                                            "label": "Unrhyw gefndir Gwyn arall",
-                                            "value": "Other",
-                                            "child_answer_id": "white-ethnic-group-answer-other"
+                                "id": "white-ethnic-group-answer",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "Saesneg, Cymraeg, Albanaidd, Gogledd Iwerddon neu Brydeinig",
+                                        "value": "English, Welsh, Scottish, Northern Irish or British"
+                                    },
+                                    {
+                                        "label": "Gwyddelig",
+                                        "value": "Irish"
+                                    },
+                                    {
+                                        "label": "Sipsi neu Deithiwr Gwyddelig",
+                                        "value": "Gypsy or Irish Traveller"
+                                    },
+                                    {
+                                        "label": "Unrhyw gefndir Gwyn arall",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "white-ethnic-group-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Rhowch eich grŵp ethnig"
                                         }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "white-ethnic-group-answer-other",
-                                    "parent_answer_id": "white-ethnic-group-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Rhowch eich grŵp ethnig"
-                                }
-                            ]
+                                    }
+                                ],
+                                "type": "Radio"
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -2962,36 +2931,33 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "mixed-ethnic-group-answer",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "Gwyn a Du Caribïaidd",
-                                            "value": "White and Black Caribbean"
-                                        },
-                                        {
-                                            "label": "Gwyn a Du Affricanaidd",
-                                            "value": "White and Black African"
-                                        },
-                                        {
-                                            "label": "Gwyn ac Asiaidd",
-                                            "value": "White and Asian"
-                                        },
-                                        {
-                                            "label": "Unrhyw gefndir ethnig cymysg neu luosog arall",
-                                            "value": "Other",
-                                            "child_answer_id": "mixed-ethnic-group-answer-other"
+                                "id": "mixed-ethnic-group-answer",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "Gwyn a Du Caribïaidd",
+                                        "value": "White and Black Caribbean"
+                                    },
+                                    {
+                                        "label": "Gwyn a Du Affricanaidd",
+                                        "value": "White and Black African"
+                                    },
+                                    {
+                                        "label": "Gwyn ac Asiaidd",
+                                        "value": "White and Asian"
+                                    },
+                                    {
+                                        "label": "Unrhyw gefndir ethnig cymysg neu luosog arall",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "mixed-ethnic-group-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Rhowch eich grŵp ethnig"
                                         }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "mixed-ethnic-group-answer-other",
-                                    "parent_answer_id": "mixed-ethnic-group-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Rhowch eich grŵp ethnig"
-                                }
-                            ]
+                                    }
+                                ],
+                                "type": "Radio"
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -3058,40 +3024,37 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "asian-ethnic-group-answer",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "Indiaidd",
-                                            "value": "Indian"
-                                        },
-                                        {
-                                            "label": "Pacistanaidd",
-                                            "value": "Pakistani"
-                                        },
-                                        {
-                                            "label": "Bangladeshaidd",
-                                            "value": "Bangladeshi"
-                                        },
-                                        {
-                                            "label": "Tsieineaidd",
-                                            "value": "Chinese"
-                                        },
-                                        {
-                                            "label": "Unrhyw gefndir Asiaidd arall",
-                                            "value": "Other",
-                                            "child_answer_id": "asian-ethnic-group-answer-other"
+                                "id": "asian-ethnic-group-answer",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "Indiaidd",
+                                        "value": "Indian"
+                                    },
+                                    {
+                                        "label": "Pacistanaidd",
+                                        "value": "Pakistani"
+                                    },
+                                    {
+                                        "label": "Bangladeshaidd",
+                                        "value": "Bangladeshi"
+                                    },
+                                    {
+                                        "label": "Tsieineaidd",
+                                        "value": "Chinese"
+                                    },
+                                    {
+                                        "label": "Unrhyw gefndir Asiaidd arall",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "asian-ethnic-group-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Rhowch eich grŵp ethnig"
                                         }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "asian-ethnic-group-answer-other",
-                                    "parent_answer_id": "asian-ethnic-group-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Rhowch eich grŵp ethnig"
-                                }
-                            ]
+                                    }
+                                ],
+                                "type": "Radio"
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -3158,32 +3121,29 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "black-ethnic-group-answer",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "Affricanaidd",
-                                            "value": "African"
-                                        },
-                                        {
-                                            "label": "Caribïaidd",
-                                            "value": "Caribbean"
-                                        },
-                                        {
-                                            "label": "Unrhyw gefndir Du, Affricanaidd neu Garibïaidd arall",
-                                            "value": "Other",
-                                            "child_answer_id": "black-ethnic-group-answer-other"
+                                "id": "black-ethnic-group-answer",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "Affricanaidd",
+                                        "value": "African"
+                                    },
+                                    {
+                                        "label": "Caribïaidd",
+                                        "value": "Caribbean"
+                                    },
+                                    {
+                                        "label": "Unrhyw gefndir Du, Affricanaidd neu Garibïaidd arall",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "black-ethnic-group-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Rhowch eich grŵp ethnig"
                                         }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "black-ethnic-group-answer-other",
-                                    "parent_answer_id": "black-ethnic-group-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Rhowch eich grŵp ethnig"
-                                }
-                            ]
+                                    }
+                                ],
+                                "type": "Radio"
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -3250,28 +3210,25 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "other-ethnic-group-answer",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "Arabaidd",
-                                            "value": "Arab"
-                                        },
-                                        {
-                                            "label": "Unrhyw gefndir arall",
-                                            "value": "Other",
-                                            "child_answer_id": "other-ethnic-group-answer-other"
+                                "id": "other-ethnic-group-answer",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "Arabaidd",
+                                        "value": "Arab"
+                                    },
+                                    {
+                                        "label": "Unrhyw gefndir arall",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "other-ethnic-group-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Rhowch eich grŵp ethnig"
                                         }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "other-ethnic-group-answer-other",
-                                    "parent_answer_id": "other-ethnic-group-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Rhowch eich grŵp ethnig"
-                                }
-                            ]
+                                    }
+                                ],
+                                "type": "Radio"
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -3339,53 +3296,50 @@
                             "description": "",
                             "type": "General",
                             "answers": [{
-                                    "id": "religion-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "Dim crefydd",
-                                            "value": "No religion"
-                                        },
-                                        {
-                                            "label": "Cristion",
-                                            "value": "Christian",
-                                            "description": "Yn cynnwys Eglwys Loegr, Catholig, Protestannaidd ac enwadau Cristnogol eraill"
-                                        },
-                                        {
-                                            "label": "Bwdhaidd",
-                                            "value": "Buddhist"
-                                        },
-                                        {
-                                            "label": "Hindŵaidd",
-                                            "value": "Hindu"
-                                        },
-                                        {
-                                            "label": "Iddewig",
-                                            "value": "Jewish"
-                                        },
-                                        {
-                                            "label": "Mwslimaidd",
-                                            "value": "Muslim"
-                                        },
-                                        {
-                                            "label": "Sikhaidd",
-                                            "value": "Sikh"
-                                        },
-                                        {
-                                            "label": "Crefydd arall",
-                                            "value": "Other",
-                                            "child_answer_id": "religion-answer-other"
+                                "id": "religion-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Dim crefydd",
+                                        "value": "No religion"
+                                    },
+                                    {
+                                        "label": "Cristion",
+                                        "value": "Christian",
+                                        "description": "Yn cynnwys Eglwys Loegr, Catholig, Protestannaidd ac enwadau Cristnogol eraill"
+                                    },
+                                    {
+                                        "label": "Bwdhaidd",
+                                        "value": "Buddhist"
+                                    },
+                                    {
+                                        "label": "Hindŵaidd",
+                                        "value": "Hindu"
+                                    },
+                                    {
+                                        "label": "Iddewig",
+                                        "value": "Jewish"
+                                    },
+                                    {
+                                        "label": "Mwslimaidd",
+                                        "value": "Muslim"
+                                    },
+                                    {
+                                        "label": "Sikhaidd",
+                                        "value": "Sikh"
+                                    },
+                                    {
+                                        "label": "Crefydd arall",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "religion-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Rhowch eich crefydd"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "religion-answer-other",
-                                    "parent_answer_id": "religion-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Rhowch eich crefydd"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -3915,16 +3869,14 @@
                                         {
                                             "label": "Rhyw drefniant arall",
                                             "value": "Some other arrangement",
-                                            "child_answer_id": "working-hours-answer-other"
+                                            "detail_answer": {
+                                                "id": "working-hours-answer-other",
+                                                "type": "TextField",
+                                                "mandatory": false,
+                                                "label": "Nodwch"
+                                            }
                                         }
                                     ]
-                                },
-                                {
-                                    "id": "working-hours-answer-other",
-                                    "parent_answer_id": "working-hours-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Nodwch"
                                 },
                                 {
                                     "id": "working-hours-answer-exclusive",
@@ -7343,53 +7295,50 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "reason-why-fewer-hours-than-usual-self-employed-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "Ar wyliau",
-                                            "value": "On leave"
-                                        },
-                                        {
-                                            "label": "Salwch neu anaf a ddisgwylir iddo barhau am lai na 4 wythnos",
-                                            "value": "Illness or injury expected to last fewer than 4 weeks"
-                                        },
-                                        {
-                                            "label": "Salwch neu anabledd a ddisgwylir iddo barhau am 4 wythnos neu fwy",
-                                            "value": "Illness or disability expected to last for 4 weeks or longer"
-                                        },
-                                        {
-                                            "label": "Absenoldeb mamolaeth neu dadolaeth",
-                                            "value": "Maternity or paternity leave"
-                                        },
-                                        {
-                                            "label": "Busnes heb ei sefydlu eto",
-                                            "value": "Business not set up yet"
-                                        },
-                                        {
-                                            "label": "Dim cleient neu gwsmer yr wythnos honno",
-                                            "value": "No client or customer that week"
-                                        },
-                                        {
-                                            "label": "Amhariad dros dro i waith",
-                                            "value": "Temporary interruption to work ",
-                                            "description": "Yn cynnwys tywydd gwael, anghydfod llafur"
-                                        },
-                                        {
-                                            "label": "Arall",
-                                            "value": "Other",
-                                            "child_answer_id": "reason-why-fewer-hours-than-usual-self-employed-answer-other"
+                                "id": "reason-why-fewer-hours-than-usual-self-employed-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Ar wyliau",
+                                        "value": "On leave"
+                                    },
+                                    {
+                                        "label": "Salwch neu anaf a ddisgwylir iddo barhau am lai na 4 wythnos",
+                                        "value": "Illness or injury expected to last fewer than 4 weeks"
+                                    },
+                                    {
+                                        "label": "Salwch neu anabledd a ddisgwylir iddo barhau am 4 wythnos neu fwy",
+                                        "value": "Illness or disability expected to last for 4 weeks or longer"
+                                    },
+                                    {
+                                        "label": "Absenoldeb mamolaeth neu dadolaeth",
+                                        "value": "Maternity or paternity leave"
+                                    },
+                                    {
+                                        "label": "Busnes heb ei sefydlu eto",
+                                        "value": "Business not set up yet"
+                                    },
+                                    {
+                                        "label": "Dim cleient neu gwsmer yr wythnos honno",
+                                        "value": "No client or customer that week"
+                                    },
+                                    {
+                                        "label": "Amhariad dros dro i waith",
+                                        "value": "Temporary interruption to work ",
+                                        "description": "Yn cynnwys tywydd gwael, anghydfod llafur"
+                                    },
+                                    {
+                                        "label": "Arall",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "reason-why-fewer-hours-than-usual-self-employed-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Nodwch"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "reason-why-fewer-hours-than-usual-self-employed-answer-other",
-                                    "parent_answer_id": "reason-why-fewer-hours-than-usual-self-employed-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Nodwch"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }]
                     },
                     {
@@ -7460,62 +7409,59 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "reason-why-fewer-hours-than-usual-employee-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "Ar wyliau",
-                                            "value": "On leave",
-                                            "description": "cyflogedig neu anghyflogedig"
-                                        },
-                                        {
-                                            "label": "Salwch neu anaf a ddisgwylir iddo barhau am lai na 4 wythnos",
-                                            "value": "Illness or injury expected to last fewer than 4 weeks"
-                                        },
-                                        {
-                                            "label": "Salwch neu anabledd a ddisgwylir iddo barhau am 4 wythnos neu fwy",
-                                            "value": "Illness or disability expected to last for 4 weeks or longer"
-                                        },
-                                        {
-                                            "label": "Absenoldeb mamolaeth neu dadolaeth",
-                                            "value": "Maternity or paternity leave"
-                                        },
-                                        {
-                                            "label": "Absenoldeb rhiant",
-                                            "value": "Parental leave"
-                                        },
-                                        {
-                                            "label": "Aros i ddechrau swydd newydd",
-                                            "value": "Waiting to start a new job"
-                                        },
-                                        {
-                                            "label": "Oriau yn amrywio",
-                                            "value": "Hours can vary"
-                                        },
-                                        {
-                                            "label": "Amhariad dros dro i waith",
-                                            "value": "Temporary interruption to work",
-                                            "description": "Yn cynnwys tywydd gwael, anghydfod llafur"
-                                        },
-                                        {
-                                            "label": "Mae’r swydd yn achlysurol",
-                                            "value": "Job is casual"
-                                        },
-                                        {
-                                            "label": "Arall",
-                                            "value": "Other",
-                                            "child_answer_id": "reason-why-fewer-hours-than-usual-employee-answer-other"
+                                "id": "reason-why-fewer-hours-than-usual-employee-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Ar wyliau",
+                                        "value": "On leave",
+                                        "description": "cyflogedig neu anghyflogedig"
+                                    },
+                                    {
+                                        "label": "Salwch neu anaf a ddisgwylir iddo barhau am lai na 4 wythnos",
+                                        "value": "Illness or injury expected to last fewer than 4 weeks"
+                                    },
+                                    {
+                                        "label": "Salwch neu anabledd a ddisgwylir iddo barhau am 4 wythnos neu fwy",
+                                        "value": "Illness or disability expected to last for 4 weeks or longer"
+                                    },
+                                    {
+                                        "label": "Absenoldeb mamolaeth neu dadolaeth",
+                                        "value": "Maternity or paternity leave"
+                                    },
+                                    {
+                                        "label": "Absenoldeb rhiant",
+                                        "value": "Parental leave"
+                                    },
+                                    {
+                                        "label": "Aros i ddechrau swydd newydd",
+                                        "value": "Waiting to start a new job"
+                                    },
+                                    {
+                                        "label": "Oriau yn amrywio",
+                                        "value": "Hours can vary"
+                                    },
+                                    {
+                                        "label": "Amhariad dros dro i waith",
+                                        "value": "Temporary interruption to work",
+                                        "description": "Yn cynnwys tywydd gwael, anghydfod llafur"
+                                    },
+                                    {
+                                        "label": "Mae’r swydd yn achlysurol",
+                                        "value": "Job is casual"
+                                    },
+                                    {
+                                        "label": "Arall",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "reason-why-fewer-hours-than-usual-employee-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Nodwch"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "reason-why-fewer-hours-than-usual-employee-answer-other",
-                                    "parent_answer_id": "reason-why-fewer-hours-than-usual-employee-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Nodwch"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -8007,52 +7953,49 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "not-be-able-to-start-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "Mewn addysg",
-                                            "value": "In education"
-                                        },
-                                        {
-                                            "label": "Gofalu am y teulu or  cartref",
-                                            "value": "Looking after the family or home"
-                                        },
-                                        {
-                                            "label": "Gofal plant yn rhy ddrud",
-                                            "value": "Childcare too expensive"
-                                        },
-                                        {
-                                            "label": "Cyfrifoldebau gofalu am oedolion",
-                                            "value": "Caring responsibilities for adults"
-                                        },
-                                        {
-                                            "label": "Salwch neu anaf a ddisgwylir iddo barhau am lai na 4 wythnos",
-                                            "value": "Illness or injury expecting to last fewer than 4 weeks"
-                                        },
-                                        {
-                                            "label": "Salwch neu anabledd a ddisgwylir iddo barhau am 4 wythnos neu fwy",
-                                            "value": "Illness or disability expecting to last for 4 weeks or longer"
-                                        },
-                                        {
-                                            "label": "Aros i gychwyn swydd a dderbyniais yn ddiweddar",
-                                            "value": "Waiting to start a job recently accepted"
-                                        },
-                                        {
-                                            "label": "Arall",
-                                            "value": "Other",
-                                            "child_answer_id": "not-be-able-to-start-answer-other"
+                                "id": "not-be-able-to-start-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Mewn addysg",
+                                        "value": "In education"
+                                    },
+                                    {
+                                        "label": "Gofalu am y teulu or  cartref",
+                                        "value": "Looking after the family or home"
+                                    },
+                                    {
+                                        "label": "Gofal plant yn rhy ddrud",
+                                        "value": "Childcare too expensive"
+                                    },
+                                    {
+                                        "label": "Cyfrifoldebau gofalu am oedolion",
+                                        "value": "Caring responsibilities for adults"
+                                    },
+                                    {
+                                        "label": "Salwch neu anaf a ddisgwylir iddo barhau am lai na 4 wythnos",
+                                        "value": "Illness or injury expecting to last fewer than 4 weeks"
+                                    },
+                                    {
+                                        "label": "Salwch neu anabledd a ddisgwylir iddo barhau am 4 wythnos neu fwy",
+                                        "value": "Illness or disability expecting to last for 4 weeks or longer"
+                                    },
+                                    {
+                                        "label": "Aros i gychwyn swydd a dderbyniais yn ddiweddar",
+                                        "value": "Waiting to start a job recently accepted"
+                                    },
+                                    {
+                                        "label": "Arall",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "not-be-able-to-start-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Nodwch"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "not-be-able-to-start-answer-other",
-                                    "parent_answer_id": "not-be-able-to-start-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Nodwch"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -8090,72 +8033,69 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "not-looking-for-work-reason-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "Wedi ymddeol o waith cyflogedig",
-                                            "value": "Retired from paid work"
-                                        },
-                                        {
-                                            "label": "Astudio",
-                                            "value": "Studying"
-                                        },
-                                        {
-                                            "label": "Gofalu am y teulu neu cartref",
-                                            "value": "Looking after the family or home"
-                                        },
-                                        {
-                                            "label": "Gofal plant yn rhy ddrud",
-                                            "value": "Childcare is too expensive"
-                                        },
-                                        {
-                                            "label": "Cyfrifoldebau gofalu am oedolion",
-                                            "value": "Caring responsibilities for adults"
-                                        },
-                                        {
-                                            "label": "Salwch neu anabledd a ddisgwylir iddo barhau am 4 wythnos neu fwy",
-                                            "value": "Illness or disability expecting to last for 4 weeks or longer"
-                                        },
-                                        {
-                                            "label": "Salwch neu anaf a ddisgwylir iddo barhau am lai na 4 wythnos",
-                                            "value": "Illness or injury expected to last fewer than 4 weeks"
-                                        },
-                                        {
-                                            "label": "Aros i gychwyn swydd a dderbyniwyd yn ddiweddar",
-                                            "value": "Waiting to start a job recently accepted"
-                                        },
-                                        {
-                                            "label": "Aros am ganlyniadau cais am swydd",
-                                            "value": "Waiting for the result of a job application"
-                                        },
-                                        {
-                                            "label": "Doedd yna ddim swyddi addas ar gael",
-                                            "value": "No suitable jobs were available"
-                                        },
-                                        {
-                                            "label": "Heb ddechrau chwilio eto",
-                                            "value": "Not yet started looking"
-                                        },
-                                        {
-                                            "label": "Nid oedd angen gwaith",
-                                            "value": "Did not need employment"
-                                        },
-                                        {
-                                            "label": "Arall",
-                                            "value": "Other",
-                                            "child_answer_id": "not-looking-for-work-reason-answer-other"
+                                "id": "not-looking-for-work-reason-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Wedi ymddeol o waith cyflogedig",
+                                        "value": "Retired from paid work"
+                                    },
+                                    {
+                                        "label": "Astudio",
+                                        "value": "Studying"
+                                    },
+                                    {
+                                        "label": "Gofalu am y teulu neu cartref",
+                                        "value": "Looking after the family or home"
+                                    },
+                                    {
+                                        "label": "Gofal plant yn rhy ddrud",
+                                        "value": "Childcare is too expensive"
+                                    },
+                                    {
+                                        "label": "Cyfrifoldebau gofalu am oedolion",
+                                        "value": "Caring responsibilities for adults"
+                                    },
+                                    {
+                                        "label": "Salwch neu anabledd a ddisgwylir iddo barhau am 4 wythnos neu fwy",
+                                        "value": "Illness or disability expecting to last for 4 weeks or longer"
+                                    },
+                                    {
+                                        "label": "Salwch neu anaf a ddisgwylir iddo barhau am lai na 4 wythnos",
+                                        "value": "Illness or injury expected to last fewer than 4 weeks"
+                                    },
+                                    {
+                                        "label": "Aros i gychwyn swydd a dderbyniwyd yn ddiweddar",
+                                        "value": "Waiting to start a job recently accepted"
+                                    },
+                                    {
+                                        "label": "Aros am ganlyniadau cais am swydd",
+                                        "value": "Waiting for the result of a job application"
+                                    },
+                                    {
+                                        "label": "Doedd yna ddim swyddi addas ar gael",
+                                        "value": "No suitable jobs were available"
+                                    },
+                                    {
+                                        "label": "Heb ddechrau chwilio eto",
+                                        "value": "Not yet started looking"
+                                    },
+                                    {
+                                        "label": "Nid oedd angen gwaith",
+                                        "value": "Did not need employment"
+                                    },
+                                    {
+                                        "label": "Arall",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "not-looking-for-work-reason-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Nodwch"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "not-looking-for-work-reason-answer-other",
-                                    "parent_answer_id": "not-looking-for-work-reason-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Nodwch"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -8936,6 +8876,7 @@
                                 "id": "no-primary-dob-age-answer",
                                 "unit": "duration-year",
                                 "type": "Unit",
+                                "label": "Oedran",
                                 "unit_length": "long",
                                 "mandatory": false,
                                 "max_value": {
@@ -9075,44 +9016,41 @@
                                 }
                             ],
                             "answers": [{
-                                    "id": "no-primary-nationality-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "Prydeinig",
-                                            "value": "British"
-                                        },
-                                        {
-                                            "label": "Gwyddelig",
-                                            "value": "Irish"
-                                        },
-                                        {
-                                            "label": "Indiaidd",
-                                            "value": "Indian"
-                                        },
-                                        {
-                                            "label": "Pacistanaidd",
-                                            "value": "Pakistani"
-                                        },
-                                        {
-                                            "label": "Pwylaidd",
-                                            "value": "Polish"
-                                        },
-                                        {
-                                            "label": "Arall",
-                                            "value": "Other",
-                                            "child_answer_id": "no-primary-nationality-answer-other"
+                                "id": "no-primary-nationality-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Prydeinig",
+                                        "value": "British"
+                                    },
+                                    {
+                                        "label": "Gwyddelig",
+                                        "value": "Irish"
+                                    },
+                                    {
+                                        "label": "Indiaidd",
+                                        "value": "Indian"
+                                    },
+                                    {
+                                        "label": "Pacistanaidd",
+                                        "value": "Pakistani"
+                                    },
+                                    {
+                                        "label": "Pwylaidd",
+                                        "value": "Polish"
+                                    },
+                                    {
+                                        "label": "Arall",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "no-primary-nationality-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Rhowch eich cenedligrwydd"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "no-primary-nationality-answer-other",
-                                    "parent_answer_id": "no-primary-nationality-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Rhowch eich cenedligrwydd"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }]
                     },
                     {
@@ -9141,60 +9079,57 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "no-primary-country-of-birth-wales-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "Cymru",
-                                            "value": "Wales"
-                                        },
-                                        {
-                                            "label": "Lloegr",
-                                            "value": "England"
-                                        },
-                                        {
-                                            "label": "Yr Alban",
-                                            "value": "Scotland"
-                                        },
-                                        {
-                                            "label": "Gogledd Iwerddon",
-                                            "value": "Northern Ireland"
-                                        },
-                                        {
-                                            "label": "Gweriniaeth Iwerddon",
-                                            "value": "Republic of Ireland"
-                                        },
-                                        {
-                                            "label": "Ynys Manaw neu Ynysoedd y Sianel",
-                                            "value": "Isle of Man or Channel Islands"
-                                        },
-                                        {
-                                            "label": "India",
-                                            "value": "India"
-                                        },
-                                        {
-                                            "label": "Pacistan",
-                                            "value": "Pakistan"
-                                        },
-                                        {
-                                            "label": "Gwlad Pwyl",
-                                            "value": "Poland"
-                                        },
-                                        {
-                                            "label": "Arall",
-                                            "value": "Other",
-                                            "child_answer_id": "no-primary-country-of-birth-wales-answer-other"
+                                "id": "no-primary-country-of-birth-wales-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Cymru",
+                                        "value": "Wales"
+                                    },
+                                    {
+                                        "label": "Lloegr",
+                                        "value": "England"
+                                    },
+                                    {
+                                        "label": "Yr Alban",
+                                        "value": "Scotland"
+                                    },
+                                    {
+                                        "label": "Gogledd Iwerddon",
+                                        "value": "Northern Ireland"
+                                    },
+                                    {
+                                        "label": "Gweriniaeth Iwerddon",
+                                        "value": "Republic of Ireland"
+                                    },
+                                    {
+                                        "label": "Ynys Manaw neu Ynysoedd y Sianel",
+                                        "value": "Isle of Man or Channel Islands"
+                                    },
+                                    {
+                                        "label": "India",
+                                        "value": "India"
+                                    },
+                                    {
+                                        "label": "Pacistan",
+                                        "value": "Pakistan"
+                                    },
+                                    {
+                                        "label": "Gwlad Pwyl",
+                                        "value": "Poland"
+                                    },
+                                    {
+                                        "label": "Arall",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "no-primary-country-of-birth-wales-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Nodwch gwlad lle y’ch ganwyd"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "no-primary-country-of-birth-wales-answer-other",
-                                    "parent_answer_id": "no-primary-country-of-birth-wales-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Nodwch gwlad lle y’ch ganwyd"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -9284,60 +9219,57 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "no-primary-country-of-birth-scotland-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "Yr Alban",
-                                            "value": "Scotland"
-                                        },
-                                        {
-                                            "label": "Lloegr",
-                                            "value": "England"
-                                        },
-                                        {
-                                            "label": "Cymru",
-                                            "value": "Wales"
-                                        },
-                                        {
-                                            "label": "Gogledd Iwerddon",
-                                            "value": "Northern Ireland"
-                                        },
-                                        {
-                                            "label": "Gweriniaeth Iwerddon",
-                                            "value": "Republic of Ireland"
-                                        },
-                                        {
-                                            "label": "Ynys Manaw neu Ynysoedd y Sianel",
-                                            "value": "Isle of Man or Channel Islands"
-                                        },
-                                        {
-                                            "label": "India",
-                                            "value": "India"
-                                        },
-                                        {
-                                            "label": "Pacistan",
-                                            "value": "Pakistan"
-                                        },
-                                        {
-                                            "label": "Gwlad Pwyl",
-                                            "value": "Poland"
-                                        },
-                                        {
-                                            "label": "Arall",
-                                            "value": "Other",
-                                            "child_answer_id": "no-primary-country-of-birth-scotland-answer-other"
+                                "id": "no-primary-country-of-birth-scotland-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Yr Alban",
+                                        "value": "Scotland"
+                                    },
+                                    {
+                                        "label": "Lloegr",
+                                        "value": "England"
+                                    },
+                                    {
+                                        "label": "Cymru",
+                                        "value": "Wales"
+                                    },
+                                    {
+                                        "label": "Gogledd Iwerddon",
+                                        "value": "Northern Ireland"
+                                    },
+                                    {
+                                        "label": "Gweriniaeth Iwerddon",
+                                        "value": "Republic of Ireland"
+                                    },
+                                    {
+                                        "label": "Ynys Manaw neu Ynysoedd y Sianel",
+                                        "value": "Isle of Man or Channel Islands"
+                                    },
+                                    {
+                                        "label": "India",
+                                        "value": "India"
+                                    },
+                                    {
+                                        "label": "Pacistan",
+                                        "value": "Pakistan"
+                                    },
+                                    {
+                                        "label": "Gwlad Pwyl",
+                                        "value": "Poland"
+                                    },
+                                    {
+                                        "label": "Arall",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "no-primary-country-of-birth-scotland-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Nodwch gwlad lle y’ch ganwyd"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "no-primary-country-of-birth-scotland-answer-other",
-                                    "parent_answer_id": "no-primary-country-of-birth-scotland-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Nodwch gwlad lle y’ch ganwyd"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -9421,60 +9353,57 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "no-primary-country-of-birth-england-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "Lloegr",
-                                            "value": "England"
-                                        },
-                                        {
-                                            "label": "Cymru",
-                                            "value": "Wales"
-                                        },
-                                        {
-                                            "label": "Yr Alban",
-                                            "value": "Scotland"
-                                        },
-                                        {
-                                            "label": "Gogledd Iwerddon",
-                                            "value": "Northern Ireland"
-                                        },
-                                        {
-                                            "label": "Gweriniaeth Iwerddon",
-                                            "value": "Republic of Ireland"
-                                        },
-                                        {
-                                            "label": "Ynys Manaw neu Ynysoedd y Sianel",
-                                            "value": "Isle of Man or Channel Islands"
-                                        },
-                                        {
-                                            "label": "India",
-                                            "value": "India"
-                                        },
-                                        {
-                                            "label": "Pacistan",
-                                            "value": "Pakistan"
-                                        },
-                                        {
-                                            "label": "Gwlad Pwyl",
-                                            "value": "Poland"
-                                        },
-                                        {
-                                            "label": "Arall",
-                                            "value": "Other",
-                                            "child_answer_id": "no-primary-country-of-birth-england-answer-other"
+                                "id": "no-primary-country-of-birth-england-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Lloegr",
+                                        "value": "England"
+                                    },
+                                    {
+                                        "label": "Cymru",
+                                        "value": "Wales"
+                                    },
+                                    {
+                                        "label": "Yr Alban",
+                                        "value": "Scotland"
+                                    },
+                                    {
+                                        "label": "Gogledd Iwerddon",
+                                        "value": "Northern Ireland"
+                                    },
+                                    {
+                                        "label": "Gweriniaeth Iwerddon",
+                                        "value": "Republic of Ireland"
+                                    },
+                                    {
+                                        "label": "Ynys Manaw neu Ynysoedd y Sianel",
+                                        "value": "Isle of Man or Channel Islands"
+                                    },
+                                    {
+                                        "label": "India",
+                                        "value": "India"
+                                    },
+                                    {
+                                        "label": "Pacistan",
+                                        "value": "Pakistan"
+                                    },
+                                    {
+                                        "label": "Gwlad Pwyl",
+                                        "value": "Poland"
+                                    },
+                                    {
+                                        "label": "Arall",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "no-primary-country-of-birth-england-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Nodwch gwlad lle y’ch ganwyd"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "no-primary-country-of-birth-england-answer-other",
-                                    "parent_answer_id": "no-primary-country-of-birth-england-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Nodwch gwlad lle y’ch ganwyd"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -9866,52 +9795,49 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "no-primary-why-uk-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "Ar gyfer gwaith",
-                                            "value": "For employment"
-                                        },
-                                        {
-                                            "label": "I astudio",
-                                            "value": "For study"
-                                        },
-                                        {
-                                            "label": "Fel cymar neu ddibynnydd i ddinesydd neu berson wedi setlo yn y Deyrnas Unedig",
-                                            "value": "As a spouse or dependent of a UK citizen or settled person"
-                                        },
-                                        {
-                                            "label": "Fel cymar neu ddibynnydd i rywun sy’n dod i neu sydd eisoes yn y Deyrnas Unedig i ddibenion gwaith neu astudio",
-                                            "value": "As a spouse or dependent of someone who is coming to or is already in the UK for work or study reasons"
-                                        },
-                                        {
-                                            "label": "I briodi neu ffurfio partneriaeth sifil yn y Deyrnas Unedig gyda rhywun nad yw’n ddinesydd o’r Deyrnas Unedig",
-                                            "value": "To get married or form a civil partnership in the UK with a non-UK citizen"
-                                        },
-                                        {
-                                            "label": "I geisio lloches",
-                                            "value": "Seeking asylum"
-                                        },
-                                        {
-                                            "label": "Fel ymwelydd",
-                                            "value": "As a visitor"
-                                        },
-                                        {
-                                            "label": "Rheswm arall",
-                                            "value": "Another reason",
-                                            "child_answer_id": "no-primary-why-uk-answer-other"
+                                "id": "no-primary-why-uk-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Ar gyfer gwaith",
+                                        "value": "For employment"
+                                    },
+                                    {
+                                        "label": "I astudio",
+                                        "value": "For study"
+                                    },
+                                    {
+                                        "label": "Fel cymar neu ddibynnydd i ddinesydd neu berson wedi setlo yn y Deyrnas Unedig",
+                                        "value": "As a spouse or dependent of a UK citizen or settled person"
+                                    },
+                                    {
+                                        "label": "Fel cymar neu ddibynnydd i rywun sy’n dod i neu sydd eisoes yn y Deyrnas Unedig i ddibenion gwaith neu astudio",
+                                        "value": "As a spouse or dependent of someone who is coming to or is already in the UK for work or study reasons"
+                                    },
+                                    {
+                                        "label": "I briodi neu ffurfio partneriaeth sifil yn y Deyrnas Unedig gyda rhywun nad yw’n ddinesydd o’r Deyrnas Unedig",
+                                        "value": "To get married or form a civil partnership in the UK with a non-UK citizen"
+                                    },
+                                    {
+                                        "label": "I geisio lloches",
+                                        "value": "Seeking asylum"
+                                    },
+                                    {
+                                        "label": "Fel ymwelydd",
+                                        "value": "As a visitor"
+                                    },
+                                    {
+                                        "label": "Rheswm arall",
+                                        "value": "Another reason",
+                                        "detail_answer": {
+                                            "id": "no-primary-why-uk-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Nodwch"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "no-primary-why-uk-answer-other",
-                                    "parent_answer_id": "no-primary-why-uk-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Nodwch"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }],
                         "routing_rules": [{
                             "goto": {
@@ -9938,52 +9864,49 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "no-primary-why-uk-continuous-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "Ar gyfer gwaith",
-                                            "value": "For employment"
-                                        },
-                                        {
-                                            "label": "I astudio",
-                                            "value": "For study"
-                                        },
-                                        {
-                                            "label": "Fel cymar neu ddibynnydd i ddinesydd neu berson wedi setlo yn y Deyrnas Unedig",
-                                            "value": "As a spouse or dependent of a UK citizen or settled person"
-                                        },
-                                        {
-                                            "label": "Fel cymar neu ddibynnydd i rywun sy’n dod i neu sydd eisoes yn y Deyrnas Unedig i ddibenion gwaith neu astudio",
-                                            "value": "As a spouse or dependent of someone who is coming to or is already in the UK for work or study reasons"
-                                        },
-                                        {
-                                            "label": "I briodi neu ffurfio partneriaeth sifil yn y Deyrnas Unedig gyda rhywun nad yw’n ddinesydd o’r Deyrnas Unedig",
-                                            "value": "To get married or form a civil partnership in the UK with a non-UK citizen"
-                                        },
-                                        {
-                                            "label": "I geisio lloches",
-                                            "value": "Seeking asylum"
-                                        },
-                                        {
-                                            "label": "Fel ymwelydd",
-                                            "value": "As a visitor"
-                                        },
-                                        {
-                                            "label": "Rheswm arall",
-                                            "value": "Another reason",
-                                            "child_answer_id": "no-primary-why-uk-continuous-answer-other"
+                                "id": "no-primary-why-uk-continuous-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Ar gyfer gwaith",
+                                        "value": "For employment"
+                                    },
+                                    {
+                                        "label": "I astudio",
+                                        "value": "For study"
+                                    },
+                                    {
+                                        "label": "Fel cymar neu ddibynnydd i ddinesydd neu berson wedi setlo yn y Deyrnas Unedig",
+                                        "value": "As a spouse or dependent of a UK citizen or settled person"
+                                    },
+                                    {
+                                        "label": "Fel cymar neu ddibynnydd i rywun sy’n dod i neu sydd eisoes yn y Deyrnas Unedig i ddibenion gwaith neu astudio",
+                                        "value": "As a spouse or dependent of someone who is coming to or is already in the UK for work or study reasons"
+                                    },
+                                    {
+                                        "label": "I briodi neu ffurfio partneriaeth sifil yn y Deyrnas Unedig gyda rhywun nad yw’n ddinesydd o’r Deyrnas Unedig",
+                                        "value": "To get married or form a civil partnership in the UK with a non-UK citizen"
+                                    },
+                                    {
+                                        "label": "I geisio lloches",
+                                        "value": "Seeking asylum"
+                                    },
+                                    {
+                                        "label": "Fel ymwelydd",
+                                        "value": "As a visitor"
+                                    },
+                                    {
+                                        "label": "Rheswm arall",
+                                        "value": "Another reason",
+                                        "detail_answer": {
+                                            "id": "no-primary-why-uk-continuous-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Nodwch"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "no-primary-why-uk-continuous-answer-other",
-                                    "parent_answer_id": "no-primary-why-uk-continuous-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Nodwch"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }],
                         "routing_rules": [{
                             "goto": {
@@ -10010,44 +9933,41 @@
                                 ],
                                 "type": "General",
                                 "answers": [{
-                                        "id": "no-primary-national-identity-england-answer",
-                                        "mandatory": false,
-                                        "type": "Checkbox",
-                                        "options": [{
-                                                "label": "Saesneg",
-                                                "value": "English"
-                                            },
-                                            {
-                                                "label": "Cymraeg",
-                                                "value": "Welsh"
-                                            },
-                                            {
-                                                "label": "Albanaidd",
-                                                "value": "Scottish"
-                                            },
-                                            {
-                                                "label": "Gogledd Iwerddon",
-                                                "value": "Northern Irish"
-                                            },
-                                            {
-                                                "label": "Prydeinig",
-                                                "value": "British"
-                                            },
-                                            {
-                                                "label": "Arall",
-                                                "value": "Other",
-                                                "child_answer_id": "no-primary-national-identity-england-answer-other"
+                                    "id": "no-primary-national-identity-england-answer",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "options": [{
+                                            "label": "Saesneg",
+                                            "value": "English"
+                                        },
+                                        {
+                                            "label": "Cymraeg",
+                                            "value": "Welsh"
+                                        },
+                                        {
+                                            "label": "Albanaidd",
+                                            "value": "Scottish"
+                                        },
+                                        {
+                                            "label": "Gogledd Iwerddon",
+                                            "value": "Northern Irish"
+                                        },
+                                        {
+                                            "label": "Prydeinig",
+                                            "value": "British"
+                                        },
+                                        {
+                                            "label": "Arall",
+                                            "value": "Other",
+                                            "detail_answer": {
+                                                "id": "no-primary-national-identity-england-answer-other",
+                                                "type": "TextField",
+                                                "mandatory": false,
+                                                "label": "Rhowch eich hunaniaeth genedlaethol"
                                             }
-                                        ]
-                                    },
-                                    {
-                                        "id": "no-primary-national-identity-england-answer-other",
-                                        "parent_answer_id": "no-primary-national-identity-england-answer",
-                                        "type": "TextField",
-                                        "mandatory": false,
-                                        "label": "Rhowch eich hunaniaeth genedlaethol"
-                                    }
-                                ],
+                                        }
+                                    ]
+                                }],
                                 "skip_conditions": [{
                                     "when": [{
                                         "meta": "country",
@@ -10072,44 +9992,41 @@
                                 ],
                                 "type": "General",
                                 "answers": [{
-                                        "id": "no-primary-national-identity-wales-answer",
-                                        "mandatory": false,
-                                        "type": "Checkbox",
-                                        "options": [{
-                                                "label": "Cymraeg",
-                                                "value": "Welsh"
-                                            },
-                                            {
-                                                "label": "Saesneg",
-                                                "value": "English"
-                                            },
-                                            {
-                                                "label": "Albanaidd",
-                                                "value": "Scottish"
-                                            },
-                                            {
-                                                "label": "Gogledd Iwerddon",
-                                                "value": "Northern Irish"
-                                            },
-                                            {
-                                                "label": "Prydeinig",
-                                                "value": "British"
-                                            },
-                                            {
-                                                "label": "Arall",
-                                                "value": "Other",
-                                                "child_answer_id": "no-primary-national-identity-wales-answer-other"
+                                    "id": "no-primary-national-identity-wales-answer",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "options": [{
+                                            "label": "Cymraeg",
+                                            "value": "Welsh"
+                                        },
+                                        {
+                                            "label": "Saesneg",
+                                            "value": "English"
+                                        },
+                                        {
+                                            "label": "Albanaidd",
+                                            "value": "Scottish"
+                                        },
+                                        {
+                                            "label": "Gogledd Iwerddon",
+                                            "value": "Northern Irish"
+                                        },
+                                        {
+                                            "label": "Prydeinig",
+                                            "value": "British"
+                                        },
+                                        {
+                                            "label": "Arall",
+                                            "value": "Other",
+                                            "detail_answer": {
+                                                "id": "no-primary-national-identity-wales-answer-other",
+                                                "type": "TextField",
+                                                "mandatory": false,
+                                                "label": "Rhowch eich hunaniaeth genedlaethol"
                                             }
-                                        ]
-                                    },
-                                    {
-                                        "id": "no-primary-national-identity-wales-answer-other",
-                                        "parent_answer_id": "no-primary-national-identity-wales-answer",
-                                        "type": "TextField",
-                                        "mandatory": false,
-                                        "label": "Rhowch eich hunaniaeth genedlaethol"
-                                    }
-                                ],
+                                        }
+                                    ]
+                                }],
                                 "skip_conditions": [{
                                     "when": [{
                                         "meta": "country",
@@ -10134,44 +10051,41 @@
                                 ],
                                 "type": "General",
                                 "answers": [{
-                                        "id": "no-primary-national-identity-scotland-answer",
-                                        "mandatory": false,
-                                        "type": "Checkbox",
-                                        "options": [{
-                                                "label": "Albanaidd",
-                                                "value": "Scottish"
-                                            },
-                                            {
-                                                "label": "Saesneg",
-                                                "value": "English"
-                                            },
-                                            {
-                                                "label": "Cymraeg",
-                                                "value": "Welsh"
-                                            },
-                                            {
-                                                "label": "Gogledd Iwerddon",
-                                                "value": "Northern Irish"
-                                            },
-                                            {
-                                                "label": "Prydeinig",
-                                                "value": "British"
-                                            },
-                                            {
-                                                "label": "Arall",
-                                                "value": "Other",
-                                                "child_answer_id": "no-primary-national-identity-scotland-answer-other"
+                                    "id": "no-primary-national-identity-scotland-answer",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "options": [{
+                                            "label": "Albanaidd",
+                                            "value": "Scottish"
+                                        },
+                                        {
+                                            "label": "Saesneg",
+                                            "value": "English"
+                                        },
+                                        {
+                                            "label": "Cymraeg",
+                                            "value": "Welsh"
+                                        },
+                                        {
+                                            "label": "Gogledd Iwerddon",
+                                            "value": "Northern Irish"
+                                        },
+                                        {
+                                            "label": "Prydeinig",
+                                            "value": "British"
+                                        },
+                                        {
+                                            "label": "Arall",
+                                            "value": "Other",
+                                            "detail_answer": {
+                                                "id": "no-primary-national-identity-scotland-answer-other",
+                                                "type": "TextField",
+                                                "mandatory": false,
+                                                "label": "Rhowch eich hunaniaeth genedlaethol"
                                             }
-                                        ]
-                                    },
-                                    {
-                                        "id": "no-primary-national-identity-scotland-answer-other",
-                                        "parent_answer_id": "no-primary-national-identity-scotland-answer",
-                                        "type": "TextField",
-                                        "mandatory": false,
-                                        "label": "Rhowch eich hunaniaeth genedlaethol"
-                                    }
-                                ],
+                                        }
+                                    ]
+                                }],
                                 "skip_conditions": [{
                                     "when": [{
                                             "meta": "country",
@@ -10503,36 +10417,33 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "no-primary-white-ethnic-group-answer",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "Saesneg, Cymraeg, Albanaidd, Gogledd Iwerddon neu Brydeinig",
-                                            "value": "English, Welsh, Scottish, Northern Irish or British"
-                                        },
-                                        {
-                                            "label": "Gwyddelig",
-                                            "value": "Irish"
-                                        },
-                                        {
-                                            "label": "Sipsi neu Deithiwr Gwyddelig",
-                                            "value": "Gypsy or Irish Traveller"
-                                        },
-                                        {
-                                            "label": "Unrhyw gefndir Gwyn arall",
-                                            "value": "Other",
-                                            "child_answer_id": "no-primary-white-ethnic-group-answer-other"
+                                "id": "no-primary-white-ethnic-group-answer",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "Saesneg, Cymraeg, Albanaidd, Gogledd Iwerddon neu Brydeinig",
+                                        "value": "English, Welsh, Scottish, Northern Irish or British"
+                                    },
+                                    {
+                                        "label": "Gwyddelig",
+                                        "value": "Irish"
+                                    },
+                                    {
+                                        "label": "Sipsi neu Deithiwr Gwyddelig",
+                                        "value": "Gypsy or Irish Traveller"
+                                    },
+                                    {
+                                        "label": "Unrhyw gefndir Gwyn arall",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "no-primary-white-ethnic-group-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Rhowch eich grŵp ethnig"
                                         }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "no-primary-white-ethnic-group-answer-other",
-                                    "parent_answer_id": "no-primary-white-ethnic-group-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Rhowch eich grŵp ethnig"
-                                }
-                            ]
+                                    }
+                                ],
+                                "type": "Radio"
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -10599,36 +10510,33 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "no-primary-mixed-ethnic-group-answer",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "Gwyn a Du Caribïaidd",
-                                            "value": "White and Black Caribbean"
-                                        },
-                                        {
-                                            "label": "Gwyn a Du Affricanaidd",
-                                            "value": "White and Black African"
-                                        },
-                                        {
-                                            "label": "Gwyn ac Asiaidd",
-                                            "value": "White and Asian"
-                                        },
-                                        {
-                                            "label": "Unrhyw gefndir ethnig cymysg neu luosog arall",
-                                            "value": "Other",
-                                            "child_answer_id": "no-primary-mixed-ethnic-group-answer-other"
+                                "id": "no-primary-mixed-ethnic-group-answer",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "Gwyn a Du Caribïaidd",
+                                        "value": "White and Black Caribbean"
+                                    },
+                                    {
+                                        "label": "Gwyn a Du Affricanaidd",
+                                        "value": "White and Black African"
+                                    },
+                                    {
+                                        "label": "Gwyn ac Asiaidd",
+                                        "value": "White and Asian"
+                                    },
+                                    {
+                                        "label": "Unrhyw gefndir ethnig cymysg neu luosog arall",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "no-primary-mixed-ethnic-group-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Rhowch eich grŵp ethnig"
                                         }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "no-primary-mixed-ethnic-group-answer-other",
-                                    "parent_answer_id": "no-primary-mixed-ethnic-group-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Rhowch eich grŵp ethnig"
-                                }
-                            ]
+                                    }
+                                ],
+                                "type": "Radio"
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -10695,40 +10603,37 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "no-primary-asian-ethnic-group-answer",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "Indiaidd",
-                                            "value": "Indian"
-                                        },
-                                        {
-                                            "label": "Pacistanaidd",
-                                            "value": "Pakistani"
-                                        },
-                                        {
-                                            "label": "Bangladeshaidd",
-                                            "value": "Bangladeshi"
-                                        },
-                                        {
-                                            "label": "Tsieineaidd",
-                                            "value": "Chinese"
-                                        },
-                                        {
-                                            "label": "Unrhyw gefndir Asiaidd arall",
-                                            "value": "Other",
-                                            "child_answer_id": "no-primary-asian-ethnic-group-answer-other"
+                                "id": "no-primary-asian-ethnic-group-answer",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "Indiaidd",
+                                        "value": "Indian"
+                                    },
+                                    {
+                                        "label": "Pacistanaidd",
+                                        "value": "Pakistani"
+                                    },
+                                    {
+                                        "label": "Bangladeshaidd",
+                                        "value": "Bangladeshi"
+                                    },
+                                    {
+                                        "label": "Tsieineaidd",
+                                        "value": "Chinese"
+                                    },
+                                    {
+                                        "label": "Unrhyw gefndir Asiaidd arall",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "no-primary-asian-ethnic-group-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Rhowch eich grŵp ethnig"
                                         }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "no-primary-asian-ethnic-group-answer-other",
-                                    "parent_answer_id": "no-primary-asian-ethnic-group-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Rhowch eich grŵp ethnig"
-                                }
-                            ]
+                                    }
+                                ],
+                                "type": "Radio"
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -10795,32 +10700,29 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "no-primary-black-ethnic-group-answer",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "Affricanaidd",
-                                            "value": "African"
-                                        },
-                                        {
-                                            "label": "Caribïaidd",
-                                            "value": "Caribbean"
-                                        },
-                                        {
-                                            "label": "Unrhyw gefndir Du, Affricanaidd neu Garibïaidd arall",
-                                            "value": "Other",
-                                            "child_answer_id": "no-primary-black-ethnic-group-answer-other"
+                                "id": "no-primary-black-ethnic-group-answer",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "Affricanaidd",
+                                        "value": "African"
+                                    },
+                                    {
+                                        "label": "Caribïaidd",
+                                        "value": "Caribbean"
+                                    },
+                                    {
+                                        "label": "Unrhyw gefndir Du, Affricanaidd neu Garibïaidd arall",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "no-primary-black-ethnic-group-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Rhowch eich grŵp ethnig"
                                         }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "no-primary-black-ethnic-group-answer-other",
-                                    "parent_answer_id": "no-primary-black-ethnic-group-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Rhowch eich grŵp ethnig"
-                                }
-                            ]
+                                    }
+                                ],
+                                "type": "Radio"
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -10887,28 +10789,25 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "no-primary-other-ethnic-group-answer",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "Arabaidd",
-                                            "value": "Arab"
-                                        },
-                                        {
-                                            "label": "Unrhyw gefndir arall",
-                                            "value": "Other",
-                                            "child_answer_id": "no-primary-other-ethnic-group-answer-other"
+                                "id": "no-primary-other-ethnic-group-answer",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "Arabaidd",
+                                        "value": "Arab"
+                                    },
+                                    {
+                                        "label": "Unrhyw gefndir arall",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "no-primary-other-ethnic-group-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Rhowch eich grŵp ethnig"
                                         }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "no-primary-other-ethnic-group-answer-other",
-                                    "parent_answer_id": "no-primary-other-ethnic-group-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Rhowch eich grŵp ethnig"
-                                }
-                            ]
+                                    }
+                                ],
+                                "type": "Radio"
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -10976,53 +10875,50 @@
                             "description": "",
                             "type": "General",
                             "answers": [{
-                                    "id": "no-primary-religion-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "Dim crefydd",
-                                            "value": "No religion"
-                                        },
-                                        {
-                                            "label": "Cristion",
-                                            "value": "Christian",
-                                            "description": "Yn cynnwys Eglwys Loegr, Catholig, Protestannaidd ac enwadau Cristnogol eraill"
-                                        },
-                                        {
-                                            "label": "Bwdhaidd",
-                                            "value": "Buddhist"
-                                        },
-                                        {
-                                            "label": "Hindŵaidd",
-                                            "value": "Hindu"
-                                        },
-                                        {
-                                            "label": "Iddewig",
-                                            "value": "Jewish"
-                                        },
-                                        {
-                                            "label": "Mwslimaidd",
-                                            "value": "Muslim"
-                                        },
-                                        {
-                                            "label": "Sikhaidd",
-                                            "value": "Sikh"
-                                        },
-                                        {
-                                            "label": "Crefydd arall",
-                                            "value": "Other",
-                                            "child_answer_id": "no-primary-religion-answer-other"
+                                "id": "no-primary-religion-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Dim crefydd",
+                                        "value": "No religion"
+                                    },
+                                    {
+                                        "label": "Cristion",
+                                        "value": "Christian",
+                                        "description": "Yn cynnwys Eglwys Loegr, Catholig, Protestannaidd ac enwadau Cristnogol eraill"
+                                    },
+                                    {
+                                        "label": "Bwdhaidd",
+                                        "value": "Buddhist"
+                                    },
+                                    {
+                                        "label": "Hindŵaidd",
+                                        "value": "Hindu"
+                                    },
+                                    {
+                                        "label": "Iddewig",
+                                        "value": "Jewish"
+                                    },
+                                    {
+                                        "label": "Mwslimaidd",
+                                        "value": "Muslim"
+                                    },
+                                    {
+                                        "label": "Sikhaidd",
+                                        "value": "Sikh"
+                                    },
+                                    {
+                                        "label": "Crefydd arall",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "no-primary-religion-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Rhowch eich crefydd"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "no-primary-religion-answer-other",
-                                    "parent_answer_id": "no-primary-religion-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Rhowch eich crefydd"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -11552,16 +11448,14 @@
                                         {
                                             "label": "Rhyw drefniant arall",
                                             "value": "Some other arrangement",
-                                            "child_answer_id": "no-primary-working-hours-answer-other"
+                                            "detail_answer": {
+                                                "id": "no-primary-working-hours-answer-other",
+                                                "type": "TextField",
+                                                "mandatory": false,
+                                                "label": "Nodwch"
+                                            }
                                         }
                                     ]
-                                },
-                                {
-                                    "id": "no-primary-working-hours-answer-other",
-                                    "parent_answer_id": "no-primary-working-hours-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Nodwch"
                                 },
                                 {
                                     "id": "no-primary-working-hours-answer-exclusive",
@@ -14980,53 +14874,50 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "no-primary-reason-why-fewer-hours-than-usual-self-employed-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "Ar wyliau",
-                                            "value": "On leave"
-                                        },
-                                        {
-                                            "label": "Salwch neu anaf a ddisgwylir iddo barhau am lai na 4 wythnos",
-                                            "value": "Illness or injury expected to last fewer than 4 weeks"
-                                        },
-                                        {
-                                            "label": "Salwch neu anabledd a ddisgwylir iddo barhau am 4 wythnos neu fwy",
-                                            "value": "Illness or disability expected to last for 4 weeks or longer"
-                                        },
-                                        {
-                                            "label": "Absenoldeb mamolaeth neu dadolaeth",
-                                            "value": "Maternity or paternity leave"
-                                        },
-                                        {
-                                            "label": "Busnes heb ei sefydlu eto",
-                                            "value": "Business not set up yet"
-                                        },
-                                        {
-                                            "label": "Dim cleient neu gwsmer yr wythnos honno",
-                                            "value": "No client or customer that week"
-                                        },
-                                        {
-                                            "label": "Amhariad dros dro i waith",
-                                            "value": "Temporary interruption to work ",
-                                            "description": "Yn cynnwys tywydd gwael, anghydfod llafur"
-                                        },
-                                        {
-                                            "label": "Arall",
-                                            "value": "Other",
-                                            "child_answer_id": "no-primary-reason-why-fewer-hours-than-usual-self-employed-answer-other"
+                                "id": "no-primary-reason-why-fewer-hours-than-usual-self-employed-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Ar wyliau",
+                                        "value": "On leave"
+                                    },
+                                    {
+                                        "label": "Salwch neu anaf a ddisgwylir iddo barhau am lai na 4 wythnos",
+                                        "value": "Illness or injury expected to last fewer than 4 weeks"
+                                    },
+                                    {
+                                        "label": "Salwch neu anabledd a ddisgwylir iddo barhau am 4 wythnos neu fwy",
+                                        "value": "Illness or disability expected to last for 4 weeks or longer"
+                                    },
+                                    {
+                                        "label": "Absenoldeb mamolaeth neu dadolaeth",
+                                        "value": "Maternity or paternity leave"
+                                    },
+                                    {
+                                        "label": "Busnes heb ei sefydlu eto",
+                                        "value": "Business not set up yet"
+                                    },
+                                    {
+                                        "label": "Dim cleient neu gwsmer yr wythnos honno",
+                                        "value": "No client or customer that week"
+                                    },
+                                    {
+                                        "label": "Amhariad dros dro i waith",
+                                        "value": "Temporary interruption to work ",
+                                        "description": "Yn cynnwys tywydd gwael, anghydfod llafur"
+                                    },
+                                    {
+                                        "label": "Arall",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "no-primary-reason-why-fewer-hours-than-usual-self-employed-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Nodwch"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "no-primary-reason-why-fewer-hours-than-usual-self-employed-answer-other",
-                                    "parent_answer_id": "no-primary-reason-why-fewer-hours-than-usual-self-employed-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Nodwch"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }]
                     },
                     {
@@ -15097,62 +14988,59 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "no-primary-reason-why-fewer-hours-than-usual-employee-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "Ar wyliau",
-                                            "value": "On leave",
-                                            "description": "cyflogedig neu anghyflogedig"
-                                        },
-                                        {
-                                            "label": "Salwch neu anaf a ddisgwylir iddo barhau am lai na 4 wythnos",
-                                            "value": "Illness or injury expected to last fewer than 4 weeks"
-                                        },
-                                        {
-                                            "label": "Salwch neu anabledd a ddisgwylir iddo barhau am 4 wythnos neu fwy",
-                                            "value": "Illness or disability expected to last for 4 weeks or longer"
-                                        },
-                                        {
-                                            "label": "Absenoldeb mamolaeth neu dadolaeth",
-                                            "value": "Maternity or paternity leave"
-                                        },
-                                        {
-                                            "label": "Absenoldeb rhiant",
-                                            "value": "Parental leave"
-                                        },
-                                        {
-                                            "label": "Aros i ddechrau swydd newydd",
-                                            "value": "Waiting to start a new job"
-                                        },
-                                        {
-                                            "label": "Oriau yn amrywio",
-                                            "value": "Hours can vary"
-                                        },
-                                        {
-                                            "label": "Amhariad dros dro i waith",
-                                            "value": "Temporary interruption to work",
-                                            "description": "Yn cynnwys tywydd gwael, anghydfod llafur"
-                                        },
-                                        {
-                                            "label": "Mae’r swydd yn achlysurol",
-                                            "value": "Job is casual"
-                                        },
-                                        {
-                                            "label": "Arall",
-                                            "value": "Other",
-                                            "child_answer_id": "no-primary-reason-why-fewer-hours-than-usual-employee-answer-other"
+                                "id": "no-primary-reason-why-fewer-hours-than-usual-employee-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Ar wyliau",
+                                        "value": "On leave",
+                                        "description": "cyflogedig neu anghyflogedig"
+                                    },
+                                    {
+                                        "label": "Salwch neu anaf a ddisgwylir iddo barhau am lai na 4 wythnos",
+                                        "value": "Illness or injury expected to last fewer than 4 weeks"
+                                    },
+                                    {
+                                        "label": "Salwch neu anabledd a ddisgwylir iddo barhau am 4 wythnos neu fwy",
+                                        "value": "Illness or disability expected to last for 4 weeks or longer"
+                                    },
+                                    {
+                                        "label": "Absenoldeb mamolaeth neu dadolaeth",
+                                        "value": "Maternity or paternity leave"
+                                    },
+                                    {
+                                        "label": "Absenoldeb rhiant",
+                                        "value": "Parental leave"
+                                    },
+                                    {
+                                        "label": "Aros i ddechrau swydd newydd",
+                                        "value": "Waiting to start a new job"
+                                    },
+                                    {
+                                        "label": "Oriau yn amrywio",
+                                        "value": "Hours can vary"
+                                    },
+                                    {
+                                        "label": "Amhariad dros dro i waith",
+                                        "value": "Temporary interruption to work",
+                                        "description": "Yn cynnwys tywydd gwael, anghydfod llafur"
+                                    },
+                                    {
+                                        "label": "Mae’r swydd yn achlysurol",
+                                        "value": "Job is casual"
+                                    },
+                                    {
+                                        "label": "Arall",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "no-primary-reason-why-fewer-hours-than-usual-employee-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Nodwch"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "no-primary-reason-why-fewer-hours-than-usual-employee-answer-other",
-                                    "parent_answer_id": "no-primary-reason-why-fewer-hours-than-usual-employee-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Nodwch"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -15644,52 +15532,49 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "no-primary-not-be-able-to-start-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "Mewn addysg",
-                                            "value": "In education"
-                                        },
-                                        {
-                                            "label": "Gofalu am y teulu or  cartref",
-                                            "value": "Looking after the family or home"
-                                        },
-                                        {
-                                            "label": "Gofal plant yn rhy ddrud",
-                                            "value": "Childcare too expensive"
-                                        },
-                                        {
-                                            "label": "Cyfrifoldebau gofalu am oedolion",
-                                            "value": "Caring responsibilities for adults"
-                                        },
-                                        {
-                                            "label": "Salwch neu anaf a ddisgwylir iddo barhau am lai na 4 wythnos",
-                                            "value": "Illness or injury expecting to last fewer than 4 weeks"
-                                        },
-                                        {
-                                            "label": "Salwch neu anabledd a ddisgwylir iddo barhau am 4 wythnos neu fwy",
-                                            "value": "Illness or disability expecting to last for 4 weeks or longer"
-                                        },
-                                        {
-                                            "label": "Aros i gychwyn swydd a dderbyniais yn ddiweddar",
-                                            "value": "Waiting to start a job recently accepted"
-                                        },
-                                        {
-                                            "label": "Arall",
-                                            "value": "Other",
-                                            "child_answer_id": "no-primary-not-be-able-to-start-answer-other"
+                                "id": "no-primary-not-be-able-to-start-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Mewn addysg",
+                                        "value": "In education"
+                                    },
+                                    {
+                                        "label": "Gofalu am y teulu or  cartref",
+                                        "value": "Looking after the family or home"
+                                    },
+                                    {
+                                        "label": "Gofal plant yn rhy ddrud",
+                                        "value": "Childcare too expensive"
+                                    },
+                                    {
+                                        "label": "Cyfrifoldebau gofalu am oedolion",
+                                        "value": "Caring responsibilities for adults"
+                                    },
+                                    {
+                                        "label": "Salwch neu anaf a ddisgwylir iddo barhau am lai na 4 wythnos",
+                                        "value": "Illness or injury expecting to last fewer than 4 weeks"
+                                    },
+                                    {
+                                        "label": "Salwch neu anabledd a ddisgwylir iddo barhau am 4 wythnos neu fwy",
+                                        "value": "Illness or disability expecting to last for 4 weeks or longer"
+                                    },
+                                    {
+                                        "label": "Aros i gychwyn swydd a dderbyniais yn ddiweddar",
+                                        "value": "Waiting to start a job recently accepted"
+                                    },
+                                    {
+                                        "label": "Arall",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "no-primary-not-be-able-to-start-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Nodwch"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "no-primary-not-be-able-to-start-answer-other",
-                                    "parent_answer_id": "no-primary-not-be-able-to-start-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Nodwch"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -15727,72 +15612,69 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "no-primary-not-looking-for-work-reason-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "Wedi ymddeol o waith cyflogedig",
-                                            "value": "Retired from paid work"
-                                        },
-                                        {
-                                            "label": "Astudio",
-                                            "value": "Studying"
-                                        },
-                                        {
-                                            "label": "Gofalu am y teulu neu cartref",
-                                            "value": "Looking after the family or home"
-                                        },
-                                        {
-                                            "label": "Gofal plant yn rhy ddrud",
-                                            "value": "Childcare is too expensive"
-                                        },
-                                        {
-                                            "label": "Cyfrifoldebau gofalu am oedolion",
-                                            "value": "Caring responsibilities for adults"
-                                        },
-                                        {
-                                            "label": "Salwch neu anabledd a ddisgwylir iddo barhau am 4 wythnos neu fwy",
-                                            "value": "Illness or disability expecting to last for 4 weeks or longer"
-                                        },
-                                        {
-                                            "label": "Salwch neu anaf a ddisgwylir iddo barhau am lai na 4 wythnos",
-                                            "value": "Illness or injury expected to last fewer than 4 weeks"
-                                        },
-                                        {
-                                            "label": "Aros i gychwyn swydd a dderbyniwyd yn ddiweddar",
-                                            "value": "Waiting to start a job recently accepted"
-                                        },
-                                        {
-                                            "label": "Aros am ganlyniadau cais am swydd",
-                                            "value": "Waiting for the result of a job application"
-                                        },
-                                        {
-                                            "label": "Doedd yna ddim swyddi addas ar gael",
-                                            "value": "No suitable jobs were available"
-                                        },
-                                        {
-                                            "label": "Heb ddechrau chwilio eto",
-                                            "value": "Not yet started looking"
-                                        },
-                                        {
-                                            "label": "Nid oedd angen gwaith",
-                                            "value": "Did not need employment"
-                                        },
-                                        {
-                                            "label": "Arall",
-                                            "value": "Other",
-                                            "child_answer_id": "no-primary-not-looking-for-work-reason-answer-other"
+                                "id": "no-primary-not-looking-for-work-reason-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Wedi ymddeol o waith cyflogedig",
+                                        "value": "Retired from paid work"
+                                    },
+                                    {
+                                        "label": "Astudio",
+                                        "value": "Studying"
+                                    },
+                                    {
+                                        "label": "Gofalu am y teulu neu cartref",
+                                        "value": "Looking after the family or home"
+                                    },
+                                    {
+                                        "label": "Gofal plant yn rhy ddrud",
+                                        "value": "Childcare is too expensive"
+                                    },
+                                    {
+                                        "label": "Cyfrifoldebau gofalu am oedolion",
+                                        "value": "Caring responsibilities for adults"
+                                    },
+                                    {
+                                        "label": "Salwch neu anabledd a ddisgwylir iddo barhau am 4 wythnos neu fwy",
+                                        "value": "Illness or disability expecting to last for 4 weeks or longer"
+                                    },
+                                    {
+                                        "label": "Salwch neu anaf a ddisgwylir iddo barhau am lai na 4 wythnos",
+                                        "value": "Illness or injury expected to last fewer than 4 weeks"
+                                    },
+                                    {
+                                        "label": "Aros i gychwyn swydd a dderbyniwyd yn ddiweddar",
+                                        "value": "Waiting to start a job recently accepted"
+                                    },
+                                    {
+                                        "label": "Aros am ganlyniadau cais am swydd",
+                                        "value": "Waiting for the result of a job application"
+                                    },
+                                    {
+                                        "label": "Doedd yna ddim swyddi addas ar gael",
+                                        "value": "No suitable jobs were available"
+                                    },
+                                    {
+                                        "label": "Heb ddechrau chwilio eto",
+                                        "value": "Not yet started looking"
+                                    },
+                                    {
+                                        "label": "Nid oedd angen gwaith",
+                                        "value": "Did not need employment"
+                                    },
+                                    {
+                                        "label": "Arall",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "no-primary-not-looking-for-work-reason-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Nodwch"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "no-primary-not-looking-for-work-reason-answer-other",
-                                    "parent_answer_id": "no-primary-not-looking-for-work-reason-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Nodwch"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {

--- a/data/en/0_star_wars.json
+++ b/data/en/0_star_wars.json
@@ -60,10 +60,7 @@
                             "value": "I prefer Star Trek"
                         }, {
                             "label": "Other",
-                            "value": "other",
-                            "other": {
-                                "label": "Please specify other"
-                            }
+                            "value": "other"
                         }],
                         "q_code": "20",
                         "type": "Radio"

--- a/data/en/census_communal.json
+++ b/data/en/census_communal.json
@@ -44,15 +44,14 @@
                         }, {
                             "label": "Other",
                             "value": "Other",
-                            "child_answer_id": "establishment-type-answer-other"
+                            "detail_answer": {
+                                "id": "establishment-type-answer-other",
+                                "type": "TextField",
+                                "mandatory": false,
+                                "label": "Please specify"
+                            }
                         }],
                         "type": "Radio"
-                    }, {
-                        "id": "establishment-type-answer-other",
-                        "parent_answer_id": "establishment-type-answer",
-                        "type": "TextField",
-                        "mandatory": false,
-                        "label": "Please specify"
                     }]
                 }]
             }, {
@@ -164,15 +163,14 @@
                         }, {
                             "label": "Other",
                             "value": "Other",
-                            "child_answer_id": "describe-residents-answer-other"
+                            "detail_answer": {
+                                "id": "describe-residents-answer-other",
+                                "type": "TextField",
+                                "mandatory": false,
+                                "label": "Please specify"
+                            }
                         }],
                         "type": "Checkbox"
-                    }, {
-                        "id": "describe-residents-answer-other",
-                        "parent_answer_id": "describe-residents-answer",
-                        "type": "TextField",
-                        "mandatory": false,
-                        "label": "Please specify"
                     }]
                 }]
             }, {
@@ -249,15 +247,14 @@
                         }, {
                             "label": "Other",
                             "value": "Other",
-                            "child_answer_id": "why-paper-individual-answer-other"
+                            "detail_answer": {
+                                "id": "why-paper-individual-answer-other",
+                                "type": "TextField",
+                                "mandatory": false,
+                                "label": "Please specify"
+                            }
                         }],
                         "type": "Checkbox"
-                    }, {
-                        "id": "why-paper-individual-answer-other",
-                        "parent_answer_id": "why-paper-individual-answer",
-                        "type": "TextField",
-                        "mandatory": false,
-                        "label": "Please specify"
                     }]
                 }]
             }, {
@@ -316,15 +313,14 @@
                         }, {
                             "label": "Other",
                             "value": "Other",
-                            "child_answer_id": "why-paper-establishment-answer-other"
+                            "detail_answer": {
+                                "id": "why-paper-establishment-answer-other",
+                                "type": "TextField",
+                                "mandatory": false,
+                                "label": "Please specify"
+                            }
                         }],
                         "type": "Checkbox"
-                    }, {
-                        "id": "why-paper-establishment-answer-other",
-                        "parent_answer_id": "why-paper-establishment-answer",
-                        "type": "TextField",
-                        "mandatory": false,
-                        "label": "Please specify"
                     }]
                 }]
             }, {

--- a/data/en/census_household.json
+++ b/data/en/census_household.json
@@ -734,40 +734,37 @@
                                 }]
                             },
                             "answers": [{
-                                    "id": "number-of-vehicles-answer",
-                                    "mandatory": true,
-                                    "options": [{
-                                            "label": "None",
-                                            "value": "None"
-                                        },
-                                        {
-                                            "label": "1",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "label": "2",
-                                            "value": "2"
-                                        },
-                                        {
-                                            "label": "3",
-                                            "value": "3"
-                                        },
-                                        {
-                                            "label": "4 or more",
-                                            "value": "4 or more",
-                                            "child_answer_id": "number-of-vehicles-answer-other"
+                                "id": "number-of-vehicles-answer",
+                                "mandatory": true,
+                                "options": [{
+                                        "label": "None",
+                                        "value": "None"
+                                    },
+                                    {
+                                        "label": "1",
+                                        "value": "1"
+                                    },
+                                    {
+                                        "label": "2",
+                                        "value": "2"
+                                    },
+                                    {
+                                        "label": "3",
+                                        "value": "3"
+                                    },
+                                    {
+                                        "label": "4 or more",
+                                        "value": "4 or more",
+                                        "detail_answer": {
+                                            "id": "number-of-vehicles-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please specify number of cars or vans"
                                         }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "number-of-vehicles-answer-other",
-                                    "parent_answer_id": "number-of-vehicles-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please specify number of cars or vans"
-                                }
-                            ]
+                                    }
+                                ],
+                                "type": "Radio"
+                            }]
                         }]
                     },
                     {
@@ -1241,32 +1238,29 @@
                             }],
                             "description": "This could be more than 30 days in a row, or divided across the year",
                             "answers": [{
-                                    "id": "another-address-answer",
-                                    "mandatory": true,
-                                    "options": [{
-                                            "label": "No",
-                                            "value": "No"
-                                        },
-                                        {
-                                            "label": "Yes, an address within the UK",
-                                            "value": "Yes, an address within the UK"
-                                        },
-                                        {
-                                            "label": "Yes, an address outside the UK",
-                                            "value": "Other",
-                                            "child_answer_id": "another-address-answer-other"
+                                "id": "another-address-answer",
+                                "mandatory": true,
+                                "options": [{
+                                        "label": "No",
+                                        "value": "No"
+                                    },
+                                    {
+                                        "label": "Yes, an address within the UK",
+                                        "value": "Yes, an address within the UK"
+                                    },
+                                    {
+                                        "label": "Yes, an address outside the UK",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "another-address-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please specify a country"
                                         }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "another-address-answer-other",
-                                    "parent_answer_id": "another-address-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please specify a country"
-                                }
-                            ]
+                                    }
+                                ],
+                                "type": "Radio"
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -1847,44 +1841,41 @@
                                 ],
                                 "type": "General",
                                 "answers": [{
-                                        "id": "country-of-birth-england-answer",
-                                        "mandatory": true,
-                                        "options": [{
-                                                "label": "England",
-                                                "value": "England"
-                                            },
-                                            {
-                                                "label": "Wales",
-                                                "value": "Wales"
-                                            },
-                                            {
-                                                "label": "Scotland",
-                                                "value": "Scotland"
-                                            },
-                                            {
-                                                "label": "Northern Ireland",
-                                                "value": "Northern Ireland"
-                                            },
-                                            {
-                                                "label": "Republic of Ireland",
-                                                "value": "Republic of Ireland"
-                                            },
-                                            {
-                                                "label": "Elsewhere",
-                                                "value": "Other",
-                                                "child_answer_id": "country-of-birth-england-answer-other"
+                                    "id": "country-of-birth-england-answer",
+                                    "mandatory": true,
+                                    "options": [{
+                                            "label": "England",
+                                            "value": "England"
+                                        },
+                                        {
+                                            "label": "Wales",
+                                            "value": "Wales"
+                                        },
+                                        {
+                                            "label": "Scotland",
+                                            "value": "Scotland"
+                                        },
+                                        {
+                                            "label": "Northern Ireland",
+                                            "value": "Northern Ireland"
+                                        },
+                                        {
+                                            "label": "Republic of Ireland",
+                                            "value": "Republic of Ireland"
+                                        },
+                                        {
+                                            "label": "Elsewhere",
+                                            "value": "Other",
+                                            "detail_answer": {
+                                                "id": "country-of-birth-england-answer-other",
+                                                "type": "TextField",
+                                                "mandatory": false,
+                                                "label": "Please specify current name of country"
                                             }
-                                        ],
-                                        "type": "Radio"
-                                    },
-                                    {
-                                        "id": "country-of-birth-england-answer-other",
-                                        "parent_answer_id": "country-of-birth-england-answer",
-                                        "type": "TextField",
-                                        "mandatory": false,
-                                        "label": "Please specify current name of country"
-                                    }
-                                ],
+                                        }
+                                    ],
+                                    "type": "Radio"
+                                }],
                                 "skip_conditions": [{
                                     "when": [{
                                         "meta": "region_code",
@@ -1909,44 +1900,41 @@
                                 ],
                                 "type": "General",
                                 "answers": [{
-                                        "id": "country-of-birth-wales-answer",
-                                        "mandatory": true,
-                                        "options": [{
-                                                "label": "Wales",
-                                                "value": "Wales"
-                                            },
-                                            {
-                                                "label": "England",
-                                                "value": "England"
-                                            },
-                                            {
-                                                "label": "Scotland",
-                                                "value": "Scotland"
-                                            },
-                                            {
-                                                "label": "Northern Ireland",
-                                                "value": "Northern Ireland"
-                                            },
-                                            {
-                                                "label": "Republic of Ireland",
-                                                "value": "Republic of Ireland"
-                                            },
-                                            {
-                                                "label": "Elsewhere",
-                                                "value": "Other",
-                                                "child_answer_id": "country-of-birth-wales-answer-other"
+                                    "id": "country-of-birth-wales-answer",
+                                    "mandatory": true,
+                                    "options": [{
+                                            "label": "Wales",
+                                            "value": "Wales"
+                                        },
+                                        {
+                                            "label": "England",
+                                            "value": "England"
+                                        },
+                                        {
+                                            "label": "Scotland",
+                                            "value": "Scotland"
+                                        },
+                                        {
+                                            "label": "Northern Ireland",
+                                            "value": "Northern Ireland"
+                                        },
+                                        {
+                                            "label": "Republic of Ireland",
+                                            "value": "Republic of Ireland"
+                                        },
+                                        {
+                                            "label": "Elsewhere",
+                                            "value": "Other",
+                                            "detail_answer": {
+                                                "id": "country-of-birth-wales-answer-other",
+                                                "type": "TextField",
+                                                "mandatory": false,
+                                                "label": "Please specify current name of country"
                                             }
-                                        ],
-                                        "type": "Radio"
-                                    },
-                                    {
-                                        "id": "country-of-birth-wales-answer-other",
-                                        "parent_answer_id": "country-of-birth-wales-answer",
-                                        "type": "TextField",
-                                        "mandatory": false,
-                                        "label": "Please specify current name of country"
-                                    }
-                                ],
+                                        }
+                                    ],
+                                    "type": "Radio"
+                                }],
                                 "skip_conditions": [{
                                     "when": [{
                                         "meta": "region_code",
@@ -2360,44 +2348,41 @@
                                     }]
                                 }],
                                 "answers": [{
-                                        "id": "national-identity-england-answer",
-                                        "mandatory": true,
-                                        "options": [{
-                                                "label": "English",
-                                                "value": "English"
-                                            },
-                                            {
-                                                "label": "Welsh",
-                                                "value": "Welsh"
-                                            },
-                                            {
-                                                "label": "Scottish",
-                                                "value": "Scottish"
-                                            },
-                                            {
-                                                "label": "Northern Irish",
-                                                "value": "Northern Irish"
-                                            },
-                                            {
-                                                "label": "British",
-                                                "value": "British"
-                                            },
-                                            {
-                                                "label": "Other",
-                                                "value": "Other",
-                                                "child_answer_id": "national-identity-england-answer-other"
+                                    "id": "national-identity-england-answer",
+                                    "mandatory": true,
+                                    "options": [{
+                                            "label": "English",
+                                            "value": "English"
+                                        },
+                                        {
+                                            "label": "Welsh",
+                                            "value": "Welsh"
+                                        },
+                                        {
+                                            "label": "Scottish",
+                                            "value": "Scottish"
+                                        },
+                                        {
+                                            "label": "Northern Irish",
+                                            "value": "Northern Irish"
+                                        },
+                                        {
+                                            "label": "British",
+                                            "value": "British"
+                                        },
+                                        {
+                                            "label": "Other",
+                                            "value": "Other",
+                                            "detail_answer": {
+                                                "id": "national-identity-england-answer-other",
+                                                "type": "TextField",
+                                                "mandatory": false,
+                                                "label": "Please describe your national identity"
                                             }
-                                        ],
-                                        "type": "Checkbox"
-                                    },
-                                    {
-                                        "id": "national-identity-england-answer-other",
-                                        "parent_answer_id": "national-identity-england-answer",
-                                        "type": "TextField",
-                                        "mandatory": false,
-                                        "label": "Please describe your national identity"
-                                    }
-                                ],
+                                        }
+                                    ],
+                                    "type": "Checkbox"
+                                }],
                                 "skip_conditions": [{
                                     "when": [{
                                         "meta": "region_code",
@@ -2428,45 +2413,42 @@
                                     }]
                                 }],
                                 "answers": [{
-                                        "id": "national-identity-wales-answer",
-                                        "label": "Select all that apply",
-                                        "mandatory": true,
-                                        "options": [{
-                                                "label": "Welsh",
-                                                "value": "Welsh"
-                                            },
-                                            {
-                                                "label": "English",
-                                                "value": "English"
-                                            },
-                                            {
-                                                "label": "Scottish",
-                                                "value": "Scottish"
-                                            },
-                                            {
-                                                "label": "Northern Irish",
-                                                "value": "Northern Irish"
-                                            },
-                                            {
-                                                "label": "British",
-                                                "value": "British"
-                                            },
-                                            {
-                                                "label": "Other",
-                                                "value": "Other",
-                                                "child_answer_id": "national-identity-wales-answer-other"
+                                    "id": "national-identity-wales-answer",
+                                    "label": "Select all that apply",
+                                    "mandatory": true,
+                                    "options": [{
+                                            "label": "Welsh",
+                                            "value": "Welsh"
+                                        },
+                                        {
+                                            "label": "English",
+                                            "value": "English"
+                                        },
+                                        {
+                                            "label": "Scottish",
+                                            "value": "Scottish"
+                                        },
+                                        {
+                                            "label": "Northern Irish",
+                                            "value": "Northern Irish"
+                                        },
+                                        {
+                                            "label": "British",
+                                            "value": "British"
+                                        },
+                                        {
+                                            "label": "Other",
+                                            "value": "Other",
+                                            "detail_answer": {
+                                                "id": "national-identity-wales-answer-other",
+                                                "type": "TextField",
+                                                "mandatory": false,
+                                                "label": "Please describe your national identity"
                                             }
-                                        ],
-                                        "type": "Checkbox"
-                                    },
-                                    {
-                                        "id": "national-identity-wales-answer-other",
-                                        "parent_answer_id": "national-identity-wales-answer",
-                                        "type": "TextField",
-                                        "mandatory": false,
-                                        "label": "Please describe your national identity"
-                                    }
-                                ],
+                                        }
+                                    ],
+                                    "type": "Checkbox"
+                                }],
                                 "skip_conditions": [{
                                     "when": [{
                                         "meta": "region_code",
@@ -2725,40 +2707,37 @@
                                 ],
                                 "type": "General",
                                 "answers": [{
-                                        "id": "white-ethnic-group-england-answer",
-                                        "mandatory": true,
-                                        "options": [{
-                                                "label": "English, Welsh, Scottish, Northern Irish or British",
-                                                "value": "English, Welsh, Scottish, Northern Irish or British"
-                                            },
-                                            {
-                                                "label": "Irish",
-                                                "value": "Irish"
-                                            },
-                                            {
-                                                "label": "Gypsy or Irish Traveller",
-                                                "value": "Gypsy or Irish Traveller"
-                                            },
-                                            {
-                                                "label": "Roma",
-                                                "value": "Roma"
-                                            },
-                                            {
-                                                "label": "Any other White background",
-                                                "value": "Other",
-                                                "child_answer_id": "white-ethnic-group-england-answer-other"
+                                    "id": "white-ethnic-group-england-answer",
+                                    "mandatory": true,
+                                    "options": [{
+                                            "label": "English, Welsh, Scottish, Northern Irish or British",
+                                            "value": "English, Welsh, Scottish, Northern Irish or British"
+                                        },
+                                        {
+                                            "label": "Irish",
+                                            "value": "Irish"
+                                        },
+                                        {
+                                            "label": "Gypsy or Irish Traveller",
+                                            "value": "Gypsy or Irish Traveller"
+                                        },
+                                        {
+                                            "label": "Roma",
+                                            "value": "Roma"
+                                        },
+                                        {
+                                            "label": "Any other White background",
+                                            "value": "Other",
+                                            "detail_answer": {
+                                                "id": "white-ethnic-group-england-answer-other",
+                                                "type": "TextField",
+                                                "mandatory": false,
+                                                "label": "Please specify White background"
                                             }
-                                        ],
-                                        "type": "Radio"
-                                    },
-                                    {
-                                        "id": "white-ethnic-group-england-answer-other",
-                                        "parent_answer_id": "white-ethnic-group-england-answer",
-                                        "type": "TextField",
-                                        "mandatory": false,
-                                        "label": "Please specify White background"
-                                    }
-                                ],
+                                        }
+                                    ],
+                                    "type": "Radio"
+                                }],
                                 "skip_conditions": [{
                                     "when": [{
                                         "meta": "region_code",
@@ -2783,40 +2762,37 @@
                                 ],
                                 "type": "General",
                                 "answers": [{
-                                        "id": "white-ethnic-group-wales-answer",
-                                        "mandatory": true,
-                                        "options": [{
-                                                "label": "Welsh, English, Scottish, Northern Irish or British",
-                                                "value": "Welsh, English, Scottish, Northern Irish or British"
-                                            },
-                                            {
-                                                "label": "Irish",
-                                                "value": "Irish"
-                                            },
-                                            {
-                                                "label": "Gypsy or Irish Traveller",
-                                                "value": "Gypsy or Irish Traveller"
-                                            },
-                                            {
-                                                "label": "Roma",
-                                                "value": "Roma"
-                                            },
-                                            {
-                                                "label": "Any other White background",
-                                                "value": "Other",
-                                                "child_answer_id": "white-ethnic-group-wales-question-other"
+                                    "id": "white-ethnic-group-wales-answer",
+                                    "mandatory": true,
+                                    "options": [{
+                                            "label": "Welsh, English, Scottish, Northern Irish or British",
+                                            "value": "Welsh, English, Scottish, Northern Irish or British"
+                                        },
+                                        {
+                                            "label": "Irish",
+                                            "value": "Irish"
+                                        },
+                                        {
+                                            "label": "Gypsy or Irish Traveller",
+                                            "value": "Gypsy or Irish Traveller"
+                                        },
+                                        {
+                                            "label": "Roma",
+                                            "value": "Roma"
+                                        },
+                                        {
+                                            "label": "Any other White background",
+                                            "value": "Other",
+                                            "detail_answer": {
+                                                "id": "white-ethnic-group-wales-question-other",
+                                                "type": "TextField",
+                                                "mandatory": false,
+                                                "label": "Please specify White background"
                                             }
-                                        ],
-                                        "type": "Radio"
-                                    },
-                                    {
-                                        "id": "white-ethnic-group-wales-question-other",
-                                        "parent_answer_id": "white-ethnic-group-wales-answer",
-                                        "type": "TextField",
-                                        "mandatory": false,
-                                        "label": "Please specify White background"
-                                    }
-                                ],
+                                        }
+                                    ],
+                                    "type": "Radio"
+                                }],
                                 "skip_conditions": [{
                                     "when": [{
                                         "meta": "region_code",
@@ -2898,36 +2874,33 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "mixed-ethnic-group-answer",
-                                    "mandatory": true,
-                                    "options": [{
-                                            "label": "White and Black Caribbean",
-                                            "value": "White and Black Caribbean"
-                                        },
-                                        {
-                                            "label": "White and Black African",
-                                            "value": "White and Black African"
-                                        },
-                                        {
-                                            "label": "White and Asian",
-                                            "value": "White and Asian"
-                                        },
-                                        {
-                                            "label": "Any other Mixed or Multiple background",
-                                            "value": "Other",
-                                            "child_answer_id": "mixed-ethnic-group-answer-other"
+                                "id": "mixed-ethnic-group-answer",
+                                "mandatory": true,
+                                "options": [{
+                                        "label": "White and Black Caribbean",
+                                        "value": "White and Black Caribbean"
+                                    },
+                                    {
+                                        "label": "White and Black African",
+                                        "value": "White and Black African"
+                                    },
+                                    {
+                                        "label": "White and Asian",
+                                        "value": "White and Asian"
+                                    },
+                                    {
+                                        "label": "Any other Mixed or Multiple background",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "mixed-ethnic-group-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please specify Mixed or Multiple background"
                                         }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "mixed-ethnic-group-answer-other",
-                                    "parent_answer_id": "mixed-ethnic-group-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please specify Mixed or Multiple background"
-                                }
-                            ]
+                                    }
+                                ],
+                                "type": "Radio"
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -3001,40 +2974,37 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "asian-ethnic-group-answer",
-                                    "mandatory": true,
-                                    "options": [{
-                                            "label": "Indian",
-                                            "value": "Indian"
-                                        },
-                                        {
-                                            "label": "Pakistani",
-                                            "value": "Pakistani"
-                                        },
-                                        {
-                                            "label": "Bangladeshi",
-                                            "value": "Bangladeshi"
-                                        },
-                                        {
-                                            "label": "Chinese",
-                                            "value": "Chinese"
-                                        },
-                                        {
-                                            "label": "Any other Asian background",
-                                            "value": "Other",
-                                            "child_answer_id": "asian-ethnic-group-answer-other"
+                                "id": "asian-ethnic-group-answer",
+                                "mandatory": true,
+                                "options": [{
+                                        "label": "Indian",
+                                        "value": "Indian"
+                                    },
+                                    {
+                                        "label": "Pakistani",
+                                        "value": "Pakistani"
+                                    },
+                                    {
+                                        "label": "Bangladeshi",
+                                        "value": "Bangladeshi"
+                                    },
+                                    {
+                                        "label": "Chinese",
+                                        "value": "Chinese"
+                                    },
+                                    {
+                                        "label": "Any other Asian background",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "asian-ethnic-group-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please specify Asian background"
                                         }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "asian-ethnic-group-answer-other",
-                                    "parent_answer_id": "asian-ethnic-group-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please specify Asian background"
-                                }
-                            ]
+                                    }
+                                ],
+                                "type": "Radio"
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -3108,32 +3078,29 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "black-ethnic-group-answer",
-                                    "mandatory": true,
-                                    "options": [{
-                                            "label": "African",
-                                            "value": "African"
-                                        },
-                                        {
-                                            "label": "Caribbean",
-                                            "value": "Caribbean"
-                                        },
-                                        {
-                                            "label": "Any other Black, African or Caribbean background",
-                                            "value": "Other",
-                                            "child_answer_id": "black-ethnic-group-answer-other"
+                                "id": "black-ethnic-group-answer",
+                                "mandatory": true,
+                                "options": [{
+                                        "label": "African",
+                                        "value": "African"
+                                    },
+                                    {
+                                        "label": "Caribbean",
+                                        "value": "Caribbean"
+                                    },
+                                    {
+                                        "label": "Any other Black, African or Caribbean background",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "black-ethnic-group-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please specify Black, African or Caribbean background"
                                         }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "black-ethnic-group-answer-other",
-                                    "parent_answer_id": "black-ethnic-group-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please specify Black, African or Caribbean background"
-                                }
-                            ]
+                                    }
+                                ],
+                                "type": "Radio"
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -3207,28 +3174,25 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "other-ethnic-group-answer",
-                                    "mandatory": true,
-                                    "options": [{
-                                            "label": "Arab",
-                                            "value": "Arab"
-                                        },
-                                        {
-                                            "label": "Any other ethnic group",
-                                            "value": "Other",
-                                            "child_answer_id": "other-ethnic-group-answer-other"
+                                "id": "other-ethnic-group-answer",
+                                "mandatory": true,
+                                "options": [{
+                                        "label": "Arab",
+                                        "value": "Arab"
+                                    },
+                                    {
+                                        "label": "Any other ethnic group",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "other-ethnic-group-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please specify other ethnic group"
                                         }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "other-ethnic-group-answer-other",
-                                    "parent_answer_id": "other-ethnic-group-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please specify other ethnic group"
-                                }
-                            ]
+                                    }
+                                ],
+                                "type": "Radio"
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -3291,40 +3255,37 @@
                             "title": "Which of the following best describes your sexual orientation?",
                             "type": "General",
                             "answers": [{
-                                    "id": "sexual-identity-answer",
-                                    "mandatory": true,
-                                    "options": [{
-                                            "label": "Straight or Heterosexual",
-                                            "value": "Straight or Heterosexual"
-                                        },
-                                        {
-                                            "label": "Gay or Lesbian",
-                                            "value": "Gay or Lesbian"
-                                        },
-                                        {
-                                            "label": "Bisexual",
-                                            "value": "Bisexual"
-                                        },
-                                        {
-                                            "label": "Other sexual orientation",
-                                            "value": "Other sexual orientation",
-                                            "child_answer_id": "sexual-identity-answer-other"
-                                        },
-                                        {
-                                            "label": "Prefer not to say",
-                                            "value": "Prefer not to say"
+                                "id": "sexual-identity-answer",
+                                "mandatory": true,
+                                "options": [{
+                                        "label": "Straight or Heterosexual",
+                                        "value": "Straight or Heterosexual"
+                                    },
+                                    {
+                                        "label": "Gay or Lesbian",
+                                        "value": "Gay or Lesbian"
+                                    },
+                                    {
+                                        "label": "Bisexual",
+                                        "value": "Bisexual"
+                                    },
+                                    {
+                                        "label": "Other sexual orientation",
+                                        "value": "Other sexual orientation",
+                                        "detail_answer": {
+                                            "id": "sexual-identity-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please specify your sexual orientation"
                                         }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "sexual-identity-answer-other",
-                                    "parent_answer_id": "sexual-identity-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please specify your sexual orientation"
-                                }
-                            ]
+                                    },
+                                    {
+                                        "label": "Prefer not to say",
+                                        "value": "Prefer not to say"
+                                    }
+                                ],
+                                "type": "Radio"
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -3366,40 +3327,37 @@
                             "title": "Which of the following best describes <em>{{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name_possessive}}</em> sexual orientation?",
                             "type": "General",
                             "answers": [{
-                                    "id": "sexual-identity-answer-proxy",
-                                    "mandatory": true,
-                                    "options": [{
-                                            "label": "Straight or Heterosexual",
-                                            "value": "Straight or Heterosexual"
-                                        },
-                                        {
-                                            "label": "Gay or Lesbian",
-                                            "value": "Gay or Lesbian"
-                                        },
-                                        {
-                                            "label": "Bisexual",
-                                            "value": "Bisexual"
-                                        },
-                                        {
-                                            "label": "Other sexual orientation",
-                                            "value": "Other sexual orientation",
-                                            "child_answer_id": "sexual-identity-answer-other-proxy"
-                                        },
-                                        {
-                                            "label": "Prefer not to say",
-                                            "value": "Prefer not to say"
+                                "id": "sexual-identity-answer-proxy",
+                                "mandatory": true,
+                                "options": [{
+                                        "label": "Straight or Heterosexual",
+                                        "value": "Straight or Heterosexual"
+                                    },
+                                    {
+                                        "label": "Gay or Lesbian",
+                                        "value": "Gay or Lesbian"
+                                    },
+                                    {
+                                        "label": "Bisexual",
+                                        "value": "Bisexual"
+                                    },
+                                    {
+                                        "label": "Other sexual orientation",
+                                        "value": "Other sexual orientation",
+                                        "detail_answer": {
+                                            "id": "sexual-identity-answer-other-proxy",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please specify their sexual orientation"
                                         }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "sexual-identity-answer-other-proxy",
-                                    "parent_answer_id": "sexual-identity-answer-proxy",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please specify their sexual orientation"
-                                }
-                            ]
+                                    },
+                                    {
+                                        "label": "Prefer not to say",
+                                        "value": "Prefer not to say"
+                                    }
+                                ],
+                                "type": "Radio"
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -3452,32 +3410,29 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "birth-gender-answer",
-                                    "mandatory": true,
-                                    "options": [{
-                                            "label": "Yes",
-                                            "value": "Yes"
-                                        },
-                                        {
-                                            "label": "No",
-                                            "value": "No",
-                                            "child_answer_id": "birth-gender-answer-other"
-                                        },
-                                        {
-                                            "label": "Prefer not to say",
-                                            "value": "Prefer not to say"
+                                "id": "birth-gender-answer",
+                                "mandatory": true,
+                                "options": [{
+                                        "label": "Yes",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No",
+                                        "value": "No",
+                                        "detail_answer": {
+                                            "id": "birth-gender-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please specify gender"
                                         }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "birth-gender-answer-other",
-                                    "parent_answer_id": "birth-gender-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please specify gender"
-                                }
-                            ]
+                                    },
+                                    {
+                                        "label": "Prefer not to say",
+                                        "value": "Prefer not to say"
+                                    }
+                                ],
+                                "type": "Radio"
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -3575,29 +3530,26 @@
                                     }]
                                 }],
                                 "answers": [{
-                                        "id": "language-england-answer",
-                                        "mandatory": true,
-                                        "options": [{
-                                                "label": "English",
-                                                "value": "English"
-                                            },
-                                            {
-                                                "label": "Other",
-                                                "value": "Other",
-                                                "description": "Including British Sign Language",
-                                                "child_answer_id": "language-england-answer-other"
+                                    "id": "language-england-answer",
+                                    "mandatory": true,
+                                    "options": [{
+                                            "label": "English",
+                                            "value": "English"
+                                        },
+                                        {
+                                            "label": "Other",
+                                            "value": "Other",
+                                            "description": "Including British Sign Language",
+                                            "detail_answer": {
+                                                "id": "language-england-answer-other",
+                                                "type": "TextField",
+                                                "mandatory": false,
+                                                "label": "Please specify main language"
                                             }
-                                        ],
-                                        "type": "Radio"
-                                    },
-                                    {
-                                        "id": "language-england-answer-other",
-                                        "parent_answer_id": "language-england-answer",
-                                        "type": "TextField",
-                                        "mandatory": false,
-                                        "label": "Please specify main language"
-                                    }
-                                ],
+                                        }
+                                    ],
+                                    "type": "Radio"
+                                }],
                                 "skip_conditions": [{
                                     "when": [{
                                         "meta": "region_code",
@@ -3628,29 +3580,26 @@
                                     }]
                                 }],
                                 "answers": [{
-                                        "id": "language-welsh-answer",
-                                        "mandatory": true,
-                                        "options": [{
-                                                "label": "English or Welsh",
-                                                "value": "English or Welsh"
-                                            },
-                                            {
-                                                "label": "Other",
-                                                "value": "Other",
-                                                "description": "Including British Sign Language",
-                                                "child_answer_id": "language-welsh-answer-other"
+                                    "id": "language-welsh-answer",
+                                    "mandatory": true,
+                                    "options": [{
+                                            "label": "English or Welsh",
+                                            "value": "English or Welsh"
+                                        },
+                                        {
+                                            "label": "Other",
+                                            "value": "Other",
+                                            "description": "Including British Sign Language",
+                                            "detail_answer": {
+                                                "id": "language-welsh-answer-other",
+                                                "type": "TextField",
+                                                "mandatory": false,
+                                                "label": "Please specify main language"
                                             }
-                                        ],
-                                        "type": "Radio"
-                                    },
-                                    {
-                                        "id": "language-welsh-answer-other",
-                                        "parent_answer_id": "language-welsh-answer",
-                                        "type": "TextField",
-                                        "mandatory": false,
-                                        "label": "Please specify main language"
-                                    }
-                                ],
+                                        }
+                                    ],
+                                    "type": "Radio"
+                                }],
                                 "skip_conditions": [{
                                     "when": [{
                                         "meta": "region_code",
@@ -3749,54 +3698,51 @@
                             "description": "This question is voluntary",
                             "type": "General",
                             "answers": [{
-                                    "id": "religion-answer",
-                                    "mandatory": false,
-                                    "label": "Select one option only",
-                                    "options": [{
-                                            "label": "No religion",
-                                            "value": "No religion"
-                                        },
-                                        {
-                                            "label": "Christian",
-                                            "value": "Christian",
-                                            "description": "Including Church of England, Catholic, Protestant and all other Christian denominations"
-                                        },
-                                        {
-                                            "label": "Buddhist",
-                                            "value": "Buddhist"
-                                        },
-                                        {
-                                            "label": "Hindu",
-                                            "value": "Hindu"
-                                        },
-                                        {
-                                            "label": "Jewish",
-                                            "value": "Jewish"
-                                        },
-                                        {
-                                            "label": "Muslim",
-                                            "value": "Muslim"
-                                        },
-                                        {
-                                            "label": "Sikh",
-                                            "value": "Sikh"
-                                        },
-                                        {
-                                            "label": "Any other religion",
-                                            "value": "Other",
-                                            "child_answer_id": "religion-answer-other"
+                                "id": "religion-answer",
+                                "mandatory": false,
+                                "label": "Select one option only",
+                                "options": [{
+                                        "label": "No religion",
+                                        "value": "No religion"
+                                    },
+                                    {
+                                        "label": "Christian",
+                                        "value": "Christian",
+                                        "description": "Including Church of England, Catholic, Protestant and all other Christian denominations"
+                                    },
+                                    {
+                                        "label": "Buddhist",
+                                        "value": "Buddhist"
+                                    },
+                                    {
+                                        "label": "Hindu",
+                                        "value": "Hindu"
+                                    },
+                                    {
+                                        "label": "Jewish",
+                                        "value": "Jewish"
+                                    },
+                                    {
+                                        "label": "Muslim",
+                                        "value": "Muslim"
+                                    },
+                                    {
+                                        "label": "Sikh",
+                                        "value": "Sikh"
+                                    },
+                                    {
+                                        "label": "Any other religion",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "religion-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please specify other religion"
                                         }
-                                    ],
-                                    "type": "Checkbox"
-                                },
-                                {
-                                    "id": "religion-answer-other",
-                                    "parent_answer_id": "religion-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please specify other religion"
-                                }
-                            ]
+                                    }
+                                ],
+                                "type": "Checkbox"
+                            }]
                         }]
                     },
                     {
@@ -3819,36 +3765,33 @@
                             "type": "General",
                             "description": "If they had no usual address one year ago, state the address where they were staying",
                             "answers": [{
-                                    "id": "past-usual-address-answer",
-                                    "mandatory": true,
-                                    "options": [{
-                                            "label": "{{answers['address-line-1']}}, {{answers['address-line-2']}}",
-                                            "value": "householdaddress"
-                                        },
-                                        {
-                                            "label": "Student term time or boarding school address in the UK",
-                                            "value": "Student term time or boarding school address in the UK"
-                                        },
-                                        {
-                                            "label": "Another address in the UK",
-                                            "value": "Another address in the UK"
-                                        },
-                                        {
-                                            "label": "An address outside the UK",
-                                            "value": "Other",
-                                            "child_answer_id": "past-usual-address-answer-other"
+                                "id": "past-usual-address-answer",
+                                "mandatory": true,
+                                "options": [{
+                                        "label": "{{answers['address-line-1']}}, {{answers['address-line-2']}}",
+                                        "value": "householdaddress"
+                                    },
+                                    {
+                                        "label": "Student term time or boarding school address in the UK",
+                                        "value": "Student term time or boarding school address in the UK"
+                                    },
+                                    {
+                                        "label": "Another address in the UK",
+                                        "value": "Another address in the UK"
+                                    },
+                                    {
+                                        "label": "An address outside the UK",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "past-usual-address-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please enter the country"
                                         }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "past-usual-address-answer-other",
-                                    "parent_answer_id": "past-usual-address-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter the country"
-                                }
-                            ]
+                                    }
+                                ],
+                                "type": "Radio"
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -3963,16 +3906,14 @@
                                         {
                                             "label": "Other",
                                             "value": "Other",
-                                            "child_answer_id": "passport-answer-other"
+                                            "detail_answer": {
+                                                "id": "passport-answer-other",
+                                                "type": "TextField",
+                                                "mandatory": false,
+                                                "label": "Please specify the passports held"
+                                            }
                                         }
                                     ]
-                                },
-                                {
-                                    "id": "passport-answer-other",
-                                    "parent_answer_id": "passports-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please specify the passports held"
                                 },
                                 {
                                     "id": "passports-answer-exclusive",
@@ -6201,28 +6142,25 @@
                                 "title": "Does this person usually live in the United Kingdom?",
                                 "type": "General",
                                 "answers": [{
-                                        "id": "visitor-uk-resident-answer",
-                                        "mandatory": false,
-                                        "options": [{
-                                                "label": "Yes, usually lives in the United Kingdom",
-                                                "value": "Yes, usually lives in the United Kingdom"
-                                            },
-                                            {
-                                                "label": "No, usually lives outside the United Kingdom (please specify)",
-                                                "value": "Other",
-                                                "child_answer_id": "visitor-uk-resident-answer-other"
+                                    "id": "visitor-uk-resident-answer",
+                                    "mandatory": false,
+                                    "options": [{
+                                            "label": "Yes, usually lives in the United Kingdom",
+                                            "value": "Yes, usually lives in the United Kingdom"
+                                        },
+                                        {
+                                            "label": "No, usually lives outside the United Kingdom (please specify)",
+                                            "value": "Other",
+                                            "detail_answer": {
+                                                "id": "visitor-uk-resident-answer-other",
+                                                "type": "TextField",
+                                                "mandatory": false,
+                                                "label": "Please specify country"
                                             }
-                                        ],
-                                        "type": "Radio"
-                                    },
-                                    {
-                                        "id": "visitor-uk-resident-answer-other",
-                                        "parent_answer_id": "visitor-uk-resident-answer",
-                                        "type": "TextField",
-                                        "mandatory": false,
-                                        "label": "Please specify country"
-                                    }
-                                ]
+                                        }
+                                    ],
+                                    "type": "Radio"
+                                }]
                             }],
                             "routing_rules": [{
                                     "goto": {

--- a/data/en/lms_2.json
+++ b/data/en/lms_2.json
@@ -282,48 +282,46 @@
                                 "title": "You said that {{ metadata['display_address'] }} is not your main residence. What type of address is it?",
                                 "type": "General",
                                 "answers": [{
-                                        "id": "address-type-answer-no-primary",
-                                        "mandatory": true,
-                                        "type": "Radio",
-                                        "options": [{
-                                                "label": "A previous address from which mail has been redirected",
-                                                "value": "A previous address from which mail has been redirected"
-                                            },
-                                            {
-                                                "label": "Student accommodation rented through a private landlord",
-                                                "value": "Student accommodation rented through a private landlord"
-                                            },
-                                            {
-                                                "label": "My second home",
-                                                "value": "My second home",
-                                                "description": "For example, somewhere you stay whilst on holiday or traveling, either in the UK or abroad"
-                                            },
-                                            {
-                                                "label": "A business or non-residential address",
-                                                "value": "A business or non-residential address"
-                                            },
-                                            {
-                                                "label": "A communal establishment",
-                                                "value": "A communal establishment"
-                                            },
-                                            {
-                                                "label": "This address is not familiar to me",
-                                                "value": "This address is not familiar to me"
-                                            },
-                                            {
-                                                "label": "Other, please describe",
-                                                "value": "Other, please describe",
-                                                "child_answer_id": "address-type-answer-other-no-primary"
+                                    "id": "address-type-answer-no-primary",
+                                    "mandatory": true,
+                                    "type": "Radio",
+                                    "options": [{
+                                            "label": "A previous address from which mail has been redirected",
+                                            "value": "A previous address from which mail has been redirected"
+                                        },
+                                        {
+                                            "label": "Student accommodation rented through a private landlord",
+                                            "value": "Student accommodation rented through a private landlord"
+                                        },
+                                        {
+                                            "label": "My second home",
+                                            "value": "My second home",
+                                            "description": "For example, somewhere you stay whilst on holiday or traveling, either in the UK or abroad"
+                                        },
+                                        {
+                                            "label": "A business or non-residential address",
+                                            "value": "A business or non-residential address"
+                                        },
+                                        {
+                                            "label": "A communal establishment",
+                                            "value": "A communal establishment"
+                                        },
+                                        {
+                                            "label": "This address is not familiar to me",
+                                            "value": "This address is not familiar to me"
+                                        },
+                                        {
+                                            "label": "Other",
+                                            "value": "Other, please describe",
+                                            "detail_answer": {
+                                                "id": "address-type-answer-other-no-primary",
+                                                "mandatory": false,
+                                                "type": "TextField",
+                                                "label": "Please describe"
                                             }
-                                        ]
-                                    },
-                                    {
-                                        "parent_answer_id": "address-type-answer-no-primary",
-                                        "id": "address-type-answer-other-no-primary",
-                                        "mandatory": false,
-                                        "type": "TextField"
-                                    }
-                                ]
+                                        }
+                                    ]
+                                }]
                             }]
                         },
                         {
@@ -1297,6 +1295,7 @@
                                 "id": "dob-age-answer",
                                 "unit": "duration-year",
                                 "type": "Unit",
+                                "label": "Your age",
                                 "unit_length": "long",
                                 "mandatory": false,
                                 "max_value": {
@@ -1436,44 +1435,41 @@
                                 }
                             ],
                             "answers": [{
-                                    "id": "nationality-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "British",
-                                            "value": "British"
-                                        },
-                                        {
-                                            "label": "Irish",
-                                            "value": "Irish"
-                                        },
-                                        {
-                                            "label": "Indian",
-                                            "value": "Indian"
-                                        },
-                                        {
-                                            "label": "Pakistani",
-                                            "value": "Pakistani"
-                                        },
-                                        {
-                                            "label": "Polish",
-                                            "value": "Polish"
-                                        },
-                                        {
-                                            "label": "Other",
-                                            "value": "Other",
-                                            "child_answer_id": "nationality-answer-other"
+                                "id": "nationality-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "British",
+                                        "value": "British"
+                                    },
+                                    {
+                                        "label": "Irish",
+                                        "value": "Irish"
+                                    },
+                                    {
+                                        "label": "Indian",
+                                        "value": "Indian"
+                                    },
+                                    {
+                                        "label": "Pakistani",
+                                        "value": "Pakistani"
+                                    },
+                                    {
+                                        "label": "Polish",
+                                        "value": "Polish"
+                                    },
+                                    {
+                                        "label": "Other",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "nationality-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please enter nationality"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "nationality-answer-other",
-                                    "parent_answer_id": "nationality-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter nationality"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }]
                     },
                     {
@@ -1502,60 +1498,57 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "country-of-birth-wales-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "Wales",
-                                            "value": "Wales"
-                                        },
-                                        {
-                                            "label": "England",
-                                            "value": "England"
-                                        },
-                                        {
-                                            "label": "Scotland",
-                                            "value": "Scotland"
-                                        },
-                                        {
-                                            "label": "Northern Ireland",
-                                            "value": "Northern Ireland"
-                                        },
-                                        {
-                                            "label": "Republic of Ireland",
-                                            "value": "Republic of Ireland"
-                                        },
-                                        {
-                                            "label": "Isle of Man or Channel Islands",
-                                            "value": "Isle of Man or Channel Islands"
-                                        },
-                                        {
-                                            "label": "India",
-                                            "value": "India"
-                                        },
-                                        {
-                                            "label": "Pakistan",
-                                            "value": "Pakistan"
-                                        },
-                                        {
-                                            "label": "Poland",
-                                            "value": "Poland"
-                                        },
-                                        {
-                                            "label": "Other",
-                                            "value": "Other",
-                                            "child_answer_id": "country-of-birth-wales-answer-other"
+                                "id": "country-of-birth-wales-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Wales",
+                                        "value": "Wales"
+                                    },
+                                    {
+                                        "label": "England",
+                                        "value": "England"
+                                    },
+                                    {
+                                        "label": "Scotland",
+                                        "value": "Scotland"
+                                    },
+                                    {
+                                        "label": "Northern Ireland",
+                                        "value": "Northern Ireland"
+                                    },
+                                    {
+                                        "label": "Republic of Ireland",
+                                        "value": "Republic of Ireland"
+                                    },
+                                    {
+                                        "label": "Isle of Man or Channel Islands",
+                                        "value": "Isle of Man or Channel Islands"
+                                    },
+                                    {
+                                        "label": "India",
+                                        "value": "India"
+                                    },
+                                    {
+                                        "label": "Pakistan",
+                                        "value": "Pakistan"
+                                    },
+                                    {
+                                        "label": "Poland",
+                                        "value": "Poland"
+                                    },
+                                    {
+                                        "label": "Other",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "country-of-birth-wales-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please enter country of birth"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "country-of-birth-wales-answer-other",
-                                    "parent_answer_id": "country-of-birth-wales-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter country of birth"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -1645,60 +1638,57 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "country-of-birth-scotland-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "Scotland",
-                                            "value": "Scotland"
-                                        },
-                                        {
-                                            "label": "England",
-                                            "value": "England"
-                                        },
-                                        {
-                                            "label": "Wales",
-                                            "value": "Wales"
-                                        },
-                                        {
-                                            "label": "Northern Ireland",
-                                            "value": "Northern Ireland"
-                                        },
-                                        {
-                                            "label": "Republic of Ireland",
-                                            "value": "Republic of Ireland"
-                                        },
-                                        {
-                                            "label": "Isle of Man or Channel Islands",
-                                            "value": "Isle of Man or Channel Islands"
-                                        },
-                                        {
-                                            "label": "India",
-                                            "value": "India"
-                                        },
-                                        {
-                                            "label": "Pakistan",
-                                            "value": "Pakistan"
-                                        },
-                                        {
-                                            "label": "Poland",
-                                            "value": "Poland"
-                                        },
-                                        {
-                                            "label": "Other",
-                                            "value": "Other",
-                                            "child_answer_id": "country-of-birth-scotland-answer-other"
+                                "id": "country-of-birth-scotland-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Scotland",
+                                        "value": "Scotland"
+                                    },
+                                    {
+                                        "label": "England",
+                                        "value": "England"
+                                    },
+                                    {
+                                        "label": "Wales",
+                                        "value": "Wales"
+                                    },
+                                    {
+                                        "label": "Northern Ireland",
+                                        "value": "Northern Ireland"
+                                    },
+                                    {
+                                        "label": "Republic of Ireland",
+                                        "value": "Republic of Ireland"
+                                    },
+                                    {
+                                        "label": "Isle of Man or Channel Islands",
+                                        "value": "Isle of Man or Channel Islands"
+                                    },
+                                    {
+                                        "label": "India",
+                                        "value": "India"
+                                    },
+                                    {
+                                        "label": "Pakistan",
+                                        "value": "Pakistan"
+                                    },
+                                    {
+                                        "label": "Poland",
+                                        "value": "Poland"
+                                    },
+                                    {
+                                        "label": "Other",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "country-of-birth-scotland-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please enter country of birth"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "country-of-birth-scotland-answer-other",
-                                    "parent_answer_id": "country-of-birth-scotland-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter country of birth"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -1782,60 +1772,57 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "country-of-birth-england-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "England",
-                                            "value": "England"
-                                        },
-                                        {
-                                            "label": "Wales",
-                                            "value": "Wales"
-                                        },
-                                        {
-                                            "label": "Scotland",
-                                            "value": "Scotland"
-                                        },
-                                        {
-                                            "label": "Northern Ireland",
-                                            "value": "Northern Ireland"
-                                        },
-                                        {
-                                            "label": "Republic of Ireland",
-                                            "value": "Republic of Ireland"
-                                        },
-                                        {
-                                            "label": "Isle of Man or Channel Islands",
-                                            "value": "Isle of Man or Channel Islands"
-                                        },
-                                        {
-                                            "label": "India",
-                                            "value": "India"
-                                        },
-                                        {
-                                            "label": "Pakistan",
-                                            "value": "Pakistan"
-                                        },
-                                        {
-                                            "label": "Poland",
-                                            "value": "Poland"
-                                        },
-                                        {
-                                            "label": "Other",
-                                            "value": "Other",
-                                            "child_answer_id": "country-of-birth-england-answer-other"
+                                "id": "country-of-birth-england-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "England",
+                                        "value": "England"
+                                    },
+                                    {
+                                        "label": "Wales",
+                                        "value": "Wales"
+                                    },
+                                    {
+                                        "label": "Scotland",
+                                        "value": "Scotland"
+                                    },
+                                    {
+                                        "label": "Northern Ireland",
+                                        "value": "Northern Ireland"
+                                    },
+                                    {
+                                        "label": "Republic of Ireland",
+                                        "value": "Republic of Ireland"
+                                    },
+                                    {
+                                        "label": "Isle of Man or Channel Islands",
+                                        "value": "Isle of Man or Channel Islands"
+                                    },
+                                    {
+                                        "label": "India",
+                                        "value": "India"
+                                    },
+                                    {
+                                        "label": "Pakistan",
+                                        "value": "Pakistan"
+                                    },
+                                    {
+                                        "label": "Poland",
+                                        "value": "Poland"
+                                    },
+                                    {
+                                        "label": "Other",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "country-of-birth-england-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please enter country of birth"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "country-of-birth-england-answer-other",
-                                    "parent_answer_id": "country-of-birth-england-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter country of birth"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -2224,52 +2211,49 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "why-uk-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "For employment",
-                                            "value": "For employment"
-                                        },
-                                        {
-                                            "label": "For study",
-                                            "value": "For study"
-                                        },
-                                        {
-                                            "label": "As a spouse or dependent of a UK citizen or settled person",
-                                            "value": "As a spouse or dependent of a UK citizen or settled person"
-                                        },
-                                        {
-                                            "label": "As a spouse or dependent of someone who is coming to or is already in the UK for work or study reasons",
-                                            "value": "As a spouse or dependent of someone who is coming to or is already in the UK for work or study reasons"
-                                        },
-                                        {
-                                            "label": "To get married or form a civil partnership in the UK with a non-UK citizen",
-                                            "value": "To get married or form a civil partnership in the UK with a non-UK citizen"
-                                        },
-                                        {
-                                            "label": "Seeking asylum",
-                                            "value": "Seeking asylum"
-                                        },
-                                        {
-                                            "label": "As a visitor",
-                                            "value": "As a visitor"
-                                        },
-                                        {
-                                            "label": "Another reason",
-                                            "value": "Another reason",
-                                            "child_answer_id": "why-uk-answer-other"
+                                "id": "why-uk-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "For employment",
+                                        "value": "For employment"
+                                    },
+                                    {
+                                        "label": "For study",
+                                        "value": "For study"
+                                    },
+                                    {
+                                        "label": "As a spouse or dependent of a UK citizen or settled person",
+                                        "value": "As a spouse or dependent of a UK citizen or settled person"
+                                    },
+                                    {
+                                        "label": "As a spouse or dependent of someone who is coming to or is already in the UK for work or study reasons",
+                                        "value": "As a spouse or dependent of someone who is coming to or is already in the UK for work or study reasons"
+                                    },
+                                    {
+                                        "label": "To get married or form a civil partnership in the UK with a non-UK citizen",
+                                        "value": "To get married or form a civil partnership in the UK with a non-UK citizen"
+                                    },
+                                    {
+                                        "label": "Seeking asylum",
+                                        "value": "Seeking asylum"
+                                    },
+                                    {
+                                        "label": "As a visitor",
+                                        "value": "As a visitor"
+                                    },
+                                    {
+                                        "label": "Another reason",
+                                        "value": "Another reason",
+                                        "detail_answer": {
+                                            "id": "why-uk-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please describe"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "why-uk-answer-other",
-                                    "parent_answer_id": "why-uk-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please describe"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }],
                         "routing_rules": [{
                             "goto": {
@@ -2296,52 +2280,49 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "why-uk-continuous-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "For employment",
-                                            "value": "For employment"
-                                        },
-                                        {
-                                            "label": "For study",
-                                            "value": "For study"
-                                        },
-                                        {
-                                            "label": "As a spouse or dependent of a UK citizen or settled person",
-                                            "value": "As a spouse or dependent of a UK citizen or settled person"
-                                        },
-                                        {
-                                            "label": "As a spouse or dependent of someone who is coming to or is already in the UK for work or study reasons",
-                                            "value": "As a spouse or dependent of someone who is coming to or is already in the UK for work or study reasons"
-                                        },
-                                        {
-                                            "label": "To get married or form a civil partnership in the UK with a non-UK citizen",
-                                            "value": "To get married or form a civil partnership in the UK with a non-UK citizen"
-                                        },
-                                        {
-                                            "label": "Seeking asylum",
-                                            "value": "Seeking asylum"
-                                        },
-                                        {
-                                            "label": "As a visitor",
-                                            "value": "As a visitor"
-                                        },
-                                        {
-                                            "label": "Another reason",
-                                            "value": "Another reason",
-                                            "child_answer_id": "why-uk-continuous-answer-other"
+                                "id": "why-uk-continuous-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "For employment",
+                                        "value": "For employment"
+                                    },
+                                    {
+                                        "label": "For study",
+                                        "value": "For study"
+                                    },
+                                    {
+                                        "label": "As a spouse or dependent of a UK citizen or settled person",
+                                        "value": "As a spouse or dependent of a UK citizen or settled person"
+                                    },
+                                    {
+                                        "label": "As a spouse or dependent of someone who is coming to or is already in the UK for work or study reasons",
+                                        "value": "As a spouse or dependent of someone who is coming to or is already in the UK for work or study reasons"
+                                    },
+                                    {
+                                        "label": "To get married or form a civil partnership in the UK with a non-UK citizen",
+                                        "value": "To get married or form a civil partnership in the UK with a non-UK citizen"
+                                    },
+                                    {
+                                        "label": "Seeking asylum",
+                                        "value": "Seeking asylum"
+                                    },
+                                    {
+                                        "label": "As a visitor",
+                                        "value": "As a visitor"
+                                    },
+                                    {
+                                        "label": "Another reason",
+                                        "value": "Another reason",
+                                        "detail_answer": {
+                                            "id": "why-uk-continuous-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please describe"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "why-uk-continuous-answer-other",
-                                    "parent_answer_id": "why-uk-continuous-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please describe"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }],
                         "routing_rules": [{
                             "goto": {
@@ -2368,44 +2349,41 @@
                                 ],
                                 "type": "General",
                                 "answers": [{
-                                        "id": "national-identity-england-answer",
-                                        "mandatory": false,
-                                        "type": "Checkbox",
-                                        "options": [{
-                                                "label": "English",
-                                                "value": "English"
-                                            },
-                                            {
-                                                "label": "Welsh",
-                                                "value": "Welsh"
-                                            },
-                                            {
-                                                "label": "Scottish",
-                                                "value": "Scottish"
-                                            },
-                                            {
-                                                "label": "Northern Irish",
-                                                "value": "Northern Irish"
-                                            },
-                                            {
-                                                "label": "British",
-                                                "value": "British"
-                                            },
-                                            {
-                                                "label": "Other",
-                                                "value": "Other",
-                                                "child_answer_id": "national-identity-england-answer-other"
+                                    "id": "national-identity-england-answer",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "options": [{
+                                            "label": "English",
+                                            "value": "English"
+                                        },
+                                        {
+                                            "label": "Welsh",
+                                            "value": "Welsh"
+                                        },
+                                        {
+                                            "label": "Scottish",
+                                            "value": "Scottish"
+                                        },
+                                        {
+                                            "label": "Northern Irish",
+                                            "value": "Northern Irish"
+                                        },
+                                        {
+                                            "label": "British",
+                                            "value": "British"
+                                        },
+                                        {
+                                            "label": "Other",
+                                            "value": "Other",
+                                            "detail_answer": {
+                                                "id": "national-identity-england-answer-other",
+                                                "type": "TextField",
+                                                "mandatory": false,
+                                                "label": "Please enter national identity"
                                             }
-                                        ]
-                                    },
-                                    {
-                                        "id": "national-identity-england-answer-other",
-                                        "parent_answer_id": "national-identity-england-answer",
-                                        "type": "TextField",
-                                        "mandatory": false,
-                                        "label": "Please enter national identity"
-                                    }
-                                ],
+                                        }
+                                    ]
+                                }],
                                 "skip_conditions": [{
                                     "when": [{
                                         "meta": "country",
@@ -2430,44 +2408,41 @@
                                 ],
                                 "type": "General",
                                 "answers": [{
-                                        "id": "national-identity-wales-answer",
-                                        "mandatory": false,
-                                        "type": "Checkbox",
-                                        "options": [{
-                                                "label": "Welsh",
-                                                "value": "Welsh"
-                                            },
-                                            {
-                                                "label": "English",
-                                                "value": "English"
-                                            },
-                                            {
-                                                "label": "Scottish",
-                                                "value": "Scottish"
-                                            },
-                                            {
-                                                "label": "Northern Irish",
-                                                "value": "Northern Irish"
-                                            },
-                                            {
-                                                "label": "British",
-                                                "value": "British"
-                                            },
-                                            {
-                                                "label": "Other",
-                                                "value": "Other",
-                                                "child_answer_id": "national-identity-wales-answer-other"
+                                    "id": "national-identity-wales-answer",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "options": [{
+                                            "label": "Welsh",
+                                            "value": "Welsh"
+                                        },
+                                        {
+                                            "label": "English",
+                                            "value": "English"
+                                        },
+                                        {
+                                            "label": "Scottish",
+                                            "value": "Scottish"
+                                        },
+                                        {
+                                            "label": "Northern Irish",
+                                            "value": "Northern Irish"
+                                        },
+                                        {
+                                            "label": "British",
+                                            "value": "British"
+                                        },
+                                        {
+                                            "label": "Other",
+                                            "value": "Other",
+                                            "detail_answer": {
+                                                "id": "national-identity-wales-answer-other",
+                                                "type": "TextField",
+                                                "mandatory": false,
+                                                "label": "Please enter national identity"
                                             }
-                                        ]
-                                    },
-                                    {
-                                        "id": "national-identity-wales-answer-other",
-                                        "parent_answer_id": "national-identity-wales-answer",
-                                        "type": "TextField",
-                                        "mandatory": false,
-                                        "label": "Please enter national identity"
-                                    }
-                                ],
+                                        }
+                                    ]
+                                }],
                                 "skip_conditions": [{
                                     "when": [{
                                         "meta": "country",
@@ -2492,44 +2467,41 @@
                                 ],
                                 "type": "General",
                                 "answers": [{
-                                        "id": "national-identity-scotland-answer",
-                                        "mandatory": false,
-                                        "type": "Checkbox",
-                                        "options": [{
-                                                "label": "Scottish",
-                                                "value": "Scottish"
-                                            },
-                                            {
-                                                "label": "English",
-                                                "value": "English"
-                                            },
-                                            {
-                                                "label": "Welsh",
-                                                "value": "Welsh"
-                                            },
-                                            {
-                                                "label": "Northern Irish",
-                                                "value": "Northern Irish"
-                                            },
-                                            {
-                                                "label": "British",
-                                                "value": "British"
-                                            },
-                                            {
-                                                "label": "Other",
-                                                "value": "Other",
-                                                "child_answer_id": "national-identity-scotland-answer-other"
+                                    "id": "national-identity-scotland-answer",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "options": [{
+                                            "label": "Scottish",
+                                            "value": "Scottish"
+                                        },
+                                        {
+                                            "label": "English",
+                                            "value": "English"
+                                        },
+                                        {
+                                            "label": "Welsh",
+                                            "value": "Welsh"
+                                        },
+                                        {
+                                            "label": "Northern Irish",
+                                            "value": "Northern Irish"
+                                        },
+                                        {
+                                            "label": "British",
+                                            "value": "British"
+                                        },
+                                        {
+                                            "label": "Other",
+                                            "value": "Other",
+                                            "detail_answer": {
+                                                "id": "national-identity-scotland-answer-other",
+                                                "type": "TextField",
+                                                "mandatory": false,
+                                                "label": "Please enter national identity"
                                             }
-                                        ]
-                                    },
-                                    {
-                                        "id": "national-identity-scotland-answer-other",
-                                        "parent_answer_id": "national-identity-scotland-answer",
-                                        "type": "TextField",
-                                        "mandatory": false,
-                                        "label": "Please enter national identity"
-                                    }
-                                ],
+                                        }
+                                    ]
+                                }],
                                 "skip_conditions": [{
                                     "when": [{
                                             "meta": "country",
@@ -2861,36 +2833,33 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "white-ethnic-group-answer",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "English, Welsh, Scottish, Northern Irish or British",
-                                            "value": "English, Welsh, Scottish, Northern Irish or British"
-                                        },
-                                        {
-                                            "label": "Irish",
-                                            "value": "Irish"
-                                        },
-                                        {
-                                            "label": "Gypsy or Irish Traveller",
-                                            "value": "Gypsy or Irish Traveller"
-                                        },
-                                        {
-                                            "label": "Any other White background",
-                                            "value": "Other",
-                                            "child_answer_id": "white-ethnic-group-answer-other"
+                                "id": "white-ethnic-group-answer",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "English, Welsh, Scottish, Northern Irish or British",
+                                        "value": "English, Welsh, Scottish, Northern Irish or British"
+                                    },
+                                    {
+                                        "label": "Irish",
+                                        "value": "Irish"
+                                    },
+                                    {
+                                        "label": "Gypsy or Irish Traveller",
+                                        "value": "Gypsy or Irish Traveller"
+                                    },
+                                    {
+                                        "label": "Any other White background",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "white-ethnic-group-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please enter ethnic background"
                                         }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "white-ethnic-group-answer-other",
-                                    "parent_answer_id": "white-ethnic-group-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter ethnic background"
-                                }
-                            ]
+                                    }
+                                ],
+                                "type": "Radio"
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -2957,36 +2926,33 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "mixed-ethnic-group-answer",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "White and Black Caribbean",
-                                            "value": "White and Black Caribbean"
-                                        },
-                                        {
-                                            "label": "White and Black African",
-                                            "value": "White and Black African"
-                                        },
-                                        {
-                                            "label": "White and Asian",
-                                            "value": "White and Asian"
-                                        },
-                                        {
-                                            "label": "Any other Mixed or Multiple ethnic background",
-                                            "value": "Other",
-                                            "child_answer_id": "mixed-ethnic-group-answer-other"
+                                "id": "mixed-ethnic-group-answer",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "White and Black Caribbean",
+                                        "value": "White and Black Caribbean"
+                                    },
+                                    {
+                                        "label": "White and Black African",
+                                        "value": "White and Black African"
+                                    },
+                                    {
+                                        "label": "White and Asian",
+                                        "value": "White and Asian"
+                                    },
+                                    {
+                                        "label": "Any other Mixed or Multiple ethnic background",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "mixed-ethnic-group-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please enter ethnic background"
                                         }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "mixed-ethnic-group-answer-other",
-                                    "parent_answer_id": "mixed-ethnic-group-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter ethnic background"
-                                }
-                            ]
+                                    }
+                                ],
+                                "type": "Radio"
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -3053,40 +3019,37 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "asian-ethnic-group-answer",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "Indian",
-                                            "value": "Indian"
-                                        },
-                                        {
-                                            "label": "Pakistani",
-                                            "value": "Pakistani"
-                                        },
-                                        {
-                                            "label": "Bangladeshi",
-                                            "value": "Bangladeshi"
-                                        },
-                                        {
-                                            "label": "Chinese",
-                                            "value": "Chinese"
-                                        },
-                                        {
-                                            "label": "Any other Asian background",
-                                            "value": "Other",
-                                            "child_answer_id": "asian-ethnic-group-answer-other"
+                                "id": "asian-ethnic-group-answer",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "Indian",
+                                        "value": "Indian"
+                                    },
+                                    {
+                                        "label": "Pakistani",
+                                        "value": "Pakistani"
+                                    },
+                                    {
+                                        "label": "Bangladeshi",
+                                        "value": "Bangladeshi"
+                                    },
+                                    {
+                                        "label": "Chinese",
+                                        "value": "Chinese"
+                                    },
+                                    {
+                                        "label": "Any other Asian background",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "asian-ethnic-group-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please enter ethnic background"
                                         }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "asian-ethnic-group-answer-other",
-                                    "parent_answer_id": "asian-ethnic-group-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter ethnic background"
-                                }
-                            ]
+                                    }
+                                ],
+                                "type": "Radio"
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -3153,32 +3116,29 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "black-ethnic-group-answer",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "African",
-                                            "value": "African"
-                                        },
-                                        {
-                                            "label": "Caribbean",
-                                            "value": "Caribbean"
-                                        },
-                                        {
-                                            "label": "Any other Black, African or Caribbean background",
-                                            "value": "Other",
-                                            "child_answer_id": "black-ethnic-group-answer-other"
+                                "id": "black-ethnic-group-answer",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "African",
+                                        "value": "African"
+                                    },
+                                    {
+                                        "label": "Caribbean",
+                                        "value": "Caribbean"
+                                    },
+                                    {
+                                        "label": "Any other Black, African or Caribbean background",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "black-ethnic-group-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please enter ethnic background"
                                         }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "black-ethnic-group-answer-other",
-                                    "parent_answer_id": "black-ethnic-group-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter ethnic background"
-                                }
-                            ]
+                                    }
+                                ],
+                                "type": "Radio"
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -3245,28 +3205,25 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "other-ethnic-group-answer",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "Arab",
-                                            "value": "Arab"
-                                        },
-                                        {
-                                            "label": "Any other ethnic group",
-                                            "value": "Other",
-                                            "child_answer_id": "other-ethnic-group-answer-other"
+                                "id": "other-ethnic-group-answer",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "Arab",
+                                        "value": "Arab"
+                                    },
+                                    {
+                                        "label": "Any other ethnic group",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "other-ethnic-group-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please enter ethnic background"
                                         }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "other-ethnic-group-answer-other",
-                                    "parent_answer_id": "other-ethnic-group-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter ethnic background"
-                                }
-                            ]
+                                    }
+                                ],
+                                "type": "Radio"
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -3334,53 +3291,50 @@
                             "description": "",
                             "type": "General",
                             "answers": [{
-                                    "id": "religion-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "No religion",
-                                            "value": "No religion"
-                                        },
-                                        {
-                                            "label": "Christian",
-                                            "value": "Christian",
-                                            "description": "Including Church of England, Catholic, Protestant and other Christian denominations"
-                                        },
-                                        {
-                                            "label": "Buddhist",
-                                            "value": "Buddhist"
-                                        },
-                                        {
-                                            "label": "Hindu",
-                                            "value": "Hindu"
-                                        },
-                                        {
-                                            "label": "Jewish",
-                                            "value": "Jewish"
-                                        },
-                                        {
-                                            "label": "Muslim",
-                                            "value": "Muslim"
-                                        },
-                                        {
-                                            "label": "Sikh",
-                                            "value": "Sikh"
-                                        },
-                                        {
-                                            "label": "Other religion",
-                                            "value": "Other",
-                                            "child_answer_id": "religion-answer-other"
+                                "id": "religion-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "No religion",
+                                        "value": "No religion"
+                                    },
+                                    {
+                                        "label": "Christian",
+                                        "value": "Christian",
+                                        "description": "Including Church of England, Catholic, Protestant and other Christian denominations"
+                                    },
+                                    {
+                                        "label": "Buddhist",
+                                        "value": "Buddhist"
+                                    },
+                                    {
+                                        "label": "Hindu",
+                                        "value": "Hindu"
+                                    },
+                                    {
+                                        "label": "Jewish",
+                                        "value": "Jewish"
+                                    },
+                                    {
+                                        "label": "Muslim",
+                                        "value": "Muslim"
+                                    },
+                                    {
+                                        "label": "Sikh",
+                                        "value": "Sikh"
+                                    },
+                                    {
+                                        "label": "Other religion",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "religion-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please enter religion"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "religion-answer-other",
-                                    "parent_answer_id": "religion-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter religion"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -3910,16 +3864,14 @@
                                         {
                                             "label": "Some other arrangement",
                                             "value": "Some other arrangement",
-                                            "child_answer_id": "working-hours-answer-other"
+                                            "detail_answer": {
+                                                "id": "working-hours-answer-other",
+                                                "type": "TextField",
+                                                "mandatory": false,
+                                                "label": "Please describe"
+                                            }
                                         }
                                     ]
-                                },
-                                {
-                                    "id": "working-hours-answer-other",
-                                    "parent_answer_id": "working-hours-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please describe"
                                 },
                                 {
                                     "id": "working-hours-answer-exclusive",
@@ -7338,53 +7290,50 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "reason-why-fewer-hours-than-usual-self-employed-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "On leave",
-                                            "value": "On leave"
-                                        },
-                                        {
-                                            "label": "Illness or injury expected to last fewer than 4 weeks",
-                                            "value": "Illness or injury expected to last fewer than 4 weeks"
-                                        },
-                                        {
-                                            "label": "Illness or disability expected to last for 4 weeks or longer",
-                                            "value": "Illness or disability expected to last for 4 weeks or longer"
-                                        },
-                                        {
-                                            "label": "Maternity or paternity leave",
-                                            "value": "Maternity or paternity leave"
-                                        },
-                                        {
-                                            "label": "Business not set up yet",
-                                            "value": "Business not set up yet"
-                                        },
-                                        {
-                                            "label": "No client or customer that week",
-                                            "value": "No client or customer that week"
-                                        },
-                                        {
-                                            "label": "Temporary interruption to work",
-                                            "value": "Temporary interruption to work ",
-                                            "description": "Including bad weather"
-                                        },
-                                        {
-                                            "label": "Other",
-                                            "value": "Other",
-                                            "child_answer_id": "reason-why-fewer-hours-than-usual-self-employed-answer-other"
+                                "id": "reason-why-fewer-hours-than-usual-self-employed-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "On leave",
+                                        "value": "On leave"
+                                    },
+                                    {
+                                        "label": "Illness or injury expected to last fewer than 4 weeks",
+                                        "value": "Illness or injury expected to last fewer than 4 weeks"
+                                    },
+                                    {
+                                        "label": "Illness or disability expected to last for 4 weeks or longer",
+                                        "value": "Illness or disability expected to last for 4 weeks or longer"
+                                    },
+                                    {
+                                        "label": "Maternity or paternity leave",
+                                        "value": "Maternity or paternity leave"
+                                    },
+                                    {
+                                        "label": "Business not set up yet",
+                                        "value": "Business not set up yet"
+                                    },
+                                    {
+                                        "label": "No client or customer that week",
+                                        "value": "No client or customer that week"
+                                    },
+                                    {
+                                        "label": "Temporary interruption to work",
+                                        "value": "Temporary interruption to work ",
+                                        "description": "Including bad weather"
+                                    },
+                                    {
+                                        "label": "Other",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "reason-why-fewer-hours-than-usual-self-employed-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please describe"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "reason-why-fewer-hours-than-usual-self-employed-answer-other",
-                                    "parent_answer_id": "reason-why-fewer-hours-than-usual-self-employed-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please describe"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }]
                     },
                     {
@@ -7455,62 +7404,59 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "reason-why-fewer-hours-than-usual-employee-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "On leave",
-                                            "value": "On leave",
-                                            "description": "paid or unpaid"
-                                        },
-                                        {
-                                            "label": "Illness or injury expected to last fewer than 4 weeks",
-                                            "value": "Illness or injury expected to last fewer than 4 weeks"
-                                        },
-                                        {
-                                            "label": "Illness or disability expected to last for 4 weeks or longer",
-                                            "value": "Illness or disability expected to last for 4 weeks or longer"
-                                        },
-                                        {
-                                            "label": "Maternity or paternity leave",
-                                            "value": "Maternity or paternity leave"
-                                        },
-                                        {
-                                            "label": "Parental leave",
-                                            "value": "Parental leave"
-                                        },
-                                        {
-                                            "label": "Waiting to start a new job",
-                                            "value": "Waiting to start a new job"
-                                        },
-                                        {
-                                            "label": "Hours can vary",
-                                            "value": "Hours can vary"
-                                        },
-                                        {
-                                            "label": "Temporary interruption to work",
-                                            "value": "Temporary interruption to work",
-                                            "description": "Including bad weather, labour disputes"
-                                        },
-                                        {
-                                            "label": "Job is casual",
-                                            "value": "Job is casual"
-                                        },
-                                        {
-                                            "label": "Other",
-                                            "value": "Other",
-                                            "child_answer_id": "reason-why-fewer-hours-than-usual-employee-answer-other"
+                                "id": "reason-why-fewer-hours-than-usual-employee-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "On leave",
+                                        "value": "On leave",
+                                        "description": "paid or unpaid"
+                                    },
+                                    {
+                                        "label": "Illness or injury expected to last fewer than 4 weeks",
+                                        "value": "Illness or injury expected to last fewer than 4 weeks"
+                                    },
+                                    {
+                                        "label": "Illness or disability expected to last for 4 weeks or longer",
+                                        "value": "Illness or disability expected to last for 4 weeks or longer"
+                                    },
+                                    {
+                                        "label": "Maternity or paternity leave",
+                                        "value": "Maternity or paternity leave"
+                                    },
+                                    {
+                                        "label": "Parental leave",
+                                        "value": "Parental leave"
+                                    },
+                                    {
+                                        "label": "Waiting to start a new job",
+                                        "value": "Waiting to start a new job"
+                                    },
+                                    {
+                                        "label": "Hours can vary",
+                                        "value": "Hours can vary"
+                                    },
+                                    {
+                                        "label": "Temporary interruption to work",
+                                        "value": "Temporary interruption to work",
+                                        "description": "Including bad weather, labour disputes"
+                                    },
+                                    {
+                                        "label": "Job is casual",
+                                        "value": "Job is casual"
+                                    },
+                                    {
+                                        "label": "Other",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "reason-why-fewer-hours-than-usual-employee-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please describe"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "reason-why-fewer-hours-than-usual-employee-answer-other",
-                                    "parent_answer_id": "reason-why-fewer-hours-than-usual-employee-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please describe"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -8002,52 +7948,49 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "not-be-able-to-start-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "In education",
-                                            "value": "In education"
-                                        },
-                                        {
-                                            "label": "Looking after the family or home",
-                                            "value": "Looking after the family or home"
-                                        },
-                                        {
-                                            "label": "Childcare too expensive",
-                                            "value": "Childcare too expensive"
-                                        },
-                                        {
-                                            "label": "Caring responsibilities for adults",
-                                            "value": "Caring responsibilities for adults"
-                                        },
-                                        {
-                                            "label": "Illness or injury expecting to last fewer than 4 weeks",
-                                            "value": "Illness or injury expecting to last fewer than 4 weeks"
-                                        },
-                                        {
-                                            "label": "Illness or disability expecting to last for 4 weeks or longer",
-                                            "value": "Illness or disability expecting to last for 4 weeks or longer"
-                                        },
-                                        {
-                                            "label": "Waiting to start a job recently accepted",
-                                            "value": "Waiting to start a job recently accepted"
-                                        },
-                                        {
-                                            "label": "Other",
-                                            "value": "Other",
-                                            "child_answer_id": "not-be-able-to-start-answer-other"
+                                "id": "not-be-able-to-start-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "In education",
+                                        "value": "In education"
+                                    },
+                                    {
+                                        "label": "Looking after the family or home",
+                                        "value": "Looking after the family or home"
+                                    },
+                                    {
+                                        "label": "Childcare too expensive",
+                                        "value": "Childcare too expensive"
+                                    },
+                                    {
+                                        "label": "Caring responsibilities for adults",
+                                        "value": "Caring responsibilities for adults"
+                                    },
+                                    {
+                                        "label": "Illness or injury expecting to last fewer than 4 weeks",
+                                        "value": "Illness or injury expecting to last fewer than 4 weeks"
+                                    },
+                                    {
+                                        "label": "Illness or disability expecting to last for 4 weeks or longer",
+                                        "value": "Illness or disability expecting to last for 4 weeks or longer"
+                                    },
+                                    {
+                                        "label": "Waiting to start a job recently accepted",
+                                        "value": "Waiting to start a job recently accepted"
+                                    },
+                                    {
+                                        "label": "Other",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "not-be-able-to-start-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please describe"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "not-be-able-to-start-answer-other",
-                                    "parent_answer_id": "not-be-able-to-start-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please describe"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -8085,72 +8028,69 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "not-looking-for-work-reason-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "Retired from paid work",
-                                            "value": "Retired from paid work"
-                                        },
-                                        {
-                                            "label": "Studying",
-                                            "value": "Studying"
-                                        },
-                                        {
-                                            "label": "Looking after the family or home",
-                                            "value": "Looking after the family or home"
-                                        },
-                                        {
-                                            "label": "Childcare is too expensive",
-                                            "value": "Childcare is too expensive"
-                                        },
-                                        {
-                                            "label": "Caring responsibilities for adults",
-                                            "value": "Caring responsibilities for adults"
-                                        },
-                                        {
-                                            "label": "Illness or disability expecting to last for 4 weeks or longer",
-                                            "value": "Illness or disability expecting to last for 4 weeks or longer"
-                                        },
-                                        {
-                                            "label": "Illness or injury expected to last fewer than 4 weeks",
-                                            "value": "Illness or injury expected to last fewer than 4 weeks"
-                                        },
-                                        {
-                                            "label": "Waiting to start a job recently accepted",
-                                            "value": "Waiting to start a job recently accepted"
-                                        },
-                                        {
-                                            "label": "Waiting for the result of a job application",
-                                            "value": "Waiting for the result of a job application"
-                                        },
-                                        {
-                                            "label": "No suitable jobs were available",
-                                            "value": "No suitable jobs were available"
-                                        },
-                                        {
-                                            "label": "Not yet started looking",
-                                            "value": "Not yet started looking"
-                                        },
-                                        {
-                                            "label": "Did not need employment",
-                                            "value": "Did not need employment"
-                                        },
-                                        {
-                                            "label": "Other",
-                                            "value": "Other",
-                                            "child_answer_id": "not-looking-for-work-reason-answer-other"
+                                "id": "not-looking-for-work-reason-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Retired from paid work",
+                                        "value": "Retired from paid work"
+                                    },
+                                    {
+                                        "label": "Studying",
+                                        "value": "Studying"
+                                    },
+                                    {
+                                        "label": "Looking after the family or home",
+                                        "value": "Looking after the family or home"
+                                    },
+                                    {
+                                        "label": "Childcare is too expensive",
+                                        "value": "Childcare is too expensive"
+                                    },
+                                    {
+                                        "label": "Caring responsibilities for adults",
+                                        "value": "Caring responsibilities for adults"
+                                    },
+                                    {
+                                        "label": "Illness or disability expecting to last for 4 weeks or longer",
+                                        "value": "Illness or disability expecting to last for 4 weeks or longer"
+                                    },
+                                    {
+                                        "label": "Illness or injury expected to last fewer than 4 weeks",
+                                        "value": "Illness or injury expected to last fewer than 4 weeks"
+                                    },
+                                    {
+                                        "label": "Waiting to start a job recently accepted",
+                                        "value": "Waiting to start a job recently accepted"
+                                    },
+                                    {
+                                        "label": "Waiting for the result of a job application",
+                                        "value": "Waiting for the result of a job application"
+                                    },
+                                    {
+                                        "label": "No suitable jobs were available",
+                                        "value": "No suitable jobs were available"
+                                    },
+                                    {
+                                        "label": "Not yet started looking",
+                                        "value": "Not yet started looking"
+                                    },
+                                    {
+                                        "label": "Did not need employment",
+                                        "value": "Did not need employment"
+                                    },
+                                    {
+                                        "label": "Other",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "not-looking-for-work-reason-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please describe"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "not-looking-for-work-reason-answer-other",
-                                    "parent_answer_id": "not-looking-for-work-reason-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please describe"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -8924,6 +8864,7 @@
                             "type": "General",
                             "answers": [{
                                 "id": "no-primary-dob-age-answer",
+                                "label": "Your age",
                                 "unit": "duration-year",
                                 "type": "Unit",
                                 "unit_length": "long",
@@ -9065,44 +9006,41 @@
                                 }
                             ],
                             "answers": [{
-                                    "id": "no-primary-nationality-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "British",
-                                            "value": "British"
-                                        },
-                                        {
-                                            "label": "Irish",
-                                            "value": "Irish"
-                                        },
-                                        {
-                                            "label": "Indian",
-                                            "value": "Indian"
-                                        },
-                                        {
-                                            "label": "Pakistani",
-                                            "value": "Pakistani"
-                                        },
-                                        {
-                                            "label": "Polish",
-                                            "value": "Polish"
-                                        },
-                                        {
-                                            "label": "Other",
-                                            "value": "Other",
-                                            "child_answer_id": "no-primary-nationality-answer-other"
+                                "id": "no-primary-nationality-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "British",
+                                        "value": "British"
+                                    },
+                                    {
+                                        "label": "Irish",
+                                        "value": "Irish"
+                                    },
+                                    {
+                                        "label": "Indian",
+                                        "value": "Indian"
+                                    },
+                                    {
+                                        "label": "Pakistani",
+                                        "value": "Pakistani"
+                                    },
+                                    {
+                                        "label": "Polish",
+                                        "value": "Polish"
+                                    },
+                                    {
+                                        "label": "Other",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "no-primary-nationality-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please enter nationality"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "no-primary-nationality-answer-other",
-                                    "parent_answer_id": "no-primary-nationality-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter nationality"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }]
                     },
                     {
@@ -9131,60 +9069,57 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "no-primary-country-of-birth-wales-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "Wales",
-                                            "value": "Wales"
-                                        },
-                                        {
-                                            "label": "England",
-                                            "value": "England"
-                                        },
-                                        {
-                                            "label": "Scotland",
-                                            "value": "Scotland"
-                                        },
-                                        {
-                                            "label": "Northern Ireland",
-                                            "value": "Northern Ireland"
-                                        },
-                                        {
-                                            "label": "Republic of Ireland",
-                                            "value": "Republic of Ireland"
-                                        },
-                                        {
-                                            "label": "Isle of Man or Channel Islands",
-                                            "value": "Isle of Man or Channel Islands"
-                                        },
-                                        {
-                                            "label": "India",
-                                            "value": "India"
-                                        },
-                                        {
-                                            "label": "Pakistan",
-                                            "value": "Pakistan"
-                                        },
-                                        {
-                                            "label": "Poland",
-                                            "value": "Poland"
-                                        },
-                                        {
-                                            "label": "Other",
-                                            "value": "Other",
-                                            "child_answer_id": "no-primary-country-of-birth-wales-answer-other"
+                                "id": "no-primary-country-of-birth-wales-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Wales",
+                                        "value": "Wales"
+                                    },
+                                    {
+                                        "label": "England",
+                                        "value": "England"
+                                    },
+                                    {
+                                        "label": "Scotland",
+                                        "value": "Scotland"
+                                    },
+                                    {
+                                        "label": "Northern Ireland",
+                                        "value": "Northern Ireland"
+                                    },
+                                    {
+                                        "label": "Republic of Ireland",
+                                        "value": "Republic of Ireland"
+                                    },
+                                    {
+                                        "label": "Isle of Man or Channel Islands",
+                                        "value": "Isle of Man or Channel Islands"
+                                    },
+                                    {
+                                        "label": "India",
+                                        "value": "India"
+                                    },
+                                    {
+                                        "label": "Pakistan",
+                                        "value": "Pakistan"
+                                    },
+                                    {
+                                        "label": "Poland",
+                                        "value": "Poland"
+                                    },
+                                    {
+                                        "label": "Other",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "no-primary-country-of-birth-wales-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please enter country of birth"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "no-primary-country-of-birth-wales-answer-other",
-                                    "parent_answer_id": "no-primary-country-of-birth-wales-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter country of birth"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -9274,60 +9209,57 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "no-primary-country-of-birth-scotland-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "Scotland",
-                                            "value": "Scotland"
-                                        },
-                                        {
-                                            "label": "England",
-                                            "value": "England"
-                                        },
-                                        {
-                                            "label": "Wales",
-                                            "value": "Wales"
-                                        },
-                                        {
-                                            "label": "Northern Ireland",
-                                            "value": "Northern Ireland"
-                                        },
-                                        {
-                                            "label": "Republic of Ireland",
-                                            "value": "Republic of Ireland"
-                                        },
-                                        {
-                                            "label": "Isle of Man or Channel Islands",
-                                            "value": "Isle of Man or Channel Islands"
-                                        },
-                                        {
-                                            "label": "India",
-                                            "value": "India"
-                                        },
-                                        {
-                                            "label": "Pakistan",
-                                            "value": "Pakistan"
-                                        },
-                                        {
-                                            "label": "Poland",
-                                            "value": "Poland"
-                                        },
-                                        {
-                                            "label": "Other",
-                                            "value": "Other",
-                                            "child_answer_id": "no-primary-country-of-birth-scotland-answer-other"
+                                "id": "no-primary-country-of-birth-scotland-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Scotland",
+                                        "value": "Scotland"
+                                    },
+                                    {
+                                        "label": "England",
+                                        "value": "England"
+                                    },
+                                    {
+                                        "label": "Wales",
+                                        "value": "Wales"
+                                    },
+                                    {
+                                        "label": "Northern Ireland",
+                                        "value": "Northern Ireland"
+                                    },
+                                    {
+                                        "label": "Republic of Ireland",
+                                        "value": "Republic of Ireland"
+                                    },
+                                    {
+                                        "label": "Isle of Man or Channel Islands",
+                                        "value": "Isle of Man or Channel Islands"
+                                    },
+                                    {
+                                        "label": "India",
+                                        "value": "India"
+                                    },
+                                    {
+                                        "label": "Pakistan",
+                                        "value": "Pakistan"
+                                    },
+                                    {
+                                        "label": "Poland",
+                                        "value": "Poland"
+                                    },
+                                    {
+                                        "label": "Other",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "no-primary-country-of-birth-scotland-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please enter country of birth"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "no-primary-country-of-birth-scotland-answer-other",
-                                    "parent_answer_id": "no-primary-country-of-birth-scotland-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter country of birth"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -9411,60 +9343,57 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "no-primary-country-of-birth-england-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "England",
-                                            "value": "England"
-                                        },
-                                        {
-                                            "label": "Wales",
-                                            "value": "Wales"
-                                        },
-                                        {
-                                            "label": "Scotland",
-                                            "value": "Scotland"
-                                        },
-                                        {
-                                            "label": "Northern Ireland",
-                                            "value": "Northern Ireland"
-                                        },
-                                        {
-                                            "label": "Republic of Ireland",
-                                            "value": "Republic of Ireland"
-                                        },
-                                        {
-                                            "label": "Isle of Man or Channel Islands",
-                                            "value": "Isle of Man or Channel Islands"
-                                        },
-                                        {
-                                            "label": "India",
-                                            "value": "India"
-                                        },
-                                        {
-                                            "label": "Pakistan",
-                                            "value": "Pakistan"
-                                        },
-                                        {
-                                            "label": "Poland",
-                                            "value": "Poland"
-                                        },
-                                        {
-                                            "label": "Other",
-                                            "value": "Other",
-                                            "child_answer_id": "no-primary-country-of-birth-england-answer-other"
+                                "id": "no-primary-country-of-birth-england-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "England",
+                                        "value": "England"
+                                    },
+                                    {
+                                        "label": "Wales",
+                                        "value": "Wales"
+                                    },
+                                    {
+                                        "label": "Scotland",
+                                        "value": "Scotland"
+                                    },
+                                    {
+                                        "label": "Northern Ireland",
+                                        "value": "Northern Ireland"
+                                    },
+                                    {
+                                        "label": "Republic of Ireland",
+                                        "value": "Republic of Ireland"
+                                    },
+                                    {
+                                        "label": "Isle of Man or Channel Islands",
+                                        "value": "Isle of Man or Channel Islands"
+                                    },
+                                    {
+                                        "label": "India",
+                                        "value": "India"
+                                    },
+                                    {
+                                        "label": "Pakistan",
+                                        "value": "Pakistan"
+                                    },
+                                    {
+                                        "label": "Poland",
+                                        "value": "Poland"
+                                    },
+                                    {
+                                        "label": "Other",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "no-primary-country-of-birth-england-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please enter country of birth"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "no-primary-country-of-birth-england-answer-other",
-                                    "parent_answer_id": "no-primary-country-of-birth-england-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter country of birth"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -9851,52 +9780,49 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "no-primary-why-uk-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "For employment",
-                                            "value": "For employment"
-                                        },
-                                        {
-                                            "label": "For study",
-                                            "value": "For study"
-                                        },
-                                        {
-                                            "label": "As a spouse or dependent of a UK citizen or settled person",
-                                            "value": "As a spouse or dependent of a UK citizen or settled person"
-                                        },
-                                        {
-                                            "label": "As a spouse or dependent of someone who is coming to or is already in the UK for work or study reasons",
-                                            "value": "As a spouse or dependent of someone who is coming to or is already in the UK for work or study reasons"
-                                        },
-                                        {
-                                            "label": "To get married or form a civil partnership in the UK with a non-UK citizen",
-                                            "value": "To get married or form a civil partnership in the UK with a non-UK citizen"
-                                        },
-                                        {
-                                            "label": "Seeking asylum",
-                                            "value": "Seeking asylum"
-                                        },
-                                        {
-                                            "label": "As a visitor",
-                                            "value": "As a visitor"
-                                        },
-                                        {
-                                            "label": "Another reason",
-                                            "value": "Another reason",
-                                            "child_answer_id": "no-primary-why-uk-answer-other"
+                                "id": "no-primary-why-uk-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "For employment",
+                                        "value": "For employment"
+                                    },
+                                    {
+                                        "label": "For study",
+                                        "value": "For study"
+                                    },
+                                    {
+                                        "label": "As a spouse or dependent of a UK citizen or settled person",
+                                        "value": "As a spouse or dependent of a UK citizen or settled person"
+                                    },
+                                    {
+                                        "label": "As a spouse or dependent of someone who is coming to or is already in the UK for work or study reasons",
+                                        "value": "As a spouse or dependent of someone who is coming to or is already in the UK for work or study reasons"
+                                    },
+                                    {
+                                        "label": "To get married or form a civil partnership in the UK with a non-UK citizen",
+                                        "value": "To get married or form a civil partnership in the UK with a non-UK citizen"
+                                    },
+                                    {
+                                        "label": "Seeking asylum",
+                                        "value": "Seeking asylum"
+                                    },
+                                    {
+                                        "label": "As a visitor",
+                                        "value": "As a visitor"
+                                    },
+                                    {
+                                        "label": "Another reason",
+                                        "value": "Another reason",
+                                        "detail_answer": {
+                                            "id": "no-primary-why-uk-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please describe"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "no-primary-why-uk-answer-other",
-                                    "parent_answer_id": "no-primary-why-uk-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please describe"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }],
                         "routing_rules": [{
                             "goto": {
@@ -9923,52 +9849,49 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "no-primary-why-uk-continuous-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "For employment",
-                                            "value": "For employment"
-                                        },
-                                        {
-                                            "label": "For study",
-                                            "value": "For study"
-                                        },
-                                        {
-                                            "label": "As a spouse or dependent of a UK citizen or settled person",
-                                            "value": "As a spouse or dependent of a UK citizen or settled person"
-                                        },
-                                        {
-                                            "label": "As a spouse or dependent of someone who is coming to or is already in the UK for work or study reasons",
-                                            "value": "As a spouse or dependent of someone who is coming to or is already in the UK for work or study reasons"
-                                        },
-                                        {
-                                            "label": "To get married or form a civil partnership in the UK with a non-UK citizen",
-                                            "value": "To get married or form a civil partnership in the UK with a non-UK citizen"
-                                        },
-                                        {
-                                            "label": "Seeking asylum",
-                                            "value": "Seeking asylum"
-                                        },
-                                        {
-                                            "label": "As a visitor",
-                                            "value": "As a visitor"
-                                        },
-                                        {
-                                            "label": "Another reason",
-                                            "value": "Another reason",
-                                            "child_answer_id": "no-primary-why-uk-continuous-answer-other"
+                                "id": "no-primary-why-uk-continuous-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "For employment",
+                                        "value": "For employment"
+                                    },
+                                    {
+                                        "label": "For study",
+                                        "value": "For study"
+                                    },
+                                    {
+                                        "label": "As a spouse or dependent of a UK citizen or settled person",
+                                        "value": "As a spouse or dependent of a UK citizen or settled person"
+                                    },
+                                    {
+                                        "label": "As a spouse or dependent of someone who is coming to or is already in the UK for work or study reasons",
+                                        "value": "As a spouse or dependent of someone who is coming to or is already in the UK for work or study reasons"
+                                    },
+                                    {
+                                        "label": "To get married or form a civil partnership in the UK with a non-UK citizen",
+                                        "value": "To get married or form a civil partnership in the UK with a non-UK citizen"
+                                    },
+                                    {
+                                        "label": "Seeking asylum",
+                                        "value": "Seeking asylum"
+                                    },
+                                    {
+                                        "label": "As a visitor",
+                                        "value": "As a visitor"
+                                    },
+                                    {
+                                        "label": "Another reason",
+                                        "value": "Another reason",
+                                        "detail_answer": {
+                                            "id": "no-primary-why-uk-continuous-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please describe"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "no-primary-why-uk-continuous-answer-other",
-                                    "parent_answer_id": "no-primary-why-uk-continuous-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please describe"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }],
                         "routing_rules": [{
                             "goto": {
@@ -9995,44 +9918,41 @@
                                 ],
                                 "type": "General",
                                 "answers": [{
-                                        "id": "no-primary-national-identity-england-answer",
-                                        "mandatory": false,
-                                        "type": "Checkbox",
-                                        "options": [{
-                                                "label": "English",
-                                                "value": "English"
-                                            },
-                                            {
-                                                "label": "Welsh",
-                                                "value": "Welsh"
-                                            },
-                                            {
-                                                "label": "Scottish",
-                                                "value": "Scottish"
-                                            },
-                                            {
-                                                "label": "Northern Irish",
-                                                "value": "Northern Irish"
-                                            },
-                                            {
-                                                "label": "British",
-                                                "value": "British"
-                                            },
-                                            {
-                                                "label": "Other",
-                                                "value": "Other",
-                                                "child_answer_id": "no-primary-national-identity-england-answer-other"
+                                    "id": "no-primary-national-identity-england-answer",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "options": [{
+                                            "label": "English",
+                                            "value": "English"
+                                        },
+                                        {
+                                            "label": "Welsh",
+                                            "value": "Welsh"
+                                        },
+                                        {
+                                            "label": "Scottish",
+                                            "value": "Scottish"
+                                        },
+                                        {
+                                            "label": "Northern Irish",
+                                            "value": "Northern Irish"
+                                        },
+                                        {
+                                            "label": "British",
+                                            "value": "British"
+                                        },
+                                        {
+                                            "label": "Other",
+                                            "value": "Other",
+                                            "detail_answer": {
+                                                "id": "no-primary-national-identity-england-answer-other",
+                                                "type": "TextField",
+                                                "mandatory": false,
+                                                "label": "Please enter national identity"
                                             }
-                                        ]
-                                    },
-                                    {
-                                        "id": "no-primary-national-identity-england-answer-other",
-                                        "parent_answer_id": "no-primary-national-identity-england-answer",
-                                        "type": "TextField",
-                                        "mandatory": false,
-                                        "label": "Please enter national identity"
-                                    }
-                                ],
+                                        }
+                                    ]
+                                }],
                                 "skip_conditions": [{
                                     "when": [{
                                         "meta": "country",
@@ -10057,44 +9977,41 @@
                                 ],
                                 "type": "General",
                                 "answers": [{
-                                        "id": "no-primary-national-identity-wales-answer",
-                                        "mandatory": false,
-                                        "type": "Checkbox",
-                                        "options": [{
-                                                "label": "Welsh",
-                                                "value": "Welsh"
-                                            },
-                                            {
-                                                "label": "English",
-                                                "value": "English"
-                                            },
-                                            {
-                                                "label": "Scottish",
-                                                "value": "Scottish"
-                                            },
-                                            {
-                                                "label": "Northern Irish",
-                                                "value": "Northern Irish"
-                                            },
-                                            {
-                                                "label": "British",
-                                                "value": "British"
-                                            },
-                                            {
-                                                "label": "Other",
-                                                "value": "Other",
-                                                "child_answer_id": "no-primary-national-identity-wales-answer-other"
+                                    "id": "no-primary-national-identity-wales-answer",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "options": [{
+                                            "label": "Welsh",
+                                            "value": "Welsh"
+                                        },
+                                        {
+                                            "label": "English",
+                                            "value": "English"
+                                        },
+                                        {
+                                            "label": "Scottish",
+                                            "value": "Scottish"
+                                        },
+                                        {
+                                            "label": "Northern Irish",
+                                            "value": "Northern Irish"
+                                        },
+                                        {
+                                            "label": "British",
+                                            "value": "British"
+                                        },
+                                        {
+                                            "label": "Other",
+                                            "value": "Other",
+                                            "detail_answer": {
+                                                "id": "no-primary-national-identity-wales-answer-other",
+                                                "type": "TextField",
+                                                "mandatory": false,
+                                                "label": "Please enter national identity"
                                             }
-                                        ]
-                                    },
-                                    {
-                                        "id": "no-primary-national-identity-wales-answer-other",
-                                        "parent_answer_id": "no-primary-national-identity-wales-answer",
-                                        "type": "TextField",
-                                        "mandatory": false,
-                                        "label": "Please enter national identity"
-                                    }
-                                ],
+                                        }
+                                    ]
+                                }],
                                 "skip_conditions": [{
                                     "when": [{
                                         "meta": "country",
@@ -10119,44 +10036,41 @@
                                 ],
                                 "type": "General",
                                 "answers": [{
-                                        "id": "no-primary-national-identity-scotland-answer",
-                                        "mandatory": false,
-                                        "type": "Checkbox",
-                                        "options": [{
-                                                "label": "Scottish",
-                                                "value": "Scottish"
-                                            },
-                                            {
-                                                "label": "English",
-                                                "value": "English"
-                                            },
-                                            {
-                                                "label": "Welsh",
-                                                "value": "Welsh"
-                                            },
-                                            {
-                                                "label": "Northern Irish",
-                                                "value": "Northern Irish"
-                                            },
-                                            {
-                                                "label": "British",
-                                                "value": "British"
-                                            },
-                                            {
-                                                "label": "Other",
-                                                "value": "Other",
-                                                "child_answer_id": "no-primary-national-identity-scotland-answer-other"
+                                    "id": "no-primary-national-identity-scotland-answer",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "options": [{
+                                            "label": "Scottish",
+                                            "value": "Scottish"
+                                        },
+                                        {
+                                            "label": "English",
+                                            "value": "English"
+                                        },
+                                        {
+                                            "label": "Welsh",
+                                            "value": "Welsh"
+                                        },
+                                        {
+                                            "label": "Northern Irish",
+                                            "value": "Northern Irish"
+                                        },
+                                        {
+                                            "label": "British",
+                                            "value": "British"
+                                        },
+                                        {
+                                            "label": "Other",
+                                            "value": "Other",
+                                            "detail_answer": {
+                                                "id": "no-primary-national-identity-scotland-answer-other",
+                                                "type": "TextField",
+                                                "mandatory": false,
+                                                "label": "Please enter national identity"
                                             }
-                                        ]
-                                    },
-                                    {
-                                        "id": "no-primary-national-identity-scotland-answer-other",
-                                        "parent_answer_id": "no-primary-national-identity-scotland-answer",
-                                        "type": "TextField",
-                                        "mandatory": false,
-                                        "label": "Please enter national identity"
-                                    }
-                                ],
+                                        }
+                                    ]
+                                }],
                                 "skip_conditions": [{
                                     "when": [{
                                             "meta": "country",
@@ -10488,36 +10402,33 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "no-primary-white-ethnic-group-answer",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "English, Welsh, Scottish, Northern Irish or British",
-                                            "value": "English, Welsh, Scottish, Northern Irish or British"
-                                        },
-                                        {
-                                            "label": "Irish",
-                                            "value": "Irish"
-                                        },
-                                        {
-                                            "label": "Gypsy or Irish Traveller",
-                                            "value": "Gypsy or Irish Traveller"
-                                        },
-                                        {
-                                            "label": "Any other White background",
-                                            "value": "Other",
-                                            "child_answer_id": "no-primary-white-ethnic-group-answer-other"
+                                "id": "no-primary-white-ethnic-group-answer",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "English, Welsh, Scottish, Northern Irish or British",
+                                        "value": "English, Welsh, Scottish, Northern Irish or British"
+                                    },
+                                    {
+                                        "label": "Irish",
+                                        "value": "Irish"
+                                    },
+                                    {
+                                        "label": "Gypsy or Irish Traveller",
+                                        "value": "Gypsy or Irish Traveller"
+                                    },
+                                    {
+                                        "label": "Any other White background",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "no-primary-white-ethnic-group-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please enter ethnic background"
                                         }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "no-primary-white-ethnic-group-answer-other",
-                                    "parent_answer_id": "no-primary-white-ethnic-group-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter ethnic background"
-                                }
-                            ]
+                                    }
+                                ],
+                                "type": "Radio"
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -10584,36 +10495,33 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "no-primary-mixed-ethnic-group-answer",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "White and Black Caribbean",
-                                            "value": "White and Black Caribbean"
-                                        },
-                                        {
-                                            "label": "White and Black African",
-                                            "value": "White and Black African"
-                                        },
-                                        {
-                                            "label": "White and Asian",
-                                            "value": "White and Asian"
-                                        },
-                                        {
-                                            "label": "Any other Mixed or Multiple ethnic background",
-                                            "value": "Other",
-                                            "child_answer_id": "no-primary-mixed-ethnic-group-answer-other"
+                                "id": "no-primary-mixed-ethnic-group-answer",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "White and Black Caribbean",
+                                        "value": "White and Black Caribbean"
+                                    },
+                                    {
+                                        "label": "White and Black African",
+                                        "value": "White and Black African"
+                                    },
+                                    {
+                                        "label": "White and Asian",
+                                        "value": "White and Asian"
+                                    },
+                                    {
+                                        "label": "Any other Mixed or Multiple ethnic background",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "no-primary-mixed-ethnic-group-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please enter ethnic background"
                                         }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "no-primary-mixed-ethnic-group-answer-other",
-                                    "parent_answer_id": "no-primary-mixed-ethnic-group-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter ethnic background"
-                                }
-                            ]
+                                    }
+                                ],
+                                "type": "Radio"
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -10680,40 +10588,37 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "no-primary-asian-ethnic-group-answer",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "Indian",
-                                            "value": "Indian"
-                                        },
-                                        {
-                                            "label": "Pakistani",
-                                            "value": "Pakistani"
-                                        },
-                                        {
-                                            "label": "Bangladeshi",
-                                            "value": "Bangladeshi"
-                                        },
-                                        {
-                                            "label": "Chinese",
-                                            "value": "Chinese"
-                                        },
-                                        {
-                                            "label": "Any other Asian background",
-                                            "value": "Other",
-                                            "child_answer_id": "no-primary-asian-ethnic-group-answer-other"
+                                "id": "no-primary-asian-ethnic-group-answer",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "Indian",
+                                        "value": "Indian"
+                                    },
+                                    {
+                                        "label": "Pakistani",
+                                        "value": "Pakistani"
+                                    },
+                                    {
+                                        "label": "Bangladeshi",
+                                        "value": "Bangladeshi"
+                                    },
+                                    {
+                                        "label": "Chinese",
+                                        "value": "Chinese"
+                                    },
+                                    {
+                                        "label": "Any other Asian background",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "no-primary-asian-ethnic-group-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please enter ethnic background"
                                         }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "no-primary-asian-ethnic-group-answer-other",
-                                    "parent_answer_id": "no-primary-asian-ethnic-group-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter ethnic background"
-                                }
-                            ]
+                                    }
+                                ],
+                                "type": "Radio"
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -10780,32 +10685,29 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "no-primary-black-ethnic-group-answer",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "African",
-                                            "value": "African"
-                                        },
-                                        {
-                                            "label": "Caribbean",
-                                            "value": "Caribbean"
-                                        },
-                                        {
-                                            "label": "Any other Black, African or Caribbean background",
-                                            "value": "Other",
-                                            "child_answer_id": "no-primary-black-ethnic-group-answer-other"
+                                "id": "no-primary-black-ethnic-group-answer",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "African",
+                                        "value": "African"
+                                    },
+                                    {
+                                        "label": "Caribbean",
+                                        "value": "Caribbean"
+                                    },
+                                    {
+                                        "label": "Any other Black, African or Caribbean background",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "no-primary-black-ethnic-group-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please enter ethnic background"
                                         }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "no-primary-black-ethnic-group-answer-other",
-                                    "parent_answer_id": "no-primary-black-ethnic-group-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter ethnic background"
-                                }
-                            ]
+                                    }
+                                ],
+                                "type": "Radio"
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -10872,28 +10774,25 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "no-primary-other-ethnic-group-answer",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "Arab",
-                                            "value": "Arab"
-                                        },
-                                        {
-                                            "label": "Any other ethnic group",
-                                            "value": "Other",
-                                            "child_answer_id": "no-primary-other-ethnic-group-answer-other"
+                                "id": "no-primary-other-ethnic-group-answer",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "Arab",
+                                        "value": "Arab"
+                                    },
+                                    {
+                                        "label": "Any other ethnic group",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "no-primary-other-ethnic-group-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please enter ethnic background"
                                         }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "no-primary-other-ethnic-group-answer-other",
-                                    "parent_answer_id": "no-primary-other-ethnic-group-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter ethnic background"
-                                }
-                            ]
+                                    }
+                                ],
+                                "type": "Radio"
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -10961,53 +10860,50 @@
                             "description": "",
                             "type": "General",
                             "answers": [{
-                                    "id": "no-primary-religion-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "No religion",
-                                            "value": "No religion"
-                                        },
-                                        {
-                                            "label": "Christian",
-                                            "value": "Christian",
-                                            "description": "Including Church of England, Catholic, Protestant and other Christian denominations"
-                                        },
-                                        {
-                                            "label": "Buddhist",
-                                            "value": "Buddhist"
-                                        },
-                                        {
-                                            "label": "Hindu",
-                                            "value": "Hindu"
-                                        },
-                                        {
-                                            "label": "Jewish",
-                                            "value": "Jewish"
-                                        },
-                                        {
-                                            "label": "Muslim",
-                                            "value": "Muslim"
-                                        },
-                                        {
-                                            "label": "Sikh",
-                                            "value": "Sikh"
-                                        },
-                                        {
-                                            "label": "Other religion",
-                                            "value": "Other",
-                                            "child_answer_id": "no-primary-religion-answer-other"
+                                "id": "no-primary-religion-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "No religion",
+                                        "value": "No religion"
+                                    },
+                                    {
+                                        "label": "Christian",
+                                        "value": "Christian",
+                                        "description": "Including Church of England, Catholic, Protestant and other Christian denominations"
+                                    },
+                                    {
+                                        "label": "Buddhist",
+                                        "value": "Buddhist"
+                                    },
+                                    {
+                                        "label": "Hindu",
+                                        "value": "Hindu"
+                                    },
+                                    {
+                                        "label": "Jewish",
+                                        "value": "Jewish"
+                                    },
+                                    {
+                                        "label": "Muslim",
+                                        "value": "Muslim"
+                                    },
+                                    {
+                                        "label": "Sikh",
+                                        "value": "Sikh"
+                                    },
+                                    {
+                                        "label": "Other religion",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "no-primary-religion-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please enter religion"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "no-primary-religion-answer-other",
-                                    "parent_answer_id": "no-primary-religion-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter religion"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -11537,16 +11433,14 @@
                                         {
                                             "label": "Some other arrangement",
                                             "value": "Some other arrangement",
-                                            "child_answer_id": "no-primary-working-hours-answer-other"
+                                            "detail_answer": {
+                                                "id": "no-primary-working-hours-answer-other",
+                                                "type": "TextField",
+                                                "mandatory": false,
+                                                "label": "Please describe"
+                                            }
                                         }
                                     ]
-                                },
-                                {
-                                    "id": "no-primary-working-hours-answer-other",
-                                    "parent_answer_id": "no-primary-working-hours-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please describe"
                                 },
                                 {
                                     "id": "no-primary-working-hours-answer-exclusive",
@@ -14965,53 +14859,50 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "no-primary-reason-why-fewer-hours-than-usual-self-employed-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "On leave",
-                                            "value": "On leave"
-                                        },
-                                        {
-                                            "label": "Illness or injury expected to last fewer than 4 weeks",
-                                            "value": "Illness or injury expected to last fewer than 4 weeks"
-                                        },
-                                        {
-                                            "label": "Illness or disability expected to last for 4 weeks or longer",
-                                            "value": "Illness or disability expected to last for 4 weeks or longer"
-                                        },
-                                        {
-                                            "label": "Maternity or paternity leave",
-                                            "value": "Maternity or paternity leave"
-                                        },
-                                        {
-                                            "label": "Business not set up yet",
-                                            "value": "Business not set up yet"
-                                        },
-                                        {
-                                            "label": "No client or customer that week",
-                                            "value": "No client or customer that week"
-                                        },
-                                        {
-                                            "label": "Temporary interruption to work",
-                                            "value": "Temporary interruption to work ",
-                                            "description": "Including bad weather"
-                                        },
-                                        {
-                                            "label": "Other",
-                                            "value": "Other",
-                                            "child_answer_id": "no-primary-reason-why-fewer-hours-than-usual-self-employed-answer-other"
+                                "id": "no-primary-reason-why-fewer-hours-than-usual-self-employed-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "On leave",
+                                        "value": "On leave"
+                                    },
+                                    {
+                                        "label": "Illness or injury expected to last fewer than 4 weeks",
+                                        "value": "Illness or injury expected to last fewer than 4 weeks"
+                                    },
+                                    {
+                                        "label": "Illness or disability expected to last for 4 weeks or longer",
+                                        "value": "Illness or disability expected to last for 4 weeks or longer"
+                                    },
+                                    {
+                                        "label": "Maternity or paternity leave",
+                                        "value": "Maternity or paternity leave"
+                                    },
+                                    {
+                                        "label": "Business not set up yet",
+                                        "value": "Business not set up yet"
+                                    },
+                                    {
+                                        "label": "No client or customer that week",
+                                        "value": "No client or customer that week"
+                                    },
+                                    {
+                                        "label": "Temporary interruption to work",
+                                        "value": "Temporary interruption to work ",
+                                        "description": "Including bad weather"
+                                    },
+                                    {
+                                        "label": "Other",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "no-primary-reason-why-fewer-hours-than-usual-self-employed-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please describe"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "no-primary-reason-why-fewer-hours-than-usual-self-employed-answer-other",
-                                    "parent_answer_id": "no-primary-reason-why-fewer-hours-than-usual-self-employed-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please describe"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }]
                     },
                     {
@@ -15082,62 +14973,59 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "no-primary-reason-why-fewer-hours-than-usual-employee-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "On leave",
-                                            "value": "On leave",
-                                            "description": "paid or unpaid"
-                                        },
-                                        {
-                                            "label": "Illness or injury expected to last fewer than 4 weeks",
-                                            "value": "Illness or injury expected to last fewer than 4 weeks"
-                                        },
-                                        {
-                                            "label": "Illness or disability expected to last for 4 weeks or longer",
-                                            "value": "Illness or disability expected to last for 4 weeks or longer"
-                                        },
-                                        {
-                                            "label": "Maternity or paternity leave",
-                                            "value": "Maternity or paternity leave"
-                                        },
-                                        {
-                                            "label": "Parental leave",
-                                            "value": "Parental leave"
-                                        },
-                                        {
-                                            "label": "Waiting to start a new job",
-                                            "value": "Waiting to start a new job"
-                                        },
-                                        {
-                                            "label": "Hours can vary",
-                                            "value": "Hours can vary"
-                                        },
-                                        {
-                                            "label": "Temporary interruption to work",
-                                            "value": "Temporary interruption to work",
-                                            "description": "Including bad weather, labour disputes"
-                                        },
-                                        {
-                                            "label": "Job is casual",
-                                            "value": "Job is casual"
-                                        },
-                                        {
-                                            "label": "Other",
-                                            "value": "Other",
-                                            "child_answer_id": "no-primary-reason-why-fewer-hours-than-usual-employee-answer-other"
+                                "id": "no-primary-reason-why-fewer-hours-than-usual-employee-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "On leave",
+                                        "value": "On leave",
+                                        "description": "paid or unpaid"
+                                    },
+                                    {
+                                        "label": "Illness or injury expected to last fewer than 4 weeks",
+                                        "value": "Illness or injury expected to last fewer than 4 weeks"
+                                    },
+                                    {
+                                        "label": "Illness or disability expected to last for 4 weeks or longer",
+                                        "value": "Illness or disability expected to last for 4 weeks or longer"
+                                    },
+                                    {
+                                        "label": "Maternity or paternity leave",
+                                        "value": "Maternity or paternity leave"
+                                    },
+                                    {
+                                        "label": "Parental leave",
+                                        "value": "Parental leave"
+                                    },
+                                    {
+                                        "label": "Waiting to start a new job",
+                                        "value": "Waiting to start a new job"
+                                    },
+                                    {
+                                        "label": "Hours can vary",
+                                        "value": "Hours can vary"
+                                    },
+                                    {
+                                        "label": "Temporary interruption to work",
+                                        "value": "Temporary interruption to work",
+                                        "description": "Including bad weather, labour disputes"
+                                    },
+                                    {
+                                        "label": "Job is casual",
+                                        "value": "Job is casual"
+                                    },
+                                    {
+                                        "label": "Other",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "no-primary-reason-why-fewer-hours-than-usual-employee-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please describe"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "no-primary-reason-why-fewer-hours-than-usual-employee-answer-other",
-                                    "parent_answer_id": "no-primary-reason-why-fewer-hours-than-usual-employee-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please describe"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -15629,52 +15517,49 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "no-primary-not-be-able-to-start-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "In education",
-                                            "value": "In education"
-                                        },
-                                        {
-                                            "label": "Looking after the family or home",
-                                            "value": "Looking after the family or home"
-                                        },
-                                        {
-                                            "label": "Childcare too expensive",
-                                            "value": "Childcare too expensive"
-                                        },
-                                        {
-                                            "label": "Caring responsibilities for adults",
-                                            "value": "Caring responsibilities for adults"
-                                        },
-                                        {
-                                            "label": "Illness or injury expecting to last fewer than 4 weeks",
-                                            "value": "Illness or injury expecting to last fewer than 4 weeks"
-                                        },
-                                        {
-                                            "label": "Illness or disability expecting to last for 4 weeks or longer",
-                                            "value": "Illness or disability expecting to last for 4 weeks or longer"
-                                        },
-                                        {
-                                            "label": "Waiting to start a job recently accepted",
-                                            "value": "Waiting to start a job recently accepted"
-                                        },
-                                        {
-                                            "label": "Other",
-                                            "value": "Other",
-                                            "child_answer_id": "no-primary-not-be-able-to-start-answer-other"
+                                "id": "no-primary-not-be-able-to-start-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "In education",
+                                        "value": "In education"
+                                    },
+                                    {
+                                        "label": "Looking after the family or home",
+                                        "value": "Looking after the family or home"
+                                    },
+                                    {
+                                        "label": "Childcare too expensive",
+                                        "value": "Childcare too expensive"
+                                    },
+                                    {
+                                        "label": "Caring responsibilities for adults",
+                                        "value": "Caring responsibilities for adults"
+                                    },
+                                    {
+                                        "label": "Illness or injury expecting to last fewer than 4 weeks",
+                                        "value": "Illness or injury expecting to last fewer than 4 weeks"
+                                    },
+                                    {
+                                        "label": "Illness or disability expecting to last for 4 weeks or longer",
+                                        "value": "Illness or disability expecting to last for 4 weeks or longer"
+                                    },
+                                    {
+                                        "label": "Waiting to start a job recently accepted",
+                                        "value": "Waiting to start a job recently accepted"
+                                    },
+                                    {
+                                        "label": "Other",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "no-primary-not-be-able-to-start-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please describe"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "no-primary-not-be-able-to-start-answer-other",
-                                    "parent_answer_id": "no-primary-not-be-able-to-start-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please describe"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -15712,72 +15597,69 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "no-primary-not-looking-for-work-reason-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "Retired from paid work",
-                                            "value": "Retired from paid work"
-                                        },
-                                        {
-                                            "label": "Studying",
-                                            "value": "Studying"
-                                        },
-                                        {
-                                            "label": "Looking after the family or home",
-                                            "value": "Looking after the family or home"
-                                        },
-                                        {
-                                            "label": "Childcare is too expensive",
-                                            "value": "Childcare is too expensive"
-                                        },
-                                        {
-                                            "label": "Caring responsibilities for adults",
-                                            "value": "Caring responsibilities for adults"
-                                        },
-                                        {
-                                            "label": "Illness or disability expecting to last for 4 weeks or longer",
-                                            "value": "Illness or disability expecting to last for 4 weeks or longer"
-                                        },
-                                        {
-                                            "label": "Illness or injury expected to last fewer than 4 weeks",
-                                            "value": "Illness or injury expected to last fewer than 4 weeks"
-                                        },
-                                        {
-                                            "label": "Waiting to start a job recently accepted",
-                                            "value": "Waiting to start a job recently accepted"
-                                        },
-                                        {
-                                            "label": "Waiting for the result of a job application",
-                                            "value": "Waiting for the result of a job application"
-                                        },
-                                        {
-                                            "label": "No suitable jobs were available",
-                                            "value": "No suitable jobs were available"
-                                        },
-                                        {
-                                            "label": "Not yet started looking",
-                                            "value": "Not yet started looking"
-                                        },
-                                        {
-                                            "label": "Did not need employment",
-                                            "value": "Did not need employment"
-                                        },
-                                        {
-                                            "label": "Other",
-                                            "value": "Other",
-                                            "child_answer_id": "no-primary-not-looking-for-work-reason-answer-other"
+                                "id": "no-primary-not-looking-for-work-reason-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "Retired from paid work",
+                                        "value": "Retired from paid work"
+                                    },
+                                    {
+                                        "label": "Studying",
+                                        "value": "Studying"
+                                    },
+                                    {
+                                        "label": "Looking after the family or home",
+                                        "value": "Looking after the family or home"
+                                    },
+                                    {
+                                        "label": "Childcare is too expensive",
+                                        "value": "Childcare is too expensive"
+                                    },
+                                    {
+                                        "label": "Caring responsibilities for adults",
+                                        "value": "Caring responsibilities for adults"
+                                    },
+                                    {
+                                        "label": "Illness or disability expecting to last for 4 weeks or longer",
+                                        "value": "Illness or disability expecting to last for 4 weeks or longer"
+                                    },
+                                    {
+                                        "label": "Illness or injury expected to last fewer than 4 weeks",
+                                        "value": "Illness or injury expected to last fewer than 4 weeks"
+                                    },
+                                    {
+                                        "label": "Waiting to start a job recently accepted",
+                                        "value": "Waiting to start a job recently accepted"
+                                    },
+                                    {
+                                        "label": "Waiting for the result of a job application",
+                                        "value": "Waiting for the result of a job application"
+                                    },
+                                    {
+                                        "label": "No suitable jobs were available",
+                                        "value": "No suitable jobs were available"
+                                    },
+                                    {
+                                        "label": "Not yet started looking",
+                                        "value": "Not yet started looking"
+                                    },
+                                    {
+                                        "label": "Did not need employment",
+                                        "value": "Did not need employment"
+                                    },
+                                    {
+                                        "label": "Other",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "no-primary-not-looking-for-work-reason-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please describe"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "no-primary-not-looking-for-work-reason-answer-other",
-                                    "parent_answer_id": "no-primary-not-looking-for-work-reason-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please describe"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {

--- a/data/en/test_checkbox.json
+++ b/data/en/test_checkbox.json
@@ -62,18 +62,17 @@
                             "q_code": "6",
                             "description": "Choose any other topping",
                             "value": "Other",
-                            "child_answer_id": "other-answer-mandatory"
+                            "detail_answer": {
+                                "mandatory": true,
+                                "id": "other-answer-mandatory",
+                                "label": "Please specify other",
+                                "type": "TextField"
+                            }
                         }],
                         "type": "Checkbox",
                         "validation": {
                             "messages": {}
                         }
-                    }, {
-                        "parent_answer_id": "mandatory-checkbox-answer",
-                        "mandatory": false,
-                        "id": "other-answer-mandatory",
-                        "label": "Please specify other",
-                        "type": "TextField"
                     }],
                     "description": "",
                     "id": "mandatory-checkbox-question",
@@ -113,19 +112,18 @@
                             "label": "Other",
                             "value": "Other",
                             "description": "Choose any other topping",
-                            "child_answer_id": "other-answer-non-mandatory"
+                            "detail_answer": {
+                                "mandatory": false,
+                                "id": "other-answer-non-mandatory",
+                                "label": "Please specify other",
+                                "type": "TextField"
+                            }
                         }],
                         "q_code": "20",
                         "type": "Checkbox",
                         "validation": {
                             "messages": {}
                         }
-                    }, {
-                        "parent_answer_id": "non-mandatory-checkbox-answer",
-                        "mandatory": false,
-                        "id": "other-answer-non-mandatory",
-                        "label": "Please specify other",
-                        "type": "TextField"
                     }],
                     "description": "",
                     "id": "non-mandatory-checkbox-question",

--- a/data/en/test_checkbox_multiple_detail_answers.json
+++ b/data/en/test_checkbox_multiple_detail_answers.json
@@ -1,0 +1,115 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.1",
+    "survey_id": "0",
+    "title": "Other input fields",
+    "theme": "default",
+    "description": "A questionnaire to demo checkbox field Other input.",
+    "messages": {
+        "NUMBER_TOO_LARGE": "Number is too large",
+        "NUMBER_TOO_SMALL": "Number cannot be less than zero",
+        "INVALID_NUMBER": "Please enter an integer"
+    },
+    "metadata": [{
+            "name": "user_id",
+            "validator": "string"
+        },
+        {
+            "name": "period_id",
+            "validator": "string"
+        },
+        {
+            "name": "ru_name",
+            "validator": "string"
+        }
+    ],
+    "sections": [{
+        "id": "default-section",
+        "groups": [{
+            "blocks": [{
+                    "type": "Question",
+                    "id": "mandatory-checkbox",
+                    "description": "",
+                    "questions": [{
+                        "answers": [{
+                            "id": "mandatory-checkbox-answer",
+                            "label": "",
+                            "mandatory": false,
+                            "options": [{
+                                    "label": "None",
+                                    "value": "None",
+                                    "q_code": "0"
+                                },
+                                {
+                                    "label": "Cheese",
+                                    "value": "Cheese",
+                                    "q_code": "1",
+                                    "detail_answer": {
+                                        "mandatory": false,
+                                        "id": "cheese-type-answer",
+                                        "label": "Type specific cheese if cheddar isn't wanted",
+                                        "type": "TextField"
+                                    }
+                                },
+                                {
+                                    "label": "Ham",
+                                    "value": "Ham",
+                                    "q_code": "2"
+                                },
+                                {
+                                    "label": "Pineapple",
+                                    "value": "Pineapple",
+                                    "q_code": "3"
+                                },
+                                {
+                                    "label": "Tuna",
+                                    "value": "Tuna",
+                                    "q_code": "4"
+                                },
+                                {
+                                    "label": "Pepperoni",
+                                    "value": "Pepperoni",
+                                    "q_code": "5"
+                                },
+                                {
+                                    "label": "Your choice",
+                                    "q_code": "6",
+                                    "description": "Choose any other topping",
+                                    "value": "Your choice",
+                                    "detail_answer": {
+                                        "mandatory": true,
+                                        "id": "your-choice-answer-mandatory",
+                                        "label": "Please specify your topping",
+                                        "type": "TextField",
+                                        "validation": {
+                                            "messages": {
+                                                "MANDATORY_TEXTFIELD": "Enter your topping choice to continue"
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "type": "Checkbox",
+                            "validation": {
+                                "messages": {}
+                            }
+                        }],
+                        "description": "",
+                        "id": "mandatory-checkbox-question",
+                        "title": "Which pizza toppings would you like?",
+                        "type": "General"
+                    }],
+                    "title": "Mandatory other option",
+                    "routing_rules": []
+                },
+                {
+                    "type": "Summary",
+                    "id": "summary"
+                }
+            ],
+            "id": "checkboxes",
+            "title": ""
+        }]
+    }]
+}

--- a/data/en/test_default.json
+++ b/data/en/test_default.json
@@ -28,6 +28,7 @@
                         "id": "answer",
                         "mandatory": false,
                         "type": "Number",
+                        "label": "Leave blank",
                         "default": 0
                     }],
                     "id": "question",

--- a/data/en/test_metadata_routing.json
+++ b/data/en/test_metadata_routing.json
@@ -33,7 +33,8 @@
                         "id": "block1-answer",
                         "mandatory": false,
                         "q_code": "20",
-                        "type": "TextField"
+                        "type": "TextField",
+                        "label": "Question 1"
                     }]
                 }],
                 "routing_rules": [{
@@ -62,7 +63,8 @@
                         "id": "block2-answer",
                         "mandatory": false,
                         "q_code": "20",
-                        "type": "TextField"
+                        "type": "TextField",
+                        "label": "Question 2"
                     }]
                 }]
             }, {
@@ -77,7 +79,8 @@
                         "id": "block3-answer",
                         "mandatory": false,
                         "q_code": "20",
-                        "type": "TextField"
+                        "type": "TextField",
+                        "label": "Question 3"
                     }]
                 }]
             }, {

--- a/data/en/test_mutually_exclusive.json
+++ b/data/en/test_mutually_exclusive.json
@@ -50,15 +50,14 @@
                                     "label": "Other",
                                     "description": "Choose any other topping",
                                     "value": "Other",
-                                    "child_answer_id": "checkbox-child-other-answer"
+                                    "detail_answer": {
+                                        "mandatory": false,
+                                        "id": "checkbox-child-other-answer",
+                                        "label": "Please specify other",
+                                        "type": "TextField"
+                                    }
                                 }
                             ]
-                        }, {
-                            "parent_answer_id": "checkbox-answer",
-                            "mandatory": false,
-                            "id": "checkbox-child-other-answer",
-                            "label": "Please specify other",
-                            "type": "TextField"
                         }, {
                             "id": "checkbox-exclusive-answer",
                             "mandatory": false,

--- a/data/en/test_navigation_routing.json
+++ b/data/en/test_navigation_routing.json
@@ -87,7 +87,8 @@
                     "answers": [{
                         "id": "question1-answer",
                         "mandatory": false,
-                        "type": "TextField"
+                        "type": "TextField",
+                        "label": "Question 1"
                     }]
                 }]
             }, {
@@ -103,7 +104,8 @@
                     "answers": [{
                         "id": "question2-answer",
                         "mandatory": false,
-                        "type": "TextField"
+                        "type": "TextField",
+                        "label": "Question 2"
                     }]
                 }]
             }]

--- a/data/en/test_radio_mandatory_with_mandatory_other.json
+++ b/data/en/test_radio_mandatory_with_mandatory_other.json
@@ -6,52 +6,58 @@
     "title": "Radio Mandatory with Mandatory Other",
     "theme": "default",
     "metadata": [{
-        "name": "user_id",
-        "validator": "string"
-    }, {
-        "name": "period_id",
-        "validator": "string"
-    }, {
-        "name": "ru_name",
-        "validator": "string"
-    }],
+            "name": "user_id",
+            "validator": "string"
+        },
+        {
+            "name": "period_id",
+            "validator": "string"
+        },
+        {
+            "name": "ru_name",
+            "validator": "string"
+        }
+    ],
     "sections": [{
         "id": "default-section",
         "groups": [{
             "id": "radio",
             "title": "Radio Mandatory with Mandatory Other",
             "blocks": [{
-                "type": "Question",
-                "id": "radio-mandatory",
-                "questions": [{
-                    "type": "General",
-                    "id": "radio-mandatory-question",
-                    "title": "What is you favourite breakfast item?",
-                    "answers": [{
-                        "type": "Radio",
-                        "id": "radio-mandatory-answer",
-                        "mandatory": true,
-                        "options": [{
-                            "label": "Toast",
-                            "value": "Toast"
-                        }, {
-                            "label": "Other",
-                            "description": "An answer is required.",
-                            "value": "Other",
-                            "child_answer_id": "other-answer-mandatory"
+                    "type": "Question",
+                    "id": "radio-mandatory",
+                    "questions": [{
+                        "type": "General",
+                        "id": "radio-mandatory-question",
+                        "title": "What is you favourite breakfast item?",
+                        "answers": [{
+                            "type": "Radio",
+                            "id": "radio-mandatory-answer",
+                            "mandatory": true,
+                            "options": [{
+                                    "label": "Toast",
+                                    "value": "Toast"
+                                },
+                                {
+                                    "label": "Other",
+                                    "description": "An answer is required.",
+                                    "value": "Other",
+                                    "detail_answer": {
+                                        "mandatory": true,
+                                        "id": "other-answer-mandatory",
+                                        "label": "Please specify other",
+                                        "type": "TextField"
+                                    }
+                                }
+                            ]
                         }]
-                    }, {
-                        "parent_answer_id": "radio-mandatory-answer",
-                        "mandatory": false,
-                        "id": "other-answer-mandatory",
-                        "label": "Please specify other",
-                        "type": "TextField"
                     }]
-                }]
-            }, {
-                "type": "Summary",
-                "id": "summary"
-            }]
+                },
+                {
+                    "type": "Summary",
+                    "id": "summary"
+                }
+            ]
         }]
     }]
 }

--- a/data/en/test_radio_mandatory_with_mandatory_other_overridden_error.json
+++ b/data/en/test_radio_mandatory_with_mandatory_other_overridden_error.json
@@ -38,19 +38,18 @@
                             "label": "Other",
                             "description": "An answer is required.",
                             "value": "Other",
-                            "child_answer_id": "other-answer-mandatory"
-                        }]
-                    }, {
-                        "parent_answer_id": "radio-mandatory-answer",
-                        "mandatory": true,
-                        "id": "other-answer-mandatory",
-                        "label": "Please specify other",
-                        "type": "TextField",
-                        "validation": {
-                            "messages": {
-                                "MANDATORY_TEXTFIELD": "Test error message is overridden"
+                            "detail_answer": {
+                                "mandatory": true,
+                                "id": "other-answer-mandatory",
+                                "label": "Please specify other",
+                                "type": "TextField",
+                                "validation": {
+                                    "messages": {
+                                        "MANDATORY_TEXTFIELD": "Test error message is overridden"
+                                    }
+                                }
                             }
-                        }
+                        }]
                     }]
                 }]
             }, {

--- a/data/en/test_radio_mandatory_with_optional_other.json
+++ b/data/en/test_radio_mandatory_with_optional_other.json
@@ -38,14 +38,13 @@
                             "label": "Other",
                             "description": "An answer is required.",
                             "value": "Other",
-                            "child_answer_id": "other-answer-mandatory"
+                            "detail_answer": {
+                                "mandatory": false,
+                                "id": "other-answer-mandatory",
+                                "label": "Please specify other",
+                                "type": "TextField"
+                            }
                         }]
-                    }, {
-                        "parent_answer_id": "radio-mandatory-answer",
-                        "mandatory": false,
-                        "id": "other-answer-mandatory",
-                        "label": "Please specify other",
-                        "type": "TextField"
                     }]
                 }]
             }, {

--- a/data/en/test_radio_multiple_detail_answers.json
+++ b/data/en/test_radio_multiple_detail_answers.json
@@ -1,0 +1,75 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.2",
+    "survey_id": "0",
+    "title": "Radio Mandatory with Mandatory Other Overridden Error",
+    "theme": "default",
+    "metadata": [{
+        "name": "user_id",
+        "validator": "string"
+    }, {
+        "name": "period_id",
+        "validator": "string"
+    }, {
+        "name": "ru_name",
+        "validator": "string"
+    }],
+    "sections": [{
+        "id": "default-section",
+        "groups": [{
+            "id": "radio",
+            "title": "Radio Mandatory with Mandatory Other Overridden Error",
+            "blocks": [{
+                    "type": "Question",
+                    "id": "radio-mandatory",
+                    "questions": [{
+                        "type": "General",
+                        "id": "radio-mandatory-question",
+                        "title": "What is you favourite breakfast item?",
+                        "answers": [{
+                            "type": "Radio",
+                            "id": "radio-mandatory-answer",
+                            "mandatory": true,
+                            "options": [{
+                                    "label": "Toast",
+                                    "value": "Toast"
+                                },
+                                {
+                                    "label": "Eggs",
+                                    "value": "Eggs",
+                                    "detail_answer": {
+                                        "mandatory": false,
+                                        "id": "eggs-answer",
+                                        "label": "Please write your favourite egg type",
+                                        "type": "TextField"
+                                    }
+                                },
+                                {
+                                    "label": "Favourite not listed",
+                                    "description": "An answer is required.",
+                                    "value": "Favourite not listed",
+                                    "detail_answer": {
+                                        "mandatory": true,
+                                        "id": "alternate-answer",
+                                        "label": "Please write your favourite",
+                                        "type": "TextField",
+                                        "validation": {
+                                            "messages": {
+                                                "MANDATORY_TEXTFIELD": "Enter your favourite to continue"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }]
+                    }]
+                },
+                {
+                    "type": "Summary",
+                    "id": "summary"
+                }
+            ]
+        }]
+    }]
+}

--- a/data/en/test_radio_optional_with_mandatory_other.json
+++ b/data/en/test_radio_optional_with_mandatory_other.json
@@ -38,14 +38,13 @@
                             "label": "Other",
                             "description": "This is mandatory.",
                             "value": "Other",
-                            "child_answer_id": "other-answer-non-mandatory"
+                            "detail_answer": {
+                                "mandatory": false,
+                                "id": "other-answer-non-mandatory",
+                                "label": "Please specify other",
+                                "type": "TextField"
+                            }
                         }]
-                    }, {
-                        "parent_answer_id": "radio-non-mandatory-answer",
-                        "mandatory": false,
-                        "id": "other-answer-non-mandatory",
-                        "label": "Please specify other",
-                        "type": "TextField"
                     }]
                 }]
             }, {

--- a/data/en/test_radio_optional_with_mandatory_other_overridden_error.json
+++ b/data/en/test_radio_optional_with_mandatory_other_overridden_error.json
@@ -38,19 +38,18 @@
                             "label": "Other",
                             "description": "This is mandatory.",
                             "value": "Other",
-                            "child_answer_id": "other-answer-non-mandatory"
-                        }]
-                    }, {
-                        "parent_answer_id": "radio-non-mandatory-answer",
-                        "mandatory": false,
-                        "id": "other-answer-non-mandatory",
-                        "label": "Please specify other",
-                        "type": "TextField",
-                        "validation": {
-                            "messages": {
-                                "MANDATORY_TEXTFIELD": "Test error message is overridden"
+                            "detail_answer": {
+                                "mandatory": true,
+                                "id": "other-answer-non-mandatory",
+                                "label": "Please specify other",
+                                "type": "TextField",
+                                "validation": {
+                                    "messages": {
+                                        "MANDATORY_TEXTFIELD": "Test error message is overridden"
+                                    }
+                                }
                             }
-                        }
+                        }]
                     }]
                 }]
             }, {

--- a/data/en/test_radio_optional_with_optional_other.json
+++ b/data/en/test_radio_optional_with_optional_other.json
@@ -38,14 +38,13 @@
                             "label": "Other",
                             "description": "This is optional.",
                             "value": "Other",
-                            "child_answer_id": "other-answer-non-mandatory"
+                            "detail_answer": {
+                                "mandatory": false,
+                                "id": "other-answer-non-mandatory",
+                                "label": "Please specify other",
+                                "type": "TextField"
+                            }
                         }]
-                    }, {
-                        "parent_answer_id": "radio-non-mandatory-answer",
-                        "mandatory": false,
-                        "id": "other-answer-non-mandatory",
-                        "label": "Please specify other",
-                        "type": "TextField"
                     }]
                 }]
             }, {

--- a/data/en/test_routing_checkbox_set_not_set.json
+++ b/data/en/test_routing_checkbox_set_not_set.json
@@ -50,18 +50,17 @@
                                 "label": "Other",
                                 "value": "Other",
                                 "description": "Choose any other topping",
-                                "child_answer_id": "other-answer-topping"
+                                "detail_answer": {
+                                    "mandatory": false,
+                                    "id": "other-answer-topping",
+                                    "label": "Please specify other",
+                                    "type": "TextField"
+                                }
                             }],
                             "type": "Checkbox",
                             "validation": {
                                 "messages": {}
                             }
-                        }, {
-                            "parent_answer_id": "topping-checkbox-answer",
-                            "mandatory": false,
-                            "id": "other-answer-topping",
-                            "label": "Please specify other",
-                            "type": "TextField"
                         }],
                         "description": "",
                         "id": "topping-checkbox-question",

--- a/data/en/test_routing_not_affected_by_answers_not_on_path.json
+++ b/data/en/test_routing_not_affected_by_answers_not_on_path.json
@@ -64,6 +64,7 @@
                     "answers": [{
                         "id": "invalid-path-answer",
                         "mandatory": true,
+                        "label": "Number",
                         "type": "Number"
                     }],
                     "id": "invalid-path-question",
@@ -89,7 +90,8 @@
                     "answers": [{
                         "id": "valid-path-answer",
                         "mandatory": true,
-                        "type": "Number"
+                        "type": "Number",
+                        "label": "Number"
                     }],
                     "id": "valid-path-question",
                     "title": "Enter a number and continue",

--- a/data/en/test_routing_number_equals.json
+++ b/data/en/test_routing_number_equals.json
@@ -27,7 +27,8 @@
                     "answers": [{
                         "id": "answer",
                         "mandatory": true,
-                        "type": "Number"
+                        "type": "Number",
+                        "label": "123"
                     }],
                     "id": "question",
                     "title": "Enter the number 123",

--- a/data/en/test_routing_number_greater_than.json
+++ b/data/en/test_routing_number_greater_than.json
@@ -27,7 +27,8 @@
                     "answers": [{
                         "id": "answer",
                         "mandatory": true,
-                        "type": "Number"
+                        "type": "Number",
+                        "label": "Greater than 123"
                     }],
                     "id": "question",
                     "title": "Enter the number greater than 123",

--- a/data/en/test_routing_number_greater_than_or_equal.json
+++ b/data/en/test_routing_number_greater_than_or_equal.json
@@ -27,7 +27,8 @@
                     "answers": [{
                         "id": "answer",
                         "mandatory": true,
-                        "type": "Number"
+                        "type": "Number",
+                        "label": "Greater than 123"
                     }],
                     "id": "question",
                     "title": "Enter the number greater than or equal to 123",

--- a/data/en/test_routing_number_greater_than_or_equal_single_condition.json
+++ b/data/en/test_routing_number_greater_than_or_equal_single_condition.json
@@ -30,7 +30,8 @@
                         "answers": [{
                             "id": "answer",
                             "mandatory": true,
-                            "type": "Number"
+                            "type": "Number",
+                            "label": "123 or greater"
                         }],
                         "id": "question",
                         "title": "Enter the number greater than or equal to 123",

--- a/data/en/test_routing_number_less_than.json
+++ b/data/en/test_routing_number_less_than.json
@@ -27,7 +27,8 @@
                     "answers": [{
                         "id": "answer",
                         "mandatory": true,
-                        "type": "Number"
+                        "type": "Number",
+                        "label": "Less than 123"
                     }],
                     "id": "question",
                     "title": "Enter the number less than 123",

--- a/data/en/test_routing_number_less_than_or_equal.json
+++ b/data/en/test_routing_number_less_than_or_equal.json
@@ -27,7 +27,8 @@
                     "answers": [{
                         "id": "answer",
                         "mandatory": true,
-                        "type": "Number"
+                        "type": "Number",
+                        "label": "Less than or equal to 123"
                     }],
                     "id": "question",
                     "title": "Enter the number less than or equal to 123",

--- a/data/en/test_routing_number_less_than_or_equal_single_condition.json
+++ b/data/en/test_routing_number_less_than_or_equal_single_condition.json
@@ -30,7 +30,8 @@
                         "answers": [{
                             "id": "answer",
                             "mandatory": true,
-                            "type": "Number"
+                            "type": "Number",
+                            "label": "Number"
                         }],
                         "id": "question",
                         "title": "Enter the number less than or equal to 123",

--- a/data/en/test_routing_number_not_equals.json
+++ b/data/en/test_routing_number_not_equals.json
@@ -27,7 +27,8 @@
                     "answers": [{
                         "id": "answer",
                         "mandatory": true,
-                        "type": "Number"
+                        "type": "Number",
+                        "label": "Not 123"
                     }],
                     "id": "question",
                     "title": "Enter the number that isn't 123",

--- a/data/en/test_routing_on_multiple_select.json
+++ b/data/en/test_routing_on_multiple_select.json
@@ -67,6 +67,7 @@
                     "type": "General",
                     "answers": [{
                         "id": "block2-answer",
+                        "label": "Question 2",
                         "mandatory": false,
                         "q_code": "20",
                         "type": "TextField"
@@ -82,6 +83,7 @@
                     "type": "General",
                     "answers": [{
                         "id": "block3-answer",
+                        "label": "Question 3",
                         "mandatory": false,
                         "q_code": "20",
                         "type": "TextField"

--- a/data/en/test_summary.json
+++ b/data/en/test_summary.json
@@ -44,17 +44,16 @@
                             "label": "Other",
                             "description": "An answer is required.",
                             "value": "Other",
-                            "child_answer_id": "other-answer-mandatory"
+                            "detail_answer": {
+                                "mandatory": false,
+                                "id": "other-answer-mandatory",
+                                "label": "Please specify other",
+                                "q_code": "20",
+                                "type": "TextField"
+                            }
                         }],
                         "q_code": "20",
                         "type": "Radio"
-                    }, {
-                        "parent_answer_id": "radio-answer",
-                        "mandatory": false,
-                        "id": "other-answer-mandatory",
-                        "label": "Please specify other",
-                        "q_code": "20",
-                        "type": "TextField"
                     }],
                     "description": "",
                     "id": "radio-question",

--- a/data/en/test_titles.json
+++ b/data/en/test_titles.json
@@ -158,7 +158,8 @@
                     "answers": [{
                         "type": "Number",
                         "id": "age-answer",
-                        "mandatory": true
+                        "mandatory": true,
+                        "label": "Your age"
                     }]
                 }, {
                     "id": "sure-question",

--- a/data/en/test_titles_conditional_within_repeating_block.json
+++ b/data/en/test_titles_conditional_within_repeating_block.json
@@ -175,7 +175,6 @@
                         }]
                     }, {
                         "id": "religion-answer-other",
-                        "parent_answer_id": "religion-answer",
                         "type": "TextField",
                         "mandatory": false,
                         "label": "Please enter religion"

--- a/data/en/test_titles_radio_and_checkbox.json
+++ b/data/en/test_titles_radio_and_checkbox.json
@@ -26,7 +26,7 @@
                 "type": "Question",
                 "questions": [{
                     "id": "name-question",
-                    "title": "what is your name",
+                    "title": "What is your name?",
                     "type": "General",
                     "guidance": {
                         "content": [{
@@ -36,6 +36,7 @@
                     },
                     "answers": [{
                         "id": "name-answer",
+                        "label": "Your name",
                         "type": "TextField",
                         "mandatory": true
                     }]

--- a/data/en/test_view_submitted_response.json
+++ b/data/en/test_view_submitted_response.json
@@ -48,17 +48,16 @@
                             "label": "Other",
                             "description": "An answer is required.",
                             "value": "Other",
-                            "child_answer_id": "other-answer-mandatory"
+                            "detail_answer": {
+                                "mandatory": false,
+                                "id": "other-answer-mandatory",
+                                "label": "Please specify other",
+                                "q_code": "20",
+                                "type": "TextField"
+                            }
                         }],
                         "q_code": "20",
                         "type": "Radio"
-                    }, {
-                        "parent_answer_id": "radio-answer",
-                        "mandatory": false,
-                        "id": "other-answer-mandatory",
-                        "label": "Please specify other",
-                        "q_code": "20",
-                        "type": "TextField"
                     }],
                     "description": "",
                     "id": "radio-question",

--- a/tests/app/forms/test_fields.py
+++ b/tests/app/forms/test_fields.py
@@ -1,7 +1,7 @@
-from wtforms import validators, StringField, FormField, SelectField, SelectMultipleField
+from wtforms import validators, StringField, FormField, SelectField
 
 from app.data_model.answer_store import AnswerStore
-from app.forms.custom_fields import MaxTextAreaField
+from app.forms.custom_fields import MaxTextAreaField, CustomSelectMultipleField, CustomSelectField
 from app.forms.date_form import DateField, MonthYearField, YearField
 from app.forms.fields import CustomIntegerField, CustomDecimalField, get_field, get_mandatory_validator, get_length_validator, _coerce_str_unless_none
 from app.validation.error_messages import error_messages
@@ -268,9 +268,9 @@ class TestFields(AppContextTestCase):
         unbound_field = get_field(radio_json, radio_json['label'], error_messages, self.answer_store,
                                   self.metadata)
 
-        expected_choices = [(option['label'], option['value']) for option in radio_json['options']]
+        expected_choices = [(option['label'], option['value'], None) for option in radio_json['options']]
 
-        self.assertEqual(unbound_field.field_class, SelectField)
+        self.assertEqual(unbound_field.field_class, CustomSelectField)
         self.assertTrue(unbound_field.kwargs['coerce'], _coerce_str_unless_none)
         self.assertEqual(unbound_field.kwargs['label'], radio_json['label'])
         self.assertEqual(unbound_field.kwargs['description'], radio_json['guidance'])
@@ -360,9 +360,9 @@ class TestFields(AppContextTestCase):
         unbound_field = get_field(checkbox_json, checkbox_json['label'], error_messages, self.answer_store,
                                   self.metadata)
 
-        expected_choices = [(option['value'], option['label']) for option in checkbox_json['options']]
+        expected_choices = [(option['value'], option['label'], None) for option in checkbox_json['options']]
 
-        self.assertEqual(unbound_field.field_class, SelectMultipleField)
+        self.assertEqual(unbound_field.field_class, CustomSelectMultipleField)
         self.assertEqual(unbound_field.kwargs['label'], checkbox_json['label'])
         self.assertEqual(unbound_field.kwargs['description'], checkbox_json['guidance'])
         self.assertEqual(unbound_field.kwargs['choices'], expected_choices)

--- a/tests/app/helpers/test_form_helper.py
+++ b/tests/app/helpers/test_form_helper.py
@@ -435,19 +435,17 @@ class TestFormHelper(AppContextTestCase):
                 },
                 {
                     'answer_id': 'other-answer-mandatory',
-                    'block_id': 'block-1',
+                    'block_id': 'radio-mandatory',
                     'value': 'Other text field value',
                     'answer_instance': 0,
                 }
             ])
 
-            radio_answer = schema.get_answers_for_block('radio-mandatory')[0]
-            text_answer = 'other-answer-mandatory'
-
-            form = post_form_for_location(schema, block_json, location, answer_store, metadata=None, request_form=MultiDict({
-                '{answer_id}'.format(answer_id=radio_answer['id']): 'Other',
-                '{answer_id}'.format(answer_id=text_answer): 'Other text field value',
-            }))
+            request_form = MultiDict({
+                'radio-mandatory-answer': 'Other',
+                'other-answer-mandatory': 'Other text field value',
+            })
+            form = post_form_for_location(schema, block_json, location, answer_store, metadata=None, request_form=request_form)
 
             other_text_field = getattr(form, 'other-answer-mandatory')
             self.assertEqual(other_text_field.data, 'Other text field value')

--- a/tests/app/questionnaire/test_questionnaire_schema.py
+++ b/tests/app/questionnaire/test_questionnaire_schema.py
@@ -78,20 +78,6 @@ class TestQuestionnaireSchema(AppContextTestCase):
 
         self.assertEqual(len(groups), 1)
 
-    def test_get_parent_options_for_block(self):
-        schema = load_schema_from_params('test', 'checkbox')
-
-        parent_options = schema.get_parent_options_for_block('mandatory-checkbox')
-
-        expected = {
-            'mandatory-checkbox-answer': {
-                'index': 6,
-                'child_answer_id': 'other-answer-mandatory'
-            }
-        }
-
-        self.assertEqual(parent_options, expected)
-
     def test_get_summary_and_confirmation_blocks_returns_only_summary(self):
         survey_json = {
             'sections': [{

--- a/tests/app/submitter/test_convert_payload_0_0_1.py
+++ b/tests/app/submitter/test_convert_payload_0_0_1.py
@@ -163,7 +163,7 @@ class TestConvertPayload001(TestConverter):  # pylint: disable=too-many-public-m
 
             self.assertEqual(len(answer_object['data']), 0)
 
-    def test_get_checkbox_answer_with_duplicate_child_answer_ids(self):
+    def test_get_checkbox_answer_with_duplicate_detail_answer_ids(self):
         with self._app.test_request_context():
             routing_path = [Location(group_id='favourite-food', group_instance=0, block_id='crisps')]
             answers = [create_answer('crisps-answer', [
@@ -189,7 +189,7 @@ class TestConvertPayload001(TestConverter):  # pylint: disable=too-many-public-m
                                     'q_code': '4',
                                     'description': 'Choose any other flavour',
                                     'value': 'Other',
-                                    'child_answer_id': 'other-answer-mandatory'
+                                    'detail_answer': {'id': 'other-answer-mandatory'}
                                 }
                             ]
                         }
@@ -237,16 +237,14 @@ class TestConvertPayload001(TestConverter):  # pylint: disable=too-many-public-m
                                     'q_code': '4',
                                     'description': 'Choose any other flavour',
                                     'value': 'Other',
-                                    'child_answer_id': 'other-answer-mandatory'
+                                    'detail_answer': {
+                                        'mandatory': True,
+                                        'id': 'other-answer-mandatory',
+                                        'label': 'Please specify other',
+                                        'type': 'TextField'
+                                    }
                                 }
                             ]
-                        },
-                        {
-                            'parent_answer_id': 'crisps-answer',
-                            'mandatory': True,
-                            'id': 'other-answer-mandatory',
-                            'label': 'Please specify other',
-                            'type': 'TextField'
                         }
                     ]
                 }
@@ -298,16 +296,14 @@ class TestConvertPayload001(TestConverter):  # pylint: disable=too-many-public-m
                                     'q_code': '4',
                                     'description': 'Choose any other flavour',
                                     'value': 'Other',
-                                    'child_answer_id': 'other-answer-mandatory'
+                                    'detail_answer':  {
+                                        'mandatory': True,
+                                        'id': 'other-answer-mandatory',
+                                        'label': 'Please specify other',
+                                        'type': 'TextField'
+                                    }
                                 }
                             ]
-                        },
-                        {
-                            'parent_answer_id': 'crisps-answer',
-                            'mandatory': True,
-                            'id': 'other-answer-mandatory',
-                            'label': 'Please specify other',
-                            'type': 'TextField'
                         }
                     ]
                 }
@@ -359,16 +355,14 @@ class TestConvertPayload001(TestConverter):  # pylint: disable=too-many-public-m
                                     'q_code': '4',
                                     'description': 'Choose any other flavour',
                                     'value': 'Other',
-                                    'child_answer_id': 'other-answer-mandatory'
+                                    'detail_answer': {
+                                        'mandatory': True,
+                                        'id': 'other-answer-mandatory',
+                                        'label': 'Please specify other',
+                                        'type': 'TextField'
+                                    }
                                 }
                             ]
-                        },
-                        {
-                            'parent_answer_id': 'crisps-answer',
-                            'mandatory': True,
-                            'id': 'other-answer-mandatory',
-                            'label': 'Please specify other',
-                            'type': 'TextField'
                         }
                     ]
                 }

--- a/tests/app/templating/summary/test_question.py
+++ b/tests/app/templating/summary/test_question.py
@@ -244,7 +244,7 @@ class TestQuestion(AppContextTestCase):   # pylint: disable=too-many-public-meth
         self.assertEqual(question.answers[0]['value'][0].label, 'Light Side label')
         self.assertEqual(question.answers[0]['value'][1].label, 'Dark Side label')
 
-    def test_checkbox_button_other_option_empty(self):
+    def test_checkbox_button_detail_answer_empty(self):
         # Given
         self.answer_store.add_or_update(Answer(
             answer_id='answer_1',
@@ -271,9 +271,9 @@ class TestQuestion(AppContextTestCase):   # pylint: disable=too-many-public-meth
         # Then
         self.assertEqual(len(question.answers[0]['value']), 1)
         self.assertEqual(question.answers[0]['value'][0].label, 'Other option label')
-        self.assertEqual(question.answers[0]['value'][0].should_display_other, True)
+        self.assertEqual(question.answers[0]['value'][0].detail_answer_value, None)
 
-    def test_checkbox_answer_with_other_value_returns_the_value(self):
+    def test_checkbox_answer_with_detail_answer_returns_the_value(self):
         # Given
         self.answer_store.add_or_update(Answer(
             answer_id='answer_1',
@@ -290,17 +290,16 @@ class TestQuestion(AppContextTestCase):   # pylint: disable=too-many-public-meth
         }, {
             'label': 'Other',
             'value': 'Other',
-            'child_answer_id': 'child_answer'
+            'detail_answer': {
+                'id': 'child_answer',
+                'type': 'TextField'
+            }
         }]
         answer_schema = [{
             'id': 'answer_1',
             'label': 'Which side?',
             'type': 'Checkbox',
             'options': options
-        }, {
-            'parent_answer_id': 'answer_1',
-            'id': 'child_answer',
-            'type': 'TextField'
         }]
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL',
                            'answers': answer_schema}
@@ -311,7 +310,7 @@ class TestQuestion(AppContextTestCase):   # pylint: disable=too-many-public-meth
 
         # Then
         self.assertEqual(len(question.answers[0]['value']), 2)
-        self.assertEqual(question.answers[0]['child_answer_value'], 'Test')
+        self.assertEqual(question.answers[0]['value'][1].detail_answer_value, 'Test')
 
     def test_checkbox_button_other_option_text(self):
         # Given
@@ -329,7 +328,7 @@ class TestQuestion(AppContextTestCase):   # pylint: disable=too-many-public-meth
         }, {
             'label': 'other',
             'value': 'other',
-            'child_answer_id': 'child_answer'
+            'detail_answer': {'id': 'child_answer'}
         }]
         answer_schema = {'id': 'answer_1', 'label': 'Which side?', 'type': 'Checkbox', 'options': options}
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema]}
@@ -341,7 +340,7 @@ class TestQuestion(AppContextTestCase):   # pylint: disable=too-many-public-meth
         # Then
         self.assertEqual(len(question.answers[0]['value']), 2)
         self.assertEqual(question.answers[0]['value'][0].label, 'Light Side')
-        self.assertEqual(question.answers[0]['child_answer_value'], 'Neither')
+        self.assertEqual(question.answers[0]['value'][1].detail_answer_value, 'Neither')
 
     def test_checkbox_button_none_selected_should_be_none(self):
         # Given
@@ -363,58 +362,6 @@ class TestQuestion(AppContextTestCase):   # pylint: disable=too-many-public-meth
         # Then
         self.assertEqual(question.answers[0]['value'], None)
 
-    def test_radio_button_other_option_empty(self):
-        # Given
-        self.answer_store.add_or_update(Answer(
-            answer_id='answer_1',
-            value='',
-        ))
-        options = [{
-            'label': 'Light Side',
-            'value': 'Light Side',
-        }, {
-            'label': 'Other option label',
-            'value': 'other',
-            'other': {
-                'label': 'Please specify other'
-            }
-        }]
-        answer_schema = {'id': 'answer_1', 'label': 'Which side?', 'type': 'Radio', 'options': options}
-        question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema]}
-
-        # When
-        with patch('app.templating.summary.question.get_question_title', return_value=False):
-            question = Question(question_schema, self.answer_store, self.metadata, self.schema, 0)
-
-        # Then
-        self.assertEqual(question.answers[0]['value'], 'Other option label')
-
-    def test_radio_button_other_option_text(self):
-        # Given
-        self.answer_store.add_or_update(Answer(
-            answer_id='answer_1',
-            value='I want to be on the dark side',
-        ))
-        options = [{
-            'label': 'Light Side',
-            'value': 'Light Side',
-        }, {
-            'label': 'Other option label',
-            'value': 'other',
-            'other': {
-                'label': 'Please specify other'
-            }
-        }]
-        answer_schema = {'id': 'answer_1', 'label': 'Which side?', 'type': 'Radio', 'options': options}
-        question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL', 'answers': [answer_schema]}
-
-        # When
-        with patch('app.templating.summary.question.get_question_title', return_value=False):
-            question = Question(question_schema, self.answer_store, self.metadata, self.schema, 0)
-
-        # Then
-        self.assertEqual(question.answers[0]['value'], 'I want to be on the dark side')
-
     def test_radio_button_none_selected_should_be_none(self):
         # Given
         options = [{
@@ -431,7 +378,7 @@ class TestQuestion(AppContextTestCase):   # pylint: disable=too-many-public-meth
         # Then
         self.assertEqual(question.answers[0]['value'], None)
 
-    def test_radio_answer_with_other_value_returns_the_value(self):
+    def test_radio_answer_with_detail_answer_returns_the_value(self):
         # Given
         self.answer_store.add_or_update(Answer(
             answer_id='answer_1',
@@ -444,17 +391,16 @@ class TestQuestion(AppContextTestCase):   # pylint: disable=too-many-public-meth
         options = [{
             'label': 'Other',
             'value': 'Other',
-            'child_answer_id': 'child_answer'
+            'detail_answer': {
+                'id': 'child_answer',
+                'type': 'TextField'
+            }
         }]
         answer_schema = [{
             'id': 'answer_1',
             'label': 'Which side?',
             'type': 'Radio',
             'options': options
-        }, {
-            'parent_answer_id': 'answer_1',
-            'id': 'child_answer',
-            'type': 'TextField'
         }]
         question_schema = {'id': 'question_id', 'title': 'question_title', 'type': 'GENERAL',
                            'answers': answer_schema}
@@ -464,7 +410,7 @@ class TestQuestion(AppContextTestCase):   # pylint: disable=too-many-public-meth
             question = Question(question_schema, self.answer_store, self.metadata, self.schema, 0)
 
         # Then
-        self.assertEqual(question.answers[0]['child_answer_value'], 'Test')
+        self.assertEqual(question.answers[0]['value']['detail_answer_value'], 'Test')
 
     def test_build_answers_repeating_answers(self):
         # Given

--- a/tests/app/validation/test_number_range_validator.py
+++ b/tests/app/validation/test_number_range_validator.py
@@ -125,7 +125,7 @@ class TestNumberRangeValidator(unittest.TestCase):
         label = answer['label']
         returned_error_messages = answer['validation']['messages']
 
-        integer_field = get_number_field(answer, label, '', returned_error_messages, self.store)
+        integer_field = get_number_field(answer, label, '', returned_error_messages, self.store, False)
 
         self.assertTrue(integer_field.field_class == CustomIntegerField)
 
@@ -167,7 +167,7 @@ class TestNumberRangeValidator(unittest.TestCase):
         label = answer['label']
         returned_error_messages = answer['validation']['messages']
 
-        integer_field = get_number_field(answer, label, '', returned_error_messages, self.store)
+        integer_field = get_number_field(answer, label, '', returned_error_messages, self.store, False)
 
         self.assertTrue(integer_field.field_class == CustomIntegerField)
 
@@ -203,7 +203,7 @@ class TestNumberRangeValidator(unittest.TestCase):
         label = answer['label']
         error_message = error_messages['NUMBER_TOO_LARGE'] % dict(max=max_value)
 
-        integer_field = get_number_field(answer, label, '', error_messages, self.store)
+        integer_field = get_number_field(answer, label, '', error_messages, self.store, False)
 
         self.assertTrue(integer_field.field_class == CustomIntegerField)
 
@@ -239,7 +239,7 @@ class TestNumberRangeValidator(unittest.TestCase):
         label = answer['label']
         error_message = error_messages['NUMBER_TOO_SMALL'] % dict(min=min_value)
 
-        integer_field = get_number_field(answer, label, '', error_messages, self.store)
+        integer_field = get_number_field(answer, label, '', error_messages, self.store, False)
 
         self.assertTrue(integer_field.field_class == CustomIntegerField)
 
@@ -284,7 +284,7 @@ class TestNumberRangeValidator(unittest.TestCase):
         label = answer['label']
         returned_error_messages = answer['validation']['messages']
 
-        integer_field = get_number_field(answer, label, '', error_messages, self.store)
+        integer_field = get_number_field(answer, label, '', error_messages, self.store, False)
 
         self.assertTrue(integer_field.field_class == CustomIntegerField)
 
@@ -332,7 +332,7 @@ class TestNumberRangeValidator(unittest.TestCase):
         label = answer['label']
         returned_error_messages = answer['validation']['messages']
 
-        integer_field = get_number_field(answer, label, '', returned_error_messages, self.store)
+        integer_field = get_number_field(answer, label, '', returned_error_messages, self.store, False)
 
         self.assertTrue(integer_field.field_class == CustomIntegerField)
 
@@ -374,7 +374,7 @@ class TestNumberRangeValidator(unittest.TestCase):
         label = answer['label']
         returned_error_messages = answer['validation']['messages']
 
-        integer_field = get_number_field(answer, label, '', returned_error_messages, self.store)
+        integer_field = get_number_field(answer, label, '', returned_error_messages, self.store, False)
 
         for validator in integer_field.kwargs['validators']:
             if isinstance(validator, NumberRange):
@@ -405,7 +405,7 @@ class TestNumberRangeValidator(unittest.TestCase):
         returned_error_messages = answer['validation']['messages']
 
         with self.assertRaises(Exception) as ite:
-            get_number_field(answer, label, '', returned_error_messages, self.store)
+            get_number_field(answer, label, '', returned_error_messages, self.store, False)
 
         self.assertEqual(str(ite.exception),
                          'min_value: -1000000000 < system minimum: -999999999 for answer id: test-range')
@@ -432,7 +432,7 @@ class TestNumberRangeValidator(unittest.TestCase):
         returned_error_messages = answer['validation']['messages']
 
         with self.assertRaises(Exception) as ite:
-            get_number_field(answer, label, '', returned_error_messages, self.store)
+            get_number_field(answer, label, '', returned_error_messages, self.store, False)
 
         self.assertEqual(str(ite.exception),
                          'max_value: 10000000000 > system maximum: 9999999999 for answer id: test-range')
@@ -462,7 +462,7 @@ class TestNumberRangeValidator(unittest.TestCase):
         returned_error_messages = answer['validation']['messages']
 
         with self.assertRaises(Exception) as ite:
-            get_number_field(answer, label, '', returned_error_messages, self.store)
+            get_number_field(answer, label, '', returned_error_messages, self.store, False)
 
         self.assertEqual(str(ite.exception), 'min_value: 20 > max_value: 10 for answer id: test-range')
 
@@ -489,7 +489,7 @@ class TestNumberRangeValidator(unittest.TestCase):
         returned_error_messages = answer['validation']['messages']
 
         with self.assertRaises(Exception) as ite:
-            get_number_field(answer, label, '', returned_error_messages, self.store)
+            get_number_field(answer, label, '', returned_error_messages, self.store, False)
 
         self.assertEqual(str(ite.exception),
                          'answer: set-maximum-cat value: cat for answer id: test-range is not a valid number')
@@ -515,7 +515,7 @@ class TestNumberRangeValidator(unittest.TestCase):
         label = answer['label']
         returned_error_messages = answer['validation']['messages']
 
-        integer_field = get_number_field(answer, label, '', error_messages, self.store)
+        integer_field = get_number_field(answer, label, '', error_messages, self.store, False)
 
         self.assertTrue(integer_field.field_class == CustomIntegerField)
 
@@ -558,7 +558,7 @@ class TestNumberRangeValidator(unittest.TestCase):
         label = answer['label']
         returned_error_messages = answer['validation']['messages']
 
-        integer_field = get_number_field(answer, label, '', returned_error_messages, self.store)
+        integer_field = get_number_field(answer, label, '', returned_error_messages, self.store, False)
 
         self.assertTrue(integer_field.field_class == CustomIntegerField)
 

--- a/tests/app/validation/test_number_validator.py
+++ b/tests/app/validation/test_number_validator.py
@@ -140,7 +140,7 @@ class TestNumberValidator(unittest.TestCase):
         label = answer['label']
         returned_error_messages = answer['validation']['messages']
 
-        decimal_field = get_number_field(answer, label, '', returned_error_messages, AnswerStore())
+        decimal_field = get_number_field(answer, label, '', returned_error_messages, AnswerStore(), False)
 
         self.assertTrue(decimal_field.field_class == CustomDecimalField)
 
@@ -180,7 +180,7 @@ class TestNumberValidator(unittest.TestCase):
         returned_error_messages = answer['validation']['messages']
 
         with self.assertRaises(Exception) as ite:
-            get_number_field(answer, label, '', returned_error_messages, AnswerStore())
+            get_number_field(answer, label, '', returned_error_messages, AnswerStore(), False)
 
             self.assertEqual(str(ite.exception), 'decimal_places: 10 > system maximum: {} for answer id: test-range'
                              .format(MAX_DECIMAL_PLACES))

--- a/tests/functional/generate_pages.py
+++ b/tests/functional/generate_pages.py
@@ -227,10 +227,10 @@ def process_options(answer_id, options, page_spec, base_prefix):
 
         # Add a selector for an option which exposes another input, e.g.
         # an 'Other' option which exposes a text input for the user to fill in
-        if 'child_answer_id' in option:
+        if 'detail_answer' in option:
             option_context = {
-                'answerId': option['child_answer_id'],
-                'answerName': option_name + 'Text'
+                'answerId': option['detail_answer']['id'],
+                'answerName': option_name + 'Detail'
             }
             page_spec.write(ANSWER_GETTER.substitute(option_context))
 
@@ -246,11 +246,7 @@ def process_answer(question_type, answer, page_spec, long_names, page_name):
     if answer_name is None or answer_name == '':
         answer_name = 'answer'
 
-    if 'parent_answer_id' in answer:
-        logger.debug('\t\tSkipping Child Answer: %s', answer['id'])
-        return
-
-    elif answer['type'] in ('Radio', 'Checkbox'):
+    if answer['type'] in ('Radio', 'Checkbox'):
         process_options(answer['id'], answer['options'], page_spec, prefix)
 
     elif answer['type'] in 'Date':

--- a/tests/functional/spec/checkbox.spec.js
+++ b/tests/functional/spec/checkbox.spec.js
@@ -13,7 +13,7 @@ describe('Checkbox with "other" option', function() {
       return browser
         .getText(MandatoryCheckboxPage.otherLabel()).should.eventually.have.string('Choose any other topping')
         .click(MandatoryCheckboxPage.other())
-        .isVisible(MandatoryCheckboxPage.otherText()).should.eventually.be.true;
+        .isVisible(MandatoryCheckboxPage.otherDetail()).should.eventually.be.true;
     });
   });
 
@@ -38,7 +38,7 @@ describe('Checkbox with "other" option', function() {
         .isVisible(MandatoryCheckboxPage.error()).should.eventually.be.true
 
       // When
-        .setValue(MandatoryCheckboxPage.otherText(), 'Other Text')
+        .setValue(MandatoryCheckboxPage.otherDetail(), 'Other Text')
         .click(MandatoryCheckboxPage.submit())
         .getUrl().should.eventually.contain(NonMandatoryCheckboxPage.pageName);
     });
@@ -51,7 +51,7 @@ describe('Checkbox with "other" option', function() {
       return browser
       // When
         .click(MandatoryCheckboxPage.other())
-        .setValue(MandatoryCheckboxPage.otherText(), 'Other value')
+        .setValue(MandatoryCheckboxPage.otherDetail(), 'Other value')
         .click(MandatoryCheckboxPage.submit())
         .click(NonMandatoryCheckboxPage.submit())
       // Then
@@ -65,7 +65,7 @@ describe('Checkbox with "other" option', function() {
       return browser
       // When
         .click(MandatoryCheckboxPage.other())
-        .setValue(MandatoryCheckboxPage.otherText(), 'Other value')
+        .setValue(MandatoryCheckboxPage.otherDetail(), 'Other value')
         .click(MandatoryCheckboxPage.submit())
         .click(NonMandatoryCheckboxPage.other())
         .click(NonMandatoryCheckboxPage.submit())
@@ -81,10 +81,10 @@ describe('Checkbox with "other" option', function() {
       return browser
       // When
         .click(MandatoryCheckboxPage.other())
-        .setValue(MandatoryCheckboxPage.otherText(), 'Other value')
+        .setValue(MandatoryCheckboxPage.otherDetail(), 'Other value')
         .click(MandatoryCheckboxPage.submit())
         .click(NonMandatoryCheckboxPage.other())
-        .setValue(NonMandatoryCheckboxPage.otherText(), 'The other value')
+        .setValue(NonMandatoryCheckboxPage.otherDetail(), 'The other value')
         .click(NonMandatoryCheckboxPage.submit())
       // Then
         .getText(SummaryPage.nonMandatoryCheckboxAnswer()).should.eventually.have.string('The other value');
@@ -99,7 +99,7 @@ describe('Checkbox with "other" option', function() {
       return browser
       // When
         .click(MandatoryCheckboxPage.other())
-        .setValue(MandatoryCheckboxPage.otherText(), 'Other value')
+        .setValue(MandatoryCheckboxPage.otherDetail(), 'Other value')
         .click(MandatoryCheckboxPage.submit())
         .click(NonMandatoryCheckboxPage.previous())
         .click(MandatoryCheckboxPage.other())
@@ -108,7 +108,7 @@ describe('Checkbox with "other" option', function() {
         .click(NonMandatoryCheckboxPage.previous())
       // Then
         .click(MandatoryCheckboxPage.other())
-        .getValue(MandatoryCheckboxPage.otherText()).should.eventually.be.equal('');
+        .getValue(MandatoryCheckboxPage.otherDetail()).should.eventually.be.equal('');
     });
 
   });

--- a/tests/functional/spec/components/checkbox/checkbox_multiple_detail_answers.spec.js
+++ b/tests/functional/spec/components/checkbox/checkbox_multiple_detail_answers.spec.js
@@ -1,0 +1,114 @@
+const helpers = require('../../../helpers');
+
+const MandatoryCheckboxPage = require('../../../generated_pages/checkbox_multiple_detail_answers/mandatory-checkbox.page');
+const SummaryPage = require('../../../generated_pages/checkbox_multiple_detail_answers/summary.page');
+
+describe('Checkbox with multiple "detail_answer" options', function() {
+
+  const checkbox_schema = 'test_checkbox_multiple_detail_answers.json';
+
+  it('Given detail answer options are available, When the user clicks an option, Then the detail answer input should be visible.', function() {
+    return helpers.openQuestionnaire(checkbox_schema).then(() => {
+      return browser
+        .click(MandatoryCheckboxPage.yourChoice())
+        .isVisible(MandatoryCheckboxPage.yourChoiceDetail()).should.eventually.be.true
+        .click(MandatoryCheckboxPage.cheese())
+        .isVisible(MandatoryCheckboxPage.cheeseDetail()).should.eventually.be.true;
+    });
+  });
+
+  it('Given a mandatory detail answer, When I select the option but leave the input field empty and submit, Then an error should be displayed.', function() {
+    // Given
+    return helpers.openQuestionnaire(checkbox_schema).then(() => {
+      return browser
+      // When
+        // Non-Mandatory detail answer given
+        .click(MandatoryCheckboxPage.cheese())
+        .setValue(MandatoryCheckboxPage.cheeseDetail(), 'Mozzarella')
+        // Mandatory detail answer left blank
+        .click(MandatoryCheckboxPage.yourChoice())
+        .click(MandatoryCheckboxPage.submit())
+      // Then
+        .isVisible(MandatoryCheckboxPage.error()).should.eventually.be.true
+        .getText(MandatoryCheckboxPage.errorNumber(1)).should.eventually.contain('Enter your topping choice to continue');
+    });
+  });
+
+  it('Given a selected checkbox answer with an error for a mandatory detail answer, When I enter valid value and submit the page, Then the error is cleared and I navigate to next page.', function() {
+    // Given
+    return helpers.openQuestionnaire(checkbox_schema).then(() => {
+      return browser
+        .click(MandatoryCheckboxPage.yourChoice())
+        .click(MandatoryCheckboxPage.submit())
+        .isVisible(MandatoryCheckboxPage.error()).should.eventually.be.true
+
+      // When
+        .setValue(MandatoryCheckboxPage.yourChoiceDetail(), 'Bacon')
+        .click(MandatoryCheckboxPage.submit())
+        .getUrl().should.eventually.contain(SummaryPage.pageName);
+    });
+  });
+
+
+  it('Given a non-mandatory detail answer, When the user does not provide any text, Then just the option value should be displayed on the summary screen', function() {
+    // Given
+    return helpers.openQuestionnaire(checkbox_schema).then(() => {
+      return browser
+      // When
+        .click(MandatoryCheckboxPage.cheese())
+        .isVisible(MandatoryCheckboxPage.cheeseDetail()).should.eventually.be.true
+        .click(MandatoryCheckboxPage.submit())
+      // Then
+        .getText(SummaryPage.mandatoryCheckboxAnswer()).should.eventually.equal('Cheese');
+    });
+  });
+
+  it('Given multiple detail answers, When the user provides text for all, Then that text should be displayed on the summary screen', function() {
+    // Given
+    return helpers.openQuestionnaire(checkbox_schema).then(() => {
+      return browser
+      // When
+        .click(MandatoryCheckboxPage.cheese())
+        .setValue(MandatoryCheckboxPage.cheeseDetail(), 'Mozzarella')
+        .click(MandatoryCheckboxPage.yourChoice())
+        .setValue(MandatoryCheckboxPage.yourChoiceDetail(), 'Bacon')
+        .click(MandatoryCheckboxPage.submit())
+      // Then
+        .getText(SummaryPage.mandatoryCheckboxAnswer()).should.eventually.equal('Cheese\nMozzarella\nYour choice\nBacon');
+    });
+  });
+
+  it('Given multiple detail answers, When the user provides text for just one, Then that text should be displayed on the summary screen', function() {
+    // Given
+    return helpers.openQuestionnaire(checkbox_schema).then(() => {
+      return browser
+      // When
+        .click(MandatoryCheckboxPage.yourChoice())
+        .setValue(MandatoryCheckboxPage.yourChoiceDetail(), 'Bacon')
+        .click(MandatoryCheckboxPage.submit())
+      // Then
+        .getText(SummaryPage.mandatoryCheckboxAnswer()).should.eventually.equal('Your choice\nBacon');
+    });
+  });
+
+  it('Given I have previously added text in a detail answer and saved, When I uncheck the detail answer option and select a different checkbox, Then the text entered in the detail answer field should be empty.', function() {
+    // Given
+    return helpers.openQuestionnaire(checkbox_schema).then(() => {
+      return browser
+      // When
+        .click(MandatoryCheckboxPage.cheese())
+        .setValue(MandatoryCheckboxPage.cheeseDetail(), 'Mozzarella')
+        .click(MandatoryCheckboxPage.submit())
+        .click(SummaryPage.previous())
+        .click(MandatoryCheckboxPage.cheese())
+        .click(MandatoryCheckboxPage.ham())
+        .click(MandatoryCheckboxPage.submit())
+        .click(SummaryPage.previous())
+      // Then
+        .click(MandatoryCheckboxPage.cheese())
+        .getValue(MandatoryCheckboxPage.cheeseDetail()).should.eventually.be.equal('');
+    });
+
+  });
+
+});

--- a/tests/functional/spec/components/checkbox/mutually_exclusive/mutually_exclusive_checkbox.spec.js
+++ b/tests/functional/spec/components/checkbox/mutually_exclusive/mutually_exclusive_checkbox.spec.js
@@ -17,12 +17,12 @@ describe('Component: Mutually Exclusive Checkbox With Single Checkbox Override',
         .click(MandatoryCheckboxPage.checkboxBritish())
         .click(MandatoryCheckboxPage.checkboxIrish())
         .click(MandatoryCheckboxPage.checkboxOther())
-        .setValue(MandatoryCheckboxPage.checkboxOtherText(), 'The other option')
+        .setValue(MandatoryCheckboxPage.checkboxOtherDetail(), 'The other option')
 
         .isSelected(MandatoryCheckboxPage.checkboxBritish()).should.eventually.be.true
         .isSelected(MandatoryCheckboxPage.checkboxIrish()).should.eventually.be.true
         .isSelected(MandatoryCheckboxPage.checkboxOther()).should.eventually.be.true
-        .getValue(MandatoryCheckboxPage.checkboxOtherText()).should.eventually.contain('The other option')
+        .getValue(MandatoryCheckboxPage.checkboxOtherDetail()).should.eventually.contain('The other option')
 
         // When
         .click(MandatoryCheckboxPage.checkboxExclusiveIPreferNotToSay())
@@ -32,7 +32,7 @@ describe('Component: Mutually Exclusive Checkbox With Single Checkbox Override',
         .isSelected(MandatoryCheckboxPage.checkboxBritish()).should.eventually.be.false
         .isSelected(MandatoryCheckboxPage.checkboxIrish()).should.eventually.be.false
         .isSelected(MandatoryCheckboxPage.checkboxOther()).should.eventually.be.false
-        .getValue(MandatoryCheckboxPage.checkboxOtherText()).should.eventually.contain('')
+        .getValue(MandatoryCheckboxPage.checkboxOtherDetail()).should.eventually.contain('')
 
         .click(MandatoryCheckboxPage.submit())
 

--- a/tests/functional/spec/components/radio/radio.spec.js
+++ b/tests/functional/spec/components/radio/radio.spec.js
@@ -31,7 +31,7 @@ describe('Component: Radio', function() {
     it('When I have selected a other text field, Then the selected option should be displayed in the summary', function() {
       return browser
        .click(RadioMandatoryPage.other())
-       .setValue(RadioMandatoryPage.otherText(), 'Hello World')
+       .setValue(RadioMandatoryPage.otherDetail(), 'Hello World')
        .click(RadioMandatoryPage.submit())
        .getUrl().should.eventually.contain(RadioSummaryPage.pageName)
        .getText(RadioSummaryPage.radioMandatoryAnswer()).should.eventually.contain('Hello World');
@@ -134,28 +134,11 @@ describe('Component: Radio', function() {
     it('When I submit data in the other text field it should be persisted and Then displayed on the summary', function() {
       return browser
        .click(RadioNonMandatoryPage.other())
-       .setValue(RadioNonMandatoryPage.otherText(), 'Hello World')
+       .setValue(RadioNonMandatoryPage.otherDetail(), 'Hello World')
        .click(RadioNonMandatoryPage.submit())
        .getUrl().should.eventually.contain(RadioSummaryPage.pageName)
        .getText(RadioSummaryPage.radioNonMandatoryAnswer()).should.eventually.contain('Hello World');
     });
-  });
-
-  describe('Given I start a Optional other Optional survey', function() {
-
-    var RadioNonMandatoryPage = require('../../../generated_pages/radio_optional_with_optional_other/radio-non-mandatory.page');
-    var RadioSummaryPage = require('../../../generated_pages/radio_optional_with_optional_other/summary.page');
-
-    before(function() {
-      return helpers.openQuestionnaire('test_radio_optional_with_optional_other.json');
-    });
-
-    it('When I select no option I should be directed to the summary and Then answer should be displayed on the summary', function() {
-      return browser
-       .click(RadioNonMandatoryPage.other())
-       .click(RadioNonMandatoryPage.submit())
-       .getText(RadioSummaryPage.radioNonMandatoryAnswer()).should.eventually.contain('No answer provided');
-     });
   });
 
 });

--- a/tests/functional/spec/components/radio/radio_multiple_detail_answers.spec.js
+++ b/tests/functional/spec/components/radio/radio_multiple_detail_answers.spec.js
@@ -1,0 +1,95 @@
+const helpers = require('../../../helpers');
+
+const MandatoryRadioPage = require('../../../generated_pages/radio_multiple_detail_answers/radio-mandatory.page');
+const SummaryPage = require('../../../generated_pages/radio_multiple_detail_answers/summary.page');
+
+describe('Radio with multiple "detail_answer" options', function() {
+
+  const radio_schema = 'test_radio_multiple_detail_answers.json';
+
+  it('Given detail answer options are available, When the user clicks an option, Then the detail answer input should be visible.', function() {
+    return helpers.openQuestionnaire(radio_schema).then(() => {
+      return browser
+        .click(MandatoryRadioPage.eggs())
+        .isVisible(MandatoryRadioPage.eggsDetail()).should.eventually.be.true
+        .click(MandatoryRadioPage.favouriteNotListed())
+        .isVisible(MandatoryRadioPage.favouriteNotListedDetail()).should.eventually.be.true;
+    });
+  });
+
+  it('Given a mandatory detail answer, When I select the option but leave the input field empty and submit, Then an error should be displayed.', function() {
+    // Given
+    return helpers.openQuestionnaire(radio_schema).then(() => {
+      return browser
+      // When
+        .click(MandatoryRadioPage.favouriteNotListed())
+        .click(MandatoryRadioPage.submit())
+      // Then
+        .isVisible(MandatoryRadioPage.error()).should.eventually.be.true
+        .getText(MandatoryRadioPage.errorNumber(1)).should.eventually.contain('Enter your favourite to continue');
+    });
+  });
+
+  it('Given a selected checkbox answer with an error for a mandatory detail answer, When I enter valid value and submit the page, Then the error is cleared and I navigate to next page.', function() {
+    // Given
+    return helpers.openQuestionnaire(radio_schema).then(() => {
+      return browser
+        .click(MandatoryRadioPage.favouriteNotListed())
+        .click(MandatoryRadioPage.submit())
+        .isVisible(MandatoryRadioPage.error()).should.eventually.be.true
+
+      // When
+        .setValue(MandatoryRadioPage.favouriteNotListedDetail(), 'Bacon')
+        .click(MandatoryRadioPage.submit())
+        .getUrl().should.eventually.contain(SummaryPage.pageName);
+    });
+  });
+
+
+  it('Given a non-mandatory detail answer, When the user does not provide any text, Then just the option value should be displayed on the summary screen', function() {
+    // Given
+    return helpers.openQuestionnaire(radio_schema).then(() => {
+      return browser
+      // When
+        .click(MandatoryRadioPage.eggs())
+        .isVisible(MandatoryRadioPage.eggsDetail()).should.eventually.be.true
+        .click(MandatoryRadioPage.submit())
+      // Then
+        .getText(SummaryPage.radioMandatoryAnswer()).should.eventually.equal('Eggs');
+    });
+  });
+
+  it('Given a detail answer, When the user provides text, Then that text should be displayed on the summary screen', function() {
+    // Given
+    return helpers.openQuestionnaire(radio_schema).then(() => {
+      return browser
+      // When
+        .click(MandatoryRadioPage.eggs())
+        .setValue(MandatoryRadioPage.eggsDetail(), 'Scrambled')
+        .click(MandatoryRadioPage.submit())
+      // Then
+        .getText(SummaryPage.radioMandatoryAnswer()).should.eventually.equal('Eggs\nScrambled');
+    });
+  });
+
+
+  it('Given I have previously added text in a detail answer and saved, When I select a different radio and save, Then the text entered in the detail answer field should be empty.', function() {
+    // Given
+    return helpers.openQuestionnaire(radio_schema).then(() => {
+      return browser
+      // When
+        .click(MandatoryRadioPage.favouriteNotListed())
+        .setValue(MandatoryRadioPage.favouriteNotListedDetail(), 'Bacon')
+        .click(MandatoryRadioPage.submit())
+        .click(SummaryPage.previous())
+        .click(MandatoryRadioPage.eggs())
+        .click(MandatoryRadioPage.submit())
+        .click(SummaryPage.previous())
+      // Then
+        .click(MandatoryRadioPage.favouriteNotListed())
+        .getValue(MandatoryRadioPage.favouriteNotListedDetail()).should.eventually.be.equal('');
+    });
+
+  });
+
+});


### PR DESCRIPTION
### What is the context of this PR?
Allow runner to provide respondents with more than 1 write in field for a response option so that they can give more detail about the response option they have chosen.

### How to review 
Existing "other" options still work as expected.
Additional features in:
`test_checkbox_multiple_detail_answers.json` and
`test_radio_mutlitple_detail_answers.json`

### Checklist

* [ ] New static content marked up for translation
* [x] Newly defined schema content included in eq-translations repo
