### PR TITLE
Introduce AnswerStoreUpdater

### DIFF
--- a/app/questionnaire/answer_store_updater.py
+++ b/app/questionnaire/answer_store_updater.py
@@ -1,0 +1,163 @@
+from collections import defaultdict
+
+from app.data_model.answer_store import Answer
+from app.helpers.schema_helpers import get_group_instance_id
+from app.questionnaire.location import Location
+
+
+class AnswerStoreUpdater:
+    """Component responsible for any actions that need to happen as a result of updating the answer store
+    """
+
+    def __init__(self, current_location, schema, questionnaire_store):
+        self._current_location = current_location
+        self._schema = schema
+        self._questionnaire_store = questionnaire_store
+        self._answer_store = self._questionnaire_store.answer_store
+
+    def save_form(self, form):
+        if self._should_save_serialised_answers():
+            self._update_questionnaire_store_with_answer_data(form.serialise())
+        else:
+            self._update_questionnaire_store_with_form_data(form.data)
+
+        self._questionnaire_store.add_or_update()
+
+    def _update_questionnaire_store_with_answer_data(self, answers):
+        survey_answer_ids = self._schema.get_answer_ids_for_block(self._current_location.block_id)
+
+        valid_answers = (
+            answer for answer in answers
+            if answer.answer_id in survey_answer_ids
+        )
+
+        for answer in valid_answers:
+            answer.group_instance_id = get_group_instance_id(self._schema, self._answer_store, self._current_location,
+                                                             answer.answer_instance)
+            self._answer_store.add_or_update(answer)
+
+        if self._current_location not in self._questionnaire_store.completed_blocks:
+            self._questionnaire_store.completed_blocks.append(self._current_location)
+
+    def _update_questionnaire_store_with_form_data(self, answers):
+        survey_answer_ids = self._schema.get_answer_ids_for_block(self._current_location.block_id)
+
+        for answer_id, answer_value in answers.items():
+
+            # If answer is not answered then check for a schema specified default
+            if answer_value is None:
+                answer_value = self._schema.get_answer(answer_id).get('default')
+
+            if answer_id in survey_answer_ids:
+                if answer_value is not None:
+                    answer = Answer(answer_id=answer_id,
+                                    value=answer_value,
+                                    group_instance_id=get_group_instance_id(self._schema, self._answer_store,
+                                                                            self._current_location),
+                                    group_instance=self._current_location.group_instance)
+
+                    latest_answer_store_hash = self._answer_store.get_hash()
+                    self._answer_store.add_or_update(answer)
+
+                    if latest_answer_store_hash != self._answer_store.get_hash() and self._schema.answer_dependencies[answer_id]:
+                        self._remove_dependent_answers_from_completed_blocks(answer_id)
+                else:
+                    self._remove_answer_from_questionnaire_store(answer_id)
+
+        if self._current_location not in self._questionnaire_store.completed_blocks:
+            self._questionnaire_store.completed_blocks.append(self._current_location)
+
+    def _remove_dependent_answers_from_completed_blocks(self, answer_id):
+        """
+        Gets a list of answers ids that are dependent on the answer_id passed in.
+        Then for each dependent answer it will remove it's block from those completed.
+        This will therefore force the respondent to revisit that block.
+        The dependent answers themselves remain untouched.
+        :param answer_id: the answer that has changed
+        :return: None
+        """
+        answer_in_repeating_group = self._schema.answer_is_in_repeating_group(answer_id)
+        dependencies = self._schema.answer_dependencies[answer_id]
+        group_instance = self._current_location.group_instance
+
+        for dependency in dependencies:
+            dependency_in_repeating_group = self._schema.answer_is_in_repeating_group(dependency)
+
+            answer = self._schema.get_answer(dependency)
+            question = self._schema.get_question(answer['parent_id'])
+            block = self._schema.get_block(question['parent_id'])
+
+            if dependency_in_repeating_group and not answer_in_repeating_group:
+                self._questionnaire_store.remove_completed_blocks(group_id=block['parent_id'], block_id=block['id'])
+            else:
+                location = Location(block['parent_id'], group_instance, block['id'])
+                if location in self._questionnaire_store.completed_blocks:
+                    self._questionnaire_store.remove_completed_blocks(location=location)
+
+    def _remove_answer_from_questionnaire_store(self, answer_id):
+        group_instance = self._current_location.group_instance or 0
+        self._answer_store.remove(answer_ids=[answer_id],
+                                  group_instance=group_instance,
+                                  answer_instance=0)
+
+    def _should_save_serialised_answers(self):
+        """Returns `True` if the answer store should be updated with answer values provided by a form's
+        serialise() method rather than those processed by the form object
+        """
+        return self._schema.block_has_question_type(self._current_location.block_id, 'Relationship') or \
+            self._current_location.block_id == 'household-composition'
+
+    def household_answers_changed(self, stripped_form):
+        answer_ids = self._schema.get_answer_ids_for_block('household-composition')
+        household_answers = self._answer_store.filter(answer_ids)
+
+        del stripped_form['csrf_token']
+
+        remove = [k for k in stripped_form if 'action[' in k]
+
+        for k in remove:
+            del stripped_form[k]
+
+        if household_answers.count() != len(stripped_form):
+            return True
+
+        for household_answer in household_answers:
+            answer = self._get_answer_instance_id(household_answer.get('answer_id'), household_answer.get('answer_instance', 0))
+
+            if household_answer and (household_answer['value'] or '') != stripped_form[answer]:
+                return True
+
+        return False
+
+    def remove_repeating_on_household_answers(self):
+        answer_ids = self._schema.get_answer_ids_for_block('household-composition')
+        self._answer_store.remove(answer_ids=answer_ids)
+
+        for answer in self._schema.get_answers_that_repeat_in_block('household-composition'):
+            groups_to_delete = self._schema.get_groups_that_repeat_with_answer_id(answer['id'])
+            for group in groups_to_delete:
+                answer_ids = self._schema.get_answer_ids_for_group(group['id'])
+                self._answer_store.remove(answer_ids=answer_ids)
+                self._questionnaire_store.completed_blocks[:] = [b for b in self._questionnaire_store.completed_blocks if
+                                                                 b.group_id != group['id']]
+
+    def remove_empty_household_members(self):
+        answer_ids = self._schema.get_answer_ids_for_block('household-composition')
+        household_answers = self._answer_store.filter(answer_ids=answer_ids)
+        household_member_name = defaultdict(list)
+        for household_answer in household_answers:
+            if household_answer['answer_id'] == 'first-name' or household_answer['answer_id'] == 'last-name':
+                household_member_name[household_answer['answer_instance']].append(household_answer['value'])
+
+        to_be_removed = []
+        for k, v in household_member_name.items():
+            name_value = ''.join(v).strip()
+            if not name_value:
+                to_be_removed.append(k)
+
+        for instance_to_remove in to_be_removed:
+            self._answer_store.remove(answer_ids=answer_ids, answer_instance=instance_to_remove)
+
+    @staticmethod
+    def _get_answer_instance_id(answer_id, answer_index):
+        return 'household-{}-{}'.format(answer_index, answer_id)

--- a/tests/app/questionnaire/test_answer_store_updater.py
+++ b/tests/app/questionnaire/test_answer_store_updater.py
@@ -1,0 +1,249 @@
+# import unittest
+# from mock import patch, MagicMock
+# from app.data_model.answer_store import Answer, AnswerStore
+# from app.data_model.questionnaire_store import QuestionnaireStore
+# from app.questionnaire.answer_store_updater import AnswerStoreUpdater
+# from app.questionnaire.location import Location
+# from app.questionnaire.questionnaire_schema import QuestionnaireSchema
+#
+#
+# class TestAnswerStoreUpdater(unittest.TestCase):
+#     def setUp(self):
+#         super().setUp()
+#
+#         self.location = Location('group_foo', 0, 'block_bar')
+#         self.schema = MagicMock(spec=QuestionnaireSchema)
+#         self.answer_store = MagicMock(spec=AnswerStore)
+#         self.questionnaire_store = MagicMock(
+#             spec=QuestionnaireStore,
+#             completed_blocks=[],
+#             answer_store=self.answer_store
+#         )
+#         self.answer_store_updater = AnswerStoreUpdater(self.location, self.schema, self.questionnaire_store)
+#
+#     def test_save_form_with_answer_data(self):
+#         self.location.block_id = 'household-composition'
+#
+#         answers = [
+#             Answer(
+#                 group_instance=0,
+#                 answer_id='first-name',
+#                 answer_instance=0,
+#                 value='Joe'
+#             ), Answer(
+#                 group_instance=0,
+#                 answer_id='middle-names',
+#                 answer_instance=0,
+#                 value=''
+#             ), Answer(
+#                 group_instance=0,
+#                 answer_id='last-name',
+#                 answer_instance=0,
+#                 value='Bloggs'
+#             ), Answer(
+#                 group_instance=0,
+#                 answer_id='first-name',
+#                 answer_instance=1,
+#                 value='Bob'
+#             ), Answer(
+#                 group_instance=0,
+#                 answer_id='middle-names',
+#                 answer_instance=1,
+#                 value=''
+#             ), Answer(
+#                 group_instance=0,
+#                 answer_id='last-name',
+#                 answer_instance=1,
+#                 value='Seymour'
+#             )
+#         ]
+#
+#         form = MagicMock()
+#         form.serialise.return_value = answers
+#
+#         self.schema.get_answer_ids_for_block.return_value = [
+#             'first-name',
+#             'middle-names',
+#             'last-name'
+#         ]
+#
+#         self.answer_store_updater.save_form(form)
+#
+#         self.assertEqual(self.questionnaire_store.completed_blocks, [self.location])
+#
+#         self.assertEqual(len(answers), self.answer_store.add_or_update.call_count)
+#
+#         # answers should be passed straight through as Answer objects
+#         answer_calls = map(mock.call, answers)
+#         self.answer_store.add_or_update.assert_has_calls(answer_calls, any_order=True)
+#
+#     def test_save_form_with_form_data(self):
+#         answer_id = 'answer'
+#         answer_value = '1000'
+#         self.schema.get_answer_ids_for_block.return_value = [answer_id]
+#         self.schema.block_has_question_type.return_value = False
+#         self.schema.get_group_dependencies.return_value = None
+#         self.schema.location_requires_group_instance.return_value = None
+#
+#         form = MagicMock(data={answer_id: answer_value})
+#
+#         self.answer_store_updater.save_form(form)
+#
+#         self.assertEqual(self.questionnaire_store.completed_blocks, [self.location])
+#
+#         self.assertEqual(1, self.answer_store.add_or_update.call_count)
+#         created_answer = self.answer_store.add_or_update.call_args[0][0]
+#         self.assertEqual(created_answer.__dict__, {
+#             'group_instance': 0,
+#             'group_instance_id': None,
+#             'answer_id': answer_id,
+#             'answer_instance': 0,
+#             'value': answer_value
+#         })
+#
+#     @patch('app.questionnaire.answer_store_updater.get_group_instance_id', MagicMock(return_value='df24f3e5-7da9-4a91-8c7a-8798caae2f95'))
+#     def test_save_form_stores_specific_group(self):
+#         answer_id = 'answer'
+#         answer_value = '1000'
+#         self.location.group_instance = 1
+#         self.schema.get_answer_ids_for_block.return_value = [answer_id]
+#         self.schema.block_has_question_type.return_value = False
+#         self.schema.get_group_dependencies.return_value = None
+#
+#         form = MagicMock(data={answer_id: answer_value})
+#
+#         # @patch('')
+#         self.answer_store_updater.save_form(form)
+#
+#         self.assertEqual(self.questionnaire_store.completed_blocks, [self.location])
+#
+#         self.assertEqual(1, self.answer_store.add_or_update.call_count)
+#         created_answer = self.answer_store.add_or_update.call_args[0][0]
+#         self.assertEqual(created_answer.__dict__, {
+#             'group_instance': self.location.group_instance,
+#             'group_instance_id': 'df24f3e5-7da9-4a91-8c7a-8798caae2f95',
+#             'answer_id': answer_id,
+#             'answer_instance': 0,
+#             'value': answer_value
+#         })
+#
+#     def test_save_form_data_with_default_value(self):
+#         answer_id = 'answer'
+#         default_value = 0
+#         self.schema.get_answer_ids_for_block.return_value = [answer_id]
+#         self.schema.get_answer.return_value = {'default': default_value}
+#         self.schema.block_has_question_type.return_value = False
+#         self.schema.location_requires_group_instance.return_value = False
+#
+#         # No answer given so will use schema defined default
+#         form_data = {
+#             answer_id: None
+#         }
+#         form = MagicMock(data=form_data)
+#
+#         self.answer_store_updater.save_form(form)
+#
+#         self.assertEqual(self.questionnaire_store.completed_blocks, [self.location])
+#
+#         self.assertEqual(1, self.answer_store.add_or_update.call_count)
+#         created_answer = self.answer_store.add_or_update.call_args[0][0]
+#         self.assertEqual(created_answer.__dict__, {
+#             'group_instance': 0,
+#             'group_instance_id': None,
+#             'answer_id': answer_id,
+#             'answer_instance': 0,
+#             'value': default_value
+#         })
+#
+#
+# class TestAnswerStoreUpdaterDependencies(unittest.TestCase):
+#     def setUp(self):
+#         super().setUp()
+#
+#         self.schema = MagicMock(
+#             spec=QuestionnaireSchema,
+#             get_answer=MagicMock(),
+#             get_question=MagicMock(),
+#             get_block=MagicMock(),
+#             get_group=MagicMock(),
+#         )
+#         self.answer_store = MagicMock(spec=AnswerStore)
+#         self.questionnaire_store = MagicMock(
+#             spec=QuestionnaireStore,
+#             completed_blocks=[],
+#             answer_store=self.answer_store,
+#         )
+#
+#     def test_save_form_removes_completed_block_for_dependencies(self):
+#         parent_id, dependent_answer_id = 'parent_answer', 'dependent_answer'
+#         parent_location = Location('group', 0, 'min-block')
+#         dependent_location = Location('group', 0, 'dependent-block')
+#
+#         self.questionnaire_store.completed_blocks = [parent_location, dependent_location]
+#         self.schema.block_has_question_type.return_value = False
+#         self.schema.get_answer_ids_for_block.return_value = [parent_id]
+#         self.schema._answer_dependencies = {parent_id: [dependent_answer_id]}
+#         self.schema.get_block.return_value = {'id': dependent_location.block_id, 'parent_id': dependent_location.group_id}
+#
+#         # rotate the hash every time get_hash() is called to simulate the stored answer changing
+#         self.answer_store.get_hash.side_effect = ['first_hash', 'second_hash']
+#
+#         form = MagicMock(data={parent_id: '10'})
+#
+#         answer_store_updater = AnswerStoreUpdater(parent_location, self.schema, self.questionnaire_store)
+#         answer_store_updater.save_form(form)
+#
+#         self.questionnaire_store.remove_completed_blocks.assert_called_with(location=dependent_location)
+#
+#         self.assertEqual(1, self.answer_store.add_or_update.call_count)
+#         created_answer = self.answer_store.add_or_update.call_args[0][0]
+#         self.assertEqual(created_answer.__dict__, {
+#             'group_instance': 0,
+#             'answer_id': parent_id,
+#             'answer_instance': 0,
+#             'value': '10'
+#         })
+#
+#         self.assertFalse(self.answer_store.remove.called)
+#
+#     def test_save_form_removes_completed_block_for_dependencies_repeating(self):
+#         """
+#         Tests that all dependent completed blocks are removed across all repeating groups when
+#         parent answer is not in a repeating group
+#         """
+#         parent_id, dependent_answer_id = 'parent_answer', 'dependent_answer'
+#         parent_location = Location('group', 0, 'min-block')
+#         dependent_location = Location('group', 0, 'dependent-block')
+#
+#         self.questionnaire_store.completed_blocks = [parent_location, dependent_location]
+#
+#         self.schema.get_answer_ids_for_block.return_value = [parent_id]
+#         self.schema.dependencies = {parent_id: [dependent_answer_id]}
+#         self.schema.get_block.return_value = {'id': dependent_location.block_id, 'parent_id': dependent_location.group_id}
+#
+#         # the dependent answer is in a repeating group, the parent is not
+#         self.schema.answer_is_in_repeating_group = lambda _answer_id: _answer_id == dependent_answer_id
+#
+#         # rotate the hash every time get_hash() is called to simulate the stored answer changing
+#         self.answer_store.get_hash.side_effect = ['first_hash', 'second_hash']
+#
+#         form = MagicMock(data={parent_id: '10'})
+#
+#         answer_store_updater = AnswerStoreUpdater(parent_location, self.schema, self.questionnaire_store)
+#         answer_store_updater.save_form(form)
+#
+#         self.questionnaire_store.remove_completed_blocks.assert_called_with(
+#             group_id=dependent_location.group_id,
+#             block_id=dependent_location.block_id
+#         )
+#
+#         self.assertEqual(1, self.answer_store.add_or_update.call_count)
+#         created_answer = self.answer_store.add_or_update.call_args[0][0]
+#         self.assertEqual(created_answer.__dict__, {
+#             'group_instance': 0,
+#             'answer_id': parent_id,
+#             'answer_instance': 0,
+#             'value': '10'
+#         })
+#
+#         self.assertFalse(self.answer_store.remove.called)


### PR DESCRIPTION
### What is the context of this PR?
Introduced a new component to handle logic around what happens when the answer store gets updated. I'm hoping this:

- Makes the code more understandable
- Better defines the responsibilities of this object
- Provides a component that can be better tested as a single unit
- Allows a few of the schema-specific integration tests to be removed

Since David's initial additions, I have moved household action from the `questionnaire` view into the `AnswerStoreUpdater` also. I've kept the original commits so you can compare.

### How to review 
- All tests should pass
- Code coverage should not reduce
- No changes to functionality
