### PR TITLE
Fix issue with census individual main job block page title

### DIFF
--- a/data-source/blocks/individual/employment/ever_worked.jsonnet
+++ b/data-source/blocks/individual/employment/ever_worked.jsonnet
@@ -89,7 +89,7 @@ local proxyLabel = 'No, has never worked';
     },
     {
       goto: {
-        block: 'main-employment-block',
+        block: 'last-main-employment-block',
       },
     },
   ],

--- a/data-source/blocks/individual/employment/last_main_employment_block.jsonnet
+++ b/data-source/blocks/individual/employment/last_main_employment_block.jsonnet
@@ -3,13 +3,13 @@ local rules = import '../../../lib/rules.libsonnet';
 
 {
   type: 'Interstitial',
-  id: 'main-employment-block',
-  title: 'Main job',
+  id: 'last-main-employment-block',
+  title: 'Last main job',
   content_variants: [
     {
       content: [
         {
-          description: 'The next set of questions is about your main job. Your main job is the job in which you usually work the most hours',
+          description: 'The next set of questions is about your last main job. Your main job is the job in which you usually worked the most hours',
         },
       ],
       when: [rules.proxyNo],
@@ -18,19 +18,12 @@ local rules = import '../../../lib/rules.libsonnet';
       content: [
         {
           description: {
-            text: 'The next set of questions is about <em>{person_name_possessive}</em> main job. Their main job is the job in which they usually work the most hours',
+            text: 'The next set of questions is about <em>{person_name_possessive}</em> last main job. Their main job is the job in which they usually worked the most hours',
             placeholders: [placeholders.personNamePossessive],
           },
         },
       ],
       when: [rules.proxyYes],
-    },
-  ],
-  routing_rules: [
-    {
-      goto: {
-        block: 'main-job-type',
-      },
     },
   ],
 }

--- a/data-source/census_individual.jsonnet
+++ b/data-source/census_individual.jsonnet
@@ -70,6 +70,7 @@ local job_description = import 'blocks/individual/employment/job_description.jso
 local job_pending = import 'blocks/individual/employment/job_pending.jsonnet';
 local job_title = import 'blocks/individual/employment/job_title.jsonnet';
 local jobseeker = import 'blocks/individual/employment/jobseeker.jsonnet';
+local last_main_employment_block = import 'blocks/individual/employment/last_main_employment_block.jsonnet';
 local main_employment_block = import 'blocks/individual/employment/main_employment_block.jsonnet';
 local main_job_type = import 'blocks/individual/employment/main_job_type.jsonnet';
 local supervise = import 'blocks/individual/employment/supervise.jsonnet';
@@ -203,6 +204,7 @@ function(region_code, census_date) {
             job_pending,
             ever_worked,
             main_employment_block,
+            last_main_employment_block,
             main_job_type,
             business_name,
             job_title,


### PR DESCRIPTION
### What is the context of this PR?
Requested by Charlotte to fix the block title not being the H1 on the page.
Since the block title is not part of variants, I have duplicated the block.

### How to review 
- Ensure title for `main-employment` and `last main-employment` blocks are now be wrapped in H1 tags.
- Routing works as expected.