### PR TITLE
Remove the build arg for application version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM ubuntu:18.04 as builder
 
-ARG APP_VERSION=unknown
-
 RUN apt-get update \
     && apt-get install -y curl git locales make build-essential
 
@@ -20,7 +18,6 @@ WORKDIR /usr/src/app
 COPY . /usr/src/app
 RUN yarn compile
 RUN ./scripts/translate_schemas.sh
-RUN printf $APP_VERSION > .application-version
 
 # We don't want node_modules to be copied to the runtime image
 RUN rm -rf node_modules


### PR DESCRIPTION
### What is the context of this PR?
The dockerfile was previously changed to use a build arg for the application version.

This was making concourse builds complex.

### How to review 
Ensure the build works and picks up the version from the .application-version file in the directory where you build the image.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
