### PR TITLE
Build schemas based on region

### DIFF
--- a/data-source/blocks/individual/employment/employers_business.jsonnet
+++ b/data-source/blocks/individual/employment/employers_business.jsonnet
@@ -1,27 +1,6 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import '../../../lib/rules.libsonnet';
 
-local question(title, description) = {
-  id: 'employers-business-question',
-  title: title,
-  description: description,
-  type: 'General',
-  answers: [
-    {
-      id: 'employers-business-answer',
-      label: 'Description',
-      mandatory: true,
-      type: 'TextArea',
-      max_length: 200,
-      validation: {
-        messages: {
-          MAX_LENGTH_EXCEEDED: 'Your answer has to be less than %(max)d characters long',
-        },
-      },
-    },
-  ],
-};
-
 local nonProxyTitle = 'What is the main activity of your organisation, business or freelance work?';
 local proxyTitle = {
   text: 'What is the main activity of <em>{person_name_possessive}</em> organisation, business or freelance work?',
@@ -41,41 +20,49 @@ local pastProxyTitle = {
 local englandDescription = 'For example clothing retail, general hospital, primary education, food wholesale, civil service DWP, local government housing.';
 local walesDescription = 'For example clothing retail, general hospital, primary education, food wholesale, civil service Welsh Government, local government housing.';
 
-{
+local question(title, region_code) = (
+  local description = if region_code == 'GB-WLS' then walesDescription else englandDescription;
+  {
+    id: 'employers-business-question',
+    title: title,
+    description: description,
+    type: 'General',
+    answers: [
+      {
+        id: 'employers-business-answer',
+        label: 'Description',
+        mandatory: true,
+        type: 'TextArea',
+        max_length: 200,
+        validation: {
+          messages: {
+            MAX_LENGTH_EXCEEDED: 'Your answer has to be less than %(max)d characters long',
+          },
+        },
+      },
+    ],
+  }
+);
+
+function(region_code) {
   type: 'Question',
   id: 'employers-business',
   question_variants: [
     {
-      question: question(nonProxyTitle, englandDescription),
-      when: [rules.proxyNo, rules.mainJob, rules.regionNotWales],
+      question: question(nonProxyTitle, region_code),
+      when: [rules.proxyNo, rules.mainJob],
     },
     {
-      question: question(proxyTitle, englandDescription),
-      when: [rules.proxyYes, rules.mainJob, rules.regionNotWales],
+      question: question(proxyTitle, region_code),
+      when: [rules.proxyYes, rules.mainJob],
     },
     {
-      question: question(pastNonProxyTitle, englandDescription),
-      when: [rules.proxyNo, rules.lastMainJob, rules.regionNotWales],
+      question: question(pastNonProxyTitle, region_code),
+      when: [rules.proxyNo, rules.lastMainJob],
     },
     {
-      question: question(pastProxyTitle, englandDescription),
-      when: [rules.proxyYes, rules.lastMainJob, rules.regionNotWales],
-    },
-    {
-      question: question(nonProxyTitle, walesDescription),
-      when: [rules.proxyNo, rules.mainJob, rules.regionWales],
-    },
-    {
-      question: question(proxyTitle, walesDescription),
-      when: [rules.proxyYes, rules.mainJob, rules.regionWales],
-    },
-    {
-      question: question(pastNonProxyTitle, walesDescription),
-      when: [rules.proxyNo, rules.lastMainJob, rules.regionWales],
-    },
-    {
-      question: question(pastProxyTitle, walesDescription),
-      when: [rules.proxyYes, rules.lastMainJob, rules.regionWales],
+      question: question(pastProxyTitle, region_code),
+      when: [rules.proxyYes, rules.lastMainJob],
     },
   ],
 }

--- a/data-source/blocks/individual/identity-and-health/arrive_in_uk.jsonnet
+++ b/data-source/blocks/individual/identity-and-health/arrive_in_uk.jsonnet
@@ -23,7 +23,7 @@ local proxyTitle = {
   ],
 };
 
-{
+function(region_code, census_date) {
   type: 'Question',
   id: 'arrive-in-uk',
   question_variants: [
@@ -45,7 +45,7 @@ local proxyTitle = {
             id: 'arrive-in-uk-answer',
             condition: 'greater than',
             date_comparison: {
-              value: std.extVar('census_date'),
+              value: census_date,
               offset_by: {
                 years: -1,
               },
@@ -62,7 +62,7 @@ local proxyTitle = {
             id: 'arrive-in-uk-answer',
             condition: 'equals',
             date_comparison: {
-              value: std.extVar('census_date'),
+              value: census_date,
               offset_by: {
                 years: -1,
               },
@@ -73,13 +73,7 @@ local proxyTitle = {
     },
     {
       goto: {
-        block: 'understand-welsh',
-        when: [rules.regionWales],
-      },
-    },
-    {
-      goto: {
-        block: 'language',
+        block: if region_code == 'GB-WLS' then 'understand-welsh' else 'language',
       },
     },
   ],

--- a/data-source/blocks/individual/identity-and-health/country_of_birth.jsonnet
+++ b/data-source/blocks/individual/identity-and-health/country_of_birth.jsonnet
@@ -1,19 +1,6 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import '../../../lib/rules.libsonnet';
 
-local question(title, options) = {
-  id: 'country-of-birth-question',
-  title: title,
-  type: 'General',
-  answers: [
-    {
-      id: 'country-of-birth-answer',
-      mandatory: true,
-      type: 'Radio',
-    } + options,
-  ],
-};
-
 local nonProxyTitle = 'What is your country of birth?';
 local proxyTitle = {
   text: 'What is <em>{person_name_possessive}</em> country of birth?',
@@ -92,25 +79,33 @@ local walesOptions = {
   ],
 };
 
-{
+local question(title, region_code) = (
+  local radioOptions = if region_code == 'GB-WLS' then walesOptions else englandOptions;
+  {
+    id: 'country-of-birth-question',
+    title: title,
+    type: 'General',
+    answers: [
+      {
+        id: 'country-of-birth-answer',
+        mandatory: true,
+        type: 'Radio',
+      } + radioOptions,
+    ],
+  }
+);
+
+function(region_code) {
   type: 'Question',
   id: 'country-of-birth',
   question_variants: [
     {
-      question: question(nonProxyTitle, englandOptions),
-      when: [rules.proxyNo, rules.regionNotWales],
+      question: question(nonProxyTitle, region_code),
+      when: [rules.proxyNo],
     },
     {
-      question: question(proxyTitle, englandOptions),
-      when: [rules.proxyYes, rules.regionNotWales],
-    },
-    {
-      question: question(nonProxyTitle, walesOptions),
-      when: [rules.proxyNo, rules.regionWales],
-    },
-    {
-      question: question(proxyTitle, walesOptions),
-      when: [rules.proxyYes, rules.regionWales],
+      question: question(proxyTitle, region_code),
+      when: [rules.proxyYes],
     },
   ],
   routing_rules: [
@@ -140,19 +135,7 @@ local walesOptions = {
     },
     {
       goto: {
-        block: 'understand-welsh',
-        when: [
-          {
-            meta: 'region_code',
-            condition: 'equals',
-            value: 'GB-WLS',
-          },
-        ],
-      },
-    },
-    {
-      goto: {
-        block: 'language',
+        block: if region_code == 'GB-WLS' then 'understand-welsh' else 'language',
       },
     },
   ],

--- a/data-source/blocks/individual/identity-and-health/ethnic_group.jsonnet
+++ b/data-source/blocks/individual/identity-and-health/ethnic_group.jsonnet
@@ -1,59 +1,6 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import '../../../lib/rules.libsonnet';
 
-local question(title, description) = {
-  id: 'ethnic-group-question',
-  title: title,
-  type: 'General',
-  answers: [
-    {
-      guidance: {
-        show_guidance: 'Why your answer is important',
-        hide_guidance: 'Why your answer is important',
-        content: [
-          {
-            description: 'Your answer will help to support equality and fairness in your community. Councils and government use information on ethnic group to make sure they:',
-            list: [
-              'provide services and share funding fairly',
-              'understand and represent everyone’s interests',
-            ],
-          },
-        ],
-      },
-      id: 'ethnic-group-answer',
-      mandatory: true,
-      options: [
-        {
-          label: 'White',
-          value: 'White',
-          description: description,
-        },
-        {
-          label: 'Mixed or Multiple ethnic groups',
-          value: 'Mixed or Multiple ethnic groups',
-          description: 'Includes White and Black Caribbean, White and Black African, White and Asian or any other Mixed or Multiple background',
-        },
-        {
-          label: 'Asian or Asian British',
-          value: 'Asian or Asian British',
-          description: 'Includes Indian, Pakistani, Bangladeshi, Chinese or any other Asian background',
-        },
-        {
-          label: 'Black, Black British, Caribbean or African',
-          value: 'Black, Black British, Caribbean or African',
-          description: 'Includes Black British, Caribbean, African or any other Black background',
-        },
-        {
-          label: 'Other ethnic group',
-          value: 'Other ethnic group',
-          description: 'Includes Arab or any other ethnic group',
-        },
-      ],
-      type: 'Radio',
-    },
-  ],
-};
-
 local nonProxyTitle = 'What is your ethnic group?';
 local proxyTitle = {
   text: 'What is <em>{person_name_possessive}</em> ethnic group?',
@@ -61,28 +8,77 @@ local proxyTitle = {
     placeholders.personNamePossessive,
   ],
 };
+
 local englandDescription = 'Includes British, Northern Irish, Irish, Gypsy, Irish Traveller, Roma or any other White background';
 local walesDescription = 'Includes Welsh, British, Northern Irish, Irish, Gypsy, Irish Traveller, Roma or any other White background';
 
-{
+local question(title, region_code) = (
+  local regionDescription = if region_code == 'GB-WLS' then walesDescription else englandDescription;
+  {
+    id: 'ethnic-group-question',
+    title: title,
+    type: 'General',
+    answers: [
+      {
+        guidance: {
+          show_guidance: 'Why your answer is important',
+          hide_guidance: 'Why your answer is important',
+          content: [
+            {
+              description: 'Your answer will help to support equality and fairness in your community. Councils and government use information on ethnic group to make sure they:',
+              list: [
+                'provide services and share funding fairly',
+                'understand and represent everyone’s interests',
+              ],
+            },
+          ],
+        },
+        id: 'ethnic-group-answer',
+        mandatory: true,
+        options: [
+          {
+            label: 'White',
+            value: 'White',
+            description: regionDescription,
+          },
+          {
+            label: 'Mixed or Multiple ethnic groups',
+            value: 'Mixed or Multiple ethnic groups',
+            description: 'Includes White and Black Caribbean, White and Black African, White and Asian or any other Mixed or Multiple background',
+          },
+          {
+            label: 'Asian or Asian British',
+            value: 'Asian or Asian British',
+            description: 'Includes Indian, Pakistani, Bangladeshi, Chinese or any other Asian background',
+          },
+          {
+            label: 'Black, Black British, Caribbean or African',
+            value: 'Black, Black British, Caribbean or African',
+            description: 'Includes Black British, Caribbean, African or any other Black background',
+          },
+          {
+            label: 'Other ethnic group',
+            value: 'Other ethnic group',
+            description: 'Includes Arab or any other ethnic group',
+          },
+        ],
+        type: 'Radio',
+      },
+    ],
+  }
+);
+
+function(region_code) {
   type: 'Question',
   id: 'ethnic-group',
   question_variants: [
     {
-      question: question(nonProxyTitle, englandDescription),
-      when: [rules.proxyNo, rules.regionNotWales],
+      question: question(nonProxyTitle, region_code),
+      when: [rules.proxyNo],
     },
     {
-      question: question(proxyTitle, englandDescription),
-      when: [rules.proxyYes, rules.regionNotWales],
-    },
-    {
-      question: question(nonProxyTitle, walesDescription),
-      when: [rules.proxyNo, rules.regionWales],
-    },
-    {
-      question: question(proxyTitle, walesDescription),
-      when: [rules.proxyYes, rules.regionWales],
+      question: question(proxyTitle, region_code),
+      when: [rules.proxyYes],
     },
   ],
   routing_rules: [

--- a/data-source/blocks/individual/identity-and-health/ethnic_group_white.jsonnet
+++ b/data-source/blocks/individual/identity-and-health/ethnic_group_white.jsonnet
@@ -1,56 +1,6 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import '../../../lib/rules.libsonnet';
 
-local question(title, option) = {
-  id: 'white-ethnic-group-question',
-  title: title,
-  type: 'General',
-  answers: [
-    {
-      guidance: {
-        show_guidance: 'Why your answer is important',
-        hide_guidance: 'Why your answer is important',
-        content: [
-          {
-            description: 'How you define your ethnic group is up to you. Sharing this information enables the government and other organisations to provide appropriate resources and policies such as housing, education, health and criminal justice.',
-          },
-        ],
-      },
-      id: 'white-ethnic-group-answer',
-      mandatory: true,
-      options: [
-        {
-          label: option,
-          value: option,
-        },
-        {
-          label: 'Irish',
-          value: 'Irish',
-        },
-        {
-          label: 'Gypsy or Irish Traveller',
-          value: 'Gypsy or Irish Traveller',
-        },
-        {
-          label: 'Roma',
-          value: 'Roma',
-        },
-        {
-          label: 'Any other White background',
-          value: 'Other',
-          detail_answer: {
-            id: 'white-ethnic-group-answer-other',
-            type: 'TextField',
-            mandatory: false,
-            label: 'Please specify White background',
-          },
-        },
-      ],
-      type: 'Radio',
-    },
-  ],
-};
-
 local nonProxyTitle = 'Which one best describes your White ethnic group or background?';
 local proxyTitle = {
   text: 'Which one best describes <em>{person_name_possessive}</em> White ethnic group or background?',
@@ -58,28 +8,74 @@ local proxyTitle = {
     placeholders.personNamePossessive,
   ],
 };
+
 local englandOption = 'English, Welsh, Scottish, Northern Irish or British';
 local walesOption = 'Welsh, English, Scottish, Northern Irish or British';
 
-{
+local question(title, region_code) = (
+  local radioOptions = if region_code == 'GB-WLS' then walesOption else englandOption;
+  {
+    id: 'white-ethnic-group-question',
+    title: title,
+    type: 'General',
+    answers: [
+      {
+        guidance: {
+          show_guidance: 'Why your answer is important',
+          hide_guidance: 'Why your answer is important',
+          content: [
+            {
+              description: 'How you define your ethnic group is up to you. Sharing this information enables the government and other organisations to provide appropriate resources and policies such as housing, education, health and criminal justice.',
+            },
+          ],
+        },
+        id: 'white-ethnic-group-answer',
+        mandatory: true,
+        options: [
+          {
+            label: radioOptions,
+            value: radioOptions,
+          },
+          {
+            label: 'Irish',
+            value: 'Irish',
+          },
+          {
+            label: 'Gypsy or Irish Traveller',
+            value: 'Gypsy or Irish Traveller',
+          },
+          {
+            label: 'Roma',
+            value: 'Roma',
+          },
+          {
+            label: 'Any other White background',
+            value: 'Other',
+            detail_answer: {
+              id: 'white-ethnic-group-answer-other',
+              type: 'TextField',
+              mandatory: false,
+              label: 'Please specify White background',
+            },
+          },
+        ],
+        type: 'Radio',
+      },
+    ],
+  }
+);
+
+function(region_code) {
   type: 'Question',
   id: 'white-ethnic-group',
   question_variants: [
     {
-      question: question(nonProxyTitle, englandOption),
-      when: [rules.proxyNo, rules.regionNotWales],
+      question: question(nonProxyTitle, region_code),
+      when: [rules.proxyNo],
     },
     {
-      question: question(proxyTitle, englandOption),
-      when: [rules.proxyYes, rules.regionNotWales],
-    },
-    {
-      question: question(nonProxyTitle, walesOption),
-      when: [rules.proxyNo, rules.regionWales],
-    },
-    {
-      question: question(proxyTitle, walesOption),
-      when: [rules.proxyYes, rules.regionWales],
+      question: question(proxyTitle, region_code),
+      when: [rules.proxyYes],
     },
   ],
   routing_rules: [

--- a/data-source/blocks/individual/identity-and-health/language.jsonnet
+++ b/data-source/blocks/individual/identity-and-health/language.jsonnet
@@ -1,41 +1,6 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import '../../../lib/rules.libsonnet';
 
-local question(title, definitionDescription, regionOption) = {
-  id: 'language-question',
-  title: title,
-  type: 'General',
-  definitions: [{
-    title: 'What do we mean by “main language”?',
-    content: [
-      {
-        description: definitionDescription,
-      },
-    ],
-  }],
-  answers: [
-    {
-      id: 'language-answer',
-      mandatory: true,
-      type: 'Radio',
-      options: [
-        regionOption,
-        {
-          label: 'Other',
-          value: 'Other',
-          description: 'Including British Sign Language',
-          detail_answer: {
-            id: 'language-answer-other',
-            type: 'TextField',
-            mandatory: false,
-            label: 'Please specify main language',
-          },
-        },
-      ],
-    },
-  ],
-};
-
 local nonProxyTitle = 'What is your main language?';
 local proxyTitle = {
   text: 'What is <em>{person_name_possessive}</em> main language?',
@@ -43,8 +8,6 @@ local proxyTitle = {
     placeholders.personNamePossessive,
   ],
 };
-local nonProxyDefinitionDescription = 'Your main language is the language you use most naturally. It could be the language you use at home.';
-local proxyDefinitionDescription = 'Their main language is the language they use most naturally. It could be the language they use at home.';
 
 local englandOption = {
   label: 'English',
@@ -56,25 +19,58 @@ local walesOption = {
   value: 'English or Welsh',
 };
 
-{
+local nonProxyDefinitionDescription = 'Your main language is the language you use most naturally. It could be the language you use at home.';
+local proxyDefinitionDescription = 'Their main language is the language they use most naturally. It could be the language they use at home.';
+
+local question(title, definitionDescription, region_code) = (
+  local regionOption = if region_code == 'GB-WLS' then walesOption else englandOption;
+  {
+    id: 'language-question',
+    title: title,
+    type: 'General',
+    definitions: [{
+      title: 'What do we mean by “main language”?',
+      content: [
+        {
+          description: definitionDescription,
+        },
+      ],
+    }],
+    answers: [
+      {
+        id: 'language-answer',
+        mandatory: true,
+        type: 'Radio',
+        options: [
+          regionOption,
+          {
+            label: 'Other',
+            value: 'Other',
+            description: 'Including British Sign Language',
+            detail_answer: {
+              id: 'language-answer-other',
+              type: 'TextField',
+              mandatory: false,
+              label: 'Please specify main language',
+            },
+          },
+        ],
+      },
+    ],
+  }
+);
+
+function(region_code) {
   type: 'Question',
   id: 'language',
   question_variants: [
     {
-      question: question(nonProxyTitle, nonProxyDefinitionDescription, englandOption),
-      when: [rules.proxyNo, rules.regionNotWales],
+      question: question(nonProxyTitle, nonProxyDefinitionDescription, region_code),
+      when: [rules.proxyNo],
     },
     {
-      question: question(proxyTitle, proxyDefinitionDescription, englandOption),
-      when: [rules.proxyYes, rules.regionNotWales],
-    },
-    {
-      question: question(nonProxyTitle, nonProxyDefinitionDescription, walesOption),
-      when: [rules.proxyNo, rules.regionWales],
-    },
-    {
-      question: question(proxyTitle, proxyDefinitionDescription, walesOption),
-      when: [rules.proxyYes, rules.regionWales],
+      question: question(proxyTitle, proxyDefinitionDescription, region_code),
+      when: [rules.proxyYes],
     },
   ],
   routing_rules: [

--- a/data-source/blocks/individual/identity-and-health/length_of_stay.jsonnet
+++ b/data-source/blocks/individual/identity-and-health/length_of_stay.jsonnet
@@ -25,6 +25,7 @@ local question(title) = {
 };
 
 local nonProxyTitle = 'Including the time already spent here, how long do you intend to stay in the United Kingdom?';
+
 local proxyTitle = {
   text: 'Including the time already spent here, how long does <em>{person_name}</em> intend to stay in the United Kingdom?',
   placeholders: [
@@ -32,7 +33,7 @@ local proxyTitle = {
   ],
 };
 
-{
+function(region_code) {
   type: 'Question',
   id: 'length-of-stay',
   question_variants: [
@@ -48,19 +49,7 @@ local proxyTitle = {
   routing_rules: [
     {
       goto: {
-        block: 'understand-welsh',
-        when: [
-          {
-            meta: 'region_code',
-            condition: 'equals',
-            value: 'GB-WLS',
-          },
-        ],
-      },
-    },
-    {
-      goto: {
-        block: 'language',
+        block: if region_code == 'GB-WLS' then 'understand-welsh' else 'language',
       },
     },
   ],

--- a/data-source/blocks/individual/identity-and-health/national_identity.jsonnet
+++ b/data-source/blocks/individual/identity-and-health/national_identity.jsonnet
@@ -1,50 +1,14 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import '../../../lib/rules.libsonnet';
 
-local question(title, definitionContent, regionOptions) = {
-  id: 'national-identity-question',
-  title: title,
-  type: 'General',
-  definitions: [
-    {
-      title: 'What do we mean by “national identity”?',
-      content: definitionContent,
-    },
-  ],
-  answers: [
-    {
-      id: 'national-identity-answer',
-      mandatory: true,
-      type: 'Checkbox',
-      options: regionOptions + [
-        {
-          label: 'Scottish',
-          value: 'Scottish',
-        },
-        {
-          label: 'Northern Irish',
-          value: 'Northern Irish',
-        },
-        {
-          label: 'British',
-          value: 'British',
-        },
-        {
-          label: 'Other',
-          value: 'Other',
-          detail_answer: {
-            id: 'national-identity-answer-other',
-            type: 'TextField',
-            mandatory: false,
-            label: 'Please describe your national identity',
-          },
-        },
-      ],
-    },
+local nonProxyTitle = 'How would you describe your national identity?';
+local proxyTitle = {
+  text: 'How would <em>{person_name}</em> describe their national identity?',
+  placeholders: [
+    placeholders.personName,
   ],
 };
 
-local nonProxyTitle = 'How would you describe your national identity?';
 local nonProxyDefinitionContent = [
   {
     description: 'National identity is not dependent on your ethnic group or citizenship.',
@@ -53,12 +17,7 @@ local nonProxyDefinitionContent = [
     description: 'It is about the country or countries where you feel you belong or think of as home.',
   },
 ];
-local proxyTitle = {
-  text: 'How would <em>{person_name}</em> describe their national identity?',
-  placeholders: [
-    placeholders.personName,
-  ],
-};
+
 local proxyDefinitionContent = [
   {
     description: 'National identity is not dependent on their ethnic group or citizenship.',
@@ -90,25 +49,63 @@ local walesOptions = [
   },
 ];
 
-{
+local question(title, definitionContent, region_code) = (
+  local regionOptions = if region_code == 'GB-WLS' then walesOptions else englandOptions;
+  {
+    id: 'national-identity-question',
+    title: title,
+    type: 'General',
+    definitions: [
+      {
+        title: 'What do we mean by “national identity”?',
+        content: definitionContent,
+      },
+    ],
+    answers: [
+      {
+        id: 'national-identity-answer',
+        mandatory: true,
+        type: 'Checkbox',
+        options: regionOptions + [
+          {
+            label: 'Scottish',
+            value: 'Scottish',
+          },
+          {
+            label: 'Northern Irish',
+            value: 'Northern Irish',
+          },
+          {
+            label: 'British',
+            value: 'British',
+          },
+          {
+            label: 'Other',
+            value: 'Other',
+            detail_answer: {
+              id: 'national-identity-answer-other',
+              type: 'TextField',
+              mandatory: false,
+              label: 'Please describe your national identity',
+            },
+          },
+        ],
+      },
+    ],
+  }
+);
+
+function(region_code) {
   type: 'Question',
   id: 'national-identity',
   question_variants: [
     {
-      question: question(nonProxyTitle, nonProxyDefinitionContent, englandOptions),
-      when: [rules.proxyNo, rules.regionNotWales],
+      question: question(nonProxyTitle, nonProxyDefinitionContent, region_code),
+      when: [rules.proxyNo],
     },
     {
-      question: question(proxyTitle, proxyDefinitionContent, englandOptions),
-      when: [rules.proxyYes, rules.regionNotWales],
-    },
-    {
-      question: question(nonProxyTitle, nonProxyDefinitionContent, walesOptions),
-      when: [rules.proxyNo, rules.regionWales],
-    },
-    {
-      question: question(proxyTitle, proxyDefinitionContent, walesOptions),
-      when: [rules.proxyYes, rules.regionWales],
+      question: question(proxyTitle, proxyDefinitionContent, region_code),
+      when: [rules.proxyYes],
     },
   ],
 }

--- a/data-source/blocks/individual/identity-and-health/religion.jsonnet
+++ b/data-source/blocks/individual/identity-and-health/religion.jsonnet
@@ -1,62 +1,6 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import '../../../lib/rules.libsonnet';
 
-local question(title, description) = {
-  id: 'religion-question',
-  title: title,
-  description: 'This question is voluntary',
-  type: 'General',
-  answers: [
-    {
-      id: 'religion-answer',
-      mandatory: false,
-      label: 'Select one option only',
-      options: [
-        {
-          label: 'No religion',
-          value: 'No religion',
-        },
-        {
-          label: 'Christian',
-          value: 'Christian',
-          description: description,
-        },
-        {
-          label: 'Buddhist',
-          value: 'Buddhist',
-        },
-        {
-          label: 'Hindu',
-          value: 'Hindu',
-        },
-        {
-          label: 'Jewish',
-          value: 'Jewish',
-        },
-        {
-          label: 'Muslim',
-          value: 'Muslim',
-        },
-        {
-          label: 'Sikh',
-          value: 'Sikh',
-        },
-        {
-          label: 'Any other religion',
-          value: 'Other',
-          detail_answer: {
-            id: 'religion-answer-other',
-            type: 'TextField',
-            mandatory: false,
-            label: 'Please specify other religion',
-          },
-        },
-      ],
-      type: 'Checkbox',
-    },
-  ],
-};
-
 local nonProxyTitle = 'What is your religion?';
 local proxyTitle = {
   text: 'What is <em>{person_name_possessive}</em> religion?',
@@ -64,28 +8,80 @@ local proxyTitle = {
     placeholders.personNamePossessive,
   ],
 };
+
 local englandDescription = 'Including Church of England, Catholic, Protestant and all other Christian denominations';
 local walesDescription = 'All denominations';
 
-{
+local question(title, region_code) = (
+  local optionDescription = if region_code == 'GB-WLS' then walesDescription else englandDescription;
+  {
+    id: 'religion-question',
+    title: title,
+    description: 'This question is voluntary',
+    type: 'General',
+    answers: [
+      {
+        id: 'religion-answer',
+        mandatory: false,
+        label: 'Select one option only',
+        options: [
+          {
+            label: 'No religion',
+            value: 'No religion',
+          },
+          {
+            label: 'Christian',
+            value: 'Christian',
+            description: optionDescription,
+          },
+          {
+            label: 'Buddhist',
+            value: 'Buddhist',
+          },
+          {
+            label: 'Hindu',
+            value: 'Hindu',
+          },
+          {
+            label: 'Jewish',
+            value: 'Jewish',
+          },
+          {
+            label: 'Muslim',
+            value: 'Muslim',
+          },
+          {
+            label: 'Sikh',
+            value: 'Sikh',
+          },
+          {
+            label: 'Any other religion',
+            value: 'Other',
+            detail_answer: {
+              id: 'religion-answer-other',
+              type: 'TextField',
+              mandatory: false,
+              label: 'Please specify other religion',
+            },
+          },
+        ],
+        type: 'Checkbox',
+      },
+    ],
+  }
+);
+
+function(region_code) {
   type: 'Question',
   id: 'religion',
   question_variants: [
     {
-      question: question(nonProxyTitle, englandDescription),
-      when: [rules.proxyNo, rules.regionNotWales],
+      question: question(nonProxyTitle, region_code),
+      when: [rules.proxyNo],
     },
     {
-      question: question(proxyTitle, englandDescription),
-      when: [rules.proxyYes, rules.regionNotWales],
-    },
-    {
-      question: question(nonProxyTitle, walesDescription),
-      when: [rules.proxyNo, rules.regionWales],
-    },
-    {
-      question: question(proxyTitle, walesDescription),
-      when: [rules.proxyYes, rules.regionWales],
+      question: question(proxyTitle, region_code),
+      when: [rules.proxyYes],
     },
   ],
 }

--- a/data-source/blocks/individual/identity-and-health/when_arrive_in_uk.jsonnet
+++ b/data-source/blocks/individual/identity-and-health/when_arrive_in_uk.jsonnet
@@ -24,30 +24,31 @@ local question(title) = {
   ],
 };
 
-local nonProxyTitle = {
+local nonProxyTitle(census_date) = {
   text: 'Did you arrive in the UK, on or after {census_date}',
   placeholders: [
-    placeholders.censusDate,
-  ],
-};
-local proxyTitle = {
-  text: 'Did <em>{person_name}</em> arrive in the UK, on or after {census_date}',
-  placeholders: [
-    placeholders.personName,
-    placeholders.censusDate,
+    placeholders.censusDate(census_date),
   ],
 };
 
-{
+local proxyTitle(census_date) = {
+  text: 'Did <em>{person_name}</em> arrive in the UK, on or after {census_date}',
+  placeholders: [
+    placeholders.personName,
+    placeholders.censusDate(census_date),
+  ],
+};
+
+function(region_code, census_date) {
   type: 'Question',
   id: 'when-arrive-in-uk',
   question_variants: [
     {
-      question: question(nonProxyTitle),
+      question: question(nonProxyTitle(census_date)),
       when: [rules.proxyNo],
     },
     {
-      question: question(proxyTitle),
+      question: question(proxyTitle(census_date)),
       when: [rules.proxyYes],
     },
   ],
@@ -66,19 +67,7 @@ local proxyTitle = {
     },
     {
       goto: {
-        block: 'understand-welsh',
-        when: [
-          {
-            meta: 'region_code',
-            condition: 'equals',
-            value: 'GB-WLS',
-          },
-        ],
-      },
-    },
-    {
-      goto: {
-        block: 'language',
+        block: if region_code == 'GB-WLS' then 'understand-welsh' else 'language',
       },
     },
   ],

--- a/data-source/blocks/individual/personal-details/marriage_type.jsonnet
+++ b/data-source/blocks/individual/personal-details/marriage_type.jsonnet
@@ -65,30 +65,30 @@ local gotoRule(blockId, whenValue) = {
   },
 };
 
-local nonProxyTitle = {
+local nonProxyTitle(census_date) = {
   text: 'On {census_date}, what is your legal marital or registered civil partnership status?',
   placeholders: [
-    placeholders.censusDate,
+    placeholders.censusDate(census_date),
   ],
 };
-local proxyTitle = {
+local proxyTitle(census_date) = {
   text: 'On {census_date}, what is <em>{person_name_possessive}</em> legal marital or registered civil partnership status?',
   placeholders: [
-    placeholders.censusDate,
+    placeholders.censusDate(census_date),
     placeholders.personNamePossessive,
   ],
 };
 
-{
+function(census_date) {
   type: 'Question',
   id: 'marriage-type',
   question_variants: [
     {
-      question: question(nonProxyTitle),
+      question: question(nonProxyTitle(census_date)),
       when: [rules.proxyNo],
     },
     {
-      question: question(proxyTitle),
+      question: question(proxyTitle(census_date)),
       when: [rules.proxyYes],
     },
   ],

--- a/data-source/blocks/individual/qualifications/a_level.jsonnet
+++ b/data-source/blocks/individual/qualifications/a_level.jsonnet
@@ -1,55 +1,6 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import '../../../lib/rules.libsonnet';
 
-local question(title, guidanceTitle, regionOptions) = {
-  id: 'a-level-question',
-  title: title,
-  guidance: {
-    content: [
-      {
-        title: guidanceTitle,
-      },
-    ],
-  },
-  type: 'MutuallyExclusive',
-  mandatory: true,
-  answers: [
-    {
-      id: 'a-level-answer',
-      mandatory: false,
-      type: 'Checkbox',
-      options: [
-        {
-          label: '2 or more A levels',
-          value: '2 or more A levels',
-          description: 'Include 4 or more AS levels',
-        },
-        {
-          label: '1 A level',
-          value: '1 A level',
-          description: 'Include 2 to 3 AS levels',
-        },
-        {
-          label: '1 AS level',
-          value: '1 AS level',
-        },
-      ] + regionOptions,
-    },
-    {
-      id: 'a-level-answer-exclusive',
-      type: 'Checkbox',
-      mandatory: false,
-      options: [
-        {
-          label: 'None of these apply',
-          value: 'None of these apply',
-          description: 'Questions on GCSEs and equivalents will follow',
-        },
-      ],
-    },
-  ],
-};
-
 local nonProxyTitle = 'Have you achieved an AS, A level or equivalent qualification?';
 local proxyTitle = {
   text: 'Has <em>{person_name}</em> achieved an AS, A level or equivalent qualification?',
@@ -60,30 +11,76 @@ local proxyTitle = {
 
 local englandGuidanceTitle = 'Include equivalent qualifications achieved anywhere outside England and Wales';
 local walesGuidanceTitle = 'Include equivalent qualifications achieved anywhere outside Wales and England';
-local walesOptions = [{
+
+local walesOption = [{
   label: 'Advanced Welsh Baccalaureate',
   value: 'Advanced Welsh Baccalaureate',
 }];
 
-{
+local question(title, region_code) = (
+  local regionGuidanceTitle = if region_code == 'GB-WLS' then walesGuidanceTitle else englandGuidanceTitle;
+  local regionOptions = if region_code == 'GB-WLS' then walesOption else [];
+  {
+    id: 'a-level-question',
+    title: title,
+    guidance: {
+      content: [
+        {
+          title: regionGuidanceTitle,
+        },
+      ],
+    },
+    type: 'MutuallyExclusive',
+    mandatory: true,
+    answers: [
+      {
+        id: 'a-level-answer',
+        mandatory: false,
+        type: 'Checkbox',
+        options: [
+          {
+            label: '2 or more A levels',
+            value: '2 or more A levels',
+            description: 'Include 4 or more AS levels',
+          },
+          {
+            label: '1 A level',
+            value: '1 A level',
+            description: 'Include 2 to 3 AS levels',
+          },
+          {
+            label: '1 AS level',
+            value: '1 AS level',
+          },
+        ] + regionOptions,
+      },
+      {
+        id: 'a-level-answer-exclusive',
+        type: 'Checkbox',
+        mandatory: false,
+        options: [
+          {
+            label: 'None of these apply',
+            value: 'None of these apply',
+            description: 'Questions on GCSEs and equivalents will follow',
+          },
+        ],
+      },
+    ],
+  }
+);
+
+function(region_code) {
   type: 'Question',
   id: 'a-level',
   question_variants: [
     {
-      question: question(nonProxyTitle, englandGuidanceTitle, []),
-      when: [rules.proxyNo, rules.regionNotWales],
+      question: question(nonProxyTitle, region_code),
+      when: [rules.proxyNo],
     },
     {
-      question: question(proxyTitle, englandGuidanceTitle, []),
-      when: [rules.proxyYes, rules.regionNotWales],
-    },
-    {
-      question: question(nonProxyTitle, walesGuidanceTitle, walesOptions),
-      when: [rules.proxyNo, rules.regionWales],
-    },
-    {
-      question: question(proxyTitle, walesGuidanceTitle, walesOptions),
-      when: [rules.proxyYes, rules.regionWales],
+      question: question(proxyTitle, region_code),
+      when: [rules.proxyYes],
     },
   ],
 }

--- a/data-source/blocks/individual/qualifications/apprenticeship.jsonnet
+++ b/data-source/blocks/individual/qualifications/apprenticeship.jsonnet
@@ -1,37 +1,6 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import '../../../lib/rules.libsonnet';
 
-local question(title, regionGuidanceTitle) = {
-  id: 'apprenticeship-question',
-  title: title,
-  type: 'General',
-  guidance: {
-    content: [
-      {
-        title: regionGuidanceTitle,
-      },
-    ],
-  },
-  answers: [
-    {
-      id: 'apprenticeship-answer',
-      mandatory: true,
-      options: [
-        {
-          label: 'Yes',
-          value: 'Yes',
-          description: 'For example trade, advanced, foundation, modern',
-        },
-        {
-          label: 'No',
-          value: 'No',
-        },
-      ],
-      type: 'Radio',
-    },
-  ],
-};
-
 local nonProxyTitle = 'Have you completed an apprenticeship?';
 local proxyTitle = {
   text: 'Has <em>{person_name}</em> completed an apprenticeship?',
@@ -40,29 +9,54 @@ local proxyTitle = {
   ],
 };
 
-local notWalesGuidanceTitle = 'Include equivalent apprenticeships completed anywhere outside England and Wales';
+local walesGuidanceTitle = 'Include equivalent apprenticeships completed anywhere outside England and Wales';
+local englandGuidanceTitle = 'Include equivalent apprenticeships completed anywhere outside Wales and England';
 
-local walesGuidanceTitle = 'Include equivalent apprenticeships completed anywhere outside Wales and England';
+local question(title, region_code) = (
+  local regionGuidanceTitle = if region_code == 'GB-WLS' then walesGuidanceTitle else englandGuidanceTitle;
+  {
+    id: 'apprenticeship-question',
+    title: title,
+    type: 'General',
+    guidance: {
+      content: [
+        {
+          title: regionGuidanceTitle,
+        },
+      ],
+    },
+    answers: [
+      {
+        id: 'apprenticeship-answer',
+        mandatory: true,
+        options: [
+          {
+            label: 'Yes',
+            value: 'Yes',
+            description: 'For example trade, advanced, foundation, modern',
+          },
+          {
+            label: 'No',
+            value: 'No',
+          },
+        ],
+        type: 'Radio',
+      },
+    ],
+  }
+);
 
-{
+function(region_code) {
   type: 'Question',
   id: 'apprenticeship',
   question_variants: [
     {
-      question: question(nonProxyTitle, notWalesGuidanceTitle),
-      when: [rules.proxyNo, rules.regionNotWales],
+      question: question(nonProxyTitle, region_code),
+      when: [rules.proxyNo],
     },
     {
-      question: question(proxyTitle, notWalesGuidanceTitle),
-      when: [rules.proxyYes, rules.regionNotWales],
-    },
-    {
-      question: question(nonProxyTitle, walesGuidanceTitle),
-      when: [rules.proxyNo, rules.regionWales],
-    },
-    {
-      question: question(proxyTitle, walesGuidanceTitle),
-      when: [rules.proxyYes, rules.regionWales],
+      question: question(proxyTitle, region_code),
+      when: [rules.proxyYes],
     },
   ],
 }

--- a/data-source/blocks/individual/qualifications/degree.jsonnet
+++ b/data-source/blocks/individual/qualifications/degree.jsonnet
@@ -1,38 +1,6 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import '../../../lib/rules.libsonnet';
 
-local question(title, guidanceTitle) = {
-  id: 'degree-question',
-  title: title,
-  type: 'General',
-  guidance: {
-    content: [
-      {
-        title: guidanceTitle,
-      },
-    ],
-  },
-  answers: [
-    {
-      id: 'degree-answer',
-      mandatory: true,
-      type: 'Radio',
-      options: [
-        {
-          label: 'Yes',
-          value: 'Yes',
-          description: 'For example degree, foundation degree, HND or HNC, NVQ level 4 and above, teaching or nursing',
-        },
-        {
-          label: 'No',
-          value: 'No',
-          description: 'Questions on other NVQs, A levels, GCSEs and equivalents will follow',
-        },
-      ],
-    },
-  ],
-};
-
 local nonProxyTitle = 'Have you achieved a qualification at degree level or above?';
 local proxyTitle = {
   text: 'Has <em>{person_name}</em> achieved a qualification at degree level or above?',
@@ -44,25 +12,52 @@ local proxyTitle = {
 local englandGuidanceTitle = 'Include equivalent qualifications achieved anywhere outside England and Wales';
 local walesGuidanceTitle = 'Include equivalent qualifications achieved anywhere outside Wales and England';
 
-{
+local question(title, region_code) = (
+  local regionGuidanceTitle = if region_code == 'GB-WLS' then walesGuidanceTitle else englandGuidanceTitle;
+  {
+    id: 'degree-question',
+    title: title,
+    type: 'General',
+    guidance: {
+      content: [
+        {
+          title: regionGuidanceTitle,
+        },
+      ],
+    },
+    answers: [
+      {
+        id: 'degree-answer',
+        mandatory: true,
+        type: 'Radio',
+        options: [
+          {
+            label: 'Yes',
+            value: 'Yes',
+            description: 'For example degree, foundation degree, HND or HNC, NVQ level 4 and above, teaching or nursing',
+          },
+          {
+            label: 'No',
+            value: 'No',
+            description: 'Questions on other NVQs, A levels, GCSEs and equivalents will follow',
+          },
+        ],
+      },
+    ],
+  }
+);
+
+function(region_code) {
   type: 'Question',
   id: 'degree',
   question_variants: [
     {
-      question: question(nonProxyTitle, englandGuidanceTitle),
-      when: [rules.proxyNo, rules.regionNotWales],
+      question: question(nonProxyTitle, region_code),
+      when: [rules.proxyNo],
     },
     {
-      question: question(proxyTitle, englandGuidanceTitle),
-      when: [rules.proxyYes, rules.regionNotWales],
-    },
-    {
-      question: question(nonProxyTitle, walesGuidanceTitle),
-      when: [rules.proxyNo, rules.regionWales],
-    },
-    {
-      question: question(proxyTitle, walesGuidanceTitle),
-      when: [rules.proxyYes, rules.regionWales],
+      question: question(proxyTitle, region_code),
+      when: [rules.proxyYes],
     },
   ],
 }

--- a/data-source/blocks/individual/qualifications/gcse.jsonnet
+++ b/data-source/blocks/individual/qualifications/gcse.jsonnet
@@ -1,55 +1,6 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import '../../../lib/rules.libsonnet';
 
-local question(title, guidanceTitle, regionOptions) = {
-  id: 'gcse-question',
-  title: title,
-  type: 'MutuallyExclusive',
-  mandatory: true,
-  guidance: {
-    content: [
-      {
-        title: guidanceTitle,
-      },
-    ],
-  },
-  answers: [
-    {
-      id: 'gcse-answer',
-      mandatory: false,
-      type: 'Checkbox',
-      options: [
-        {
-          label: '5 or more GCSEs grades A* to C or 9 to 4',
-          value: '5 or more GCSEs',
-          description: 'Include 5 or more O level passes or CSEs grades 1',
-        },
-        {
-          label: 'Any other GCSEs',
-          value: 'Any other GCSEs',
-          description: 'Include any other O levels or CSEs at any grades',
-        },
-        {
-          label: 'Basic skills course',
-          value: 'Basic skills course',
-          description: 'Skills for life, literacy, numeracy and language',
-        },
-      ] + regionOptions,
-    },
-    {
-      id: 'gcse-answer-exclusive',
-      type: 'Checkbox',
-      mandatory: false,
-      options: [
-        {
-          label: 'None of these apply',
-          value: 'None of these apply',
-        },
-      ],
-    },
-  ],
-};
-
 local nonProxyTitle = 'Have you achieved a GCSE or equivalent qualification?';
 local proxyTitle = {
   text: 'Has <em>{person_name}</em> achieved a GCSE or equivalent qualification?',
@@ -72,25 +23,70 @@ local walesOptions = [
   },
 ];
 
-{
+local question(title, region_code) = (
+  local regionGuidanceTitle = if region_code == 'GB-WLS' then walesGuidanceTitle else englandGuidanceTitle;
+  local regionOptions = if region_code == 'GB-WLS' then walesOptions else [];
+  {
+    id: 'gcse-question',
+    title: title,
+    type: 'MutuallyExclusive',
+    mandatory: true,
+    guidance: {
+      content: [
+        {
+          title: regionGuidanceTitle,
+        },
+      ],
+    },
+    answers: [
+      {
+        id: 'gcse-answer',
+        mandatory: false,
+        type: 'Checkbox',
+        options: [
+          {
+            label: '5 or more GCSEs grades A* to C or 9 to 4',
+            value: '5 or more GCSEs',
+            description: 'Include 5 or more O level passes or CSEs grades 1',
+          },
+          {
+            label: 'Any other GCSEs',
+            value: 'Any other GCSEs',
+            description: 'Include any other O levels or CSEs at any grades',
+          },
+          {
+            label: 'Basic skills course',
+            value: 'Basic skills course',
+            description: 'Skills for life, literacy, numeracy and language',
+          },
+        ] + regionOptions,
+      },
+      {
+        id: 'gcse-answer-exclusive',
+        type: 'Checkbox',
+        mandatory: false,
+        options: [
+          {
+            label: 'None of these apply',
+            value: 'None of these apply',
+          },
+        ],
+      },
+    ],
+  }
+);
+
+function(region_code) {
   type: 'Question',
   id: 'gcse',
   question_variants: [
     {
-      question: question(nonProxyTitle, englandGuidanceTitle, []),
-      when: [rules.proxyNo, rules.regionNotWales],
+      question: question(nonProxyTitle, region_code),
+      when: [rules.proxyNo],
     },
     {
-      question: question(proxyTitle, englandGuidanceTitle, []),
-      when: [rules.proxyYes, rules.regionNotWales],
-    },
-    {
-      question: question(nonProxyTitle, walesGuidanceTitle, walesOptions),
-      when: [rules.proxyNo, rules.regionWales],
-    },
-    {
-      question: question(proxyTitle, walesGuidanceTitle, walesOptions),
-      when: [rules.proxyYes, rules.regionWales],
+      question: question(proxyTitle, region_code),
+      when: [rules.proxyYes],
     },
   ],
   routing_rules: [

--- a/data-source/blocks/individual/qualifications/nvq_level.jsonnet
+++ b/data-source/blocks/individual/qualifications/nvq_level.jsonnet
@@ -1,55 +1,6 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import '../../../lib/rules.libsonnet';
 
-local question(title, guidanceTitle) = {
-  id: 'nvq-level-question',
-  title: title,
-  type: 'MutuallyExclusive',
-  guidance: {
-    content: [
-      {
-        title: guidanceTitle,
-      },
-    ],
-  },
-  mandatory: true,
-  answers: [
-    {
-      id: 'nvq-level-answer',
-      mandatory: false,
-      type: 'Checkbox',
-      options: [
-        {
-          label: 'NVQ level 3 or equivalent',
-          value: 'NVQ level 3 or equivalent',
-          description: 'For example BTEC National, OND or ONC, City and Guilds Advanced Craft',
-        },
-        {
-          label: 'NVQ level 2 or equivalent',
-          value: 'NVQ level 2 or equivalent',
-          description: 'For example BTEC General, City and Guilds Craft',
-        },
-        {
-          label: 'NVQ level 1 or equivalent',
-          value: 'NVQ level 1 or equivalent',
-        },
-      ],
-    },
-    {
-      id: 'nvq-level-answer-exclusive',
-      type: 'Checkbox',
-      mandatory: false,
-      options: [
-        {
-          label: 'None of these apply',
-          value: 'None of these apply',
-          description: 'Questions on A levels, GCSEs and equivalents will follow',
-        },
-      ],
-    },
-  ],
-};
-
 local nonProxyTitle = 'Have you achieved an NVQ or equivalent qualification?';
 local proxyTitle = {
   text: 'Has <em>{person_name}</em> achieved an NVQ or equivalent qualification?',
@@ -61,25 +12,69 @@ local proxyTitle = {
 local englandGuidanceTitle = 'Include equivalent qualifications achieved anywhere outside England and Wales';
 local walesGuidanceTitle = 'Include equivalent qualifications achieved anywhere outside Wales and England';
 
-{
+local question(title, region_code) = (
+  local regionGuidanceTitle = if region_code == 'GB-WLS' then walesGuidanceTitle else englandGuidanceTitle;
+  {
+    id: 'nvq-level-question',
+    title: title,
+    type: 'MutuallyExclusive',
+    guidance: {
+      content: [
+        {
+          title: regionGuidanceTitle,
+        },
+      ],
+    },
+    mandatory: true,
+    answers: [
+      {
+        id: 'nvq-level-answer',
+        mandatory: false,
+        type: 'Checkbox',
+        options: [
+          {
+            label: 'NVQ level 3 or equivalent',
+            value: 'NVQ level 3 or equivalent',
+            description: 'For example BTEC National, OND or ONC, City and Guilds Advanced Craft',
+          },
+          {
+            label: 'NVQ level 2 or equivalent',
+            value: 'NVQ level 2 or equivalent',
+            description: 'For example BTEC General, City and Guilds Craft',
+          },
+          {
+            label: 'NVQ level 1 or equivalent',
+            value: 'NVQ level 1 or equivalent',
+          },
+        ],
+      },
+      {
+        id: 'nvq-level-answer-exclusive',
+        type: 'Checkbox',
+        mandatory: false,
+        options: [
+          {
+            label: 'None of these apply',
+            value: 'None of these apply',
+            description: 'Questions on A levels, GCSEs and equivalents will follow',
+          },
+        ],
+      },
+    ],
+  }
+);
+
+function(region_code) {
   type: 'Question',
   id: 'nvq-level',
   question_variants: [
     {
-      question: question(nonProxyTitle, englandGuidanceTitle),
-      when: [rules.proxyNo, rules.regionNotWales],
+      question: question(nonProxyTitle, region_code),
+      when: [rules.proxyNo],
     },
     {
-      question: question(proxyTitle, englandGuidanceTitle),
-      when: [rules.proxyYes, rules.regionNotWales],
-    },
-    {
-      question: question(nonProxyTitle, walesGuidanceTitle),
-      when: [rules.proxyNo, rules.regionWales],
-    },
-    {
-      question: question(proxyTitle, walesGuidanceTitle),
-      when: [rules.proxyYes, rules.regionWales],
+      question: question(proxyTitle, region_code),
+      when: [rules.proxyYes],
     },
   ],
 }

--- a/data-source/blocks/individual/qualifications/other_qualifications.jsonnet
+++ b/data-source/blocks/individual/qualifications/other_qualifications.jsonnet
@@ -1,32 +1,6 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import '../../../lib/rules.libsonnet';
 
-local question(title, regionOptions) = {
-  id: 'other-qualifications-question',
-  title: title,
-  type: 'MutuallyExclusive',
-  mandatory: true,
-  answers: [
-    {
-      id: 'other-qualifications-answer',
-      mandatory: false,
-      type: 'Checkbox',
-      options: regionOptions,
-    },
-    {
-      id: 'other-qualifications-answer-exclusive',
-      type: 'Checkbox',
-      mandatory: false,
-      options: [
-        {
-          label: 'No qualifications',
-          value: 'No qualifications',
-        },
-      ],
-    },
-  ],
-};
-
 local nonProxyTitle = 'Have you achieved any other qualifications?';
 local proxyTitle = {
   text: 'Has <em>{person_name}</em> achieved any other qualifications?',
@@ -57,25 +31,46 @@ local walesOptions = [
   },
 ];
 
-{
+local question(title, region_code) = (
+  local regionOptions = if region_code == 'GB-WLS' then walesOptions else englandOptions;
+  {
+    id: 'other-qualifications-question',
+    title: title,
+    type: 'MutuallyExclusive',
+    mandatory: true,
+    answers: [
+      {
+        id: 'other-qualifications-answer',
+        mandatory: false,
+        type: 'Checkbox',
+        options: regionOptions,
+      },
+      {
+        id: 'other-qualifications-answer-exclusive',
+        type: 'Checkbox',
+        mandatory: false,
+        options: [
+          {
+            label: 'No qualifications',
+            value: 'No qualifications',
+          },
+        ],
+      },
+    ],
+  }
+);
+
+function(region_code) {
   type: 'Question',
   id: 'other-qualifications',
   question_variants: [
     {
-      question: question(nonProxyTitle, englandOptions),
-      when: [rules.proxyNo, rules.regionNotWales],
+      question: question(nonProxyTitle, region_code),
+      when: [rules.proxyNo],
     },
     {
-      question: question(proxyTitle, englandOptions),
-      when: [rules.proxyYes, rules.regionNotWales],
-    },
-    {
-      question: question(nonProxyTitle, walesOptions),
-      when: [rules.proxyNo, rules.regionWales],
-    },
-    {
-      question: question(proxyTitle, walesOptions),
-      when: [rules.proxyYes, rules.regionWales],
+      question: question(proxyTitle, region_code),
+      when: [rules.proxyYes],
     },
   ],
   routing_rules: [

--- a/data-source/blocks/individual/qualifications/qualifications.jsonnet
+++ b/data-source/blocks/individual/qualifications/qualifications.jsonnet
@@ -1,52 +1,39 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import '../../../lib/rules.libsonnet';
 
-{
-  type: 'Interstitial',
-  id: 'qualifications',
-  title: 'Qualifications',
-  content_variants: [
-    {
-      content: [
-        {
-          title: 'Qualifications',
-          description: 'The next set of questions is about any qualifications you have ever achieved in England, Wales or worldwide, including equivalents, even if you are not using them now.',
-        },
-      ],
-      when: [rules.proxyNo, rules.regionNotWales],
-    },
-    {
-      content: [
-        {
-          title: 'Qualifications',
-          description: 'The next set of questions is about any qualifications you have ever achieved in Wales, England or worldwide, including equivalents, even if you are not using them now.',
-        },
-      ],
-      when: [rules.proxyNo, rules.regionWales],
-    },
-    {
-      content: [
-        {
-          title: 'Qualifications',
-          description: {
-            text: 'The next set of questions is about any qualifications <em>{person_name}</em>, has ever achieved in England, Wales or worldwide, including equivalents, even if they are not using them now.',
-            placeholders: [placeholders.personName],
+local englandDescriptionNonProxy = 'The next set of questions is about any qualifications you have ever achieved in England, Wales or worldwide, including equivalents, even if you are not using them now.';
+local englandDescriptionProxy = 'The next set of questions is about any qualifications <em>{person_name}</em>, has ever achieved in England, Wales or worldwide, including equivalents, even if they are not using them now.';
+
+local walesDescriptionNonProxy = 'The next set of questions is about any qualifications you have ever achieved in Wales, England or worldwide, including equivalents, even if you are not using them now.';
+local walesDescriptionProxy = 'The next set of questions is about any qualifications <em>{person_name}</em>, has ever achieved in Wales, England or worldwide, including equivalents, even if they are not using them now.';
+
+function(region_code) (
+  local regionDescriptionNonProxy = if region_code == 'GB-WLS' then walesDescriptionNonProxy else englandDescriptionNonProxy;
+  local regionDescriptionProxy = if region_code == 'GB-WLS' then walesDescriptionProxy else englandDescriptionProxy;
+  {
+    type: 'Interstitial',
+    id: 'qualifications',
+    title: 'Qualifications',
+    content_variants: [
+      {
+        content: [
+          {
+            description: regionDescriptionNonProxy,
           },
-        },
-      ],
-      when: [rules.proxyYes, rules.regionNotWales],
-    },
-    {
-      content: [
-        {
-          title: 'Qualifications',
-          description: {
-            text: 'The next set of questions is about any qualifications <em>{person_name}</em>, has ever achieved in Wales, England or worldwide, including equivalents, even if they are not using them now.',
-            placeholders: [placeholders.personName],
+        ],
+        when: [rules.proxyNo],
+      },
+      {
+        content: [
+          {
+            description: {
+              text: regionDescriptionProxy,
+              placeholders: [placeholders.personName],
+            },
           },
-        },
-      ],
-      when: [rules.proxyYes, rules.regionWales],
-    },
-  ],
-}
+        ],
+        when: [rules.proxyYes],
+      },
+    ],
+  }
+)

--- a/data-source/census_individual.jsonnet
+++ b/data-source/census_individual.jsonnet
@@ -79,7 +79,9 @@ local comments = import 'blocks/comments.json';
 
 local confirmation = import 'blocks/confirmation.json';
 
-{
+local understandWelshBlock(region_code) = if region_code == 'GB-WLS' then [understand_welsh] else [];
+
+function(region_code, census_date) {
   mime_type: 'application/json/ons/eq',
   schema_version: '0.0.1',
   data_version: '0.0.3',
@@ -89,7 +91,7 @@ local confirmation = import 'blocks/confirmation.json';
   theme: 'census',
   legal_basis: 'Voluntary',
   eq_id: 'census',
-  form_type: 'household',
+  form_type: if region_code == 'GB-WLS' then 'individual_gb_wls' else 'individual_gb_eng',
   navigation: {
     visible: false,
   },
@@ -100,10 +102,6 @@ local confirmation = import 'blocks/confirmation.json';
     },
     {
       name: 'period_id',
-      validator: 'string',
-    },
-    {
-      name: 'region_code',
       validator: 'string',
     },
     {
@@ -136,7 +134,7 @@ local confirmation = import 'blocks/confirmation.json';
             date_of_birth,
             confirm_dob,
             sex,
-            marriage_type,
+            marriage_type(census_date),
             current_marriage_status,
             previous_marriage_status,
             current_partnership_status,
@@ -154,21 +152,21 @@ local confirmation = import 'blocks/confirmation.json';
           id: 'identity-and-health-group',
           title: 'Identity and Health',
           blocks: [
-            country_of_birth,
-            arrive_in_uk,
-            when_arrive_in_uk,
-            length_of_stay,
-            understand_welsh,
-            language,
+            country_of_birth(region_code),
+            arrive_in_uk(region_code, census_date),
+            when_arrive_in_uk(region_code, census_date),
+            length_of_stay(region_code),
+          ] + understandWelshBlock(region_code) + [
+            language(region_code),
             speak_english,
-            national_identity,
-            ethnic_group,
-            ethnic_group_white,
+            national_identity(region_code),
+            ethnic_group(region_code),
+            ethnic_group_white(region_code),
             ethnic_group_mixed,
             ethnic_group_asian,
             ethnic_group_black,
             ethnic_group_other,
-            religion,
+            religion(region_code),
             past_usual_household_address,
             last_year_address,
             passports,
@@ -184,13 +182,13 @@ local confirmation = import 'blocks/confirmation.json';
           id: 'qualifications-group',
           title: 'Qualifications',
           blocks: [
-            qualifications,
-            apprenticeship,
-            degree,
-            nvq_level,
-            a_level,
-            gcse,
-            other_qualifications,
+            qualifications(region_code),
+            apprenticeship(region_code),
+            degree(region_code),
+            nvq_level(region_code),
+            a_level(region_code),
+            gcse(region_code),
+            other_qualifications(region_code),
           ],
         },
         {
@@ -209,7 +207,7 @@ local confirmation = import 'blocks/confirmation.json';
             business_name,
             job_title,
             job_description,
-            employers_business,
+            employers_business(region_code),
             supervise,
             hours_worked,
             work_travel,

--- a/data-source/lib/placeholders.libsonnet
+++ b/data-source/lib/placeholders.libsonnet
@@ -48,13 +48,13 @@
       },
     }],
   },
-  censusDate: {
+  censusDate(census_date): {
     placeholder: 'census_date',
     transforms: [{
       transform: 'format_date',
       arguments: {
         date_to_format: {
-          value: std.extVar('census_date'),
+          value: census_date,
         },
         date_format: 'd MMMM YYYY',
       },

--- a/data-source/lib/rules.libsonnet
+++ b/data-source/lib/rules.libsonnet
@@ -19,16 +19,6 @@
       },
     },
   },
-  regionNotWales: {
-    meta: 'region_code',
-    condition: 'not equals',
-    value: 'GB-WLS',
-  },
-  regionWales: {
-    meta: 'region_code',
-    condition: 'equals',
-    value: 'GB-WLS',
-  },
   mainJob: {
     id: 'employment-status-answer-exclusive',
     condition: 'not set',

--- a/scripts/build_schemas.sh
+++ b/scripts/build_schemas.sh
@@ -1,9 +1,23 @@
-#!/bin/sh 
+#!/usr/bin/env bash
 
-if [ -x "$(command -v jsonnet)" ]; then
-  jsonnet --ext-str census_date="2019-09-01" data-source/census_individual.jsonnet > data-source/census_individual.json
-  gulp format:census
-  mv data-source/*.json data/en
+if [[ -x "$(command -v jsonnet)" ]]; then
+    # Build schemas for each region
+    for region_code in GB-WLS GB-ENG; do
+        SOURCE_FILE="data-source/census_individual.jsonnet"
+        # Lowercase the region code and replace '-' with '_'
+        FORMATTED_REGION_CODE=$(echo "${region_code}" | tr '[:upper:]' '[:lower:]' | tr - _)
+        DESTINATION_FILE="data-source/census_individual_${FORMATTED_REGION_CODE}.json"
+
+        jsonnet --tla-str region_code=${region_code} --tla-str census_date="2019-09-01" "${SOURCE_FILE}" > "${DESTINATION_FILE}"
+        echo "Built ${DESTINATION_FILE}"
+    done
+
+    # Format Census JSON files
+    yarn gulp format:census
+
+    # Move newly built schemas to 'en' dir
+    mv data-source/*.json data/en
+
 else
-  echo "Jsonnet not available - skipping schema build"
+    echo "Jsonnet not available - skipping schema build"
 fi


### PR DESCRIPTION
### What is the context of this PR?
Removed routing based on `region_code` instead, the schema now build only the relevant blocks and rules for the specified regions in `build_schemas.sh`

### How to review 
1. Ensure a schema per region is built
2. The survey still functions as expected for each region.

Some of the additions I have done could potentially be made into a method in a separate file for reuse, as at the moment, the region-specific code is just implemented inline in the block files. Would be good to hear thought on making it any simpler/clearer.
Also, the `if` conditions currently only takes into account Wales/England, but will need altering when we have NI.