### PR TITLE
Update readme to include sqlite3

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,21 +38,10 @@ pipenv run scripts/run_tests_unit.sh
 
 
 ## Pre-Requisites
-In order to run locally you'll need PostgreSQL, Node.js and snappy installed
+In order to run locally you'll need PostgreSQL, Node.js, sqlite3, snappy and pyenv installed
 
-PostgreSQL
 ```
-brew install postgres
-```
-
-npm
-```
-brew install npm
-```
-
-snappy
-```
-brew install snappy
+brew install postgres snappy npm sqlite3 pyenv
 ```
 
 Note that npm currently requires Python 2.x for some of the setup steps,
@@ -67,7 +56,6 @@ purpose.
 Upgrade pip and install dependencies:
 
 ```
-brew install pyenv
 pyenv install
 pip install --upgrade pip setuptools pipenv
 pipenv install --dev


### PR DESCRIPTION
### What is the context of this PR?
People were having issues running this repo because sqlite3 wasn't installed before python. This PR updates the readme to include installing sqlite3 and simplifies the install commands.

### How to review 


### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
