### PR TITLE
Add a version of docker-compose for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ To run the unit tests locally:
 pipenv run scripts/run_tests_unit.sh
 ```
 
+If you want to run the app locally, but all other dependencies in docker, you can use the docker-compose-dev.yaml file:
+
+```
+docker-compose -f docker-compose-dev.yml up -d
+```
 
 ### Pre-Requisites
 In order to run locally you'll need Node.js, snappy, pyenv and Jsonnet installed

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,22 @@
+version: '3'
+
+services:
+
+  datastore:
+    image: knarz/datastore-emulator
+    ports:
+      - "8432:8432"
+
+  redis:
+    image: redis:4
+    ports:
+      - "6379:6379"
+
+  go-launch-a-survey:
+    image: onsdigital/go-launch-a-survey:latest
+    environment:
+      SURVEY_RUNNER_URL: http://localhost:5000
+      SURVEY_RUNNER_SCHEMA_URL: http://docker.for.mac.host.internal:5000
+    restart: always
+    ports:
+      - "8000:8000"


### PR DESCRIPTION
### What is the context of this PR?
There are quite a few services that we normally spin up in docker seperately, while running the app locally. I thought it would be useful to add a docker-compose file for this.

### How to review 
Is it in the right place?
Does it work?

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
