### PR TITLE
Document Jinja filter schema usage

### DIFF
--- a/app/jinja_filters.py
+++ b/app/jinja_filters.py
@@ -43,34 +43,25 @@ def get_currency_symbol(currency='GBP'):
 
 
 @blueprint.app_template_filter()
-def format_currency_for_input(value, decimal_places=0):
-    if value is None or value == '':
-        return ''
-    if decimal_places is None or decimal_places == 0:
-        return format_number(value)
-    return get_formatted_currency(value).replace(get_currency_symbol(), '')
-
-
-@blueprint.app_template_filter()
 def format_percentage(value):
     return '{}%'.format(value)
 
 
 @blueprint.app_template_filter()
-def format_address_list(user_entered_address=None, metadata_address=None):
+def format_address_list(first_address=None, second_address=None):
     """
-        This function format_address_list accepts two addresses, a user submitted address and a metadata address
-        If all the items in address list are 'Undefined' (nothing in answer_store) then we retrieve the metadata.
+        The function format_address_list accepts two lists of address values.
+        If all the items in the first address list are empty or 'Undefined' then we use the second address.
 
-        :param user_entered_address user entered address which is a list of answer fields
-        :param metadata_address metadata address which is a list of answer fields passed to us
-        :return: the value of the address to be piped
+        :param (list) first_address
+        :param (list) second_address
+        :return: first address if values present else second address
     """
-    if all(isinstance(field, Undefined) for field in user_entered_address) or \
-       all(field == '' for field in user_entered_address):
-        address = metadata_address
+    if all(isinstance(field, Undefined) for field in first_address) or \
+       all(field == '' for field in first_address):
+        address = second_address
     else:
-        address = user_entered_address
+        address = first_address
 
     address_list = concatenated_list(list_items=address, delimiter='<br />')
 
@@ -339,13 +330,13 @@ def first_non_empty_item(context, *items):
 
 
 @blueprint.app_template_filter()
-def format_household_member_name(names):
+def format_household_name(names):
     return concatenated_list(list_items=names, delimiter=' ')
 
 
 @blueprint.app_template_filter()
-def format_household_member_name_possessive(names):
-    name = format_household_member_name(names)
+def format_household_name_possessive(names):
+    name = format_household_name(names)
     if name:
         last_char = name[-1:]
         if last_char.lower() == 's':
@@ -404,7 +395,7 @@ def format_household_summary(context, names):
     if names:
         person_list = []
         for first_name, middle_name, last_name in zip(names[0], names[1], names[2]):
-            person_list.append(format_household_member_name([first_name, middle_name, last_name]))
+            person_list.append(format_household_name([first_name, middle_name, last_name]))
 
         return format_unordered_list(context, [person_list])
     return ''
@@ -547,11 +538,6 @@ def format_currency_processor():
 @blueprint.app_context_processor
 def get_currency_symbol_processor():
     return dict(get_currency_symbol=get_currency_symbol)
-
-
-@blueprint.app_context_processor
-def format_currency_for_input_processor():
-    return dict(format_currency_for_input=format_currency_for_input)
 
 
 @blueprint.app_context_processor

--- a/app/templating/template_renderer.py
+++ b/app/templating/template_renderer.py
@@ -15,8 +15,8 @@ class TemplateRenderer:
         env.filters['concatenated_list'] = filters.concatenated_list
         env.filters['format_date'] = filters.format_date
         env.filters['format_date_custom'] = filters.format_date_custom
-        env.filters['format_household_name'] = filters.format_household_member_name
-        env.filters['format_household_name_possessive'] = filters.format_household_member_name_possessive
+        env.filters['format_household_name'] = filters.format_household_name
+        env.filters['format_household_name_possessive'] = filters.format_household_name_possessive
         env.filters['format_household_summary'] = filters.format_household_summary
         env.filters['format_number'] = filters.format_number
         env.filters['format_repeating_summary'] = filters.format_repeating_summary

--- a/data/en/lms_1.json
+++ b/data/en/lms_1.json
@@ -109,44 +109,41 @@
                                 "title": "What type of address is it?",
                                 "type": "General",
                                 "answers": [{
-                                        "id": "address-type-check-answer",
-                                        "mandatory": false,
-                                        "type": "Radio",
-                                        "options": [{
-                                                "label": "A previous address from which mail has been redirected",
-                                                "value": "A previous address from which mail has been redirected"
-                                            },
-                                            {
-                                                "label": "My second or holiday home",
-                                                "value": "My second or holiday home"
-                                            },
-                                            {
-                                                "label": "A business or non-residential address",
-                                                "value": "A business or non-residential address"
-                                            },
-                                            {
-                                                "label": "A communal establishment",
-                                                "value": "A communal establishment"
-                                            },
-                                            {
-                                                "label": "The address above is not on your letter",
-                                                "value": "The address above is not on your letter"
-                                            },
-                                            {
-                                                "label": "Other",
-                                                "value": "Other",
-                                                "child_answer_id": "address-type-check-answer-other"
+                                    "id": "address-type-check-answer",
+                                    "mandatory": false,
+                                    "type": "Radio",
+                                    "options": [{
+                                            "label": "A previous address from which mail has been redirected",
+                                            "value": "A previous address from which mail has been redirected"
+                                        },
+                                        {
+                                            "label": "My second or holiday home",
+                                            "value": "My second or holiday home"
+                                        },
+                                        {
+                                            "label": "A business or non-residential address",
+                                            "value": "A business or non-residential address"
+                                        },
+                                        {
+                                            "label": "A communal establishment",
+                                            "value": "A communal establishment"
+                                        },
+                                        {
+                                            "label": "The address above is not on your letter",
+                                            "value": "The address above is not on your letter"
+                                        },
+                                        {
+                                            "label": "Other",
+                                            "value": "Other",
+                                            "detail_answer": {
+                                                "id": "address-type-check-answer-other",
+                                                "type": "TextField",
+                                                "mandatory": false,
+                                                "label": "Please describe"
                                             }
-                                        ]
-                                    },
-                                    {
-                                        "id": "address-type-check-answer-other",
-                                        "parent_answer_id": "address-type-check-answer",
-                                        "type": "TextField",
-                                        "mandatory": false,
-                                        "label": "Please describe"
-                                    }
-                                ]
+                                        }
+                                    ]
+                                }]
                             }],
                             "routing_rules": [{
                                 "goto": {
@@ -644,44 +641,41 @@
                                 }
                             ],
                             "answers": [{
-                                    "id": "nationality-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "British",
-                                            "value": "British"
-                                        },
-                                        {
-                                            "label": "Irish",
-                                            "value": "Irish"
-                                        },
-                                        {
-                                            "label": "Indian",
-                                            "value": "Indian"
-                                        },
-                                        {
-                                            "label": "Pakistani",
-                                            "value": "Pakistani"
-                                        },
-                                        {
-                                            "label": "Polish",
-                                            "value": "Polish"
-                                        },
-                                        {
-                                            "label": "Other",
-                                            "value": "Other",
-                                            "child_answer_id": "nationality-answer-other"
+                                "id": "nationality-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "British",
+                                        "value": "British"
+                                    },
+                                    {
+                                        "label": "Irish",
+                                        "value": "Irish"
+                                    },
+                                    {
+                                        "label": "Indian",
+                                        "value": "Indian"
+                                    },
+                                    {
+                                        "label": "Pakistani",
+                                        "value": "Pakistani"
+                                    },
+                                    {
+                                        "label": "Polish",
+                                        "value": "Polish"
+                                    },
+                                    {
+                                        "label": "Other",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "nationality-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please enter nationality"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "nationality-answer-other",
-                                    "parent_answer_id": "nationality-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter nationality"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }],
                         "routing_rules": [{
                             "goto": {
@@ -708,60 +702,57 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "country-of-birth-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "England",
-                                            "value": "England"
-                                        },
-                                        {
-                                            "label": "Wales",
-                                            "value": "Wales"
-                                        },
-                                        {
-                                            "label": "Scotland",
-                                            "value": "Scotland"
-                                        },
-                                        {
-                                            "label": "Northern Ireland",
-                                            "value": "Northern Ireland"
-                                        },
-                                        {
-                                            "label": "Republic of Ireland",
-                                            "value": "Republic of Ireland"
-                                        },
-                                        {
-                                            "label": "Isle of Man or Channel Islands",
-                                            "value": "Isle of Man or Channel Islands"
-                                        },
-                                        {
-                                            "label": "India",
-                                            "value": "India"
-                                        },
-                                        {
-                                            "label": "Pakistan",
-                                            "value": "Pakistan"
-                                        },
-                                        {
-                                            "label": "Poland",
-                                            "value": "Poland"
-                                        },
-                                        {
-                                            "label": "Other",
-                                            "value": "Other",
-                                            "child_answer_id": "country-of-birth-answer-other"
+                                "id": "country-of-birth-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "England",
+                                        "value": "England"
+                                    },
+                                    {
+                                        "label": "Wales",
+                                        "value": "Wales"
+                                    },
+                                    {
+                                        "label": "Scotland",
+                                        "value": "Scotland"
+                                    },
+                                    {
+                                        "label": "Northern Ireland",
+                                        "value": "Northern Ireland"
+                                    },
+                                    {
+                                        "label": "Republic of Ireland",
+                                        "value": "Republic of Ireland"
+                                    },
+                                    {
+                                        "label": "Isle of Man or Channel Islands",
+                                        "value": "Isle of Man or Channel Islands"
+                                    },
+                                    {
+                                        "label": "India",
+                                        "value": "India"
+                                    },
+                                    {
+                                        "label": "Pakistan",
+                                        "value": "Pakistan"
+                                    },
+                                    {
+                                        "label": "Poland",
+                                        "value": "Poland"
+                                    },
+                                    {
+                                        "label": "Other",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "country-of-birth-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please enter country of birth"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "country-of-birth-answer-other",
-                                    "parent_answer_id": "country-of-birth-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter country of birth"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -1329,44 +1320,41 @@
                                 ],
                                 "type": "General",
                                 "answers": [{
-                                        "id": "national-identity-england-answer",
-                                        "mandatory": false,
-                                        "type": "Checkbox",
-                                        "options": [{
-                                                "label": "English",
-                                                "value": "English"
-                                            },
-                                            {
-                                                "label": "Welsh",
-                                                "value": "Welsh"
-                                            },
-                                            {
-                                                "label": "Scottish",
-                                                "value": "Scottish"
-                                            },
-                                            {
-                                                "label": "Northern Irish",
-                                                "value": "Northern Irish"
-                                            },
-                                            {
-                                                "label": "British",
-                                                "value": "British"
-                                            },
-                                            {
-                                                "label": "Other",
-                                                "value": "Other",
-                                                "child_answer_id": "national-identity-england-answer-other"
+                                    "id": "national-identity-england-answer",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "options": [{
+                                            "label": "English",
+                                            "value": "English"
+                                        },
+                                        {
+                                            "label": "Welsh",
+                                            "value": "Welsh"
+                                        },
+                                        {
+                                            "label": "Scottish",
+                                            "value": "Scottish"
+                                        },
+                                        {
+                                            "label": "Northern Irish",
+                                            "value": "Northern Irish"
+                                        },
+                                        {
+                                            "label": "British",
+                                            "value": "British"
+                                        },
+                                        {
+                                            "label": "Other",
+                                            "value": "Other",
+                                            "detail_answer": {
+                                                "id": "national-identity-england-answer-other",
+                                                "type": "TextField",
+                                                "mandatory": false,
+                                                "label": "Please enter national identity"
                                             }
-                                        ]
-                                    },
-                                    {
-                                        "id": "national-identity-england-answer-other",
-                                        "parent_answer_id": "national-identity-england-answer",
-                                        "type": "TextField",
-                                        "mandatory": false,
-                                        "label": "Please enter national identity"
-                                    }
-                                ],
+                                        }
+                                    ]
+                                }],
                                 "skip_conditions": [{
                                     "when": [{
                                         "meta": "country",
@@ -1391,44 +1379,41 @@
                                 ],
                                 "type": "General",
                                 "answers": [{
-                                        "id": "national-identity-wales-answer",
-                                        "mandatory": false,
-                                        "type": "Checkbox",
-                                        "options": [{
-                                                "label": "Welsh",
-                                                "value": "Welsh"
-                                            },
-                                            {
-                                                "label": "English",
-                                                "value": "English"
-                                            },
-                                            {
-                                                "label": "Scottish",
-                                                "value": "Scottish"
-                                            },
-                                            {
-                                                "label": "Northern Irish",
-                                                "value": "Northern Irish"
-                                            },
-                                            {
-                                                "label": "British",
-                                                "value": "British"
-                                            },
-                                            {
-                                                "label": "Other",
-                                                "value": "Other",
-                                                "child_answer_id": "national-identity-wales-answer-other"
+                                    "id": "national-identity-wales-answer",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "options": [{
+                                            "label": "Welsh",
+                                            "value": "Welsh"
+                                        },
+                                        {
+                                            "label": "English",
+                                            "value": "English"
+                                        },
+                                        {
+                                            "label": "Scottish",
+                                            "value": "Scottish"
+                                        },
+                                        {
+                                            "label": "Northern Irish",
+                                            "value": "Northern Irish"
+                                        },
+                                        {
+                                            "label": "British",
+                                            "value": "British"
+                                        },
+                                        {
+                                            "label": "Other",
+                                            "value": "Other",
+                                            "detail_answer": {
+                                                "id": "national-identity-wales-answer-other",
+                                                "type": "TextField",
+                                                "mandatory": false,
+                                                "label": "Please enter national identity"
                                             }
-                                        ]
-                                    },
-                                    {
-                                        "id": "national-identity-wales-answer-other",
-                                        "parent_answer_id": "national-identity-wales-answer",
-                                        "type": "TextField",
-                                        "mandatory": false,
-                                        "label": "Please enter national identity"
-                                    }
-                                ],
+                                        }
+                                    ]
+                                }],
                                 "skip_conditions": [{
                                     "when": [{
                                         "meta": "country",
@@ -1690,36 +1675,33 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "white-ethnic-group-answer",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "English, Welsh, Scottish, Northern Irish or British",
-                                            "value": "English, Welsh, Scottish, Northern Irish or British"
-                                        },
-                                        {
-                                            "label": "Irish",
-                                            "value": "Irish"
-                                        },
-                                        {
-                                            "label": "Gypsy or Irish Traveller",
-                                            "value": "Gypsy or Irish Traveller"
-                                        },
-                                        {
-                                            "label": "Any other White background",
-                                            "value": "Other",
-                                            "child_answer_id": "white-ethnic-group-answer-other"
+                                "id": "white-ethnic-group-answer",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "English, Welsh, Scottish, Northern Irish or British",
+                                        "value": "English, Welsh, Scottish, Northern Irish or British"
+                                    },
+                                    {
+                                        "label": "Irish",
+                                        "value": "Irish"
+                                    },
+                                    {
+                                        "label": "Gypsy or Irish Traveller",
+                                        "value": "Gypsy or Irish Traveller"
+                                    },
+                                    {
+                                        "label": "Any other White background",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "white-ethnic-group-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please enter ethnic background"
                                         }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "white-ethnic-group-answer-other",
-                                    "parent_answer_id": "white-ethnic-group-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter ethnic background"
-                                }
-                            ]
+                                    }
+                                ],
+                                "type": "Radio"
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -1762,36 +1744,33 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "mixed-ethnic-group-answer",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "White and Black Caribbean",
-                                            "value": "White and Black Caribbean"
-                                        },
-                                        {
-                                            "label": "White and Black African",
-                                            "value": "White and Black African"
-                                        },
-                                        {
-                                            "label": "White and Asian",
-                                            "value": "White and Asian"
-                                        },
-                                        {
-                                            "label": "Any other Mixed or multiple ethnic background",
-                                            "value": "Other",
-                                            "child_answer_id": "mixed-ethnic-group-answer-other"
+                                "id": "mixed-ethnic-group-answer",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "White and Black Caribbean",
+                                        "value": "White and Black Caribbean"
+                                    },
+                                    {
+                                        "label": "White and Black African",
+                                        "value": "White and Black African"
+                                    },
+                                    {
+                                        "label": "White and Asian",
+                                        "value": "White and Asian"
+                                    },
+                                    {
+                                        "label": "Any other Mixed or multiple ethnic background",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "mixed-ethnic-group-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please enter ethnic background"
                                         }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "mixed-ethnic-group-answer-other",
-                                    "parent_answer_id": "mixed-ethnic-group-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter ethnic background"
-                                }
-                            ]
+                                    }
+                                ],
+                                "type": "Radio"
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -1834,40 +1813,37 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "asian-ethnic-group-answer",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "Indian",
-                                            "value": "Indian"
-                                        },
-                                        {
-                                            "label": "Pakistani",
-                                            "value": "Pakistani"
-                                        },
-                                        {
-                                            "label": "Bangladeshi",
-                                            "value": "Bangladeshi"
-                                        },
-                                        {
-                                            "label": "Chinese",
-                                            "value": "Chinese"
-                                        },
-                                        {
-                                            "label": "Any other Asian background",
-                                            "value": "Other",
-                                            "child_answer_id": "asian-ethnic-group-answer-other"
+                                "id": "asian-ethnic-group-answer",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "Indian",
+                                        "value": "Indian"
+                                    },
+                                    {
+                                        "label": "Pakistani",
+                                        "value": "Pakistani"
+                                    },
+                                    {
+                                        "label": "Bangladeshi",
+                                        "value": "Bangladeshi"
+                                    },
+                                    {
+                                        "label": "Chinese",
+                                        "value": "Chinese"
+                                    },
+                                    {
+                                        "label": "Any other Asian background",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "asian-ethnic-group-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please enter ethnic background"
                                         }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "asian-ethnic-group-answer-other",
-                                    "parent_answer_id": "asian-ethnic-group-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter ethnic background"
-                                }
-                            ]
+                                    }
+                                ],
+                                "type": "Radio"
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -1910,32 +1886,29 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "black-ethnic-group-answer",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "African",
-                                            "value": "African"
-                                        },
-                                        {
-                                            "label": "Caribbean",
-                                            "value": "Caribbean"
-                                        },
-                                        {
-                                            "label": "Any other Black, African or Caribbean background",
-                                            "value": "Other",
-                                            "child_answer_id": "black-ethnic-group-answer-other"
+                                "id": "black-ethnic-group-answer",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "African",
+                                        "value": "African"
+                                    },
+                                    {
+                                        "label": "Caribbean",
+                                        "value": "Caribbean"
+                                    },
+                                    {
+                                        "label": "Any other Black, African or Caribbean background",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "black-ethnic-group-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please enter ethnic background"
                                         }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "black-ethnic-group-answer-other",
-                                    "parent_answer_id": "black-ethnic-group-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter ethnic background"
-                                }
-                            ]
+                                    }
+                                ],
+                                "type": "Radio"
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -1978,28 +1951,25 @@
                             ],
                             "type": "General",
                             "answers": [{
-                                    "id": "other-ethnic-group-answer",
-                                    "mandatory": false,
-                                    "options": [{
-                                            "label": "Arab",
-                                            "value": "Arab"
-                                        },
-                                        {
-                                            "label": "Any other ethnic group",
-                                            "value": "Other",
-                                            "child_answer_id": "other-ethnic-group-answer-other"
+                                "id": "other-ethnic-group-answer",
+                                "mandatory": false,
+                                "options": [{
+                                        "label": "Arab",
+                                        "value": "Arab"
+                                    },
+                                    {
+                                        "label": "Any other ethnic group",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "other-ethnic-group-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please enter ethnic background"
                                         }
-                                    ],
-                                    "type": "Radio"
-                                },
-                                {
-                                    "id": "other-ethnic-group-answer-other",
-                                    "parent_answer_id": "other-ethnic-group-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter ethnic background"
-                                }
-                            ]
+                                    }
+                                ],
+                                "type": "Radio"
+                            }]
                         }],
                         "routing_rules": [{
                                 "goto": {
@@ -2043,53 +2013,50 @@
                             "description": "",
                             "type": "General",
                             "answers": [{
-                                    "id": "religion-answer",
-                                    "mandatory": false,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "No religion",
-                                            "value": "No religion"
-                                        },
-                                        {
-                                            "label": "Christian",
-                                            "value": "Christian",
-                                            "description": "Including Church of England, Catholic, Protestant and other Christian denominations"
-                                        },
-                                        {
-                                            "label": "Buddhist",
-                                            "value": "Buddhist"
-                                        },
-                                        {
-                                            "label": "Hindu",
-                                            "value": "Hindu"
-                                        },
-                                        {
-                                            "label": "Jewish",
-                                            "value": "Jewish"
-                                        },
-                                        {
-                                            "label": "Muslim",
-                                            "value": "Muslim"
-                                        },
-                                        {
-                                            "label": "Sikh",
-                                            "value": "Sikh"
-                                        },
-                                        {
-                                            "label": "Other religion",
-                                            "value": "Other",
-                                            "child_answer_id": "religion-answer-other"
+                                "id": "religion-answer",
+                                "mandatory": false,
+                                "type": "Radio",
+                                "options": [{
+                                        "label": "No religion",
+                                        "value": "No religion"
+                                    },
+                                    {
+                                        "label": "Christian",
+                                        "value": "Christian",
+                                        "description": "Including Church of England, Catholic, Protestant and other Christian denominations"
+                                    },
+                                    {
+                                        "label": "Buddhist",
+                                        "value": "Buddhist"
+                                    },
+                                    {
+                                        "label": "Hindu",
+                                        "value": "Hindu"
+                                    },
+                                    {
+                                        "label": "Jewish",
+                                        "value": "Jewish"
+                                    },
+                                    {
+                                        "label": "Muslim",
+                                        "value": "Muslim"
+                                    },
+                                    {
+                                        "label": "Sikh",
+                                        "value": "Sikh"
+                                    },
+                                    {
+                                        "label": "Other religion",
+                                        "value": "Other",
+                                        "detail_answer": {
+                                            "id": "religion-answer-other",
+                                            "type": "TextField",
+                                            "mandatory": false,
+                                            "label": "Please enter religion"
                                         }
-                                    ]
-                                },
-                                {
-                                    "id": "religion-answer-other",
-                                    "parent_answer_id": "religion-answer",
-                                    "type": "TextField",
-                                    "mandatory": false,
-                                    "label": "Please enter religion"
-                                }
-                            ]
+                                    }
+                                ]
+                            }]
                         }],
                         "routing_rules": [{
                             "goto": {

--- a/doc/jinja-filters.md
+++ b/doc/jinja-filters.md
@@ -1,0 +1,446 @@
+# Jinja Filters Used by Schemas
+
+
+## format_number
+Returns the given number with the appropriate thousands grouping and decimal separator as determined by the locale.
+Uses Babel's [format_decimal](http://babel.pocoo.org/en/latest/api/numbers.html#babel.numbers.format_decimal) from `number.py`.
+
+##### Parameters: 
+- value: A single numeric value.
+
+##### Context:
+Most commonly used to display a previous answer's numeric value in a following question.
+```
+Of the <em>{{answers['total-number-employees']|format_number}}</em> total employees employed on 14 December 2018, how many male and female employees worked the following hours?
+```
+
+##### Examples:
+```
+Input:          Output:
+"100000000"     "100,000,000"
+"123.40"        "123.4"
+```
+
+## format_currency
+Returns a formatted currency value. 
+Uses Babel's [format_currency](http://babel.pocoo.org/en/latest/api/numbers.html#babel.numbers.format_currency) from `number.py`.
+
+##### Parameters: 
+- value:    A single numeric value.
+- currency: An optional currency in format 'GBP' (default), 'EUR' etc.
+
+##### Context:
+Most commonly used to display a previous answer's currency value in a following question.
+```
+Of the <em>{{format_currency(answers['total-retail-turnover-answer'])}}</em> total retail turnover, what was the value of internet sales?
+```
+
+##### Examples:
+```
+Input:              Output:
+("11.99", "GBP")    "<span class='date'>£11.99</span>"
+("11000", "USD")    "<span class='date'>US$11,000.00</span>"
+```
+
+## format_address_list
+This accepts two lists of address values.
+If all the items in the first address list are empty or 'undefined' then we use the second address.
+
+##### Parameters: 
+- first_address:    List of address values
+- second_address:   List of address values
+
+##### Context:
+Used to display a full address for use in a description. 
+Used where there is potential that a respondent may provide a new address. 
+Therefore it will use that respondent entered address if present otherwise the initial address passed as metadata.
+```
+{{ format_address_list ([answers['address-line1'], answers['address-line2'], answers['locality'], answers['town-name'], answers['postcode']], [metadata['address_line1'], metadata['address_line2'], metadata['locality'], metadata['town_name'], metadata['postcode']]) }}
+```
+
+##### Examples:
+```
+first_address = ["44", "High Stret", "", "Big City", ""]
+second_address = ["123", "Testy", "Place", "Newport", "NP5 7AR"]
+
+Input:                              Output:
+(first_address, second_address)     "44<br />High Street<br />Big City"
+
+first_address = [Undefined(), Undefined(), Undefined()]
+second_address = ["123", "Testy", "Place", "Newport", "NP5 7AR"]
+
+Input:                              Output:
+(first_address, second_address)     "123<br />Testy<br />Place<br />Newport<br />NP5 7AR",
+```
+
+
+## get_current_date
+Returns the current date.
+
+##### Parameters: 
+- N/A
+
+##### Context:
+No real usage but a single question in Census currently only for test purposes.
+```
+The number of visitors staying in the household on {{ get_current_date() }}
+```
+
+##### Example:
+```
+Output:
+<span class='date'>27 December 2018</span>
+```
+
+## format_date
+Formats a date string, which can be in the format "YYYY-MM-DD", "YYYY-MM" or "YYYY".
+The output will be of the form "d MMMM YYYY", "MMMM YYYY" or "YYYY" depending on value passed.
+If the value is not a string it will just return the initial value.
+Uses Babel's [format_date](http://babel.pocoo.org/en/latest/api/dates.html#babel.dates.format_date).
+
+##### Parameters: 
+- value:    String value representing a datetime. Allowable formats "YYYY-MM-DD", "YYYY-MM" or "YYYY".
+
+##### Context:
+Used when a date is used in a question.
+```
+Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?
+```
+
+##### Examples:
+```
+Input:          Output:
+"2019-01-01"    "<span class='date'>1 January 2019</span>"
+"2019-01"       "<span class='date'>January 2019</span>"
+"2019"          "<span class='date'>2019</span>"
+```
+
+
+## format_date_custom
+Returns a date in a defined format. In most cases in order to include the day of the week.
+Uses Babel's [format_datetime](http://babel.pocoo.org/en/latest/api/dates.html#babel.dates.format_datetime).
+
+##### Parameters: 
+- value:        String value representing a datetime. Allowable formats "YYYY-MM-DD".
+- date_format:  Format of the date to return. Default 'EEEE d MMMM YYYY'
+
+##### Context:
+Used in LMS for both Questions and Options in order to add day of week to a date. 
+Often combined with `calculate_offset_from_weekday_in_last_whole_week` filter.
+```
+Did you have a paid job, either as an employee or self-employed, in the week {{ calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}) | format_date_custom( 'EEEE d MMMM YYYY' ) }} to {{ calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU') | format_date_custom( 'EEEE d MMMM YYYY' ) }}
+ 
+As an option:
+{{calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'MO') | format_date_custom('EEEE dd MMMM') }}
+```
+
+##### Examples:
+```
+Input:                              Output:
+("2018-08-14", "EEEE d MMMM YYYY")  "<span class='date'>Tuesday 14 August 2018</span>"
+("2018-08-14", "EEEE d MMMM")       "<span class='date'>Tuesday 14 August</span>"
+("2018-08-14", "EEEE d")            "<span class='date'>Tuesday 14</span>"
+("2018-08-14", "d MMMM YYYY")       "<span class='date'>14 August 2018</span>"
+```
+
+## format_conditional_date
+This is to be used when passing multiple dates as multiple arguments. It will return the first valid date formatted.
+
+##### Parameters: 
+- *dates:   Multiple date values
+
+##### Context:
+Used when you have a list of dates where only one is to be displayed in a priority order. 
+The most common use is when a respondent has the option to report for different dates other than the passed metadata period.
+If the respondent therefore enters a new reporting period then those dates would be displayed rather than the metadata period.
+```
+For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s <em>total retail turnover</em>?
+```
+
+##### Examples:
+```
+Input:                              Output:
+("2016-01-13", "2018-12-30")        "<span class='date'>13 January 2016</span>"
+("2016-01-13", None)                "<span class='date'>13 January 2016</span>"
+(None, "2018-12-30")                "<span class='date'>30 December 2018</span>"
+```
+
+## calculate_offset_from_weekday_in_last_whole_week
+Offsets a date from a particular day of the week in the previous week. 
+Intended to be used to generate reference date ranges around a particular date
+The offsets will always be based on one day of the week in the previous Mon-Sun
+
+##### Parameters: 
+- input_datetime:   The datetime (or date) to offset. Defaults to today's date.
+- offset:           Dictionary of the number of days, weeks, or years to offset by as integer values
+- day_of_week:      The day of the previous week to offset from (two letter abbreviation). Default 'MO'
+
+##### Context:
+Used in LMS for both Questions and Options. 
+Used for LMS as they would like reference dates that are more relevant to time you're filling in the survey.
+Often combined with `format_date_custom` filter.
+```
+If you had been offered a job in the week starting {{ calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}) | format_date_custom( 'EEEE d MMMM' ) }} would you be able to start before {{ calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {'weeks':2}) | format_date_custom( 'EEEE d MMMM' ) }}?
+
+As an option:
+{{calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'MO') | format_date_custom('EEEE dd MMMM') }}
+```
+
+##### Examples:
+```
+Input:                              Output:
+("2018-08-10", {}, "SU")            "2018-08-05"  # Friday outputs previous Sunday
+("2018-08-10", {}, "FR")            "2018-08-03"  # Friday outputs previous Friday
+("2018-08-10", {"years": 1}, "FR")  "2019-08-03"  # Friday outputs previous Friday + 1 year
+
+("2018-08-05", {}, "SU")            "2018-07-29"  # Sunday outputs previous Sunday (Must be a full week)
+("2018-08-05", {"weeks": 1}, "SU")  "2018-08-05"  # Previous Sunday with +1 week offset
+
+("2018-08-06", {}, "SU")            "2018-08-05"  # Monday outputs previous Sunday
+("2018-08-06", {"days": -1}, "SU")  "2018-08-04"  # Previous Sunday with -1 day offset
+```
+
+## calculate_years_difference
+Returns a difference in years between two dates.
+
+##### Parameters: 
+- from_str: datetime string of earliest date.
+- to_str:   datetime string of later date. If set to 'now' will use today's date.
+
+##### Context:
+Used in Census to work out a person's age from a given date of birth:
+```
+You are {{ calculate_years_difference (answers['date-of-birth-answer'][group_instance], 'now') }} old. Is this correct?
+
+As an option:
+Yes, I am {{ calculate_years_difference (answers['date-of-birth-answer'][group_instance], 'now') }} old
+```
+
+##### Examples:
+```
+Input:                          Output:
+("2017-01-30", "2018-01-30')    "1 year"
+("2015-02-02", "2018-02-01")    "2 years"
+("2016-02-29", "2017-02-28")    "1 year"
+("2016-02-29", "2020-02-28")    "3 years"
+```
+
+## format_date_range_no_repeated_month_year
+Format a date range, ensuring months and years are not repeated.
+If the dates are in the same year, the first year (YYYY) will be removed.
+If the dates are in the same month and year, the first year (YYYY) and month will be removed.
+
+##### Parameters: 
+- start_date:   Initial date in range.
+- end_date:     Final date in range.
+- date_format:  Format to return date in. Default is 'd MMMM YYYY'.
+
+##### Context:
+Used in LMS to simplify dates when often they are only a week apart.
+```
+Did you have a paid job, either as an employee or self-employed, in the week {{ format_date_range_no_repeated_month_year(calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}), calculate_offset_from_weekday_in_last_whole_week(collection_metadata['started_at'], {}, 'SU'), 'EEEE d MMMM YYYY') }}?
+```
+
+##### Examples:
+```
+Input:                                              Output:
+("2018-08-14", "2018-08-16", "EEEE d MMMM YYYY")    "<span class='date'>Tuesday 14</span> to <span class='date'>Thursday 16 August 2018</span>"
+("2018-07-31", "2018-08-16", "EEEE d MMMM YYYY")    "<span class='date'>Tuesday 31 July</span> to <span class='date'>Thursday 16 August 2018</span>"
+("2017-12-31", "2018-08-16", "EEEE d MMMM YYYY")    "<span class='date'>Sunday 31 December 2017</span> to <span class='date'>Thursday 16 August 2018</span>"
+("2017-12-31", "2018-08-16", "MMMM YYYY")           "<span class='date'>December 2017</span> to <span class='date'>August 2018</span>"
+("2018-08-14", "2018-08-16", "MMMM YYYY")           "<span class='date'>August 2018</span> to <span class='date'>August 2018</span>"
+("2017-12-31", "2018-08-16", "YYYY")                "<span class='date'>2017</span> to <span class='date'>2018</span>"
+("2017-07-31", "2018-08-16", "YYYY")                "<span class='date'>2017</span> to <span class='date'>2018</span>"
+("2018-08-14", "2018-08-16", "EEEE d")              "<span class='date'>Tuesday 14</span> to <span class='date'>Thursday 16</span>"
+```
+
+
+## first_non_empty_item
+Returns the first non empty value from a number of passed items.
+Non empty discards None, 'undefined' or empty strings. It will allow 0 and False.
+
+##### Parameters: 
+- *items:   A number of items where some of them could have no value.
+
+##### Context:
+Can be used to return the first useable item when you're unsure if all the items you pass in will have a value.
+Implemented to replace trad_as_or_ru_name hard coding. 
+```
+Did any significant changes occur to the total retail turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?
+```
+
+##### Examples:
+```
+Input:                          Output:
+("", "Second", "", "Fourth")    "Second"
+("", Undefined(), None, "0")    "0"
+('', False, None, Undefined())  "False"
+```
+
+
+## format_household_name
+Concatenates a list of names into a single space separated string.
+
+##### Parameters: 
+- names:    List of names to concatenate
+
+##### Context:
+To display a person's full name when the answers are entered as first, middle and last name. 
+```
+Are you <em>{{ [answers['first-name'][group_instance], answers['middle-names'][group_instance], answers['last-name'][group_instance]] | format_household_name }}<em>?
+```
+
+##### Examples:
+```
+Input:              Output:
+["John", "Doe"]     "John Doe"
+["John", ""]        "John"
+["", "Doe"]         "Doe"
+```
+
+
+## format_household_name_possessive
+Concatenates a list of names into a single space separated string and adds the possessive to the end (’s or just ’).
+
+##### Parameters: 
+- names:    List of names to concatenate
+
+##### Context:
+To display a person's full name when the answers are entered as first, middle and last name but also to express a person's possession within the question. 
+```
+What is {{[answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name_possessive }} date of birth?
+```
+
+##### Examples:
+```
+Input:              Output:
+["John", "Doe"]     "John Doe's"
+["John", "Jones"]   "John Jones'"
+```
+
+## format_unordered_list
+Takes the first list from a list and wraps the items of that list in "ul" and "li" tags.
+
+##### Parameters: 
+- list_items:   List of a list of items to be wrapped into a html list
+
+##### Context:
+Lists selected pay patterns for MWSS. Used as a description: 
+```
+{{ answers['pay-pattern-frequency-answer']|format_unordered_list }}
+```
+
+##### Examples:
+```
+Input:                  Output:
+[['item 1', 'item 2']]  "<ul><li>item 1</li><li>item 2</li></ul>"
+```
+
+## format_unordered_list_missing_items
+Will take a list of items and a list of possible items and return the possible items that are not in the initial list.
+
+##### Parameters: 
+- possible_items:   All possible items 
+- list_items:       Items actually present.
+
+##### Context:
+Used to return items that have not been selected from a Checkbox in e-commerce. Used as a description.
+```
+{{ format_unordered_list_missing_items(['Online ordering or reservation/booking', 'Description of goods or services, price lists', 'Order tracking', 'The possibility for visitors to customise or design the goods or services online', 'Personalised content for regular/repeat visitors', 'Links or references to this business’ social media profiles'], answers['answer1836']) }}
+```
+
+##### Examples:
+```
+possible_items = ['item 1', 'item 2', 'item 3', 'item 4']
+list_items = [['item 1', 'item 3']]
+
+Input:                          Output:
+(possible_items, list_items)    "<ul><li>item 2</li><li>item 4</li></ul>"
+```
+
+
+## format_household_summary
+A merge of `format_household_name` and `format_unordered_list` in order to return a list of full names in "ul" and "li' tags 
+
+##### Parameters: 
+- names:    A list containing lists of first, middle and last names [[all first names], [all middle names], [all last names]]
+
+##### Context:
+Used in Census to list everybody currently added to who lives here section. Used in a description.
+```
+<h2 class='neptune'>Your household includes:</h2> {{ [answers['first-name'], answers['middle-names'], answers['last-name']]|format_household_summary }}
+```
+
+##### Example:
+```
+Input: ([
+            ['fist1', 'first2', 'first3', 'first4'],
+            ['middle1', '', '', 'middle4'],
+            ['last1', 'last2', 'last3', '']
+        ])
+
+Ouput: "<ul>
+            <li>first1 middle1 last1</li>
+            <li>first2 last2</li>
+            <li>first3 last3</li>
+            <li>first4 middle4</li>
+       </ul>"
+```
+
+## format_repeating_summary
+Similar to `format_household_summary` but can handle lists from a series of sources.
+
+##### Parameters: 
+- items:        List of lists, If there is a third level of lists, these will be zipped together e.g. [['John', 'Smith'], [['Jane', 'Sarah'], ['Smith', 'Smith']]]
+- delimiter:    Default space.
+
+##### Context:
+Used in LMS to list everybody currently added to who lives here section. Used in a description.
+``` 
+{{ [[answers['primary-household-member-first-name'], answers['primary-household-member-last-name']], [answers['other-household-member-first-name'], answers['other-household-member-last-name']], [answers['student-household-member-first-name'], answers['student-household-member-last-name']]] | format_repeating_summary }}
+```
+
+##### Examples:
+```
+Input: ([
+            ['John', 'Smith'], 
+            [
+                ['Jane', 'Sarah'], 
+                ['Smith', 'Smythe']
+            ]
+        ])
+
+Ouput: "<ul>
+            <li>John Smith</li>
+            <li>Jane Smith</li>
+            <li>Sarah Smythe</li>
+       </ul>"
+
+       
+Input: ([
+            [
+                ['David', 'Sarah'], 
+                ['Smith', 'Smythe']
+            ]
+        ])
+
+Ouput: "<ul>
+            <li>David Smith</li>
+            <li>Sarah Smythe</li>
+       </ul>"
+
+
+Input: ([
+            ['', 
+             '51 Testing Gardens', 
+             '', 
+             'Bristol', 
+             'BS9 1AW'
+            ]
+        ], 
+        delimiter=', ')
+
+Ouput: "<ul>
+            <li>51 Testing Gardens, Bristol, BS9 1AW</li>
+       </ul>"
+```

--- a/tests/app/test_jinja_filters.py
+++ b/tests/app/test_jinja_filters.py
@@ -10,10 +10,10 @@ from mock import Mock
 from app.jinja_filters import (
     format_date, format_conditional_date, format_currency, get_currency_symbol,
     format_multilined_string, format_percentage, format_date_range,
-    format_household_member_name, format_datetime,
-    format_number_to_alphabetic_letter, format_unit, format_currency_for_input,
+    format_household_name, format_datetime,
+    format_number_to_alphabetic_letter, format_unit,
     format_number, format_unordered_list, format_unordered_list_missing_items,
-    format_unit_input_label, format_household_member_name_possessive,
+    format_unit_input_label, format_household_name_possessive, format_household_summary,
     concatenated_list, calculate_years_difference, get_current_date, as_london_tz,
     max_value, min_value, get_question_title, get_answer_label,
     format_duration, calculate_offset_from_weekday_in_last_whole_week, format_date_custom,
@@ -25,21 +25,6 @@ class TestJinjaFilters(AppContextTestCase):  # pylint: disable=too-many-public-m
     def setUp(self):
         self.autoescape_context = Mock(autoescape=True)
         super(TestJinjaFilters, self).setUp()
-
-    @patch('app.jinja_filters.flask_babel.get_locale', Mock(return_value='en_GB'))
-    def test_format_currency_for_input(self):
-        self.assertEqual(format_currency_for_input('100', 2), '100.00')
-        self.assertEqual(format_currency_for_input('100.0', 2), '100.00')
-        self.assertEqual(format_currency_for_input('100.00', 2), '100.00')
-        self.assertEqual(format_currency_for_input('1000'), '1,000')
-        self.assertEqual(format_currency_for_input('10000'), '10,000')
-        self.assertEqual(format_currency_for_input('100000000'), '100,000,000')
-        self.assertEqual(format_currency_for_input('100000000', 2), '100,000,000.00')
-        self.assertEqual(format_currency_for_input(0, 2), '0.00')
-        self.assertEqual(format_currency_for_input(0), '0')
-        self.assertEqual(format_currency_for_input(''), '')
-        self.assertEqual(format_currency_for_input(None), '')
-        self.assertEqual(format_currency_for_input(Undefined()), '')
 
     @patch('app.jinja_filters.flask_babel.get_locale', Mock(return_value='en_GB'))
     def test_get_currency_symbol(self):
@@ -316,113 +301,131 @@ class TestJinjaFilters(AppContextTestCase):  # pylint: disable=too-many-public-m
         # Then
         self.assertEqual(format_value, "<span class='date'>1 January 2017</span>")
 
-    def test_format_household_member_name(self):
+    def test_format_household_name(self):
         # Given
         name = ['John', 'Doe']
 
         # When
-        format_value = format_household_member_name(name)
+        format_value = format_household_name(name)
 
         self.assertEqual(format_value, 'John Doe')
 
-    def test_format_household_member_name_no_surname(self):
+    def test_format_household_name_no_surname(self):
         # Given
         name = ['John', '']
 
         # When
-        format_value = format_household_member_name(name)
+        format_value = format_household_name(name)
 
         self.assertEqual(format_value, 'John')
 
-    def test_format_household_member_name_surname_is_none(self):
+    def test_format_household_name_surname_is_none(self):
         # Given
         name = ['John', None]
 
         # When
-        format_value = format_household_member_name(name)
+        format_value = format_household_name(name)
 
         self.assertEqual(format_value, 'John')
 
-    def test_format_household_member_name_no_first_name(self):
+    def test_format_household_name_no_first_name(self):
         # Given
         name = ['', 'Doe']
 
         # When
-        format_value = format_household_member_name(name)
+        format_value = format_household_name(name)
 
         self.assertEqual(format_value, 'Doe')
 
-    def test_format_household_member_name_first_name_is_none(self):
+    def test_format_household_name_first_name_is_none(self):
         # Given
         name = [None, 'Doe']
 
         # When
-        format_value = format_household_member_name(name)
+        format_value = format_household_name(name)
 
         self.assertEqual(format_value, 'Doe')
 
-    def test_format_household_member_name_first_middle_and_last(self):
+    def test_format_household_name_first_middle_and_last(self):
         # Given
         name = ['John', 'J', 'Doe']
 
         # When
-        format_value = format_household_member_name(name)
+        format_value = format_household_name(name)
 
         self.assertEqual(format_value, 'John J Doe')
 
-    def test_format_household_member_name_no_middle_name(self):
+    def test_format_household_name_no_middle_name(self):
         # Given
         name = ['John', '', 'Doe']
 
         # When
-        format_value = format_household_member_name(name)
+        format_value = format_household_name(name)
 
         self.assertEqual(format_value, 'John Doe')
 
-    def test_format_household_member_name_middle_name_is_none(self):
+    def test_format_household_name_middle_name_is_none(self):
         # Given
         name = ['John', None, 'Doe']
 
         # When
-        format_value = format_household_member_name(name)
+        format_value = format_household_name(name)
 
         self.assertEqual(format_value, 'John Doe')
 
-    def test_format_household_member_name_trim_spaces(self):
+    def test_format_household_name_trim_spaces(self):
         # Given
         name = ['John  ', '   Doe   ']
 
         # When
-        format_value = format_household_member_name(name)
+        format_value = format_household_name(name)
 
         self.assertEqual(format_value, 'John Doe')
 
-    def test_format_household_member_name_possessive(self):
+    def test_format_household_name_possessive(self):
         # Given
         name = ['John', 'Doe']
 
         # When
-        format_value = format_household_member_name_possessive(name)
+        format_value = format_household_name_possessive(name)
 
         self.assertEqual(format_value, 'John Doe\u2019s')
 
-    def test_format_household_member_name_possessive_with_no_names(self):
+    def test_format_household_name_possessive_with_no_names(self):
         # Given
         name = [Undefined(), Undefined()]
 
         # When
-        format_value = format_household_member_name_possessive(name)
+        format_value = format_household_name_possessive(name)
 
         self.assertIsNone(format_value)
 
-    def test_format_household_member_name_possessive_trailing_s(self):
+    def test_format_household_name_possessive_trailing_s(self):
         # Given
         name = ['John', 'Does']
 
         # When
-        format_value = format_household_member_name_possessive(name)
+        format_value = format_household_name_possessive(name)
 
         self.assertEqual(format_value, 'John Does\u2019')
+
+    def test_format_household_summary(self):
+        names = [
+            ['Alice', 'Bob', '\\', 'Dave'],
+            ['', 'Berty', '"', 'Dixon'],
+            ['Aardvark', 'Brown', '!', 'Davies']
+        ]
+
+        format_value = format_household_summary(self.autoescape_context, names)
+        expected_result = '<ul>' \
+                          '<li>Alice Aardvark</li>' \
+                          '<li>Bob Berty Brown</li>' \
+                          '<li>\\ &#34; !</li>' \
+                          '<li>Dave Dixon Davies</li>' \
+                          '</ul>'
+
+        self.assertEqual(format_value, expected_result)
+
 
     def test_concatenated_list(self):
         # Given
@@ -873,7 +876,7 @@ class TestJinjaFilters(AppContextTestCase):  # pylint: disable=too-many-public-m
             ('2018-08-05', {}, 'SU', '2018-07-29'),  # Sunday outputs previous Sunday (Must be a full Sunday)
             ('2018-08-06', {}, 'SU', '2018-08-05'),  # Monday outputs previous Sunday
             ('2018-08-06', {'days': -1}, 'SU', '2018-08-04'),  # Previous sunday with -1 day offset
-            ('2018-08-05', {'weeks': 1}, 'SU', '2018-08-05'),  # Previous sunday with +1 month offset, back to input
+            ('2018-08-05', {'weeks': 1}, 'SU', '2018-08-05'),  # Previous sunday with +1 week offset, back to input
             ('2018-08-10', {}, 'FR', '2018-08-03'),  # Friday outputs previous Friday
             ('2018-08-10T13:32:20.365665', {}, 'FR', '2018-08-03'),  # Ensure we can handle datetime input
             ('2018-08-10', {'weeks': 4}, 'FR', '2018-08-31'),  # Friday outputs previous Friday + 4 weeks


### PR DESCRIPTION
### What is the context of this PR?
Document Jinja filters used in schemas
Also:
Removes unused `format_currency_for_input` filter
Renames `format_household_member_name` methods to match names used to call them
Adds a unit test for `test_format_household_summary` which was missing

### How to review 
Read the new `jinja-filters.md` file and help me make it less boring/more understandable.
Also check the couple of minor out of scope changes haven't had a negative effect.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
