### PR TITLE
Pin validator version to before variant changes

### DIFF
--- a/scripts/test_schemas.sh
+++ b/scripts/test_schemas.sh
@@ -6,8 +6,8 @@ if [ "$1" == "--local" ] || [ "$2" == "--local" ]; then
 fi
 
 if [ "$run_docker" == true ]; then
-    docker pull onsdigital/eq-schema-validator:v3
-    validator="$(docker run -d -p 5001:5000 onsdigital/eq-schema-validator:v3)"
+    docker pull onsdigital/eq-schema-validator:use-non-global-named-args
+    validator="$(docker run -d -p 5001:5000 onsdigital/eq-schema-validator:use-non-global-named-args)"
     sleep 3
 fi
 


### PR DESCRIPTION
### What is the context of this PR?

The validator PR to change variants will break our builds on runner.

To avoid this, but still allow the variant PR to be merged in validator, this PR pins the version of validator to the last tag that was built on the v3 branch.

This can be changed back to v3 after the runner implementation of variants is complete.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
