### PR TITLE
Add answer store upgrade path refactor

### DIFF
--- a/tests/integration/routing/rules.py
+++ b/tests/integration/routing/rules.py
@@ -195,7 +195,8 @@ QUIZ_PAGE_1 = [
             {
                 'answer': 'When was The Empire Strikes Back released?',
                 'answer_id': 'empire-strikes-back-from-answer-month',
-                'user_answer': '5'
+                'user_answer': '5',
+                'display_answer': 'May'
             },
             {
                 'answer': 'When was The Empire Strikes Back released?',
@@ -210,7 +211,8 @@ QUIZ_PAGE_1 = [
             {
                 'answer': 'When was The Empire Strikes Back released?',
                 'answer_id': 'empire-strikes-back-to-answer-month',
-                'user_answer': '5'
+                'user_answer': '5',
+                'display_answer': 'May'
             },
             {
                 'answer': 'When was The Empire Strikes Back released?',

--- a/tests/integration/routing/test_routing.py
+++ b/tests/integration/routing/test_routing.py
@@ -44,7 +44,7 @@ class TestRouting(IntegrationTestCase):
             # We need to assert the answer is on the page
             self.assertInBody(answer['answer'])
             # We also need to prepare the assertions for the summary page
-            rule_assertions.append(answer['user_answer'])
+            rule_assertions.append(answer.get('display_answer') or answer['user_answer'])
             rule_assertions.append(answer['answer'])
 
         return form_data, rule_assertions


### PR DESCRIPTION
### What is the context of this PR?
The PR to handle empty answer store values was closed, but I wanted to pull this out since it's a valuable change to answer store upgrades.

This change means that upgrades no longer rely on the length of the upgrades list and allow for skipped versions.

I've also added a fix for the routing test which was always broken, but worked intermittently AFAICT.

### How to review 

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
