### PR TITLE
Added parameter to specify if page header should be H1

### DIFF
--- a/app/templates/introduction.html
+++ b/app/templates/introduction.html
@@ -3,6 +3,7 @@
 {% import 'macros/helpers.html' as helpers %}
 
 {% block header %}
+    {% set header_as_h1 = true %}
     {% include 'partials/header.html' %}
 {% endblock %}
 

--- a/app/templates/partials/header.html
+++ b/app/templates/partials/header.html
@@ -1,33 +1,33 @@
 <header class="header u-mb-s">
-    <div class="header__top" role="banner">
-        <div class="container">
-            <div class="grid grid--gutterless">
-                <div class="grid__col col-6@s">
-                {% block logo %}
-                {% set logo_cdn_print = cdn_url_prefix~"/img/ons-logo-black-en.svg" %}
-                {% set logo_cdn_web = cdn_url_prefix~"/img/ons-logo-pos.svg" %}
-                    <div class="logo">
-                        <img src="{{ logo_cdn_print }}" alt="Office for National Statistics logo" class="logo__img header__logo--print">
-                        <img src="{{ logo_cdn_web }}" alt="Office for National Statistics logo" class="logo__img header__logo print__hidden">
-                    </div>
-                {% endblock logo %}
-                </div>
-                {% if account_service_url %}
-                    {% include 'partials/services-navigation.html' %}
-                {% endif %}
-            </div>
+  <div class="header__top" role="banner">
+    <div class="container">
+      <div class="grid grid--gutterless">
+        <div class="grid__col col-6@s">
+          {% block logo %} {% set logo_cdn_print = cdn_url_prefix~"/img/ons-logo-black-en.svg" %} {% set logo_cdn_web = cdn_url_prefix~"/img/ons-logo-pos.svg"
+          %}
+          <div class="logo">
+            <img src="{{ logo_cdn_print }}" alt="Office for National Statistics logo" class="logo__img header__logo--print" />
+            <img src="{{ logo_cdn_web }}" alt="Office for National Statistics logo" class="logo__img header__logo print__hidden" />
+          </div>
+          {% endblock logo %}
         </div>
-    </div>  
-    <div class="header__main">
-        <div class="container">
-            <div class="grid grid--gutterless grid--align-mid u-cf">
-                <div class="grid__col col-10@xs col-6@s col-8@m">
-                    <h1 class="header__title header__title--nav-adj">{{ survey_title }}</h1>
-                </div>
-                {% include 'partials/sign-out-button.html' %}
-                {% include 'partials/mobile-navigation-button.html' %}
-            </div>
-        </div>
+        {% if account_service_url %} {% include 'partials/services-navigation.html' %} {% endif %}
+      </div>
     </div>
-    {% include 'partials/main-navigation.html' %}
+  </div>
+  <div class="header__main">
+    <div class="container">
+      <div class="grid grid--gutterless grid--align-mid u-cf">
+        <div class="grid__col col-10@xs col-6@s col-8@m">
+          {% if header_as_h1 %}
+          <h1 class="header__title header__title--nav-adj">{{ survey_title }}</h1>
+          {% else %}
+          <div class="header__title header__title--nav-adj">{{ survey_title }}</div>
+          {% endif %}
+        </div>
+        {% include 'partials/sign-out-button.html' %} {% include 'partials/mobile-navigation-button.html' %}
+      </div>
+    </div>
+  </div>
+  {% include 'partials/main-navigation.html' %}
 </header>

--- a/app/themes/northernireland/templates/introduction.html
+++ b/app/themes/northernireland/templates/introduction.html
@@ -3,6 +3,7 @@
 {% import 'macros/helpers.html' as helpers %}
 
 {% block header %}
+    {% set header_as_h1 = true %}
     {% include theme('partials/header.html') %}
 {% endblock %}
 

--- a/app/themes/northernireland/templates/partials/header.html
+++ b/app/themes/northernireland/templates/partials/header.html
@@ -21,7 +21,11 @@
     <div class="container">
       <div class="grid grid--gutterless grid--align-mid u-cf">
         <div class="grid__col col-10@xs col-6@s col-8@m">
+          {% if header_as_h1 %}
           <h1 class="header__title ">{{ survey_title }}</h1>
+          {% else %}
+          <div class="header__title ">{{ survey_title }}</div>
+          {% endif %}
         </div>
         {% include 'partials/sign-out-button.html' %} {% include 'partials/mobile-navigation-button.html' %}
       </div>

--- a/app/themes/social/templates/partials/header.html
+++ b/app/themes/social/templates/partials/header.html
@@ -32,7 +32,7 @@
         <div class="container">
             <div class="grid grid--gutterless grid--align-mid u-cf">
                 <div class="grid__col col-10@xs col-6@s col-8@m">
-                    <h1 class="header__title ">{{ survey_title }}</h1>
+                    <div class="header__title ">{{ survey_title }}</div>
                 </div>
                 {% include 'partials/sign-out-button.html' %}
                 {% include 'partials/mobile-navigation-button.html' %}


### PR DESCRIPTION
### What is the context of this PR?
For accessibility reasons, there should only be a single h1 on the page. This should be the most relevant title possible (eg. the question title). 

Template parameter has been added so page can specify. Currently, only introduction page requires page title to be H1, all other instances are <div>

### How to review 
In Introduction page:
1. Look at any questionnaire introduction
2. inspect the header, the title is a h1
3. no other H1 exists on page

In Question/Section page
1. Look at any questionnaire question/section
2. inspect the header, the title is a div
3. inspect the question/section title, it is a H1

* Change also implemented for NI templates.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
