### PR TITLE
Make image registry configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,11 +251,11 @@ EQ_KEYS_FILE=docker-keys.yml EQ_SECRETS_FILE=docker-secrets.yml ./k8s/deploy_cre
 
 To deploy the app to the cluster, run the following command:
 ```
-./k8s/deploy_app.sh <SUBMISSION_BUCKET_NAME> <IMAGE_TAG>
+./k8s/deploy_app.sh <SUBMISSION_BUCKET_NAME> <DOCKER_REGISTRY> <IMAGE_TAG>
 ```
 ##### Example
  ```
-./k8s/deploy_app.sh census-eq-dev-1234567-survey-runner-submission v3.0.0
+./k8s/deploy_app.sh census-eq-dev-1234567-survey-runner-submission eu.gcr.io/census-eq-dev v3.0.0
  ```
  
 ### Internationalisation

--- a/k8s/deploy_app.sh
+++ b/k8s/deploy_app.sh
@@ -9,11 +9,13 @@ fi
 
 #PROJECT_ID=$1
 SUBMISSION_BUCKET_NAME=$1
-IMAGE_TAG="${2:-latest}"
+DOCKER_REGISTRY="${2:-eu.gcr.io/census-eq-ci}"
+IMAGE_TAG="${3:-latest}"
 
 helm tiller run \
     helm upgrade --install \
     survey-runner \
     k8s/helm \
     --set submissionBucket=${SUBMISSION_BUCKET_NAME} \
+    --set image.repository=${DOCKER_REGISTRY}/eq-survey-runner \
     --set image.tag=${IMAGE_TAG}


### PR DESCRIPTION
### What is the context of this PR?
At the moment, the image repository is configurable only in concourse. This is where the image is pushed to, but in helm, the repository is hardcoded hence where you push to is not necessarily where you pull from.

### How to review 
- Be able to configure your own registry. Follow readme for instructions.