### PR TITLE
Use new totaliser pattern

### DIFF
--- a/data/en/ecommerce_0051.json
+++ b/data/en/ecommerce_0051.json
@@ -1943,10 +1943,16 @@
                             "id": "question1399",
                             "title": "During 2018, of the {{ answers['answer1869'] | format_number }}% given in the previous question, what percentage was received from the following types of customer?",
                             "description": "",
-                            "type": "General",
+                            "type": "Calculated",
+                            "calculations": [{
+                                "calculation_type": "sum",
+                                "value": 100,
+                                "answers_to_calculate": ["answer1870", "answer1871"],
+                                "conditions": ["equals"]
+                            }],
                             "answers": [{
                                     "id": "answer1870",
-                                    "mandatory": true,
+                                    "mandatory": false,
                                     "type": "Percentage",
                                     "q_code": "348",
                                     "label": "Sales to private customers (B2C)",
@@ -1955,33 +1961,12 @@
                                 },
                                 {
                                     "id": "answer1871",
-                                    "mandatory": true,
+                                    "mandatory": false,
                                     "type": "Percentage",
                                     "q_code": "349",
                                     "label": "Sales to other businesses (B2B) and public authorities (B2G)",
                                     "description": "",
                                     "decimal_places": 2
-                                },
-                                {
-                                    "calculated": true,
-                                    "description": "The total percentages should be 100%",
-                                    "id": "question1399-total-percentage",
-                                    "label": "Total",
-                                    "mandatory": false,
-                                    "type": "Percentage",
-                                    "decimal_places": 2,
-                                    "min_value": {
-                                        "value": 100
-                                    },
-                                    "max_value": {
-                                        "value": 100
-                                    },
-                                    "validation": {
-                                        "messages": {
-                                            "NUMBER_TOO_SMALL": "The total percentages should equal %(min)s",
-                                            "NUMBER_TOO_LARGE": "The total percentages should equal %(max)s"
-                                        }
-                                    }
                                 }
                             ]
                         }]
@@ -2023,10 +2008,16 @@
                             "id": "question1401",
                             "title": "During 2018, what was the percentage of orders received via a website or ‘app’ for the following options?",
                             "description": "",
-                            "type": "General",
+                            "type": "Calculated",
+                            "calculations": [{
+                                "calculation_type": "sum",
+                                "value": 100,
+                                "answers_to_calculate": ["answer1873", "answer1875"],
+                                "conditions": ["equals"]
+                            }],
                             "answers": [{
                                     "id": "answer1873",
-                                    "mandatory": true,
+                                    "mandatory": false,
                                     "type": "Percentage",
                                     "q_code": "460",
                                     "label": "Percentage of orders from your business’ own website or ‘app’",
@@ -2035,33 +2026,12 @@
                                 },
                                 {
                                     "id": "answer1875",
-                                    "mandatory": true,
+                                    "mandatory": false,
                                     "type": "Percentage",
                                     "q_code": "461",
                                     "label": "Percentage of orders from an e-commerce market place website or ‘app’ used by several businesses for trading product",
                                     "description": "For example, Booking, eBay, Amazon, Amazon Business, Alibaba, Rakuten, Etsy",
                                     "decimal_places": 2
-                                },
-                                {
-                                    "calculated": true,
-                                    "description": "The total percentages should be 100%",
-                                    "id": "question1401-total-percentage",
-                                    "label": "Total",
-                                    "mandatory": false,
-                                    "type": "Percentage",
-                                    "decimal_places": 2,
-                                    "min_value": {
-                                        "value": 100
-                                    },
-                                    "max_value": {
-                                        "value": 100
-                                    },
-                                    "validation": {
-                                        "messages": {
-                                            "NUMBER_TOO_SMALL": "The total percentages should equal %(min)s",
-                                            "NUMBER_TOO_LARGE": "The total percentages should equal %(max)s"
-                                        }
-                                    }
                                 }
                             ]
                         }]

--- a/data/en/ukis_0001.json
+++ b/data/en/ukis_0001.json
@@ -4144,7 +4144,18 @@
                                 ]
                             },
                             "description": "Estimates are acceptable and percentages must <strong>total 100%</strong>",
-                            "type": "General",
+                            "type": "Calculated",
+                            "calculations": [{
+                                "calculation_type": "sum",
+                                "value": 0,
+                                "answers_to_calculate": ["answer3207", "answer3208", "answer3209", "answer3211"],
+                                "conditions": ["equals"]
+                            }, {
+                                "calculation_type": "sum",
+                                "value": 100,
+                                "answers_to_calculate": ["answer3207", "answer3208", "answer3209", "answer3211"],
+                                "conditions": ["equals"]
+                            }],
                             "answers": [{
                                     "id": "answer3207",
                                     "mandatory": false,
@@ -4208,24 +4219,6 @@
                                         "exclusive": false
                                     },
                                     "decimal_places": 0
-                                },
-                                {
-                                    "calculated": true,
-                                    "description": "The total percentages should be 100%",
-                                    "id": "total-percentage",
-                                    "label": "Total",
-                                    "mandatory": false,
-                                    "type": "Percentage",
-                                    "decimal_places": 2,
-                                    "max_value": {
-                                        "value": 100
-                                    },
-                                    "validation": {
-                                        "messages": {
-                                            "NUMBER_TOO_SMALL": "The total percentages should equal %(min)s",
-                                            "NUMBER_TOO_LARGE": "The total percentages should equal %(max)s"
-                                        }
-                                    }
                                 }
                             ]
                         }]


### PR DESCRIPTION
### What is the context of this PR?
https://trello.com/c/ZBUzk4tb/763-new-totaliser-pattern

Needed to use the new totaliser pattern

### How to review 
Test the validation on the questions in the e-commerce and ukis forms.

Note: To test the UKIS one, first answer the 'Goods and services innovation' section (saying yes to every question), followed by Turnover and exports.  Failing to do this won't cause the percentage totaliser question on ukis to appear as it's dependant on a question from the first section.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
