### PR TITLE
Remove query string from summary link

### DIFF
--- a/app/templating/summary/block.py
+++ b/app/templating/summary/block.py
@@ -10,16 +10,13 @@ class Block:
         self.id = block_schema['id']
         self.title = block_schema.get('title')
         self.number = block_schema.get('number')
-        self.link = self._build_link(block_schema, metadata)
+        self.link = self._build_link(block_schema['id'])
         self.questions = self._build_questions(block_schema, answer_store, metadata, schema)
 
     @staticmethod
-    def _build_link(block_schema, metadata):
+    def _build_link(block_id):
         return url_for('questionnaire.get_block',
-                       eq_id=metadata['eq_id'],
-                       form_type=metadata['form_type'],
-                       collection_id=metadata['collection_exercise_sid'],
-                       block_id=block_schema['id'])
+                       block_id=block_id)
 
     @staticmethod
     def _build_questions(block_schema, answer_store, metadata, schema):


### PR DESCRIPTION
### What is the context of this PR?
A Query string was being added to the summary change link as the parameters were still being passed to the `url_for` function
eg `questionnaire/dob-question-block?eq_id=test&form_type=placeholder_full&collection_id=3309bc98-00b3-41f0-8e70-d0f7c2e4a38a`

### How to review 
Check that the change link still works from the summary page

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
