### PR TITLE
Dont update session expiry too much

### DIFF
--- a/app/authentication/authenticator.py
+++ b/app/authentication/authenticator.py
@@ -48,10 +48,13 @@ def _extend_session_expiry(session_store):
     """
     session_timeout = cookie_session.get('expires_in')
     if session_timeout:
-        session_store.expiration_time = datetime.now(tz=tzutc()) + timedelta(seconds=session_timeout)
-        session_store.save()
+        new_expiration_time = datetime.now(tz=tzutc()) + timedelta(seconds=session_timeout)
 
-        logger.debug('session expiry extended')
+        # Only update expiry time if its greater than 60s different to what is currently set
+        if not session_store.expiration_time or (new_expiration_time - session_store.expiration_time).total_seconds() > 60:
+            session_store.expiration_time = new_expiration_time
+            session_store.save()
+            logger.debug('session expiry extended')
 
 
 def _is_session_valid(session_store):


### PR DESCRIPTION
### What is the context of this PR?
We are making a lot of writes to the session table that we potentially don't need to make.
When we create a new session from the `/session` login page, we create the session and then we make a request to update the expiry milliseconds later.
Also when we do a POST and redirect to a GET, we update the expiry on the POST and then again on the GET immediately after.

This PR introduces a change to not update the session expiry if it has been updated in the last 60 seconds

### How to review 
Does Session expiry continue to work as expected?
