### PR TITLE
Fix incorrect footer being used on UKIS questionnaires.

### DIFF
--- a/app/themes/ukis/templates/partials/footer-transactional.html
+++ b/app/themes/ukis/templates/partials/footer-transactional.html
@@ -1,0 +1,29 @@
+{% set ons_logo = cdn_url_prefix~"/img/ons-logo-black-en.svg" %}
+{% set olg_cdn = cdn_url_prefix~"/img/UKOpenGovernmentLicence-grey.svg" %}
+
+<footer class="footer" role="contentinfo">
+    <div class="container">
+        <div class="grid">
+            <div class="grid__col col-12@m u-mb-m">
+                <img src="{{ ons_logo }}" alt="Office for National Statistics" class="footer__poweredby-img" />
+            </div>
+            <div class="grid__col col-12@m">
+                <ul class="list list--bare">
+                    <li>
+                        <a href="/contact-us" class="footer__link footer__link--inline" target="_blank">{{ _("Contact us") }}</a>
+                    </li>
+                    <li>
+                        <a href="/cookies-privacy" class="footer__link footer__link--inline" target="_blank">{{ _("Cookies and privacy") }}</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="grid__col col-12@m">
+                <div class="footer__license footer__license--border">
+                    <img alt="OGL" class="footer__ogl-img" src="{{ olg_cdn }}"> {{ _("All content is available under the %(class_open)sOpen Government Licence v3.0%(class_close)s, except where otherwise stated",
+                    class_open='<a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" class="footer__link" target="_blank">',
+                    class_close="</a>") }}
+               </div>
+            </div>
+        </div>
+    </div>
+</footer>

--- a/app/themes/ukis/templates/partials/footer.html
+++ b/app/themes/ukis/templates/partials/footer.html
@@ -1,0 +1,55 @@
+{% set ons_logo = cdn_url_prefix~"/img/ons-logo-black-en.svg" %}
+{% set olg_cdn = cdn_url_prefix~"/img/UKOpenGovernmentLicence-grey.svg" %}
+
+<footer class="footer" role="contentinfo">
+    <div class="container">
+        <div class="grid">
+            <div class="grid__col col-12@m">
+                <img src="{{ ons_logo }}" alt="Office for National Statistics" class="footer__poweredby-img" />
+            </div>
+            <div class="grid__col col-4@m">
+                <h4 class="u-fs-r--b footer__heading">{{ _("Legal information") }}</h4>
+                <ul class="list list--bare">
+                    <li>
+                        <a href="/cookies-privacy" class="footer__link" target="_blank">{{ _("Cookies and privacy") }}</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="grid__col col-4@m">
+                <h4 class="u-fs-r--b footer__heading">{{ _("About ONS") }}</h4>
+                <ul class="list list--bare">
+                    <li>
+                        <a href="https://www.ons.gov.uk/aboutus/whatwedo" class="footer__link" target="_blank">{{ _("What we do") }}</a>
+                    </li>
+                    <li>
+                        <a href="/contact-us" class="footer__link" target="_blank">{{ _("Contact us") }}</a>
+                    </li>
+                    <li>
+                        <a href="https://www.ons.gov.uk/help/accessibility" class="footer__link" target="_blank">{{ _("Accessibility") }}</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="grid__col col-4@m">
+                <h4 class="u-fs-r--b footer__heading">{{ _("Statistics") }}</h4>
+                <ul class="list list--bare">
+                    <li>
+                        <a href="https://www.statisticsauthority.gov.uk/about-the-authority/" class="footer__link" target="_blank">{{ _("UK Statistics Authority") }}</a>
+                    </li>
+                    <li>
+                        <a href="https://www.ons.gov.uk/releasecalendar" class="footer__link" target="_blank">{{ _("Release calendar") }}</a>
+                    </li>
+                    <li>
+                        <a href="https://www.ons.gov.uk/news" class="footer__link" target="_blank">{{ _("News") }}</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="grid__col col-12@m">
+              <div class="footer__license footer__license--border">
+                    <img alt="OGL" class="footer__ogl-img" src="{{ olg_cdn }}"> {{ _("All content is available under the %(class_open)sOpen Government Licence v3.0%(class_close)s, except where otherwise stated",
+                    class_open='<a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" class="footer__link" target="_blank">',
+                    class_close="</a>") }}
+               </div>
+            </div>
+        </div>
+    </div>
+</footer>

--- a/app/themes/ukis_ni/templates/partials/footer-transactional.html
+++ b/app/themes/ukis_ni/templates/partials/footer-transactional.html
@@ -1,0 +1,29 @@
+{% set ons_logo = cdn_url_prefix~"/img/ons-logo-black-en.svg" %}
+{% set olg_cdn = cdn_url_prefix~"/img/UKOpenGovernmentLicence-grey.svg" %}
+
+<footer class="footer" role="contentinfo">
+    <div class="container">
+        <div class="grid">
+            <div class="grid__col col-12@m u-mb-m">
+                <img src="{{ ons_logo }}" alt="Office for National Statistics" class="footer__poweredby-img" />
+            </div>
+            <div class="grid__col col-12@m">
+                <ul class="list list--bare">
+                    <li>
+                        <a href="/contact-us" class="footer__link footer__link--inline" target="_blank">{{ _("Contact us") }}</a>
+                    </li>
+                    <li>
+                        <a href="/cookies-privacy" class="footer__link footer__link--inline" target="_blank">{{ _("Cookies and privacy") }}</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="grid__col col-12@m">
+                <div class="footer__license footer__license--border">
+                    <img alt="OGL" class="footer__ogl-img" src="{{ olg_cdn }}"> {{ _("All content is available under the %(class_open)sOpen Government Licence v3.0%(class_close)s, except where otherwise stated",
+                    class_open='<a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" class="footer__link" target="_blank">',
+                    class_close="</a>") }}
+               </div>
+            </div>
+        </div>
+    </div>
+</footer>

--- a/app/themes/ukis_ni/templates/partials/footer.html
+++ b/app/themes/ukis_ni/templates/partials/footer.html
@@ -1,0 +1,55 @@
+{% set ons_logo = cdn_url_prefix~"/img/ons-logo-black-en.svg" %}
+{% set olg_cdn = cdn_url_prefix~"/img/UKOpenGovernmentLicence-grey.svg" %}
+
+<footer class="footer" role="contentinfo">
+    <div class="container">
+        <div class="grid">
+            <div class="grid__col col-12@m">
+                <img src="{{ ons_logo }}" alt="Office for National Statistics" class="footer__poweredby-img" />
+            </div>
+            <div class="grid__col col-4@m">
+                <h4 class="u-fs-r--b footer__heading">{{ _("Legal information") }}</h4>
+                <ul class="list list--bare">
+                    <li>
+                        <a href="/cookies-privacy" class="footer__link" target="_blank">{{ _("Cookies and privacy") }}</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="grid__col col-4@m">
+                <h4 class="u-fs-r--b footer__heading">{{ _("About ONS") }}</h4>
+                <ul class="list list--bare">
+                    <li>
+                        <a href="https://www.ons.gov.uk/aboutus/whatwedo" class="footer__link" target="_blank">{{ _("What we do") }}</a>
+                    </li>
+                    <li>
+                        <a href="/contact-us" class="footer__link" target="_blank">Contact us</a>
+                    </li>
+                    <li>
+                        <a href="https://www.ons.gov.uk/help/accessibility" class="footer__link" target="_blank">{{ _("Accessibility") }}</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="grid__col col-4@m">
+                <h4 class="u-fs-r--b footer__heading">{{ _("Statistics") }}</h4>
+                <ul class="list list--bare">
+                    <li>
+                        <a href="https://www.statisticsauthority.gov.uk/about-the-authority/" class="footer__link" target="_blank">{{ _("UK Statistics Authority") }}</a>
+                    </li>
+                    <li>
+                        <a href="https://www.ons.gov.uk/releasecalendar" class="footer__link" target="_blank">{{ _("Release calendar") }}</a>
+                    </li>
+                    <li>
+                        <a href="https://www.ons.gov.uk/news" class="footer__link" target="_blank">{{ _("News") }}</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="grid__col col-12@m">
+                <div class="footer__license footer__license--border">
+                    <img alt="OGL" class="footer__ogl-img" src="{{ olg_cdn }}"> {{ _("All content is available under the %(class_open)sOpen Government Licence v3.0%(class_close)s, except where otherwise stated",
+                    class_open='<a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" class="footer__link" target="_blank">',
+                    class_close="</a>") }}
+               </div>
+            </div>
+        </div>
+    </div>
+</footer>

--- a/app/translations/messages.pot
+++ b/app/translations/messages.pot
@@ -1,14 +1,14 @@
 # Translations template for PROJECT.
-# Copyright (C) 2018 ORGANIZATION
+# Copyright (C) 2019 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-12-13 09:45+0000\n"
+"POT-Creation-Date: 2019-01-25 13:54+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.6.0\n"
 
-#: app/jinja_filters.py:104 app/jinja_filters.py:241
+#: app/jinja_filters.py:95 app/jinja_filters.py:232
 #: app/validation/validators.py:292
 #, python-format
 msgid "%(num)s year"
@@ -25,19 +25,19 @@ msgid_plural "%(num)s years"
 msgstr[0] ""
 msgstr[1] ""
 
-#: app/jinja_filters.py:106 app/validation/validators.py:294
+#: app/jinja_filters.py:97 app/validation/validators.py:294
 #, python-format
 msgid "%(num)s month"
 msgid_plural "%(num)s months"
 msgstr[0] ""
 msgstr[1] ""
 
-#: app/jinja_filters.py:177
+#: app/jinja_filters.py:168
 #, python-format
 msgid "%(date)s at %(time)s"
 msgstr ""
 
-#: app/jinja_filters.py:251 app/jinja_filters.py:299
+#: app/jinja_filters.py:242 app/jinja_filters.py:290
 #, python-format
 msgid "%(from_date)s to %(to_date)s"
 msgstr ""
@@ -290,20 +290,20 @@ msgstr ""
 msgid "ONS Survey"
 msgstr ""
 
-#: app/templates/layouts/_base.html:81
+#: app/templates/layouts/_base.html:79
 msgid "Skip to content"
 msgstr ""
 
-#: app/templates/layouts/_base.html:85
+#: app/templates/layouts/_base.html:83
 #: app/templates/layouts/_questionnaire.html:30
 msgid "Save and continue"
 msgstr ""
 
-#: app/templates/layouts/_base.html:96
+#: app/templates/layouts/_base.html:94
 msgid "Hide sections"
 msgstr ""
 
-#: app/templates/layouts/_base.html:96
+#: app/templates/layouts/_base.html:94
 msgid "View sections"
 msgstr ""
 
@@ -384,6 +384,9 @@ msgstr ""
 #: app/themes/northernireland/templates/partials/footer-transactional.html:12
 #: app/themes/northernireland/templates/partials/footer.html:24
 #: app/themes/social/templates/static/contact-us.html:26
+#: app/themes/ukis/templates/partials/footer-transactional.html:13
+#: app/themes/ukis/templates/partials/footer.html:25
+#: app/themes/ukis_ni/templates/partials/footer-transactional.html:13
 msgid "Contact us"
 msgstr ""
 
@@ -393,6 +396,10 @@ msgstr ""
 #: app/themes/census/templates/partials/footer.html:13
 #: app/themes/northernireland/templates/partials/footer-transactional.html:15
 #: app/themes/northernireland/templates/partials/footer.html:13
+#: app/themes/ukis/templates/partials/footer-transactional.html:16
+#: app/themes/ukis/templates/partials/footer.html:14
+#: app/themes/ukis_ni/templates/partials/footer-transactional.html:16
+#: app/themes/ukis_ni/templates/partials/footer.html:14
 msgid "Cookies and privacy"
 msgstr ""
 
@@ -402,6 +409,10 @@ msgstr ""
 #: app/themes/census/templates/partials/footer.html:47
 #: app/themes/northernireland/templates/partials/footer-transactional.html:21
 #: app/themes/northernireland/templates/partials/footer.html:47
+#: app/themes/ukis/templates/partials/footer-transactional.html:22
+#: app/themes/ukis/templates/partials/footer.html:48
+#: app/themes/ukis_ni/templates/partials/footer-transactional.html:22
+#: app/themes/ukis_ni/templates/partials/footer.html:48
 #, python-format
 msgid ""
 "All content is available under the %(class_open)sOpen Government Licence "
@@ -411,52 +422,68 @@ msgstr ""
 #: app/templates/partials/footer.html:6
 #: app/themes/census/templates/partials/footer.html:10
 #: app/themes/northernireland/templates/partials/footer.html:10
+#: app/themes/ukis/templates/partials/footer.html:11
+#: app/themes/ukis_ni/templates/partials/footer.html:11
 msgid "Legal information"
 msgstr ""
 
 #: app/templates/partials/footer.html:14
 #: app/themes/census/templates/partials/footer.html:18
 #: app/themes/northernireland/templates/partials/footer.html:18
+#: app/themes/ukis/templates/partials/footer.html:19
+#: app/themes/ukis_ni/templates/partials/footer.html:19
 msgid "About ONS"
 msgstr ""
 
 #: app/templates/partials/footer.html:17
 #: app/themes/census/templates/partials/footer.html:21
 #: app/themes/northernireland/templates/partials/footer.html:21
+#: app/themes/ukis/templates/partials/footer.html:22
+#: app/themes/ukis_ni/templates/partials/footer.html:22
 msgid "What we do"
 msgstr ""
 
 #: app/templates/partials/footer.html:23
 #: app/themes/census/templates/partials/footer.html:27
 #: app/themes/northernireland/templates/partials/footer.html:27
+#: app/themes/ukis/templates/partials/footer.html:28
+#: app/themes/ukis_ni/templates/partials/footer.html:28
 msgid "Accessibility"
 msgstr ""
 
 #: app/templates/partials/footer.html:28
 #: app/themes/census/templates/partials/footer.html:32
 #: app/themes/northernireland/templates/partials/footer.html:32
+#: app/themes/ukis/templates/partials/footer.html:33
+#: app/themes/ukis_ni/templates/partials/footer.html:33
 msgid "Statistics"
 msgstr ""
 
 #: app/templates/partials/footer.html:31
 #: app/themes/census/templates/partials/footer.html:35
 #: app/themes/northernireland/templates/partials/footer.html:35
+#: app/themes/ukis/templates/partials/footer.html:36
+#: app/themes/ukis_ni/templates/partials/footer.html:36
 msgid "UK Statistics Authority"
 msgstr ""
 
 #: app/templates/partials/footer.html:34
 #: app/themes/census/templates/partials/footer.html:38
 #: app/themes/northernireland/templates/partials/footer.html:38
+#: app/themes/ukis/templates/partials/footer.html:39
+#: app/themes/ukis_ni/templates/partials/footer.html:39
 msgid "Release calendar"
 msgstr ""
 
 #: app/templates/partials/footer.html:37
 #: app/themes/census/templates/partials/footer.html:41
 #: app/themes/northernireland/templates/partials/footer.html:41
+#: app/themes/ukis/templates/partials/footer.html:42
+#: app/themes/ukis_ni/templates/partials/footer.html:42
 msgid "News"
 msgstr ""
 
-#: app/templates/partials/main-navigation.html:5
+#: app/templates/partials/main-navigation.html:7
 #: app/templates/partials/services-navigation.html:4
 msgid "My account"
 msgstr ""
@@ -471,7 +498,6 @@ msgstr ""
 
 #: app/templates/partials/sign-out-button-navigation.html:7
 #: app/templates/partials/sign-out-button.html:7
-#: app/templates/partials/timeout.html:28
 msgid "Save and sign out"
 msgstr ""
 
@@ -483,18 +509,6 @@ msgstr ""
 #: app/templates/partials/sign-out-button-navigation.html:13
 #: app/templates/partials/sign-out-button.html:13
 msgid "Save and complete later"
-msgstr ""
-
-#: app/templates/partials/timeout.html:12
-msgid "Your session is about to expire"
-msgstr ""
-
-#: app/templates/partials/timeout.html:26
-msgid "Continuing"
-msgstr ""
-
-#: app/templates/partials/timeout.html:26
-msgid "Continue survey"
 msgstr ""
 
 #: app/templates/partials/answers/checkbox.html:8


### PR DESCRIPTION
### What is the context of this PR?
A defect was raised saying that the UKIS questionnaire was not using the correct footer in its theme.

This change sets both the footer and footer-transactional templates to the "Powered by ONS" template from the pattern library.

https://sdc-global-design-patterns.netlify.com/components/detail/footer.html

### How to review 
Launch the UKIS schema on this branch to check that the footer matches the powered by ONS variants in the pattern library.

The introduction page should use the main footer and subsequent pages should use the transactional variant of the footer.
