### PR TITLE
Fix error when feedback form submitted after questionnaire submitted.

### DIFF
--- a/app/helpers/template_helper.py
+++ b/app/helpers/template_helper.py
@@ -8,6 +8,7 @@ from structlog import get_logger
 from app.globals import get_metadata, get_session_timeout_in_seconds
 from app.templating.metadata_context import build_metadata_context
 from app.templating.template_renderer import TemplateRenderer
+from app.authentication.no_token_exception import NoTokenException
 
 logger = get_logger()
 
@@ -30,6 +31,9 @@ def with_metadata_context(func):
     @wraps(wraps)
     def metadata_context_wrapper(*args, **kwargs):
         metadata = get_metadata(current_user)
+        if not metadata:
+            raise NoTokenException(401)
+
         metadata_context = build_metadata_context(metadata)
 
         return func(*args, metadata_context=metadata_context, **kwargs)

--- a/app/views/feedback.py
+++ b/app/views/feedback.py
@@ -12,6 +12,7 @@ from app.submitter.submission_failed import SubmissionFailedException
 from app.globals import get_metadata, get_session_store
 from app.submitter.converter import convert_feedback
 from app.utilities.schema import load_schema_from_session_data
+from app.authentication.no_token_exception import NoTokenException
 
 logger = get_logger()
 
@@ -53,12 +54,13 @@ def send_feedback():
     if 'action[sign_out]' in request.form:
         return redirect(url_for('session.get_sign_out'))
 
+    metadata = get_metadata(current_user)
+    if not metadata:
+        raise NoTokenException(401)
+
     form = FeedbackForm()
 
     if form.validate():
-
-        metadata = get_metadata(current_user)
-
         message = convert_feedback(
             escape(request.form.get('message')),
             escape(request.form.get('name')),

--- a/tests/integration/views/test_feedback.py
+++ b/tests/integration/views/test_feedback.py
@@ -14,6 +14,8 @@ FEEDBACK_FORM_URL = '/feedback'
 FEEDBACK_THANKYOU_URL = '/feedback/thank-you'
 SIGNED_OUT_URL = '/signed-out'
 
+SESSION_EXPIRED_PAGE_TITLE = 'Session expired'
+
 
 class Feedback(IntegrationTestCase):
     def setUp(self):
@@ -52,6 +54,23 @@ class Feedback(IntegrationTestCase):
         self.post(url=FEEDBACK_FORM_URL, post_data=post_data, action='send_feedback')
         self.assertStatusOK()
         self.assertEqualUrl(FEEDBACK_FORM_URL)
+
+    def test_post_feedback_after_submission_returns_401(self):
+        self._submit_questionnaire()
+        self.post(url=FEEDBACK_FORM_URL, post_data={}, action='send_feedback')
+        self.assertStatusUnauthorised()
+        self.assertEqualPageTitle(SESSION_EXPIRED_PAGE_TITLE)
+
+    def test_get_feedback_after_submission_returns_401(self):
+        self._submit_questionnaire()
+        self.get(FEEDBACK_FORM_URL)
+        self.assertStatusUnauthorised()
+        self.assertEqualPageTitle(SESSION_EXPIRED_PAGE_TITLE)
+
+    def _submit_questionnaire(self):
+        self.post()
+        self.post()
+        self.post()
 
     def test_post_with_empty_message_does_not_send_message(self):
         post_data = {


### PR DESCRIPTION
…mitted and session ended

### What is the context of this PR?
Submission of feedback form gives error when submitted after questionnaire form has been submitted

### How to review 
To reproduce on Master:
1. Open survey in runner
2. Open Feedback form in new tab (right click feedback link > open in new tab)
3. Complete & submit questionnaire
4. Submit feedback form and observe error being reported

On branch, repeat above steps without error.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
