### PR TITLE
Check for action before redirect to signed-out

### DIFF
--- a/app/views/feedback.py
+++ b/app/views/feedback.py
@@ -91,7 +91,10 @@ def thank_you():
 @feedback_blueprint.route('/thank-you', methods=['POST'])
 @login_required
 def post_thank_you():
-    return redirect(url_for('session.get_sign_out'))
+    if 'action[sign_out]' in request.form:
+        return redirect(url_for('session.get_sign_out'))
+
+    return redirect(url_for('feedback.thank_you'))
 
 
 @template_helper.with_session_timeout

--- a/app/views/questionnaire.py
+++ b/app/views/questionnaire.py
@@ -273,8 +273,11 @@ def get_thank_you(schema, metadata, eq_id, form_type):
 
 @post_submission_blueprint.route('thank-you', methods=['POST'])
 @login_required
-def post_thank_you(eq_id, form_type):  # pylint: disable=unused-argument
-    return redirect(url_for('session.get_sign_out'))
+def post_thank_you(eq_id, form_type):
+    if 'action[sign_out]' in request.form:
+        return redirect(url_for('session.get_sign_out'))
+
+    return redirect(url_for('post_submission.get_thank_you', eq_id=eq_id, form_type=form_type))
 
 
 @post_submission_blueprint.route('view-submission', methods=['GET'])
@@ -339,8 +342,11 @@ def get_view_submission(schema, eq_id, form_type):  # pylint: disable=unused-arg
 
 @post_submission_blueprint.route('view-submission', methods=['POST'])
 @login_required
-def post_view_submission(eq_id, form_type):  # pylint: disable=unused-argument
-    return redirect(url_for('session.get_sign_out'))
+def post_view_submission(eq_id, form_type):
+    if 'action[sign_out]' in request.form:
+        return redirect(url_for('session.get_sign_out'))
+
+    return redirect(url_for('post_submission.get_view_submission', eq_id=eq_id, form_type=form_type))
 
 
 def _set_started_at_metadata_if_required(form, collection_metadata):

--- a/tests/integration/questionnaire/test_questionnaire_save_sign_out.py
+++ b/tests/integration/questionnaire/test_questionnaire_save_sign_out.py
@@ -87,7 +87,8 @@ class TestSaveSignOut(IntegrationTestCase):
 
     def test_thank_you_page_post_without_action(self):
         """
-        If the thank you page is posted too without an action, takes you to the signed out page.
+        If the thank you page is posted to without an action,
+        it takes you back to the thank you page.
         """
 
         self.launchSurvey('test', 'textarea')
@@ -99,5 +100,4 @@ class TestSaveSignOut(IntegrationTestCase):
 
         self.last_csrf_token = token
         self.post(action=None)
-        self.assertInUrl('/signed-out')
-        self.assertInBody('Your survey answers have been saved. You are now signed out')
+        self.assertInUrl('/thank-you')

--- a/tests/integration/views/test_view_submission.py
+++ b/tests/integration/views/test_view_submission.py
@@ -59,6 +59,12 @@ class TestViewSubmission(IntegrationTestCase):
         self.post(action='sign_out')
         self.assertEqualUrl('/signed-out')
 
+    def test_view_submission_post_no_action(self):
+        self.get('questionnaire/test/view_submitted_response/view-submission')
+
+        self.post(action=None)
+        self.assertInUrl('view-submission')
+
 
 class TestCantViewSubmission(IntegrationTestCase):
 


### PR DESCRIPTION
### What is the context of this PR?
To stop sign-out on POSTS on the `thank-you`, `view-submission` and `feedback` pages unless there is a `sign_out` action. 

### How to review 
Initial issue was caught by using the print button on view-submission page. Pressing cancel/print on that would result in a POST to the page that subsequently signed you out.


### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
