### PR TITLE
Fix issue with metadata validator in QPSES schema.

### DIFF
--- a/data/en/qpses160_0002.json
+++ b/data/en/qpses160_0002.json
@@ -799,7 +799,7 @@
         },
         {
             "name": "trad_as",
-            "validator": "string"
+            "validator": "optional_string"
         }
     ],
     "view_submitted_response": {

--- a/data/en/qpses165_0002.json
+++ b/data/en/qpses165_0002.json
@@ -799,7 +799,7 @@
         },
         {
             "name": "trad_as",
-            "validator": "string"
+            "validator": "optional_string"
         }
     ],
     "view_submitted_response": {

--- a/data/en/qpses169_0003.json
+++ b/data/en/qpses169_0003.json
@@ -798,7 +798,7 @@
         },
         {
             "name": "trad_as",
-            "validator": "string"
+            "validator": "optional_string"
         }
     ],
     "view_submitted_response": {


### PR DESCRIPTION
### What is the context of this PR?
The QPSES schemas were defining `trad_as` metadata with the `string` validator. For business surveys `trad_as` is an optional value and should therefore be using the `optional_string` validator.

### How to review 
Changes look sensible. All tests and checks should pass.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
