### PR TITLE
Validation Change - Fix test schemas that have empty labels

### DIFF
--- a/data/en/0_rogue_one.json
+++ b/data/en/0_rogue_one.json
@@ -223,7 +223,7 @@
                 "questions": [{
                     "answers": [{
                         "id": "film-takings-answer",
-                        "label": "",
+                        "label": "Estimated takings",
                         "mandatory": true,
                         "q_code": "2",
                         "type": "Currency",

--- a/data/en/test_navigation.json
+++ b/data/en/test_navigation.json
@@ -304,7 +304,7 @@
                     "questions": [{
                         "answers": [{
                             "id": "extra-cover-answer",
-                            "label": "",
+                            "label": "Extra Cover",
                             "mandatory": true,
                             "q_code": "7",
                             "type": "Number",
@@ -444,7 +444,7 @@
                             "questions": [{
                                 "answers": [{
                                     "id": "credit-card-answer",
-                                    "label": "",
+                                    "label": "Credit Card",
                                     "mandatory": true,
                                     "q_code": "11",
                                     "type": "Number"
@@ -463,7 +463,7 @@
                             "questions": [{
                                 "answers": [{
                                     "id": "expiry-date-answer",
-                                    "label": "",
+                                    "label": "Expiry Date",
                                     "mandatory": true,
                                     "q_code": "12",
                                     "type": "TextField"
@@ -482,7 +482,7 @@
                             "questions": [{
                                 "answers": [{
                                     "id": "security-code-answer",
-                                    "label": "",
+                                    "label": "Security Code",
                                     "mandatory": true,
                                     "q_code": "13",
                                     "type": "TextField"

--- a/data/en/test_navigation_confirmation.json
+++ b/data/en/test_navigation_confirmation.json
@@ -235,7 +235,7 @@
                 "questions": [{
                     "answers": [{
                         "id": "extra-cover-answer",
-                        "label": "",
+                        "label": "Extra cover",
                         "mandatory": true,
                         "q_code": "1",
                         "type": "Number",
@@ -278,7 +278,7 @@
                 "questions": [{
                     "answers": [{
                         "id": "credit-card-answer",
-                        "label": "",
+                        "label": "Credit card",
                         "mandatory": true,
                         "q_code": "1",
                         "type": "Number"
@@ -296,7 +296,7 @@
                 "questions": [{
                     "answers": [{
                         "id": "expiry-date-answer",
-                        "label": "",
+                        "label": "Expiry date",
                         "mandatory": true,
                         "q_code": "1",
                         "type": "TextField"
@@ -314,7 +314,7 @@
                 "questions": [{
                     "answers": [{
                         "id": "security-code-answer",
-                        "label": "",
+                        "label": "Security Code",
                         "mandatory": true,
                         "q_code": "1",
                         "type": "TextField"

--- a/data/en/test_repeating_and_conditional_routing.json
+++ b/data/en/test_repeating_and_conditional_routing.json
@@ -99,7 +99,7 @@
                     "answers": [{
                         "q_code": "4",
                         "id": "what-is-your-age",
-                        "label": "",
+                        "label": "Age",
                         "mandatory": true,
                         "type": "Number"
                     }]
@@ -117,7 +117,7 @@
                     "answers": [{
                         "q_code": "5",
                         "id": "what-is-your-shoe-size",
-                        "label": "",
+                        "label": "Shoe size",
                         "mandatory": true,
                         "type": "Number"
                     }]


### PR DESCRIPTION
### What is the context of this PR?
There is a validator change to ensure that labels (where they are a required field) to be populated. https://github.com/ONSdigital/eq-schema-validator/pull/111

This change updates test schemas to ensure that they are now valid against this new rule

### How to review 
1. Ensure that all schemas are valid against https://github.com/ONSdigital/eq-schema-validator/pull/111
2. Ensure that all existing tests pass