### PR TITLE
Fix dates without day_of_month piping transform bug

### DIFF
--- a/tests/app/questionnaire/test_placeholder_transforms.py
+++ b/tests/app/questionnaire/test_placeholder_transforms.py
@@ -56,9 +56,12 @@ class TestPlaceholderParser(unittest.TestCase):
         assert welsh_transforms.format_possessive('Alice Aardvark’s') == 'Alice Aardvark’s'
 
     def test_calculate_years_difference(self):
-        assert self.transforms.calculate_years_difference('2016-06-10', '2019-06-10') == '3'
-        assert self.transforms.calculate_years_difference('2010-01-01', '2018-12-31') == '8'
-        assert self.transforms.calculate_years_difference('now', 'now') == '0'
+        assert PlaceholderTransforms.calculate_years_difference('2016-06-10', '2019-06-10') == '3'
+        assert PlaceholderTransforms.calculate_years_difference('2010-01-01', '2018-12-31') == '8'
+        assert PlaceholderTransforms.calculate_years_difference('2011-01', '2015-04') == '4'
+        assert PlaceholderTransforms.calculate_years_difference('now', 'now') == '0'
+        with self.assertRaises(ValueError):
+            PlaceholderTransforms.calculate_years_difference('2018', 'now')
 
     def test_concatenate_list(self):
         list_to_concatenate = ['Milk', 'Eggs', 'Flour', 'Water']


### PR DESCRIPTION
### What is the context of this PR?
This fixes the issue where a transform of `calculate_years_difference()` would fail on dates where only a year and month were supplied, such as 2016-02, whilst working for full dates of 2016-02-23.

Issue was a single date format string. This has been supplemented with a fallback string which is tried if the `strptime()` method throws a ValueError exception.

Converted method to static, as it does not rely on any instance state.

### How to review 
Run any test schema that passes just year and month (e.g. _test_difference_in_years_month_year.json_.
Observe the lack of error.
