### PR TITLE
Add type=button to the print button

### DIFF
--- a/app/templates/confirmation.html
+++ b/app/templates/confirmation.html
@@ -7,10 +7,10 @@
 {% block submit_button %}
 
 {% if content.summary and content.summary.summary_type in ('SectionSummary', 'AnswerSummary') %}
-    <button class="btn btn--loader u-mb-s js-btn-submit" data-qa="btn-submit">{{ _("Continue") }}</button>
+    <button type="submit" class="btn btn--loader u-mb-s js-btn-submit" data-qa="btn-submit">{{ _("Continue") }}</button>
 {% elif content.summary and content.summary.summary_type == 'CalculatedSummary' %}
-    <button class="btn btn--loader u-mb-s js-btn-submit" data-qa="btn-submit">{{ _("Yes, I confirm these are correct") }}</button>
+    <button type="submit" class="btn btn--loader u-mb-s js-btn-submit" data-qa="btn-submit">{{ _("Yes, I confirm these are correct") }}</button>
 {% else  %}
-    <button class="btn btn--loader u-mb-s js-btn-submit" data-qa="btn-submit" data-loading-msg='{{ _("Submitting") }}&hellip;' type="submit">{{ _("Submit answers") }}</button>
+    <button type="submit" class="btn btn--loader u-mb-s js-btn-submit" data-qa="btn-submit" data-loading-msg='{{ _("Submitting") }}&hellip;'>{{ _("Submit answers") }}</button>
 {% endif %}
 {% endblock %}

--- a/app/templates/partials/answer-guidance.html
+++ b/app/templates/partials/answer-guidance.html
@@ -7,7 +7,7 @@
             <div class="u-mt-s">
                 {% include 'partials/content-block.html' %}
             </div>
-            <button class="btn--secondary btn--small js-collapsible-close u-no-js-hide" data-ga="click" data-ga-category="Answer guidance" data-ga-action="Close panel" data-ga-label="{{_(answer_guidance.schema_item.show_guidance)}}">{{ _("Hide this") }}</button>
+            <button type="button" class="btn--secondary btn--small js-collapsible-close u-no-js-hide" data-ga="click" data-ga-category="Answer guidance" data-ga-action="Close panel" data-ga-label="{{_(answer_guidance.schema_item.show_guidance)}}">{{ _("Hide this") }}</button>
         </div>
     </div>
 </div>

--- a/app/templates/partials/feedback/expandable_inline.html
+++ b/app/templates/partials/feedback/expandable_inline.html
@@ -9,7 +9,7 @@
                 <a class="collapsible__title collapsible__title--link js-collapsible-title icon--collapsible-simple u-fs-r--b" target="_blank" data-qa="a-feedback-open" data-ga="click" data-ga-category="feedback" data-ga-action="Open panel" data-ga-label="Feedback" href="/feedback">{{ _("Give feedback and help us improve this service") }}.</a>
                 <div class="collapsible__body u-fs-r js-collapsible-body">
                     {% include theme('partials/feedback/js_feedback_form.html') %}
-                    <button class="btn--secondary btn--small js-collapsible-close u-no-js-hide" data-ga="click" data-ga-category="feedback" data-qa="a-feedback-close" data-ga-action="Cancel" data-ga-label="Feedback cancelled">{{ _("I don't want to provide feedback") }}</button>
+                    <button type="button" class="btn--secondary btn--small js-collapsible-close u-no-js-hide" data-ga="click" data-ga-category="feedback" data-qa="a-feedback-close" data-ga-action="Cancel" data-ga-label="Feedback cancelled">{{ _("I don't want to provide feedback") }}</button>
                 </div>
             </div>
         </div>

--- a/app/templates/partials/introduction/preview.html
+++ b/app/templates/partials/introduction/preview.html
@@ -19,7 +19,7 @@
 {% if intro.questions %}
 <div class="collapsible js-collapsible u-mb-s">
         <div class="collapsible__controls">
-            <button class="btn btn--secondary btn--small collapsible__control js-collapsible-toggle-all u-wa--@xs" data-ga="click" data-ga-category="Preview Survey" data-ga-action="Show all" data-ga-label="Show all" data-close-all-label="{{ _('Hide all') }}" data-open-all-label="{{ _('Show all') }}" aria-hidden="true">
+            <button type="button" class="btn btn--secondary btn--small collapsible__control js-collapsible-toggle-all u-wa--@xs" data-ga="click" data-ga-category="Preview Survey" data-ga-action="Show all" data-ga-label="Show all" data-close-all-label="{{ _('Hide all') }}" data-open-all-label="{{ _('Show all') }}" aria-hidden="true">
                 {{ _('Show all') }}</button>
         </div>
 
@@ -28,7 +28,7 @@
             {% set outer_loop = loop %}
             <h3 class="collapsible__title js-collapsible-title u-cf icon--collapsible" data-ga="click" data-ga-category="Preview Survey" data-ga-action="Open panel" data-ga-label="{{question.question}}">
                 <span class="collapsible__title-text">{{question.question}}</span>
-                <button class="btn btn--secondary btn--small collapsible__title-right js-collapsible-toggle u-wa--@xs" data-close-label="{{ _('Hide') }}" data-open-label="{{ _('Show') }}" aria-hidden="true" data-ga="click" data-ga-category="Preview Survey" data-ga-action="Open panel" data-ga-label="{{question.question}}">{{ _('Show') }}</button>
+                <button type="button" class="btn btn--secondary btn--small collapsible__title-right js-collapsible-toggle u-wa--@xs" data-close-label="{{ _('Hide') }}" data-open-label="{{ _('Show') }}" aria-hidden="true" data-ga="click" data-ga-category="Preview Survey" data-ga-action="Open panel" data-ga-label="{{question.question}}">{{ _('Show') }}</button>
             </h3>
 
             <div class="collapsible__body u-fs-r js-collapsible-body">

--- a/app/templates/partials/question-definition.html
+++ b/app/templates/partials/question-definition.html
@@ -6,7 +6,7 @@
       <h3 class="collapsible__title js-collapsible-title icon--collapsible-simple u-fs-r--b" data-definition-title-index="{{loop.index}}" data-ga="click" data-ga-category="Question definition" data-ga-action="Open panel" data-ga-label="{{ definition.title }}">{{ definition.title }}</h3>
       <div class="collapsible__body js-collapsible-body" data-definition-content-index="{{loop.index}}">
           {% include 'partials/content-block.html' %}
-          <button class="btn--secondary btn--small js-collapsible-close u-no-js-hide" data-definition-hide-button-index="{{loop.index}}" data-ga="click" data-ga-category="Question definition" data-ga-action="Close panel" data-ga-label="{{ definition.title }}">{{ _("Hide this") }}</button>
+          <button type="button" class="btn--secondary btn--small js-collapsible-close u-no-js-hide" data-definition-hide-button-index="{{loop.index}}" data-ga="click" data-ga-category="Question definition" data-ga-action="Close panel" data-ga-label="{{ definition.title }}">{{ _("Hide this") }}</button>
       </div>
   </div>
 </div>

--- a/app/templates/partials/summary/collapsible-summary.html
+++ b/app/templates/partials/summary/collapsible-summary.html
@@ -1,6 +1,6 @@
 <div class="collapsible js-collapsible">
     <div class="collapsible__controls">
-        <button class="btn btn--secondary btn--small collapsible__control js-collapsible-toggle-all u-wa--@xs" data-ga="click" data-ga-category="Preview Survey" data-ga-action="Show all" data-ga-label="Show all" data-close-all-label="{{ _('Hide all') }}" data-open-all-label="{{ _('Show all') }}" aria-hidden="true">{{ _("Show all") }}</button>
+        <button type="button" class="btn btn--secondary btn--small collapsible__control js-collapsible-toggle-all u-wa--@xs" data-ga="click" data-ga-category="Preview Survey" data-ga-action="Show all" data-ga-label="Show all" data-close-all-label="{{ _('Hide all') }}" data-open-all-label="{{ _('Show all') }}" aria-hidden="true">{{ _("Show all") }}</button>
     </div>
 
     <div class="js-collapsible-content">
@@ -9,7 +9,7 @@
             {%- set outer_loop = loop -%}
                 <h3 class="collapsible__title js-collapsible-title u-cf icon--collapsible" data-ga="click" data-ga-category="Preview Survey" data-ga-action="Open panel" data-ga-label="{{group.title}}">
                     <span class="collapsible__title-text">{{group.title}}</span>
-                    <button class="btn btn--secondary btn--small collapsible__title-right js-collapsible-toggle u-wa--@xs" id="{{ group.id }}-button" data-close-label="{{ _('Hide') }}" data-open-label="{{ _('Show') }}" aria-hidden="true" data-ga="click" data-ga-category="Preview Survey" data-ga-action="Open panel" data-ga-label="{{group.title}}">{{ _("Show") }}</button>
+                    <button type="button" class="btn btn--secondary btn--small collapsible__title-right js-collapsible-toggle u-wa--@xs" id="{{ group.id }}-button" data-close-label="{{ _('Hide') }}" data-open-label="{{ _('Show') }}" aria-hidden="true" data-ga="click" data-ga-category="Preview Survey" data-ga-action="Open panel" data-ga-label="{{group.title}}">{{ _("Show") }}</button>
                 </h3>
             {%- endif -%}
 

--- a/app/templates/view-submission.html
+++ b/app/templates/view-submission.html
@@ -27,7 +27,7 @@
     </div>
 </div>
 
-<button class="btn btn--secondary btn-print icon--print-link u-mt-s u-mb-l print__hidden u-no-js-hide">{{ _("Print this page") }} <span class="btn__icon btn__icon--print-link"></span></button>
+<button type="button" class="btn btn--secondary btn-print icon--print-link u-mt-s u-mb-l print__hidden u-no-js-hide">{{ _("Print this page") }} <span class="btn__icon btn__icon--print-link"></span></button>
 
 {% include theme('partials/summary/summary.html') %}
 

--- a/tests/integration/views/test_feedback.py
+++ b/tests/integration/views/test_feedback.py
@@ -157,6 +157,11 @@ class Feedback(IntegrationTestCase):
         self.assertStatusOK()
         self.assertEqualUrl(SIGNED_OUT_URL)
 
+    def test_feedback_thankyou_post_no_action(self):
+        self.post(url=FEEDBACK_THANKYOU_URL, post_data='', action=None)
+        self.assertStatusOK()
+        self.assertEqualUrl(FEEDBACK_THANKYOU_URL)
+
 
 def validate_json_with_schema(data, schema):
     errors = []


### PR DESCRIPTION
### What is the context of this PR?
This ensures that the print button does not submit the form.
Annoyingly buttons have a default type of submit.

Just to keep things consistent I've added types to all the buttons which rely on the default behaviour or javascript.

Adam wrote a fix for coverage which I have also included.

### How to review 
Use the 'test_view_submission' test schema to ensure the page does not change

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
