### PR TITLE
Save state in new format

### DIFF
--- a/app/data_model/questionnaire_store.py
+++ b/app/data_model/questionnaire_store.py
@@ -10,8 +10,10 @@ class QuestionnaireStore:
     The QuestionnaireStore is versioned to provide a way to migrate existing state. Versions are:
     1 - Reformat date answers from d/m/y to y-m-d
     2 - Add group_instance_id to all answers
+    3 - Compress state using snappy before encryption. Also removes base64 encoding and
+        unnecessary json wrapper around encrypted data.
     """
-    LATEST_VERSION = 2
+    LATEST_VERSION = 3
 
     def __init__(self, storage, version=None):
         self._storage = storage

--- a/app/storage/encrypted_questionnaire_storage.py
+++ b/app/storage/encrypted_questionnaire_storage.py
@@ -20,8 +20,8 @@ class EncryptedQuestionnaireStorage:
         self.encrypter = StorageEncryption(user_id, user_ik, pepper)
 
     def add_or_update(self, data, version):
-        encrypted_data = self.encrypter.encrypt_data(data)
-        encrypted_data = json.dumps({'data': encrypted_data})
+        compressed_data = snappy.compress(data)
+        encrypted_data = self.encrypter.encrypt_data(compressed_data)
         questionnaire_state = self._find_questionnaire_state()
         if questionnaire_state:
             logger.debug('updating questionnaire data', user_id=self._user_id)
@@ -38,7 +38,7 @@ class EncryptedQuestionnaireStorage:
         if questionnaire_state and questionnaire_state.state_data:
             version = questionnaire_state.version or 0
 
-            if version <= 2:
+            if version < 3:
                 decrypted_data = self._get_base64_encoded_data(questionnaire_state.state_data)
             else:
                 decrypted_data = self._get_snappy_compressed_data(questionnaire_state.state_data)

--- a/app/storage/storage_encryption.py
+++ b/app/storage/storage_encryption.py
@@ -50,7 +50,7 @@ class StorageEncryption:
         }
 
         jwe_token = jwe.JWE(
-            plaintext=base64url_encode(data),
+            plaintext=data,
             protected=protected_header,
             recipient=self.key,
         )

--- a/tests/app/data_model/test_session_store.py
+++ b/tests/app/data_model/test_session_store.py
@@ -256,7 +256,7 @@ class SessionStoreTest(AppContextTestCase):
 
 class TestSessionStoreEncoding(AppContextTestCase):
     """Session data used to be base64-encoded. For performance reasons the
-    base64 encoding is being removed.
+    base64 encoding was removed.
     """
     def setUp(self):
         super().setUp()

--- a/tests/app/storage/test_storage_encryption.py
+++ b/tests/app/storage/test_storage_encryption.py
@@ -1,5 +1,4 @@
 from unittest import TestCase
-from jwcrypto.common import base64url_decode
 import simplejson as json
 
 from app.storage.storage_encryption import StorageEncryption
@@ -54,7 +53,6 @@ class TestStorageEncryption(TestCase):
         self.assertIsInstance(encrypted_data, str)
 
         decrypted_data = self.encrypter.decrypt_data(encrypted_data)
-        decrypted_data = base64url_decode(decrypted_data.decode()).decode()
         decrypted_data = json.loads(decrypted_data)
         self.assertEqual(data, decrypted_data)
 

--- a/tests/integration/session/test_questionnaire_store_upgrade.py
+++ b/tests/integration/session/test_questionnaire_store_upgrade.py
@@ -28,15 +28,15 @@ class TestLogin(IntegrationTestCase):
 
     def test_questionnaire_store_is_upgraded(self):
         # Given
-        previous_version = QuestionnaireStore.LATEST_VERSION - 1
 
-        # Creates a QuestionnaireStore with previous version
-        with patch('app.data_model.questionnaire_store.QuestionnaireStore.get_latest_version_number', return_value=previous_version):
-            self.launchSurvey('test', '0205')
+        self.launchSurvey('test', 'numbers')
 
-        # On a subsequent request the `upgrade` method of answer_store should be called
-        with patch('app.data_model.questionnaire_store.AnswerStore.upgrade') as upgrade:
-            self.post(action='start_questionnaire')
+        # Increment the LATEST_VERSION so the `upgrade` method of answer_store is called when fetching
+        # the questionnaire store.
+        next_version = QuestionnaireStore.LATEST_VERSION + 1
+        with patch('app.data_model.questionnaire_store.QuestionnaireStore.get_latest_version_number', return_value=next_version):
+            with patch('app.data_model.questionnaire_store.AnswerStore.upgrade') as upgrade:
+                self.post(action='start_questionnaire')
 
         upgrade.assert_called_once()
 


### PR DESCRIPTION
### What is the context of this PR?
DO NOT MERGE until https://github.com/ONSdigital/eq-survey-runner/pull/1921 is in production!

Now that https://github.com/ONSdigital/eq-survey-runner/pull/1905 has gone into production, we need to enable writing of new formats.

This PR essentially reverts the changes from https://github.com/ONSdigital/eq-survey-runner/pull/1905. It adds this as version 3 of the questionnaire store.

- Data is written compressed / without base64 and without a JSON wrapper.


### How to review 

Test that nothing goes wrong when:
- starting a questionnaire on version 2 (with #1905 and #1921 )
- upgrade to version 3
- continue the questionnaire
- downgrade to version 2
- continue the questionnaire

At each stage of the above, we should probably test submission.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
