### PR TITLE
UKIS - Allow decimals on currency inputs

### DIFF
--- a/data/en/ukis_0001.json
+++ b/data/en/ukis_0001.json
@@ -4252,7 +4252,7 @@
                                         "value": 0,
                                         "exclusive": false
                                     },
-                                    "decimal_places": 0,
+                                    "decimal_places": 2,
                                     "currency": "GBP"
                                 }
                             ]
@@ -4410,7 +4410,7 @@
                                     "value": 0,
                                     "exclusive": false
                                 },
-                                "decimal_places": 0,
+                                "decimal_places": 2,
                                 "currency": "GBP"
                             }]
                         }]

--- a/data/en/ukis_0002.json
+++ b/data/en/ukis_0002.json
@@ -4232,7 +4232,7 @@
                                         "value": 0,
                                         "exclusive": false
                                     },
-                                    "decimal_places": 0,
+                                    "decimal_places": 2,
                                     "currency": "GBP"
                                 }
                             ]
@@ -4392,7 +4392,7 @@
                                     "value": 0,
                                     "exclusive": false
                                 },
-                                "decimal_places": 0,
+                                "decimal_places": 2,
                                 "currency": "GBP"
                             }]
                         }]


### PR DESCRIPTION
### What is the context of this PR?
Allow decimal values for currency inputs on questions where users can enter penny values.

### How to review 
1. Ensure you can enter values with pennies on questions referenced in slides 99 and 101. https://docs.google.com/presentation/d/1Y_SFcb5HVN7lBwTqWrQyGtFWVfMzMZu3lNGA2Bx2plc/edit#slide=id.g4362c1b198_0_0