### PR TITLE
Updated MBS 0111 adding guidance and removing preview section

### DIFF
--- a/app/helpers/template_helper.py
+++ b/app/helpers/template_helper.py
@@ -85,5 +85,6 @@ def render_template(template, **kwargs):
         account_service_url=cookie_session.get('account_service_url'),
         account_service_log_out_url=cookie_session.get('account_service_log_out_url'),
         survey_id=g.schema.json['survey_id'],
+        survey_guidance_url=g.schema.json.get('survey_guidance_url'),
         **kwargs
     )

--- a/app/templates/introduction.html
+++ b/app/templates/introduction.html
@@ -55,9 +55,14 @@
             {% endif %}
 
             {%- if legal_basis -%}
-                <h2 class="u-fs-m u-mb-xs" data-qa="legal-response">{{ _("Your response is legally required") }}</h2>
+                <h3 class="u-fs-m" data-qa="legal-response">{{ _("Your response is legally required") }}</h3>
                 <p class="u-fs-r u-mb-m" data-qa="legal-basis">{{ legal_basis }}</p>
             {%- endif -%}
+
+            {% if survey_guidance_url %}
+                <h3 class="u-fs-m" data-qa="survey-guidance-url">{{ _("Guidance to help complete this survey") }}</h3>
+                <p class="u-mb-m">{{_("There is %(opening_tag)s further guidance available%(closing_tag)s with information of what is required for this survey, and help to complete it",opening_tag="<a rel='noopener noreferrer' target='_blank' href="+survey_guidance_url+">",closing_tag="</a>")}}</p>
+            {% endif %}
 
             {% block start_survey %}
                 {% include 'partials/introduction/start-survey.html' %}

--- a/app/templates/partials/introduction/basic.html
+++ b/app/templates/partials/introduction/basic.html
@@ -1,10 +1,10 @@
 <div id="{{intro.id}}" class="u-mb-s">
     {% if intro.title %}
-    <h2 class="u-fs-l">{{ intro.title }}</h2>
+    <h3 class="u-fs-m">{{ intro.title }}</h3>
     {% endif %}
     {% for content in intro.content  %}
     {% if content.title %}
-    <h3 class="u-fs-r--b">{{ content.title }}</h3>
+    <h4 class="u-fs-r--b">{{ content.title }}</h4>
     {% endif %}
     {% if content.description %}
     <p class="u-fs-r qa-intro-description" data-qa="intro-basic-description">

--- a/app/templates/partials/introduction/preview.html
+++ b/app/templates/partials/introduction/preview.html
@@ -1,8 +1,8 @@
-<h2 class="u-fs-l u-mt-m">{{ intro.title }}</h2>
+<h3 class="u-fs-m">{{ intro.title }}</h3>
 <div class="collapsible__introduction">
 {% for content in intro.content %}
 {% if content.title  %}
-<h3 class="u-fs-r--b u-mt-s">{{ content.title }}</h3>
+<h4 class="u-fs-r--b u-mt-s">{{ content.title }}</h4>
 {% endif %}
 <p class="u-fs-r qa-intro-description" data-qa="intro-preview-description">
     {{ content.description }}

--- a/app/templates/partials/introduction/start-survey.html
+++ b/app/templates/partials/introduction/start-survey.html
@@ -1,1 +1,1 @@
-<button class="btn qa-btn-get-started" type="submit" name="action[start_questionnaire]">{{ _("Start survey") }}</button>
+<button class="btn qa-btn-get-started u-mb-m" type="submit" name="action[start_questionnaire]">{{ _("Start survey") }}</button>


### PR DESCRIPTION
### What is the context of this PR?
The Add Guidance links to forms (https://trello.com/c/csQmUQiQ) has been paired down to just MBS 0111 form with the following changes:-
- Move guidance link to above the Start Survey button
- Add heading above the guidance link to separate it from the legal section
- Normalise headings, h1 in banner, form h2, sections h3

### Dependencies
- https://github.com/ONSdigital/eq-schema-validator/pull/129

### How to review 
From Launch a Survey open each form type to ensure changes to MBS 0111 form and other forms have been successfully applied.

### Checklist

* [ ] MBS 0111 - Guidance link moved to above Start Survey button
* [ ] MBS 0111 - Added heading over Guidance link to separate from Legal section
* [ ] MBS 0111 - Section "Information You Need" has been removed
* [ ] Normalise heading under Form title (h2) as h3s
