### PR TITLE
Change data version of the stocks schemas.

### DIFF
--- a/data/en/stocks_0001.json
+++ b/data/en/stocks_0001.json
@@ -3,7 +3,7 @@
     "form_type": "0001",
     "mime_type": "application/json/ons/eq",
     "schema_version": "0.0.1",
-    "data_version": "0.0.2",
+    "data_version": "0.0.1",
     "survey_id": "017",
     "title": "Quarterly Stocks Survey",
     "sections": [{

--- a/data/en/stocks_0002.json
+++ b/data/en/stocks_0002.json
@@ -3,7 +3,7 @@
     "form_type": "0002",
     "mime_type": "application/json/ons/eq",
     "schema_version": "0.0.1",
-    "data_version": "0.0.2",
+    "data_version": "0.0.1",
     "survey_id": "017",
     "title": "Quarterly Stocks Survey",
     "sections": [{

--- a/data/en/stocks_0003.json
+++ b/data/en/stocks_0003.json
@@ -3,7 +3,7 @@
     "form_type": "0003",
     "mime_type": "application/json/ons/eq",
     "schema_version": "0.0.1",
-    "data_version": "0.0.2",
+    "data_version": "0.0.1",
     "survey_id": "017",
     "title": "Quarterly Stocks Survey",
     "sections": [{

--- a/data/en/stocks_0004.json
+++ b/data/en/stocks_0004.json
@@ -3,7 +3,7 @@
     "form_type": "0004",
     "mime_type": "application/json/ons/eq",
     "schema_version": "0.0.1",
-    "data_version": "0.0.2",
+    "data_version": "0.0.1",
     "survey_id": "017",
     "title": "Quarterly Stocks Survey",
     "sections": [{

--- a/data/en/stocks_0005.json
+++ b/data/en/stocks_0005.json
@@ -3,7 +3,7 @@
     "form_type": "0005",
     "mime_type": "application/json/ons/eq",
     "schema_version": "0.0.1",
-    "data_version": "0.0.2",
+    "data_version": "0.0.1",
     "survey_id": "017",
     "title": "Quarterly Stocks Survey",
     "sections": [{

--- a/data/en/stocks_0006.json
+++ b/data/en/stocks_0006.json
@@ -3,7 +3,7 @@
     "form_type": "0006",
     "mime_type": "application/json/ons/eq",
     "schema_version": "0.0.1",
-    "data_version": "0.0.2",
+    "data_version": "0.0.1",
     "survey_id": "017",
     "title": "Quarterly Stocks Survey",
     "sections": [{

--- a/data/en/stocks_0007.json
+++ b/data/en/stocks_0007.json
@@ -3,7 +3,7 @@
     "form_type": "0007",
     "mime_type": "application/json/ons/eq",
     "schema_version": "0.0.1",
-    "data_version": "0.0.2",
+    "data_version": "0.0.1",
     "survey_id": "017",
     "title": "Quarterly Stocks Survey",
     "sections": [{

--- a/data/en/stocks_0008.json
+++ b/data/en/stocks_0008.json
@@ -3,7 +3,7 @@
     "form_type": "0008",
     "mime_type": "application/json/ons/eq",
     "schema_version": "0.0.1",
-    "data_version": "0.0.2",
+    "data_version": "0.0.1",
     "survey_id": "017",
     "title": "Quarterly Stocks Survey",
     "sections": [{

--- a/data/en/stocks_0009.json
+++ b/data/en/stocks_0009.json
@@ -3,7 +3,7 @@
     "form_type": "0009",
     "mime_type": "application/json/ons/eq",
     "schema_version": "0.0.1",
-    "data_version": "0.0.2",
+    "data_version": "0.0.1",
     "survey_id": "017",
     "title": "Quarterly Stocks Survey",
     "sections": [{

--- a/data/en/stocks_0010.json
+++ b/data/en/stocks_0010.json
@@ -3,7 +3,7 @@
     "form_type": "0010",
     "mime_type": "application/json/ons/eq",
     "schema_version": "0.0.1",
-    "data_version": "0.0.2",
+    "data_version": "0.0.1",
     "survey_id": "017",
     "title": "Quarterly Stocks Survey",
     "sections": [{

--- a/data/en/stocks_0011.json
+++ b/data/en/stocks_0011.json
@@ -3,7 +3,7 @@
     "form_type": "0011",
     "mime_type": "application/json/ons/eq",
     "schema_version": "0.0.1",
-    "data_version": "0.0.2",
+    "data_version": "0.0.1",
     "survey_id": "017",
     "title": "Quarterly Stocks Survey",
     "sections": [{

--- a/data/en/stocks_0012.json
+++ b/data/en/stocks_0012.json
@@ -3,7 +3,7 @@
     "form_type": "0012",
     "mime_type": "application/json/ons/eq",
     "schema_version": "0.0.1",
-    "data_version": "0.0.2",
+    "data_version": "0.0.1",
     "survey_id": "017",
     "title": "Quarterly Stocks Survey",
     "sections": [{

--- a/data/en/stocks_0013.json
+++ b/data/en/stocks_0013.json
@@ -3,7 +3,7 @@
     "form_type": "0013",
     "mime_type": "application/json/ons/eq",
     "schema_version": "0.0.1",
-    "data_version": "0.0.2",
+    "data_version": "0.0.1",
     "survey_id": "017",
     "title": "Quarterly Stocks Survey",
     "sections": [{

--- a/data/en/stocks_0014.json
+++ b/data/en/stocks_0014.json
@@ -3,7 +3,7 @@
     "form_type": "0014",
     "mime_type": "application/json/ons/eq",
     "schema_version": "0.0.1",
-    "data_version": "0.0.2",
+    "data_version": "0.0.1",
     "survey_id": "017",
     "title": "Quarterly Stocks Survey",
     "sections": [{

--- a/data/en/stocks_0033.json
+++ b/data/en/stocks_0033.json
@@ -3,7 +3,7 @@
     "form_type": "0033",
     "mime_type": "application/json/ons/eq",
     "schema_version": "0.0.1",
-    "data_version": "0.0.2",
+    "data_version": "0.0.1",
     "survey_id": "017",
     "title": "Quarterly Stocks Survey",
     "sections": [{

--- a/data/en/stocks_0034.json
+++ b/data/en/stocks_0034.json
@@ -3,7 +3,7 @@
     "form_type": "0034",
     "mime_type": "application/json/ons/eq",
     "schema_version": "0.0.1",
-    "data_version": "0.0.2",
+    "data_version": "0.0.1",
     "survey_id": "017",
     "title": "Quarterly Stocks Survey",
     "sections": [{

--- a/data/en/stocks_0051.json
+++ b/data/en/stocks_0051.json
@@ -3,7 +3,7 @@
     "form_type": "0051",
     "mime_type": "application/json/ons/eq",
     "schema_version": "0.0.1",
-    "data_version": "0.0.2",
+    "data_version": "0.0.1",
     "survey_id": "017",
     "title": "Quarterly Stocks Survey",
     "sections": [{

--- a/data/en/stocks_0052.json
+++ b/data/en/stocks_0052.json
@@ -3,7 +3,7 @@
     "form_type": "0052",
     "mime_type": "application/json/ons/eq",
     "schema_version": "0.0.1",
-    "data_version": "0.0.2",
+    "data_version": "0.0.1",
     "survey_id": "017",
     "title": "Quarterly Stocks Survey",
     "sections": [{

--- a/data/en/stocks_0057.json
+++ b/data/en/stocks_0057.json
@@ -3,7 +3,7 @@
     "form_type": "0057",
     "mime_type": "application/json/ons/eq",
     "schema_version": "0.0.1",
-    "data_version": "0.0.2",
+    "data_version": "0.0.1",
     "survey_id": "017",
     "title": "Quarterly Stocks Survey",
     "sections": [{

--- a/data/en/stocks_0058.json
+++ b/data/en/stocks_0058.json
@@ -3,7 +3,7 @@
     "form_type": "0058",
     "mime_type": "application/json/ons/eq",
     "schema_version": "0.0.1",
-    "data_version": "0.0.2",
+    "data_version": "0.0.1",
     "survey_id": "017",
     "title": "Quarterly Stocks Survey",
     "sections": [{


### PR DESCRIPTION
### What is the context of this PR?
The expected downstream result on submission needs to include the q_code values.
This change modifies all the stocks schema files to use the appropriate data version.

### How to review 
Checkout master branch.
Launch the stocks schemas and answer a few questions.
Navigate to the dump/submission endpoint in runner.
Observe that QCodes are not in the submission payload.
Checkout this branch.
Do the same.
Observe that QCodes are in the submission payload.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
