### PR TITLE
Always save the latest available version of QuestionnaireStore.

### DIFF
--- a/app/data_model/questionnaire_store.py
+++ b/app/data_model/questionnaire_store.py
@@ -48,7 +48,7 @@ class QuestionnaireStore:
         new_version = self.get_latest_version_number()
         if self.version < new_version:
             self.answer_store.upgrade(self.version, schema)
-            self.version = new_version
+        self.version = new_version
 
         return self
 


### PR DESCRIPTION
### What is the context of this PR?
Currently, we are able to read version 3 in production, but can only write version 2.

While making the changes to write version 3, it became clear that there is an issue around what version we are writing for the questionnaire store.

In a deployment as follows (I've represented the version of the data with `data_version`):

1) Instance running `version 2` saves QuestionnaireStore. `{version=2, data_version=2}`
2) Instance running `version 3` loads QuestionnaireStore with `version 2`, upgrades to `version 3`, and saves `{version=3, data_version=3}`
3) Instance running `version 2` loads QuestionnaireStore with `version 3`, and saves with `{version=3, data_version=2}`

At this point we have a mismatched version number, which will cause errors when an application tries to load it.

To avoid this, we can ensure that we always write the latest version which the current code can write, rather than the highest possible version.

### How to review 
I have a branch which adds the writing functionality of version 3. This can be used to test it.

1) Checkout master, start a questionnaire
2) Checkout [`2647-update-questionnaire-store-version-for-compression-and-new-answerstore-storage-format`](https://github.com/ONSdigital/eq-survey-runner/tree/2647-update-questionnaire-store-version-for-compression-and-new-answerstore-storage-format), restart server, continue questionnaire.
3) Checkout master, restart server, continue questionnaire. 
4) You should see errors
5) Checkout this PR's branch, start a questionnaire
6) Checkout [`2647-update-questionnaire-store-version-for-compression-and-new-answerstore-storage-format`](https://github.com/ONSdigital/eq-survey-runner/tree/2647-update-questionnaire-store-version-for-compression-and-new-answerstore-storage-format), merge this PR into it, continue your questionnaire.
7) Checkout this PR, continue your questionnaire
8) Checkout [`2647-update-questionnaire-store-version-for-compression-and-new-answerstore-storage-format`](https://github.com/ONSdigital/eq-survey-runner/tree/2647-update-questionnaire-store-version-for-compression-and-new-answerstore-storage-format), continue questionnaire, and ensure it's all working

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
