### PR TITLE
Fix mobile navigation when no account url set

### DIFF
--- a/app/templates/partials/header.html
+++ b/app/templates/partials/header.html
@@ -25,15 +25,9 @@
                     <h1 class="header__title header__title--nav-adj">{{ survey_title }}</h1>
                 </div>
                 {% include 'partials/sign-out-button.html' %}
-
-                {% if account_service_url %}
-                    {% include 'partials/mobile-navigation-button.html' %}                
-                {% endif %}
-
+                {% include 'partials/mobile-navigation-button.html' %}
             </div>
         </div>
     </div>
-    {% if account_service_url %}
-        {% include 'partials/main-navigation.html' %}
-    {% endif %}
+    {% include 'partials/main-navigation.html' %}
 </header>

--- a/app/templates/partials/main-navigation.html
+++ b/app/templates/partials/main-navigation.html
@@ -1,10 +1,14 @@
+{% if account_service_url or account_service_log_out_url or save_on_signout %}
 <div class="header__nav">
     <div class="container">
         <nav class="nav nav--horizontal nav--light nav--main nav--h-m js-main-nav" aria-label="Main menu" id="main-nav">
             <ul class="nav__list" aria-label="Navigation menu" role="menubar">
-                <li class="nav__item u-d-no--@s" role="menuitem"><a href="{{account_service_url}}" id="my-account" class="nav__link">{{ _("My account") }}</a></li>
+                {% if account_service_url %}
+                    <li class="nav__item u-d-no--@s" role="menuitem"><a href="{{account_service_url}}" id="my-account" class="nav__link">{{ _("My account") }}</a></li>
+                {% endif %}
                 {% include 'partials/sign-out-button-navigation.html' %}
             </ul>
         </nav>
     </div>
 </div>
+{% endif %}

--- a/app/templates/partials/mobile-navigation-button.html
+++ b/app/templates/partials/mobile-navigation-button.html
@@ -1,1 +1,3 @@
+{% if account_service_url or account_service_log_out_url or save_on_signout %}
 <button class="btn btn--mobile js-nav-btn u-fr u-d-no--@s" type="button" id="menu-btn" aria-expanded="false" aria-controls="main-nav" aria-label="Toggle main navigation" aria-haspopup="true"><span class="btn--mobile__label"></span></button>
+{% endif %}

--- a/app/themes/northernireland/templates/partials/header.html
+++ b/app/themes/northernireland/templates/partials/header.html
@@ -22,14 +22,9 @@
                     <h1 class="header__title ">{{ survey_title }}</h1>
                 </div>
                 {% include 'partials/sign-out-button.html' %}
-
-                {% if account_service_url %}
-                    {% include 'partials/mobile-navigation-button.html' %}                
-                {% endif %}
+                {% include 'partials/mobile-navigation-button.html' %}
             </div>
         </div>
     </div>
-    {% if account_service_url %}
-        {% include 'partials/main-navigation.html' %}
-    {% endif %}
+    {% include 'partials/main-navigation.html' %}
 </header>

--- a/app/themes/social/templates/partials/header.html
+++ b/app/themes/social/templates/partials/header.html
@@ -35,7 +35,7 @@
                     <h1 class="header__title ">{{ survey_title }}</h1>
                 </div>
                 {% include 'partials/sign-out-button.html' %}
-                <button class="btn btn--mobile js-nav-btn u-fr u-d-no--@s" type="button" id="menu-btn" aria-expanded="false" aria-controls="main-nav" aria-label="Toggle main navigation" aria-haspopup="true"><span class="btn--mobile__label"></span></button>
+                {% include 'partials/mobile-navigation-button.html' %}
             </div>
         </div>
     </div>


### PR DESCRIPTION
### What is the context of this PR?
Fixes #1934

### How to review 
- Launch a survey with no account url set
- Verify the sign navigation button is displayed when the viewport is resized
- Check variations of account url and account logout url
- Also check a `northernireland` theme survey