### PR TITLE
Clone jsonnet if Makefile not present in Travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
     - pip install -U pip pipenv wheel
     - pipenv install --dev --deploy
     - pipenv check
-    - pushd /opt && if [ ! -d jsonnet ]; then git clone --branch v0.12.1 --depth 1 https://github.com/google/jsonnet.git; fi && cd jsonnet && make && popd
+    - pushd /opt && if [ ! -e jsonnet/Makefile ]; then git clone --branch v0.12.1 --depth 1 https://github.com/google/jsonnet.git; fi && cd jsonnet && make && popd
 cache:
     - yarn
     - pip


### PR DESCRIPTION
### What is the context of this PR?
Travis cache was cleared and jsonnet is not being installed because an empty directory is created by travis to store cache and the jsonnet is not cloned if the directory exists.
This ensures it is cloned if the Makefile in the dir is not present.

Ensure:
- Travis builds successfully?