### PR TITLE
Added description for other checkbox on QCAS

### DIFF
--- a/data/en/qcas_0018.json
+++ b/data/en/qcas_0018.json
@@ -851,6 +851,7 @@
                                     {
                                         "label": "Other",
                                         "value": "Other",
+                                        "description": "for example global economic conditions; leaving the EU",
                                         "q_code": "146k"
                                     }
                                 ]

--- a/data/en/qcas_0019.json
+++ b/data/en/qcas_0019.json
@@ -851,6 +851,7 @@
                                     {
                                         "label": "Other",
                                         "value": "Other",
+                                        "description": "for example global economic conditions; leaving the EU",
                                         "q_code": "146k"
                                     }
                                 ]

--- a/data/en/qcas_0020.json
+++ b/data/en/qcas_0020.json
@@ -902,6 +902,7 @@
                                     {
                                         "label": "Other",
                                         "value": "Other",
+                                        "description": "for example global economic conditions; leaving the EU",
                                         "q_code": "146k"
                                     }
                                 ]


### PR DESCRIPTION
### What is the context of this PR?
Added description "for example global economic conditions; leaving the EU" to the other checkbox on the "Please indicate the reasons for any changes in the total investment" question

### How to review 
Run through survey entering yes to everything and any random numbers in the boxes until you reach a page with checkboxes on. When you do look at the bottom one (Other) and see that it has the description "for example global economic conditions; leaving the EU".

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
