### PR TITLE
Remove address-line-{1,2}, replace with display_address

### DIFF
--- a/data-source/census_individual.jsonnet
+++ b/data-source/census_individual.jsonnet
@@ -109,11 +109,7 @@ function(region_code, census_date) {
       validator: 'optional_string',
     },
     {
-      name: 'address-line-1',
-      validator: 'string',
-    },
-    {
-      name: 'address-line-2',
+      name: 'display_address',
       validator: 'string',
     },
 

--- a/data-source/lib/placeholders.libsonnet
+++ b/data-source/lib/placeholders.libsonnet
@@ -37,16 +37,10 @@
   },
   address: {
     placeholder: 'address',
-    transforms: [{
-      transform: 'concatenate_list',
-      arguments: {
-        list_to_concatenate: {
-          source: 'metadata',
-          identifier: ['address-line-1', 'address-line-2'],
-        },
-        delimiter: ', ',
-      },
-    }],
+    value: {
+      identifier: 'display_address',
+      source: 'metadata',
+    },
   },
   censusDate(census_date): {
     placeholder: 'census_date',


### PR DESCRIPTION
### What is the context of this PR?
Previously used values for address data are no longer going to be passed in to survey-runner, and needed to be placed with the new value, `display_address`.
As this was previously done using a placeholder transform, it was already abstracted away into the library, meaning the change was done there. Additionally, the metadata needed updating in the schema header.

### How to review
Run `./scripts/build_schemas.sh` from the project directory and note no errors reported. Pass the newly generated `census_individual.json` into a running schema-validator instance, and again, check for no errors reported.