### PR TITLE
Update external guidance links for QPSES schemas.

### DIFF
--- a/data/en/qpses160_0002.json
+++ b/data/en/qpses160_0002.json
@@ -19,12 +19,16 @@
                             "type": "Basic",
                             "id": "use-of-information",
                             "content": [{
-                                "list": [
-                                    "Data should relate to all sites in England, Scotland and Wales unless otherwise stated.",
-                                    "You can provide informed estimates if actual figures aren’t available.",
-                                    "We will treat your data securely and confidentially."
-                                ]
-                            }]
+                                    "list": [
+                                        "Data should relate to all sites in England, Scotland and Wales unless otherwise stated.",
+                                        "You can provide informed estimates if actual figures aren’t available.",
+                                        "We will treat your data securely and confidentially."
+                                    ]
+                                },
+                                {
+                                    "description": "<p><a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/surveys/informationforbusinesses/businesssurveys/guidancetohelpcompletethequarterlypublicsectoremploymentsurvey'>Read the detailed guidance for completing this survey</a></p>"
+                                }
+                            ]
                         }],
                         "preview_content": {
                             "id": "preview",
@@ -117,11 +121,6 @@
                             ]
                         },
                         "secondary_content": [{
-                            "id": "detailed-guidance",
-                            "content": [{
-                                "description": "<p><a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/surveys/informationforbusinesses/businesssurveys/guidancetohelpcompletethequarterlypublicsectoremploymentsurvey'>Read more information about this survey</a></p>"
-                            }]
-                        }, {
                             "id": "how-we-use-your-data",
                             "title": "How we use your data",
                             "content": [{

--- a/data/en/qpses165_0002.json
+++ b/data/en/qpses165_0002.json
@@ -24,6 +24,8 @@
                                     "You can provide informed estimates if actual figures aren’t available.",
                                     "We will treat your data securely and confidentially."
                                 ]
+                            }, {
+                                "description": "<p><a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/surveys/informationforbusinesses/businesssurveys/guidancetohelpcompletethequarterlypublicsectoremploymentsurvey'>Read the detailed guidance for completing this survey</a></p>"
                             }]
                         }],
                         "preview_content": {
@@ -116,11 +118,6 @@
                             ]
                         },
                         "secondary_content": [{
-                            "id": "detailed-guidance",
-                            "content": [{
-                                "description": "<p><a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/surveys/informationforbusinesses/businesssurveys/guidancetohelpcompletethequarterlypublicsectoremploymentsurvey'>Read more information about this survey</a></p>"
-                            }]
-                        }, {
                             "id": "how-we-use-your-data",
                             "title": "How we use your data",
                             "content": [{

--- a/data/en/qpses169_0003.json
+++ b/data/en/qpses169_0003.json
@@ -24,6 +24,8 @@
                                     "You can provide informed estimates if actual figures aren’t available.",
                                     "We will treat your data securely and confidentially."
                                 ]
+                            }, {
+                                "description": "<p><a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/surveys/informationforbusinesses/businesssurveys/quarterlypublicsectoremploymentsurveycivilservice'>Read the detailed guidance for completing this survey</a></p>"
                             }]
                         }],
                         "preview_content": {
@@ -116,11 +118,6 @@
                             ]
                         },
                         "secondary_content": [{
-                            "id": "detailed-guidance",
-                            "content": [{
-                                "description": "<p><a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/surveys/informationforbusinesses/businesssurveys/quarterlypublicsectoremploymentsurveycivilservice'>Read more information about this survey</a></p>"
-                            }]
-                        }, {
                             "id": "how-we-use-your-data",
                             "title": "How we use your data",
                             "content": [{


### PR DESCRIPTION
### What is the context of this PR?
Moved the external guidance link above the start survey button and re-worded the link text.

### How to review 
Ensure that each of the QPSES schemas has the external guidance link above the start survey button.
The link text on each of the schemas should read "Read the detailed guidance for completing this survey".

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
