### PR TITLE
Don't store unanswered questions in answer store

### DIFF
--- a/app/questionnaire/answer_store_updater.py
+++ b/app/questionnaire/answer_store_updater.py
@@ -1,10 +1,11 @@
 from app.data_model.answer_store import Answer
-from app.forms.questionnaire_form import QuestionnaireForm
 
 
 class AnswerStoreUpdater:
     """ Component responsible for any actions that need to happen as a result of updating the answer store
     """
+
+    EMPTY_ANSWER_VALUES = (None, [], '')
 
     def __init__(self, current_location, schema, questionnaire_store, current_question):
         self._current_location = current_location
@@ -14,45 +15,28 @@ class AnswerStoreUpdater:
         self._answer_store = self._questionnaire_store.answer_store
 
     def save_answers(self, form):
-        if isinstance(form, QuestionnaireForm):
-            self._update_questionnaire_store_with_form_data(form.data)
-        else:
-            self._update_questionnaire_store_with_answer_data(form.serialise())
+        self._update_questionnaire_store_with_form_data(form.data)
 
         if self._current_location not in self._questionnaire_store.completed_blocks:
             self._questionnaire_store.completed_blocks.append(self._current_location)
 
         self._questionnaire_store.add_or_update()
 
-    def _update_questionnaire_store_with_answer_data(self, answers):
+    def _update_questionnaire_store_with_form_data(self, form_data):
         answer_ids_for_question = self._schema.get_answer_ids_for_question(self._current_question)
 
-        valid_answers = (
-            answer for answer in answers
-            if answer.answer_id in answer_ids_for_question
-        )
-
-        for answer in valid_answers:
-            self._answer_store.add_or_update(answer)
-
-    def _update_questionnaire_store_with_form_data(self, answers):
-        answer_ids_for_question = self._schema.get_answer_ids_for_question(self._current_question)
-
-        for answer_id, answer_value in answers.items():
+        for answer_id, answer_value in form_data.items():
 
             # If answer is not answered then check for a schema specified default
-            if answer_value is None:
+            if answer_value in self.EMPTY_ANSWER_VALUES:
                 answer = next((answer for answer in self._current_question.get('answers', []) if answer['id'] == answer_id), {})
                 answer_value = answer.get('default')
 
             if answer_id in answer_ids_for_question:
-                if answer_value is not None:
+                if answer_value not in self.EMPTY_ANSWER_VALUES:
                     answer = Answer(answer_id=answer_id,
                                     value=answer_value)
 
                     self._answer_store.add_or_update(answer)
                 else:
-                    self._remove_answer_from_questionnaire_store(answer_id)
-
-    def _remove_answer_from_questionnaire_store(self, answer_id):
-        self._answer_store.remove(answer_ids=[answer_id])
+                    self._answer_store.remove(answer_ids=[answer_id])

--- a/tests/integration/views/test_dump.py
+++ b/tests/integration/views/test_dump.py
@@ -64,10 +64,6 @@ class TestDumpAnswers(IntegrationTestCase):
         expected = {
             'answers': [
                 {
-                    'value': '',
-                    'answer_id': 'other-answer-mandatory',
-                },
-                {
                     'value': 'Toast',
                     'answer_id': 'radio-mandatory-answer',
                 }


### PR DESCRIPTION
### What is the context of this PR?
Resurrects the work done in https://github.com/ONSdigital/eq-survey-runner/pull/1933 to not store empty answers in the answer store. 

Also removed the `_update_questionnaire_store_with_answer_data` method as it wasn't being used any more (it was previously used for repeating answers and relationships functionality).

### How to review 
- Complete some surveys and verify empty answers are not stored in the answer store using the `/dump/answers` endpoint. 
- Try different answer variations e.g. radio, checkbox, detail answers