### PR TITLE
Use In-memory datastore when running in docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
 
   datastore:
     image: knarz/datastore-emulator
+    environment:
+        IN_MEMORY: "true"
     networks:
       - eq-env
 


### PR DESCRIPTION
This speeds up the functional tests by over 100 seconds running locally

### How to review 
Run the tests, are they faster?