### PR TITLE
Don't rebuild image at end of travis build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -60,6 +60,7 @@ tests/results
 tests/coverage
 tests/a11y
 
+
 **/_sprite.scss
 
 ## OS X
@@ -77,3 +78,7 @@ newrelic.ini
 htmlcov/
 
 *errorShots*
+
+# Ignore any generated pages for the functional tests
+tests/functional/generated_pages
+tests/


### PR DESCRIPTION
### What is the context of this PR?
The docker image is rebuilding and running yarn again after no changes where is should be using the cache

### How to review 
Is the image being re-built at the end of the build?