### PR TITLE
Enable Autoscaling of service

### DIFF
--- a/k8s/helm/templates/autoscaler.yaml
+++ b/k8s/helm/templates/autoscaler.yaml
@@ -1,0 +1,12 @@
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Chart.Name }}-autoscaler
+spec:
+  scaleTargetRef:
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    name: {{ .Chart.Name }}
+  minReplicas: {{ .Values.autoscaler.minReplicas }}
+  maxReplicas: {{ .Values.autoscaler.maxReplicas }}
+  targetCPUUtilizationPercentage: {{ .Values.autoscaler.targetCPUUtilizationPercentage }}

--- a/k8s/helm/templates/deployment.yaml
+++ b/k8s/helm/templates/deployment.yaml
@@ -75,5 +75,7 @@ spec:
               value: used-jti-claim
             - name: EQ_SUBMISSION_BACKEND
               value: gcs
+            - name: GUNICORN_WORKERS
+              value: "9"
             - name: EQ_GCS_SUBMISSION_BUCKET_ID
               value: "{{- .Values.submissionBucket }}"

--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -23,4 +23,10 @@ ingress:
     - secretName: tls-cert
 
 resources:
-  cpu: "3"
+  requests:
+    cpu: "3"
+
+autoscaler:
+    minReplicas: 3
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 50


### PR DESCRIPTION
### What is the context of this PR?
This PR adds a `HorizontalPodAutoscaler` to the runner helm chart.
This allows for the runner pods to scale based on CPU Utilisation.

### How to review 
Deploy the chart to your cluster and check that your workload had autoscaling enabled
![Screenshot 2019-04-02 at 15 43 43](https://user-images.githubusercontent.com/7594012/55411768-235b8d00-555e-11e9-8460-17034fda311a.png)
