### PR TITLE
Update jsonnet census schema in line with recent alteration requests

### DIFF
--- a/data-source/blocks/individual/employment/armed_forces.jsonnet
+++ b/data-source/blocks/individual/employment/armed_forces.jsonnet
@@ -7,7 +7,7 @@ local question(title) = {
   guidance: {
     content: [
       {
-        title: "Current serving members should select 'No'",
+        title: 'Current serving members should select “No”',
       },
     ],
   },
@@ -21,7 +21,7 @@ local question(title) = {
         hide_guidance: 'Why your answer is important',
         content: [
           {
-            description: 'We are measuring the number of people who have served in the UK Armed Forces and now left. This data is needed to support central and local government commitments made under the Armed Forces Covenant. This is a promise by the nation ensuring that those who serve or who have served in the armed forces, and their families, are treated fairly.',
+            description: 'We are measuring the number of people who have served in the UK Armed Forces and have now left. Government and councils need this information to carry out their commitments made under the Armed Forces Covenant. This is a promise by the nation ensuring that those who serve or who have served in the armed forces, and their families, are not disadvantaged.',
           },
         ],
       },

--- a/data-source/blocks/individual/employment/employer_address_depot.jsonnet
+++ b/data-source/blocks/individual/employment/employer_address_depot.jsonnet
@@ -40,7 +40,7 @@ local question(title) = {
         hide_guidance: 'Why your answer is important',
         content: [
           {
-            description: 'Workplace address and method of travel to work information is used to inform planning and modelling for transport services and policies. The information helps in the assessment of local public transport needs.',
+            description: 'The government uses information about workplace address and method of travel to work to form transport policies and plan services. The information helps to work out local transport needs.',
           },
         ],
       },

--- a/data-source/blocks/individual/employment/employer_address_workplace.jsonnet
+++ b/data-source/blocks/individual/employment/employer_address_workplace.jsonnet
@@ -40,7 +40,7 @@ local question(title) = {
         hide_guidance: 'Why your answer is important',
         content: [
           {
-            description: 'Workplace address and method of travel to work information is used to inform planning and modelling for transport services and policies. The information helps in the assessment of local public transport needs.',
+            description: 'The government uses information about workplace address and method of travel to work to form transport policies and plan services. The information helps to work out local transport needs.',
           },
         ],
       },

--- a/data-source/blocks/individual/employment/employers_business.jsonnet
+++ b/data-source/blocks/individual/employment/employers_business.jsonnet
@@ -39,7 +39,7 @@ local pastProxyTitle = {
 };
 
 local englandDescription = 'For example clothing retail, general hospital, primary education, food wholesale, civil service DWP, local government housing.';
-local walesDescription = 'For example clothing retail, general hospital, primary education, food wholesale, civil service DVLA, local government housing.';
+local walesDescription = 'For example clothing retail, general hospital, primary education, food wholesale, civil service Welsh Government, local government housing.';
 
 {
   type: 'Question',

--- a/data-source/blocks/individual/employment/jobseeker.jsonnet
+++ b/data-source/blocks/individual/employment/jobseeker.jsonnet
@@ -1,18 +1,18 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import '../../../lib/rules.libsonnet';
 
-local question(title) = {
+local question(title, guidanceHeader) = {
   id: 'jobseeker-question',
   title: title,
   type: 'General',
   answers: [
     {
       guidance: {
-        show_guidance: 'Why do I need to answer if I am retired or long term sick or disabled?',
-        hide_guidance: 'Why do I need to answer if I am retired or long term sick or disabled',
+        show_guidance: guidanceHeader,
+        hide_guidance: guidanceHeader,
         content: [
           {
-            description: 'To get a true picture of the UK working population, we ask this question to everyone who is not currently working. We ask people who are retired because the number of people continuing to work after retirement age is increasing. We ask people who are long-term sick or disabled because some intend to go back to work.',
+            description: 'To get a true picture of the UK working population, we ask this question of everyone who is not currently working. We ask people who are retired because the number of people continuing to work after retirement age is increasing. We ask people who are long-term sick or disabled because some intend to go back to work.',
           },
         ],
       },
@@ -40,17 +40,19 @@ local proxyTitle = {
     placeholders.personName,
   ],
 };
+local nonProxyGuidanceHeader = 'Why do I need to answer if I am retired or long term sick or disabled?';
+local proxyGuidanceHeader = 'Why do I need to answer if they have retired or are long term sick or disabled?';
 
 {
   type: 'Question',
   id: 'jobseeker',
   question_variants: [
     {
-      question: question(nonProxyTitle),
+      question: question(nonProxyTitle, nonProxyGuidanceHeader),
       when: [rules.proxyNo],
     },
     {
-      question: question(proxyTitle),
+      question: question(proxyTitle, proxyGuidanceHeader),
       when: [rules.proxyYes],
     },
   ],

--- a/data-source/blocks/individual/employment/main_employment_block.jsonnet
+++ b/data-source/blocks/individual/employment/main_employment_block.jsonnet
@@ -9,8 +9,8 @@ local rules = import '../../../lib/rules.libsonnet';
     {
       content: [
         {
-          title: 'Answer the next set of questions for your main job',
-          description: 'Your main job is the job in which you usually work the most hours',
+          title: 'Main job',
+          description: 'The next set of questions is about your main job. Your main job is the job in which you usually work the most hours',
         },
       ],
       when: [rules.proxyNo, rules.mainJob],
@@ -18,11 +18,11 @@ local rules = import '../../../lib/rules.libsonnet';
     {
       content: [
         {
-          title: {
-            text: 'Answer the next set of questions for {person_name_possessive} main job',
+          title: 'Main job',
+          description: {
+            text: 'The next set of questions is about <em>{person_name_possessive}</em> main job. Their main job is the job in which they usually work the most hours',
             placeholders: [placeholders.personNamePossessive],
           },
-          description: 'Their main job is the job in which they usually work the most hours',
         },
       ],
       when: [rules.proxyYes, rules.mainJob],
@@ -30,8 +30,8 @@ local rules = import '../../../lib/rules.libsonnet';
     {
       content: [
         {
-          title: 'Answer the next set of questions for your last main job',
-          description: 'Your main job is the job in which you usually worked the most hours',
+          title: 'Last main job',
+          description: 'The next set of questions is about your last main job. Your main job is the job in which you usually worked the most hours',
         },
       ],
       when: [rules.proxyNo, rules.lastMainJob],
@@ -39,11 +39,11 @@ local rules = import '../../../lib/rules.libsonnet';
     {
       content: [
         {
-          title: {
-            text: 'Answer the next set of questions for {person_name_possessive} last main job',
+          title: 'Last main job',
+          description: {
+            text: 'The next set of questions is about <em>{person_name_possessive}</em> last main job. Their main job is the job in which they usually worked the most hours',
             placeholders: [placeholders.personNamePossessive],
           },
-          description: 'Their main job is the job in which they usually worked the most hours',
         },
       ],
       when: [rules.proxyYes, rules.lastMainJob],

--- a/data-source/blocks/individual/identity-and-health/disability.jsonnet
+++ b/data-source/blocks/individual/identity-and-health/disability.jsonnet
@@ -1,20 +1,13 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import '../../../lib/rules.libsonnet';
 
-local question(title) = {
+local question(title, definitionContent) = {
   id: 'disability-question',
   title: title,
   definitions: [
     {
-      title: 'What do we mean by physical and mental health conditions or illness?',
-      content: [
-        {
-          description: 'Physical and mental health conditions or illnesses may also be described as disabilities.',
-        },
-        {
-          description: 'For example sensory impairments such as sight or hearing loss, developmental conditions such as autism or Asperger’s syndrome, and learning impairment such as Down’s syndrome or dyslexia.',
-        },
-      ],
+      title: 'What do we mean by “physical and mental health conditions or illness”?',
+      content: definitionContent,
     },
   ],
   type: 'General',
@@ -38,23 +31,39 @@ local question(title) = {
 };
 
 local nonProxyTitle = 'Do you have any physical or mental health conditions or illnesses lasting or expected to last 12 months or more?';
+local nonProxyDefinitionContent = [
+  {
+    description: 'This refers to health conditions, illnesses or impairments you may have.',
+  },
+  {
+    description: 'Consider conditions that always affect you and those that flare up from time to time. These may include, for example, sensory conditions, developmental conditions or learning impairments.',
+  },
+];
 local proxyTitle = {
   text: 'Does <em>{person_name}</em> have any physical or mental health conditions or illnesses lasting or expected to last 12 months or more?',
   placeholders: [
     placeholders.personName,
   ],
 };
+local proxyDefinitionContent = [
+  {
+    description: 'This refers to health conditions, illnesses or impairments they may have.',
+  },
+  {
+    description: 'Consider conditions that always affect them and those that flare up from time to time. These may include, for example, sensory conditions, developmental conditions or learning impairments.',
+  },
+];
 
 {
   type: 'Question',
   id: 'disability',
   question_variants: [
     {
-      question: question(nonProxyTitle),
+      question: question(nonProxyTitle, nonProxyDefinitionContent),
       when: [rules.proxyNo],
     },
     {
-      question: question(proxyTitle),
+      question: question(proxyTitle, proxyDefinitionContent),
       when: [rules.proxyYes],
     },
   ],

--- a/data-source/blocks/individual/identity-and-health/disability_limitation.jsonnet
+++ b/data-source/blocks/individual/identity-and-health/disability_limitation.jsonnet
@@ -1,25 +1,10 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import '../../../lib/rules.libsonnet';
 
-local question(title) = {
+local question(title, definition) = {
   id: 'disability-limitation-question',
   title: title,
-  definitions: [
-    {
-      title: 'What do we mean by reduce your ability?',
-      content: [
-        {
-          description: 'This question is asking whether your health condition or illness currently affects your ability to carry-out normal daily activities.',
-        },
-        {
-          description: 'You should consider whether you are still affected whilst receiving any treatment, medication or using any devices for your condition or illness. For example, if you require a hearing aid and by using the device, you experience no restriction in carrying out your day-to-day activities, then you should select ‘Not at all’.',
-        },
-        {
-          description: '‘Yes, a lot’, should be selected if you usually need some level of support of family members, friends or personal social services for most normal daily activities.',
-        },
-      ],
-    },
-  ],
+  definitions: [definition],
   type: 'General',
   answers: [
     {
@@ -45,10 +30,44 @@ local question(title) = {
 };
 
 local nonProxyTitle = 'Do any of your conditions or illnesses reduce your ability to carry out day-to-day activities?';
+local nonProxyDefinition = {
+  title: 'What do we mean by “reduce your ability”?',
+  content: [
+    {
+      description: 'We mean whether your health condition or illness currently affects your ability to carry out day-to-day activities.',
+    },
+    {
+      description: 'Consider whether you are still affected while receiving any treatment, medication or using any devices for your condition or illness.',
+    },
+    {
+      description: 'For example, if you need a hearing aid and by using the device you experience no restriction in carrying out your day-to-day activities, then you should select “Not at all”.',
+    },
+    {
+      description: 'You should select “Yes, a lot” if you usually need some level of support from family members, friends or personal social services for most normal daily activities.',
+    },
+  ],
+};
 local proxyTitle = {
   text: 'Does any of <em>{person_name_possessive}</em> conditions or illnesses reduce their ability to carry out day-to-day activities?',
   placeholders: [
     placeholders.personNamePossessive,
+  ],
+};
+local proxyDefinition = {
+  title: 'What do we mean by “reduce their ability”?',
+  content: [
+    {
+      description: 'We mean whether their health condition or illness currently affects their ability to carry out day-to-day activities.',
+    },
+    {
+      description: 'Consider whether they are still affected while receiving any treatment, medication or using any devices for their condition or illness.',
+    },
+    {
+      description: 'For example, if they need a hearing aid and by using the device they experience no restriction in carrying out their day-to-day activities, then you should select “Not at all”.',
+    },
+    {
+      description: 'You should select “Yes, a lot” if they usually need some level of support from family members, friends or personal social services for most normal daily activities.',
+    },
   ],
 };
 
@@ -57,11 +76,11 @@ local proxyTitle = {
   id: 'disability-limitation',
   question_variants: [
     {
-      question: question(nonProxyTitle),
+      question: question(nonProxyTitle, nonProxyDefinition),
       when: [rules.proxyNo],
     },
     {
-      question: question(proxyTitle),
+      question: question(proxyTitle, proxyDefinition),
       when: [rules.proxyYes],
     },
   ],

--- a/data-source/blocks/individual/identity-and-health/ethnic_group.jsonnet
+++ b/data-source/blocks/individual/identity-and-health/ethnic_group.jsonnet
@@ -12,7 +12,11 @@ local question(title, description) = {
         hide_guidance: 'Why your answer is important',
         content: [
           {
-            description: 'Your answer will help the government and other organisations to provide appropriate services and make decisions to support equality and fairness in your community.',
+            description: 'Your answer will help to support equality and fairness in your community. Councils and government use information on ethnic group to make sure they:',
+            list: [
+              'provide services and share funding fairly',
+              'understand and represent everyone’s interests',
+            ],
           },
         ],
       },

--- a/data-source/blocks/individual/identity-and-health/language.jsonnet
+++ b/data-source/blocks/individual/identity-and-health/language.jsonnet
@@ -1,26 +1,38 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import '../../../lib/rules.libsonnet';
 
-local question(title, options) = {
+local question(title, definitionDescription, regionOption) = {
   id: 'language-question',
   title: title,
   type: 'General',
-  definitions: [
-    {
-      title: "What do we mean by 'main language'?",
-      content: [
-        {
-          description: 'Main language is your first or preferred language.',
-        },
-      ],
-    },
-  ],
+  definitions: [{
+    title: 'What do we mean by “main language”?',
+    content: [
+      {
+        description: definitionDescription,
+      },
+    ],
+  }],
   answers: [
     {
       id: 'language-answer',
       mandatory: true,
       type: 'Radio',
-    } + options,
+      options: [
+        regionOption,
+        {
+          label: 'Other',
+          value: 'Other',
+          description: 'Including British Sign Language',
+          detail_answer: {
+            id: 'language-answer-other',
+            type: 'TextField',
+            mandatory: false,
+            label: 'Please specify main language',
+          },
+        },
+      ],
+    },
   ],
 };
 
@@ -31,45 +43,17 @@ local proxyTitle = {
     placeholders.personNamePossessive,
   ],
 };
+local nonProxyDefinitionDescription = 'Your main language is the language you use most naturally. It could be the language you use at home.';
+local proxyDefinitionDescription = 'Their main language is the language they use most naturally. It could be the language they use at home.';
 
-local englandOptions = {
-  options: [
-    {
-      label: 'English',
-      value: 'English',
-    },
-    {
-      label: 'Other',
-      value: 'Other',
-      description: 'Including British Sign Language',
-      detail_answer: {
-        id: 'language-answer-other',
-        type: 'TextField',
-        mandatory: false,
-        label: 'Please specify main language',
-      },
-    },
-  ],
+local englandOption = {
+  label: 'English',
+  value: 'English',
 };
 
-local walesOptions = {
-  options: [
-    {
-      label: 'English or Welsh',
-      value: 'English or Welsh',
-    },
-    {
-      label: 'Other',
-      value: 'Other',
-      description: 'Including British Sign Language',
-      detail_answer: {
-        id: 'language-answer-other',
-        type: 'TextField',
-        mandatory: false,
-        label: 'Please specify main language',
-      },
-    },
-  ],
+local walesOption = {
+  label: 'English or Welsh',
+  value: 'English or Welsh',
 };
 
 {
@@ -77,19 +61,19 @@ local walesOptions = {
   id: 'language',
   question_variants: [
     {
-      question: question(nonProxyTitle, englandOptions),
+      question: question(nonProxyTitle, nonProxyDefinitionDescription, englandOption),
       when: [rules.proxyNo, rules.regionNotWales],
     },
     {
-      question: question(proxyTitle, englandOptions),
+      question: question(proxyTitle, proxyDefinitionDescription, englandOption),
       when: [rules.proxyYes, rules.regionNotWales],
     },
     {
-      question: question(nonProxyTitle, walesOptions),
+      question: question(nonProxyTitle, nonProxyDefinitionDescription, walesOption),
       when: [rules.proxyNo, rules.regionWales],
     },
     {
-      question: question(proxyTitle, walesOptions),
+      question: question(proxyTitle, proxyDefinitionDescription, walesOption),
       when: [rules.proxyYes, rules.regionWales],
     },
   ],

--- a/data-source/blocks/individual/identity-and-health/national_identity.jsonnet
+++ b/data-source/blocks/individual/identity-and-health/national_identity.jsonnet
@@ -1,18 +1,14 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import '../../../lib/rules.libsonnet';
 
-local question(title, options) = {
+local question(title, definitionContent, regionOptions) = {
   id: 'national-identity-question',
   title: title,
   type: 'General',
   definitions: [
     {
-      title: "What do we mean by 'national identity'?",
-      content: [
-        {
-          description: 'National Identity is not dependent on your ethnic group or citizenship. This could be about the country or countries where you feel you belong, or think of as home.',
-        },
-      ],
+      title: 'What do we mean by “national identity”?',
+      content: definitionContent,
     },
   ],
   answers: [
@@ -20,106 +16,98 @@ local question(title, options) = {
       id: 'national-identity-answer',
       mandatory: true,
       type: 'Checkbox',
-    } + options,
+      options: regionOptions + [
+        {
+          label: 'Scottish',
+          value: 'Scottish',
+        },
+        {
+          label: 'Northern Irish',
+          value: 'Northern Irish',
+        },
+        {
+          label: 'British',
+          value: 'British',
+        },
+        {
+          label: 'Other',
+          value: 'Other',
+          detail_answer: {
+            id: 'national-identity-answer-other',
+            type: 'TextField',
+            mandatory: false,
+            label: 'Please describe your national identity',
+          },
+        },
+      ],
+    },
   ],
 };
 
 local nonProxyTitle = 'How would you describe your national identity?';
+local nonProxyDefinitionContent = [
+  {
+    description: 'National identity is not dependent on your ethnic group or citizenship.',
+  },
+  {
+    description: 'It is about the country or countries where you feel you belong or think of as home.',
+  },
+];
 local proxyTitle = {
   text: 'How would <em>{person_name}</em> describe their national identity?',
   placeholders: [
     placeholders.personName,
   ],
 };
+local proxyDefinitionContent = [
+  {
+    description: 'National identity is not dependent on their ethnic group or citizenship.',
+  },
+  {
+    description: 'It is about the country or countries where they feel they belong or think of as home.',
+  },
+];
 
-local englandOptions = {
-  options: [
-    {
-      label: 'English',
-      value: 'English',
-    },
-    {
-      label: 'Welsh',
-      value: 'Welsh',
-    },
-    {
-      label: 'Scottish',
-      value: 'Scottish',
-    },
-    {
-      label: 'Northern Irish',
-      value: 'Northern Irish',
-    },
-    {
-      label: 'British',
-      value: 'British',
-    },
-    {
-      label: 'Other',
-      value: 'Other',
-      detail_answer: {
-        id: 'national-identity-england-answer-other',
-        type: 'TextField',
-        mandatory: false,
-        label: 'Please describe your national identity',
-      },
-    },
-  ],
-};
+local englandOptions = [
+  {
+    label: 'English',
+    value: 'English',
+  },
+  {
+    label: 'Welsh',
+    value: 'Welsh',
+  },
+];
 
-local walesOptions = {
-  options: [
-    {
-      label: 'Welsh',
-      value: 'Welsh',
-    },
-    {
-      label: 'English',
-      value: 'English',
-    },
-    {
-      label: 'Scottish',
-      value: 'Scottish',
-    },
-    {
-      label: 'Northern Irish',
-      value: 'Northern Irish',
-    },
-    {
-      label: 'British',
-      value: 'British',
-    },
-    {
-      label: 'Other',
-      value: 'Other',
-      detail_answer: {
-        id: 'national-identity-wales-answer-other',
-        type: 'TextField',
-        mandatory: false,
-        label: 'Please describe your national identity',
-      },
-    },
-  ],
-};
+local walesOptions = [
+  {
+    label: 'Welsh',
+    value: 'Welsh',
+  },
+  {
+    label: 'English',
+    value: 'English',
+  },
+];
 
 {
   type: 'Question',
   id: 'national-identity',
   question_variants: [
     {
-      question: question(nonProxyTitle, englandOptions),
+      question: question(nonProxyTitle, nonProxyDefinitionContent, englandOptions),
       when: [rules.proxyNo, rules.regionNotWales],
     },
     {
-      question: question(proxyTitle, englandOptions),
+      question: question(proxyTitle, proxyDefinitionContent, englandOptions),
       when: [rules.proxyYes, rules.regionNotWales],
     },
     {
-      question: question(nonProxyTitle, walesOptions),
+      question: question(nonProxyTitle, nonProxyDefinitionContent, walesOptions),
       when: [rules.proxyNo, rules.regionWales],
     },
     {
-      question: question(proxyTitle, walesOptions),
+      question: question(proxyTitle, proxyDefinitionContent, walesOptions),
       when: [rules.proxyYes, rules.regionWales],
     },
   ],

--- a/data-source/blocks/individual/personal-details/another_address.jsonnet
+++ b/data-source/blocks/individual/personal-details/another_address.jsonnet
@@ -7,10 +7,10 @@ local question(title) = {
   type: 'General',
   definitions: [
     {
-      title: "What do we mean by 'another address'?",
+      title: 'What do we mean by “another address”?',
       content: [
         {
-          description: "Another address refers to a different address to the one at the start of this survey. This might be another parent or guardian’s address, a term-time address, a partner's address, or a holiday home.",
+          description: "We mean a different address to the one at the start of this survey. This might be another parent or guardian’s address, a term-time address, a partner's address or a holiday home.",
         },
       ],
     },

--- a/data-source/blocks/individual/qualifications/a_level.jsonnet
+++ b/data-source/blocks/individual/qualifications/a_level.jsonnet
@@ -1,13 +1,13 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import '../../../lib/rules.libsonnet';
 
-local question(title) = {
+local question(title, guidanceTitle, regionOptions) = {
   id: 'a-level-question',
   title: title,
   guidance: {
     content: [
       {
-        title: 'Include equivalent qualifications achieved anywhere outside England and Wales',
+        title: guidanceTitle,
       },
     ],
   },
@@ -33,7 +33,7 @@ local question(title) = {
           label: '1 AS level',
           value: '1 AS level',
         },
-      ],
+      ] + regionOptions,
     },
     {
       id: 'a-level-answer-exclusive',
@@ -58,17 +58,32 @@ local proxyTitle = {
   ],
 };
 
+local englandGuidanceTitle = 'Include equivalent qualifications achieved anywhere outside England and Wales';
+local walesGuidanceTitle = 'Include equivalent qualifications achieved anywhere outside Wales and England';
+local walesOptions = [{
+  label: 'Advanced Welsh Baccalaureate',
+  value: 'Advanced Welsh Baccalaureate',
+}];
+
 {
   type: 'Question',
   id: 'a-level',
   question_variants: [
     {
-      question: question(nonProxyTitle),
-      when: [rules.proxyNo],
+      question: question(nonProxyTitle, englandGuidanceTitle, []),
+      when: [rules.proxyNo, rules.regionNotWales],
     },
     {
-      question: question(proxyTitle),
-      when: [rules.proxyYes],
+      question: question(proxyTitle, englandGuidanceTitle, []),
+      when: [rules.proxyYes, rules.regionNotWales],
+    },
+    {
+      question: question(nonProxyTitle, walesGuidanceTitle, walesOptions),
+      when: [rules.proxyNo, rules.regionWales],
+    },
+    {
+      question: question(proxyTitle, walesGuidanceTitle, walesOptions),
+      when: [rules.proxyYes, rules.regionWales],
     },
   ],
 }

--- a/data-source/blocks/individual/qualifications/apprenticeship.jsonnet
+++ b/data-source/blocks/individual/qualifications/apprenticeship.jsonnet
@@ -1,14 +1,14 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import '../../../lib/rules.libsonnet';
 
-local question(title) = {
+local question(title, regionGuidanceTitle) = {
   id: 'apprenticeship-question',
   title: title,
   type: 'General',
   guidance: {
     content: [
       {
-        title: 'Include equivalent apprenticeships completed anywhere outside England and Wales',
+        title: regionGuidanceTitle,
       },
     ],
   },
@@ -40,17 +40,29 @@ local proxyTitle = {
   ],
 };
 
+local notWalesGuidanceTitle = 'Include equivalent apprenticeships completed anywhere outside England and Wales';
+
+local walesGuidanceTitle = 'Include equivalent apprenticeships completed anywhere outside Wales and England';
+
 {
   type: 'Question',
   id: 'apprenticeship',
   question_variants: [
     {
-      question: question(nonProxyTitle),
-      when: [rules.proxyNo],
+      question: question(nonProxyTitle, notWalesGuidanceTitle),
+      when: [rules.proxyNo, rules.regionNotWales],
     },
     {
-      question: question(proxyTitle),
-      when: [rules.proxyYes],
+      question: question(proxyTitle, notWalesGuidanceTitle),
+      when: [rules.proxyYes, rules.regionNotWales],
+    },
+    {
+      question: question(nonProxyTitle, walesGuidanceTitle),
+      when: [rules.proxyNo, rules.regionWales],
+    },
+    {
+      question: question(proxyTitle, walesGuidanceTitle),
+      when: [rules.proxyYes, rules.regionWales],
     },
   ],
 }

--- a/data-source/blocks/individual/qualifications/degree.jsonnet
+++ b/data-source/blocks/individual/qualifications/degree.jsonnet
@@ -1,14 +1,14 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import '../../../lib/rules.libsonnet';
 
-local question(title) = {
+local question(title, guidanceTitle) = {
   id: 'degree-question',
   title: title,
   type: 'General',
   guidance: {
     content: [
       {
-        title: 'Include equivalent qualifications achieved anywhere outside England and Wales',
+        title: guidanceTitle,
       },
     ],
   },
@@ -16,6 +16,7 @@ local question(title) = {
     {
       id: 'degree-answer',
       mandatory: true,
+      type: 'Radio',
       options: [
         {
           label: 'Yes',
@@ -28,7 +29,6 @@ local question(title) = {
           description: 'Questions on other NVQs, A levels, GCSEs and equivalents will follow',
         },
       ],
-      type: 'Radio',
     },
   ],
 };
@@ -41,17 +41,28 @@ local proxyTitle = {
   ],
 };
 
+local englandGuidanceTitle = 'Include equivalent qualifications achieved anywhere outside England and Wales';
+local walesGuidanceTitle = 'Include equivalent qualifications achieved anywhere outside Wales and England';
+
 {
   type: 'Question',
   id: 'degree',
   question_variants: [
     {
-      question: question(nonProxyTitle),
-      when: [rules.proxyNo],
+      question: question(nonProxyTitle, englandGuidanceTitle),
+      when: [rules.proxyNo, rules.regionNotWales],
     },
     {
-      question: question(proxyTitle),
-      when: [rules.proxyYes],
+      question: question(proxyTitle, englandGuidanceTitle),
+      when: [rules.proxyYes, rules.regionNotWales],
+    },
+    {
+      question: question(nonProxyTitle, walesGuidanceTitle),
+      when: [rules.proxyNo, rules.regionWales],
+    },
+    {
+      question: question(proxyTitle, walesGuidanceTitle),
+      when: [rules.proxyYes, rules.regionWales],
     },
   ],
 }

--- a/data-source/blocks/individual/qualifications/gcse.jsonnet
+++ b/data-source/blocks/individual/qualifications/gcse.jsonnet
@@ -1,7 +1,7 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import '../../../lib/rules.libsonnet';
 
-local question(title) = {
+local question(title, guidanceTitle, regionOptions) = {
   id: 'gcse-question',
   title: title,
   type: 'MutuallyExclusive',
@@ -9,7 +9,7 @@ local question(title) = {
   guidance: {
     content: [
       {
-        title: 'Include equivalent qualifications achieved anywhere outside England and Wales',
+        title: guidanceTitle,
       },
     ],
   },
@@ -34,7 +34,7 @@ local question(title) = {
           value: 'Basic skills course',
           description: 'Skills for life, literacy, numeracy and language',
         },
-      ],
+      ] + regionOptions,
     },
     {
       id: 'gcse-answer-exclusive',
@@ -58,17 +58,39 @@ local proxyTitle = {
   ],
 };
 
+local englandGuidanceTitle = 'Include equivalent qualifications achieved anywhere outside England and Wales';
+local walesGuidanceTitle = 'Include equivalent qualifications achieved anywhere outside Wales and England';
+
+local walesOptions = [
+  {
+    label: 'Intermediate or National Welsh Baccalaureate',
+    value: 'Intermediate or National Welsh Baccalaureate',
+  },
+  {
+    label: 'Foundation Welsh Baccalaureate',
+    value: 'Foundation Welsh Baccalaureate',
+  },
+];
+
 {
   type: 'Question',
   id: 'gcse',
   question_variants: [
     {
-      question: question(nonProxyTitle),
-      when: [rules.proxyNo],
+      question: question(nonProxyTitle, englandGuidanceTitle, []),
+      when: [rules.proxyNo, rules.regionNotWales],
     },
     {
-      question: question(proxyTitle),
-      when: [rules.proxyYes],
+      question: question(proxyTitle, englandGuidanceTitle, []),
+      when: [rules.proxyYes, rules.regionNotWales],
+    },
+    {
+      question: question(nonProxyTitle, walesGuidanceTitle, walesOptions),
+      when: [rules.proxyNo, rules.regionWales],
+    },
+    {
+      question: question(proxyTitle, walesGuidanceTitle, walesOptions),
+      when: [rules.proxyYes, rules.regionWales],
     },
   ],
   routing_rules: [
@@ -76,11 +98,6 @@ local proxyTitle = {
       goto: {
         block: 'other-qualifications',
         when: [
-          {
-            id: 'apprenticeship-answer',
-            condition: 'equals',
-            value: 'No',
-          },
           {
             id: 'degree-answer',
             condition: 'equals',

--- a/data-source/blocks/individual/qualifications/nvq_level.jsonnet
+++ b/data-source/blocks/individual/qualifications/nvq_level.jsonnet
@@ -1,14 +1,14 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import '../../../lib/rules.libsonnet';
 
-local question(title) = {
+local question(title, guidanceTitle) = {
   id: 'nvq-level-question',
   title: title,
   type: 'MutuallyExclusive',
   guidance: {
     content: [
       {
-        title: 'Include equivalent qualifications achieved anywhere outside England and Wales',
+        title: guidanceTitle,
       },
     ],
   },
@@ -58,17 +58,28 @@ local proxyTitle = {
   ],
 };
 
+local englandGuidanceTitle = 'Include equivalent qualifications achieved anywhere outside England and Wales';
+local walesGuidanceTitle = 'Include equivalent qualifications achieved anywhere outside Wales and England';
+
 {
   type: 'Question',
   id: 'nvq-level',
   question_variants: [
     {
-      question: question(nonProxyTitle),
-      when: [rules.proxyNo],
+      question: question(nonProxyTitle, englandGuidanceTitle),
+      when: [rules.proxyNo, rules.regionNotWales],
     },
     {
-      question: question(proxyTitle),
-      when: [rules.proxyYes],
+      question: question(proxyTitle, englandGuidanceTitle),
+      when: [rules.proxyYes, rules.regionNotWales],
+    },
+    {
+      question: question(nonProxyTitle, walesGuidanceTitle),
+      when: [rules.proxyNo, rules.regionWales],
+    },
+    {
+      question: question(proxyTitle, walesGuidanceTitle),
+      when: [rules.proxyYes, rules.regionWales],
     },
   ],
 }

--- a/data-source/blocks/individual/qualifications/other_qualifications.jsonnet
+++ b/data-source/blocks/individual/qualifications/other_qualifications.jsonnet
@@ -1,7 +1,7 @@
 local placeholders = import '../../../lib/placeholders.libsonnet';
 local rules = import '../../../lib/rules.libsonnet';
 
-local question(title) = {
+local question(title, regionOptions) = {
   id: 'other-qualifications-question',
   title: title,
   type: 'MutuallyExclusive',
@@ -11,16 +11,7 @@ local question(title) = {
       id: 'other-qualifications-answer',
       mandatory: false,
       type: 'Checkbox',
-      options: [
-        {
-          label: 'Yes, in England or Wales',
-          value: 'Yes, in England or Wales',
-        },
-        {
-          label: 'Yes, anywhere outside of England and Wales',
-          value: 'Yes, anywhere outside of England and Wales',
-        },
-      ],
+      options: regionOptions,
     },
     {
       id: 'other-qualifications-answer-exclusive',
@@ -44,17 +35,47 @@ local proxyTitle = {
   ],
 };
 
+local englandOptions = [
+  {
+    label: 'Yes, in England or Wales',
+    value: 'Yes, in England or Wales',
+  },
+  {
+    label: 'Yes, anywhere outside of England and Wales',
+    value: 'Yes, anywhere outside of England and Wales',
+  },
+];
+
+local walesOptions = [
+  {
+    label: 'Yes, in Wales or England',
+    value: 'Yes, in Wales or England',
+  },
+  {
+    label: 'Yes, anywhere outside of Wales and England',
+    value: 'Yes, anywhere outside of Wales and England',
+  },
+];
+
 {
   type: 'Question',
   id: 'other-qualifications',
   question_variants: [
     {
-      question: question(nonProxyTitle),
-      when: [rules.proxyNo],
+      question: question(nonProxyTitle, englandOptions),
+      when: [rules.proxyNo, rules.regionNotWales],
     },
     {
-      question: question(proxyTitle),
-      when: [rules.proxyYes],
+      question: question(proxyTitle, englandOptions),
+      when: [rules.proxyYes, rules.regionNotWales],
+    },
+    {
+      question: question(nonProxyTitle, walesOptions),
+      when: [rules.proxyNo, rules.regionWales],
+    },
+    {
+      question: question(proxyTitle, walesOptions),
+      when: [rules.proxyYes, rules.regionWales],
     },
   ],
   routing_rules: [

--- a/data-source/blocks/individual/qualifications/qualifications.jsonnet
+++ b/data-source/blocks/individual/qualifications/qualifications.jsonnet
@@ -9,23 +9,44 @@ local rules = import '../../../lib/rules.libsonnet';
     {
       content: [
         {
-          title: 'The next set of questions is about your qualifications',
-          description: 'Record any qualifications you have ever achieved in England, Wales or worldwide, including equivalents, even if you are not using them now.',
+          title: 'Qualifications',
+          description: 'The next set of questions is about any qualifications you have ever achieved in England, Wales or worldwide, including equivalents, even if you are not using them now.',
         },
       ],
-      when: [rules.proxyNo],
+      when: [rules.proxyNo, rules.regionNotWales],
     },
     {
       content: [
         {
-          title: {
-            text: 'The next set of questions is about {person_name_possessive} qualifications',
-            placeholders: [placeholders.personNamePossessive],
-          },
-          description: 'Record any qualifications they have ever achieved in England, Wales or worldwide, including equivalents, even if they are not using them now.',
+          title: 'Qualifications',
+          description: 'The next set of questions is about any qualifications you have ever achieved in Wales, England or worldwide, including equivalents, even if you are not using them now.',
         },
       ],
-      when: [rules.proxyYes],
+      when: [rules.proxyNo, rules.regionWales],
+    },
+    {
+      content: [
+        {
+          title: 'Qualifications',
+          description: {
+            text: 'The next set of questions is about any qualifications <em>{person_name}</em>, has ever achieved in England, Wales or worldwide, including equivalents, even if they are not using them now.',
+            placeholders: [placeholders.personName],
+          },
+        },
+      ],
+      when: [rules.proxyYes, rules.regionNotWales],
+    },
+    {
+      content: [
+        {
+          title: 'Qualifications',
+          description: {
+            text: 'The next set of questions is about any qualifications <em>{person_name}</em>, has ever achieved in Wales, England or worldwide, including equivalents, even if they are not using them now.',
+            placeholders: [placeholders.personName],
+          },
+        },
+      ],
+      when: [rules.proxyYes, rules.regionWales],
     },
   ],
 }


### PR DESCRIPTION
## NOTE
*This is a necessary duplicate of the original PR, after accidental overwriting of v3-schemaupdates branch. Contents should be identical as per last approval, other than having squashed all commits into one.*

## What is the context of this
This PR integrates requested changes to the schema into the Jsonnet scripts that are processed to form the individual census JSON.

https://trello.com/c/FkaHE4ap/2938-updates-to-individual-census

## How to review
Compile the Jsonnet to JSON by running scripts/build_schema.sh.
Check out and locally run the v3 branch of the eq-schema-validator.
Using a REST client of your choice (e.g. Insomnia), send the census-individual.json to the service's /validate endpoint.
Observe a 200 HTTP status code, and an empty JSON response, confirming it is compliant.