### PR TITLE
Revert all input fields from type number to text

### DIFF
--- a/app/templates/partials/answers/currency.html
+++ b/app/templates/partials/answers/currency.html
@@ -10,7 +10,7 @@
 
     <div class="input-type input-type--prefix">
         {% set input = {
-            'type': 'number',
+            'type': 'text',
             'classes': 'input-type__input',
             'hasType': true,
             'data': input._value(),

--- a/app/templates/partials/answers/date.html
+++ b/app/templates/partials/answers/date.html
@@ -9,7 +9,7 @@
         'id': day_field.id,
         'name': day_field.name,
         'classes': 'input--w-2',
-        'type': 'number',
+        'type': 'text',
         'data': day_field._value()
       } %}
       {% include 'partials/forms/input.html' %}
@@ -40,7 +40,7 @@
         'id': year_field.id,
         'name': year_field.id,
         'classes': 'input--w-4',
-        'type': 'number',
+        'type': 'text',
         'data': year_field._value()
       } %}
       {% include 'partials/forms/input.html' %}

--- a/app/templates/partials/answers/duration_unit.html
+++ b/app/templates/partials/answers/duration_unit.html
@@ -1,7 +1,7 @@
 <div class="field">
   <div class="input-type">
     {% set args = {
-      'type': 'number',
+      'type': 'text',
       'class': 'input input-type__input input--w-2 ' ~ exclusive_class,
       'aria-labelledby': 'duration-label ' + input.id + '-label'
     } %}

--- a/app/templates/partials/answers/unit.html
+++ b/app/templates/partials/answers/unit.html
@@ -14,7 +14,7 @@
 
     <div class="input-type">
         {% set input = {
-        'type': 'number',
+        'type': 'text',
         'classes': input_classes,
         'hasType': true,
         'data': input._value(),

--- a/app/templates/partials/widgets/percentage_widget.html
+++ b/app/templates/partials/widgets/percentage_widget.html
@@ -16,7 +16,7 @@
 <div class="input-type">
 
     {% set input = {
-        'type': 'number',
+        'type': 'text',
         'classes': input_classes,
         'hasType': true,
         'data': input._value(),


### PR DESCRIPTION
The input type of 'number' was causing browsers except
chrome to clear the value entirely rather than passing
it on to server side validation.

This fix just reverts the type of these inputs to 'text'.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
