### PR TITLE
UKIS - Fix duplicated qcode

### DIFF
--- a/data/en/ukis_0001.json
+++ b/data/en/ukis_0001.json
@@ -1925,7 +1925,7 @@
                                 "id": "answer3229",
                                 "mandatory": false,
                                 "type": "Radio",
-                                "q_code": "2668",
+                                "q_code": "2678",
                                 "label": "",
                                 "description": "",
                                 "options": [{

--- a/data/en/ukis_0002.json
+++ b/data/en/ukis_0002.json
@@ -1907,7 +1907,7 @@
                                 "id": "answer3229",
                                 "mandatory": false,
                                 "type": "Radio",
-                                "q_code": "2668",
+                                "q_code": "2678",
                                 "label": "",
                                 "description": "",
                                 "options": [{


### PR DESCRIPTION
### What is the context of this PR?
Fix qcode that was duplicated in UKIS for both form types.

### How to review 
1. Ensure that the qcodes are used when selecting the answers.