### PR TITLE
Bug - Downstream processing of UKIS failing due to answer piping 

### DIFF
--- a/data/en/ukis_0001.json
+++ b/data/en/ukis_0001.json
@@ -141,7 +141,7 @@
                                     "options": [{
                                             "q_code": "0410",
                                             "label": "{{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} was established",
-                                            "value": "{{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} was established"
+                                            "value": "The business was established"
                                         },
                                         {
                                             "q_code": "0420",

--- a/data/en/ukis_0002.json
+++ b/data/en/ukis_0002.json
@@ -141,7 +141,7 @@
                                     "options": [{
                                             "q_code": "0410",
                                             "label": "{{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} was established",
-                                            "value": "{{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} was established"
+                                            "value": "The business was established"
                                         },
                                         {
                                             "q_code": "0420",


### PR DESCRIPTION
### What is the context of this PR?
For the second question "Did any of the following significant events or changes occur to ESSENTIAL ENTERPRISE LTD?" the first answer option has piping for both the "label" and "value". Having piping in the value appears to block the answer being passed downstream. We therefore need to replace the piping in the value with a hard coded string. 

### How to review 
1. Ensure that the new hardcoded value is being posted to the server when you select that your business was established.
2. Ensure this is happening for both UKIS variants.
