### PR TITLE
Updating address-line claim names in the household schema to address_…

### DIFF
--- a/data/en/census_household.json
+++ b/data/en/census_household.json
@@ -29,14 +29,6 @@
             "validator": "string"
         },
         {
-            "name": "address_line1",
-            "validator": "optional_string"
-        },
-        {
-            "name": "address_line2",
-            "validator": "optional_string"
-        },
-        {
             "name": "locality",
             "validator": "optional_string"
         },
@@ -1676,7 +1668,7 @@
                                 "id": "term-time-location-answer",
                                 "mandatory": true,
                                 "options": [{
-                                        "label": "{{answers['address-line-1']}}, {{answers['address-line-2']}}",
+                                        "label": "{{metadata['display_address']}}",
                                         "value": "household-address"
                                     },
                                     {
@@ -1726,7 +1718,7 @@
                                 "id": "term-time-location-answer-with-second-address",
                                 "mandatory": true,
                                 "options": [{
-                                        "label": "{{answers['address-line-1']}}, {{answers['address-line-2']}}",
+                                        "label": "{{metadata['display_address']}}",
                                         "value": "household-address"
                                     },
                                     {
@@ -1790,7 +1782,7 @@
                                 "id": "term-time-location-answer-with-second-address-non-uk",
                                 "mandatory": true,
                                 "options": [{
-                                        "label": "{{answers['address-line-1']}}, {{answers['address-line-2']}}",
+                                        "label": "{{metadata['display_address']}}",
                                         "value": "household-address"
                                     },
                                     {
@@ -3768,7 +3760,7 @@
                                 "id": "past-usual-address-answer",
                                 "mandatory": true,
                                 "options": [{
-                                        "label": "{{answers['address-line-1']}}, {{answers['address-line-2']}}",
+                                        "label": "{{metadata['display_address']}}",
                                         "value": "householdaddress"
                                     },
                                     {
@@ -6051,7 +6043,7 @@
                         "type": "Interstitial",
                         "id": "visitor-begin-section",
                         "title": "Visitors",
-                        "description": "In this section, we’re going to ask you about any visitors that were staying overnight at <em>{{answers['address-line-1']}}</em> on 10 September 2018.",
+                        "description": "In this section, we’re going to ask you about any visitors that were staying overnight at <em>{{metadata['display_address']}}</em> on 10 September 2018.",
                         "content": [{
                                 "title": "Information you need about your visitor",
                                 "list": [


### PR DESCRIPTION
…line

### What is the context of this PR?
Changed all address-line-[1|2] references to address_line[1|2] to align with metadata claim attribute names. This was previously presenting a comma ( , ) as an answer option in various questions rather than the actual address line.

### How to review 
launch eQ census_household and address shown in various answer options are a comma separated concatenation of the address lines 1 and 2 (and not simply a comma).

These are...
term-time-location-answer
term-time-location-answer-with-second-address
term-time-location-answer-with-second-address-non-uk
past-usual-address-answer
visitor-begin-section


