### PR TITLE
Add the language to google analytics

### DIFF
--- a/app/templates/layouts/_base.html
+++ b/app/templates/layouts/_base.html
@@ -57,6 +57,8 @@
 
     ga('create', '{{analytics_ua_id}}', 'auto');
     ga('set', 'anonymizeIp', true);
+    // Language is setup as a custom dimension in google analytics
+    ga('set', 'dimension1', '{{language_code}}' || 'en');
     ga('send', 'pageview');
     </script>
     {% endif %}


### PR DESCRIPTION
### What is the context of this PR?
Send the language to google analytics. [trello](https://trello.com/c/FeKTx8Zi/2548-google-analytics-language-value)

Field for language documented here: https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#language

### How to review 
Ensure javascript is enabled 😆 	

Set the EQ_UA_ID environment variable, and change the analytics URL in _base.html to end in `analytics_debug.js` rather than `analytics.js`.

Open LMS 2 and change language to welsh. Ensure that the console shows that google analytics is sending the language.
### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
