### PR TITLE
Add form type 70 and remove metadata

### DIFF
--- a/data/en/stocks_0001.json
+++ b/data/en/stocks_0001.json
@@ -123,7 +123,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4717",
-                            "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] }} to {{ metadata['ref_p_end_date'] }}?",
+                            "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] | format_date }} to {{ metadata['ref_p_end_date'] | format_date }}?",
                             "type": "General",
                             "answers": [{
                                 "id": "answer5984",

--- a/data/en/stocks_0001.json
+++ b/data/en/stocks_0001.json
@@ -436,8 +436,8 @@
                             "type": "Question",
                             "questions": [{
                                 "id": "question4798",
-                                "title": "Did any significant changes occur to the total value of stocks for {{ metadata['trad_as'] }}?",
-                                "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ metadata['trad_as'] }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
+                                "title": "Did any significant changes occur to the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                                "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
                                 "type": "General",
                                 "answers": [{
                                     "id": "answer6092",
@@ -479,7 +479,7 @@
                             "type": "Question",
                             "questions": [{
                                 "id": "question4799",
-                                "title": "Please indicate the reasons for any changes in the total value of stocks for {{ metadata['trad_as'] }}",
+                                "title": "Please indicate the reasons for any changes in the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                                 "type": "General",
                                 "answers": [{
                                     "id": "answer6093",
@@ -581,6 +581,10 @@
         {
             "name": "ref_p_end_date",
             "validator": "string"
+        },
+        {
+            "name": "trad_as",
+            "validator": "optional_string"
         }
     ],
     "view_submitted_response": {

--- a/data/en/stocks_0001.json
+++ b/data/en/stocks_0001.json
@@ -581,14 +581,6 @@
         {
             "name": "ref_p_end_date",
             "validator": "string"
-        },
-        {
-            "name": "trad_as",
-            "validator": "string"
-        },
-        {
-            "name": "employment_date",
-            "validator": "date"
         }
     ],
     "view_submitted_response": {

--- a/data/en/stocks_0002.json
+++ b/data/en/stocks_0002.json
@@ -123,7 +123,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4717",
-                            "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] }} to {{ metadata['ref_p_end_date'] }}?",
+                            "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] | format_date }} to {{ metadata['ref_p_end_date'] | format_date }}?",
                             "type": "General",
                             "answers": [{
                                 "id": "answer5984",

--- a/data/en/stocks_0002.json
+++ b/data/en/stocks_0002.json
@@ -436,8 +436,8 @@
                             "type": "Question",
                             "questions": [{
                                 "id": "question4798",
-                                "title": "Did any significant changes occur to the total value of stocks for {{ metadata['trad_as'] }}?",
-                                "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ metadata['trad_as'] }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
+                                "title": "Did any significant changes occur to the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                                "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
                                 "type": "General",
                                 "answers": [{
                                     "id": "answer6092",
@@ -479,7 +479,7 @@
                             "type": "Question",
                             "questions": [{
                                 "id": "question4799",
-                                "title": "Please indicate the reasons for any changes in the total value of stocks for {{ metadata['trad_as'] }}",
+                                "title": "Please indicate the reasons for any changes in the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                                 "type": "General",
                                 "answers": [{
                                     "id": "answer6093",
@@ -581,6 +581,10 @@
         {
             "name": "ref_p_end_date",
             "validator": "string"
+        },
+        {
+            "name": "trad_as",
+            "validator": "optional_string"
         }
     ],
     "view_submitted_response": {

--- a/data/en/stocks_0002.json
+++ b/data/en/stocks_0002.json
@@ -581,14 +581,6 @@
         {
             "name": "ref_p_end_date",
             "validator": "string"
-        },
-        {
-            "name": "trad_as",
-            "validator": "string"
-        },
-        {
-            "name": "employment_date",
-            "validator": "date"
         }
     ],
     "view_submitted_response": {

--- a/data/en/stocks_0003.json
+++ b/data/en/stocks_0003.json
@@ -502,14 +502,6 @@
         {
             "name": "ref_p_end_date",
             "validator": "string"
-        },
-        {
-            "name": "trad_as",
-            "validator": "string"
-        },
-        {
-            "name": "employment_date",
-            "validator": "date"
         }
     ],
     "view_submitted_response": {

--- a/data/en/stocks_0003.json
+++ b/data/en/stocks_0003.json
@@ -359,8 +359,8 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4796",
-                            "title": "Did any significant changes occur to the total value of stocks for {{ metadata['trad_as'] }}?",
-                            "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ metadata['trad_as'] }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
+                            "title": "Did any significant changes occur to the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                            "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
                             "type": "General",
                             "answers": [{
                                 "id": "answer6090",
@@ -402,7 +402,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4797",
-                            "title": "Please indicate the reasons for any changes in the total value of stocks for {{ metadata['trad_as'] }}",
+                            "title": "Please indicate the reasons for any changes in the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                             "type": "General",
                             "answers": [{
                                 "id": "answer6091",
@@ -502,6 +502,10 @@
         {
             "name": "ref_p_end_date",
             "validator": "string"
+        },
+        {
+            "name": "trad_as",
+            "validator": "optional_string"
         }
     ],
     "view_submitted_response": {

--- a/data/en/stocks_0003.json
+++ b/data/en/stocks_0003.json
@@ -103,7 +103,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4707",
-                            "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] }} to {{ metadata['ref_p_end_date'] }}?",
+                            "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] | format_date }} to {{ metadata['ref_p_end_date'] | format_date }}?",
                             "type": "General",
                             "answers": [{
                                 "id": "answer5971",

--- a/data/en/stocks_0004.json
+++ b/data/en/stocks_0004.json
@@ -502,14 +502,6 @@
         {
             "name": "ref_p_end_date",
             "validator": "string"
-        },
-        {
-            "name": "trad_as",
-            "validator": "string"
-        },
-        {
-            "name": "employment_date",
-            "validator": "date"
         }
     ],
     "view_submitted_response": {

--- a/data/en/stocks_0004.json
+++ b/data/en/stocks_0004.json
@@ -359,8 +359,8 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4796",
-                            "title": "Did any significant changes occur to the total value of stocks for {{ metadata['trad_as'] }}?",
-                            "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ metadata['trad_as'] }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
+                            "title": "Did any significant changes occur to the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                            "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
                             "type": "General",
                             "answers": [{
                                 "id": "answer6090",
@@ -402,7 +402,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4797",
-                            "title": "Please indicate the reasons for any changes in the total value of stocks for {{ metadata['trad_as'] }}",
+                            "title": "Please indicate the reasons for any changes in the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                             "type": "General",
                             "answers": [{
                                 "id": "answer6091",
@@ -502,6 +502,10 @@
         {
             "name": "ref_p_end_date",
             "validator": "string"
+        },
+        {
+            "name": "trad_as",
+            "validator": "optional_string"
         }
     ],
     "view_submitted_response": {

--- a/data/en/stocks_0004.json
+++ b/data/en/stocks_0004.json
@@ -103,7 +103,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4707",
-                            "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] }} to {{ metadata['ref_p_end_date'] }}?",
+                            "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] | format_date }} to {{ metadata['ref_p_end_date'] | format_date }}?",
                             "type": "General",
                             "answers": [{
                                 "id": "answer5971",

--- a/data/en/stocks_0005.json
+++ b/data/en/stocks_0005.json
@@ -169,7 +169,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4691",
-                            "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] }} to {{ metadata['ref_p_end_date'] }}?",
+                            "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] | format_date }} to {{ metadata['ref_p_end_date'] | format_date }}?",
                             "type": "General",
                             "answers": [{
                                 "id": "answer5949",

--- a/data/en/stocks_0005.json
+++ b/data/en/stocks_0005.json
@@ -572,8 +572,8 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4794",
-                            "title": "Did any significant changes occur to the total value of stocks for {{ metadata['trad_as'] }}?",
-                            "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ metadata['trad_as'] }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
+                            "title": "Did any significant changes occur to the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                            "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
                             "type": "General",
                             "answers": [{
                                 "id": "answer6088",
@@ -615,7 +615,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4795",
-                            "title": "Please indicate the reasons for any changes in the total value of stocks for {{ metadata['trad_as'] }}",
+                            "title": "Please indicate the reasons for any changes in the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                             "type": "General",
                             "answers": [{
                                 "id": "answer6089",
@@ -715,6 +715,10 @@
         {
             "name": "ref_p_end_date",
             "validator": "string"
+        },
+        {
+            "name": "trad_as",
+            "validator": "optional_string"
         }
     ],
     "view_submitted_response": {

--- a/data/en/stocks_0005.json
+++ b/data/en/stocks_0005.json
@@ -715,14 +715,6 @@
         {
             "name": "ref_p_end_date",
             "validator": "string"
-        },
-        {
-            "name": "trad_as",
-            "validator": "string"
-        },
-        {
-            "name": "employment_date",
-            "validator": "date"
         }
     ],
     "view_submitted_response": {

--- a/data/en/stocks_0006.json
+++ b/data/en/stocks_0006.json
@@ -169,7 +169,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4691",
-                            "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] }} to {{ metadata['ref_p_end_date'] }}?",
+                            "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] | format_date }} to {{ metadata['ref_p_end_date'] | format_date }}?",
                             "type": "General",
                             "answers": [{
                                 "id": "answer5949",

--- a/data/en/stocks_0006.json
+++ b/data/en/stocks_0006.json
@@ -572,8 +572,8 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4794",
-                            "title": "Did any significant changes occur to the total value of stocks for {{ metadata['trad_as'] }}?",
-                            "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ metadata['trad_as'] }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
+                            "title": "Did any significant changes occur to the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                            "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
                             "type": "General",
                             "answers": [{
                                 "id": "answer6088",
@@ -615,7 +615,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4795",
-                            "title": "Please indicate the reasons for any changes in the total value of stocks for {{ metadata['trad_as'] }}",
+                            "title": "Please indicate the reasons for any changes in the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                             "type": "General",
                             "answers": [{
                                 "id": "answer6089",
@@ -715,6 +715,10 @@
         {
             "name": "ref_p_end_date",
             "validator": "string"
+        },
+        {
+            "name": "trad_as",
+            "validator": "optional_string"
         }
     ],
     "view_submitted_response": {

--- a/data/en/stocks_0006.json
+++ b/data/en/stocks_0006.json
@@ -715,14 +715,6 @@
         {
             "name": "ref_p_end_date",
             "validator": "string"
-        },
-        {
-            "name": "trad_as",
-            "validator": "string"
-        },
-        {
-            "name": "employment_date",
-            "validator": "date"
         }
     ],
     "view_submitted_response": {

--- a/data/en/stocks_0007.json
+++ b/data/en/stocks_0007.json
@@ -128,7 +128,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4679",
-                            "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] }} to {{ metadata['ref_p_end_date'] }}?",
+                            "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] | format_date }} to {{ metadata['ref_p_end_date'] | format_date }}?",
                             "type": "General",
                             "answers": [{
                                 "id": "answer5933",

--- a/data/en/stocks_0007.json
+++ b/data/en/stocks_0007.json
@@ -432,8 +432,8 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4792",
-                            "title": "Did any significant changes occur to the total value of stocks for {{ metadata['trad_as'] }}?",
-                            "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ metadata['trad_as'] }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
+                            "title": "Did any significant changes occur to the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                            "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
                             "type": "General",
                             "answers": [{
                                 "id": "answer6086",
@@ -475,7 +475,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4793",
-                            "title": "Please indicate the reasons for any changes in the total value of stocks for {{ metadata['trad_as'] }}",
+                            "title": "Please indicate the reasons for any changes in the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                             "type": "General",
                             "answers": [{
                                 "id": "answer6087",
@@ -575,6 +575,10 @@
         {
             "name": "ref_p_end_date",
             "validator": "string"
+        },
+        {
+            "name": "trad_as",
+            "validator": "optional_string"
         }
     ],
     "view_submitted_response": {

--- a/data/en/stocks_0007.json
+++ b/data/en/stocks_0007.json
@@ -575,14 +575,6 @@
         {
             "name": "ref_p_end_date",
             "validator": "string"
-        },
-        {
-            "name": "trad_as",
-            "validator": "string"
-        },
-        {
-            "name": "employment_date",
-            "validator": "date"
         }
     ],
     "view_submitted_response": {

--- a/data/en/stocks_0008.json
+++ b/data/en/stocks_0008.json
@@ -128,7 +128,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4679",
-                            "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] }} to {{ metadata['ref_p_end_date'] }}?",
+                            "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] | format_date }} to {{ metadata['ref_p_end_date'] | format_date }}?",
                             "type": "General",
                             "answers": [{
                                 "id": "answer5933",

--- a/data/en/stocks_0008.json
+++ b/data/en/stocks_0008.json
@@ -432,8 +432,8 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4792",
-                            "title": "Did any significant changes occur to the total value of stocks for {{ metadata['trad_as'] }}?",
-                            "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ metadata['trad_as'] }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
+                            "title": "Did any significant changes occur to the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                            "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
                             "type": "General",
                             "answers": [{
                                 "id": "answer6086",
@@ -475,7 +475,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4793",
-                            "title": "Please indicate the reasons for any changes in the total value of stocks for {{ metadata['trad_as'] }}",
+                            "title": "Please indicate the reasons for any changes in the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                             "type": "General",
                             "answers": [{
                                 "id": "answer6087",
@@ -575,6 +575,10 @@
         {
             "name": "ref_p_end_date",
             "validator": "string"
+        },
+        {
+            "name": "trad_as",
+            "validator": "optional_string"
         }
     ],
     "view_submitted_response": {

--- a/data/en/stocks_0008.json
+++ b/data/en/stocks_0008.json
@@ -575,14 +575,6 @@
         {
             "name": "ref_p_end_date",
             "validator": "string"
-        },
-        {
-            "name": "trad_as",
-            "validator": "string"
-        },
-        {
-            "name": "employment_date",
-            "validator": "date"
         }
     ],
     "view_submitted_response": {

--- a/data/en/stocks_0009.json
+++ b/data/en/stocks_0009.json
@@ -49,7 +49,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4767",
-                            "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] }} to {{ metadata['ref_p_end_date'] }}?",
+                            "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] | format_date }} to {{ metadata['ref_p_end_date'] | format_date }}?",
                             "type": "General",
                             "answers": [{
                                 "id": "answer6051",

--- a/data/en/stocks_0009.json
+++ b/data/en/stocks_0009.json
@@ -469,8 +469,8 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4806",
-                            "title": "Did any significant changes occur to the total value of stocks for {{ metadata['trad_as'] }}?",
-                            "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ metadata['trad_as'] }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
+                            "title": "Did any significant changes occur to the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                            "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
                             "type": "General",
                             "answers": [{
                                 "id": "answer6100",
@@ -512,7 +512,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4807",
-                            "title": "Please indicate the reasons for any changes in the total value of stocks for {{ metadata['trad_as'] }}",
+                            "title": "Please indicate the reasons for any changes in the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                             "type": "General",
                             "answers": [{
                                 "id": "answer6101",
@@ -612,6 +612,10 @@
         {
             "name": "ref_p_end_date",
             "validator": "string"
+        },
+        {
+            "name": "trad_as",
+            "validator": "optional_string"
         }
     ],
     "view_submitted_response": {

--- a/data/en/stocks_0009.json
+++ b/data/en/stocks_0009.json
@@ -612,14 +612,6 @@
         {
             "name": "ref_p_end_date",
             "validator": "string"
-        },
-        {
-            "name": "trad_as",
-            "validator": "string"
-        },
-        {
-            "name": "employment_date",
-            "validator": "date"
         }
     ],
     "view_submitted_response": {

--- a/data/en/stocks_0010.json
+++ b/data/en/stocks_0010.json
@@ -49,7 +49,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4767",
-                            "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] }} to {{ metadata['ref_p_end_date'] }}?",
+                            "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] | format_date }} to {{ metadata['ref_p_end_date'] | format_date }}?",
                             "type": "General",
                             "answers": [{
                                 "id": "answer6051",

--- a/data/en/stocks_0010.json
+++ b/data/en/stocks_0010.json
@@ -469,8 +469,8 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4806",
-                            "title": "Did any significant changes occur to the total value of stocks for {{ metadata['trad_as'] }}?",
-                            "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ metadata['trad_as'] }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
+                            "title": "Did any significant changes occur to the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                            "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
                             "type": "General",
                             "answers": [{
                                 "id": "answer6100",
@@ -512,7 +512,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4807",
-                            "title": "Please indicate the reasons for any changes in the total value of stocks for {{ metadata['trad_as'] }}",
+                            "title": "Please indicate the reasons for any changes in the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                             "type": "General",
                             "answers": [{
                                 "id": "answer6101",
@@ -612,6 +612,10 @@
         {
             "name": "ref_p_end_date",
             "validator": "string"
+        },
+        {
+            "name": "trad_as",
+            "validator": "optional_string"
         }
     ],
     "view_submitted_response": {

--- a/data/en/stocks_0010.json
+++ b/data/en/stocks_0010.json
@@ -612,14 +612,6 @@
         {
             "name": "ref_p_end_date",
             "validator": "string"
-        },
-        {
-            "name": "trad_as",
-            "validator": "string"
-        },
-        {
-            "name": "employment_date",
-            "validator": "date"
         }
     ],
     "view_submitted_response": {

--- a/data/en/stocks_0011.json
+++ b/data/en/stocks_0011.json
@@ -355,8 +355,8 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4802",
-                            "title": "Did any significant changes occur to the total value of stocks for {{ metadata['trad_as'] }}?",
-                            "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ metadata['trad_as'] }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
+                            "title": "Did any significant changes occur to the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                            "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
                             "type": "General",
                             "answers": [{
                                 "id": "answer6096",
@@ -398,7 +398,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4803",
-                            "title": "Please indicate the reasons for any changes in the total value of stocks for {{ metadata['trad_as'] }}",
+                            "title": "Please indicate the reasons for any changes in the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                             "type": "General",
                             "answers": [{
                                 "id": "answer6097",
@@ -498,6 +498,10 @@
         {
             "name": "ref_p_end_date",
             "validator": "string"
+        },
+        {
+            "name": "trad_as",
+            "validator": "optional_string"
         }
     ],
     "view_submitted_response": {

--- a/data/en/stocks_0011.json
+++ b/data/en/stocks_0011.json
@@ -101,7 +101,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4741",
-                            "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] }} to {{ metadata['ref_p_end_date'] }}?",
+                            "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] | format_date }} to {{ metadata['ref_p_end_date'] | format_date }}?",
                             "type": "General",
                             "answers": [{
                                 "id": "answer6016",

--- a/data/en/stocks_0011.json
+++ b/data/en/stocks_0011.json
@@ -498,14 +498,6 @@
         {
             "name": "ref_p_end_date",
             "validator": "string"
-        },
-        {
-            "name": "trad_as",
-            "validator": "string"
-        },
-        {
-            "name": "employment_date",
-            "validator": "date"
         }
     ],
     "view_submitted_response": {

--- a/data/en/stocks_0012.json
+++ b/data/en/stocks_0012.json
@@ -355,8 +355,8 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4802",
-                            "title": "Did any significant changes occur to the total value of stocks for {{ metadata['trad_as'] }}?",
-                            "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ metadata['trad_as'] }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
+                            "title": "Did any significant changes occur to the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                            "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
                             "type": "General",
                             "answers": [{
                                 "id": "answer6096",
@@ -398,7 +398,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4803",
-                            "title": "Please indicate the reasons for any changes in the total value of stocks for {{ metadata['trad_as'] }}",
+                            "title": "Please indicate the reasons for any changes in the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                             "type": "General",
                             "answers": [{
                                 "id": "answer6097",
@@ -498,6 +498,10 @@
         {
             "name": "ref_p_end_date",
             "validator": "string"
+        },
+        {
+            "name": "trad_as",
+            "validator": "optional_string"
         }
     ],
     "view_submitted_response": {

--- a/data/en/stocks_0012.json
+++ b/data/en/stocks_0012.json
@@ -101,7 +101,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4741",
-                            "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] }} to {{ metadata['ref_p_end_date'] }}?",
+                            "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] | format_date }} to {{ metadata['ref_p_end_date'] | format_date }}?",
                             "type": "General",
                             "answers": [{
                                 "id": "answer6016",

--- a/data/en/stocks_0012.json
+++ b/data/en/stocks_0012.json
@@ -498,14 +498,6 @@
         {
             "name": "ref_p_end_date",
             "validator": "string"
-        },
-        {
-            "name": "trad_as",
-            "validator": "string"
-        },
-        {
-            "name": "employment_date",
-            "validator": "date"
         }
     ],
     "view_submitted_response": {

--- a/data/en/stocks_0013.json
+++ b/data/en/stocks_0013.json
@@ -49,7 +49,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4729",
-                            "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] }} to {{ metadata['ref_p_end_date'] }}?",
+                            "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] | format_date }} to {{ metadata['ref_p_end_date'] | format_date }}?",
                             "type": "General",
                             "answers": [{
                                 "id": "answer6000",

--- a/data/en/stocks_0013.json
+++ b/data/en/stocks_0013.json
@@ -381,8 +381,8 @@
                             "type": "Question",
                             "questions": [{
                                 "id": "question4800",
-                                "title": "Did any significant changes occur to the total value of stocks for {{ metadata['trad_as'] }}?",
-                                "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ metadata['trad_as'] }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
+                                "title": "Did any significant changes occur to the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                                "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
                                 "type": "General",
                                 "answers": [{
                                     "id": "answer6094",
@@ -424,7 +424,7 @@
                             "type": "Question",
                             "questions": [{
                                 "id": "question4801",
-                                "title": "Please indicate the reasons for any changes in the total value of stocks for {{ metadata['trad_as'] }}",
+                                "title": "Please indicate the reasons for any changes in the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                                 "type": "General",
                                 "answers": [{
                                     "id": "answer6095",
@@ -526,6 +526,10 @@
         {
             "name": "ref_p_end_date",
             "validator": "string"
+        },
+        {
+            "name": "trad_as",
+            "validator": "optional_string"
         }
     ],
     "view_submitted_response": {

--- a/data/en/stocks_0013.json
+++ b/data/en/stocks_0013.json
@@ -526,14 +526,6 @@
         {
             "name": "ref_p_end_date",
             "validator": "string"
-        },
-        {
-            "name": "trad_as",
-            "validator": "string"
-        },
-        {
-            "name": "employment_date",
-            "validator": "date"
         }
     ],
     "view_submitted_response": {

--- a/data/en/stocks_0014.json
+++ b/data/en/stocks_0014.json
@@ -49,7 +49,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4729",
-                            "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] }} to {{ metadata['ref_p_end_date'] }}?",
+                            "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] | format_date }} to {{ metadata['ref_p_end_date'] | format_date }}?",
                             "type": "General",
                             "answers": [{
                                 "id": "answer6000",

--- a/data/en/stocks_0014.json
+++ b/data/en/stocks_0014.json
@@ -381,8 +381,8 @@
                             "type": "Question",
                             "questions": [{
                                 "id": "question4800",
-                                "title": "Did any significant changes occur to the total value of stocks for {{ metadata['trad_as'] }}?",
-                                "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ metadata['trad_as'] }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
+                                "title": "Did any significant changes occur to the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                                "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
                                 "type": "General",
                                 "answers": [{
                                     "id": "answer6094",
@@ -424,7 +424,7 @@
                             "type": "Question",
                             "questions": [{
                                 "id": "question4801",
-                                "title": "Please indicate the reasons for any changes in the total value of stocks for {{ metadata['trad_as'] }}",
+                                "title": "Please indicate the reasons for any changes in the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                                 "type": "General",
                                 "answers": [{
                                     "id": "answer6095",
@@ -526,6 +526,10 @@
         {
             "name": "ref_p_end_date",
             "validator": "string"
+        },
+        {
+            "name": "trad_as",
+            "validator": "optional_string"
         }
     ],
     "view_submitted_response": {

--- a/data/en/stocks_0014.json
+++ b/data/en/stocks_0014.json
@@ -526,14 +526,6 @@
         {
             "name": "ref_p_end_date",
             "validator": "string"
-        },
-        {
-            "name": "trad_as",
-            "validator": "string"
-        },
-        {
-            "name": "employment_date",
-            "validator": "date"
         }
     ],
     "view_submitted_response": {

--- a/data/en/stocks_0033.json
+++ b/data/en/stocks_0033.json
@@ -690,14 +690,6 @@
         {
             "name": "ref_p_end_date",
             "validator": "string"
-        },
-        {
-            "name": "trad_as",
-            "validator": "string"
-        },
-        {
-            "name": "employment_date",
-            "validator": "date"
         }
     ],
     "view_submitted_response": {

--- a/data/en/stocks_0033.json
+++ b/data/en/stocks_0033.json
@@ -545,8 +545,8 @@
                             "type": "Question",
                             "questions": [{
                                 "id": "question4804",
-                                "title": "Did any significant changes occur to the total value of stocks for {{ metadata['trad_as'] }}?",
-                                "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ metadata['trad_as'] }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
+                                "title": "Did any significant changes occur to the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                                "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
                                 "type": "General",
                                 "answers": [{
                                     "id": "answer6098",
@@ -588,7 +588,7 @@
                             "type": "Question",
                             "questions": [{
                                 "id": "question4805",
-                                "title": "Please indicate the reasons for any changes in the total value of stocks for {{ metadata['trad_as'] }}",
+                                "title": "Please indicate the reasons for any changes in the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                                 "type": "General",
                                 "answers": [{
                                     "id": "answer6099",
@@ -690,6 +690,10 @@
         {
             "name": "ref_p_end_date",
             "validator": "string"
+        },
+        {
+            "name": "trad_as",
+            "validator": "optional_string"
         }
     ],
     "view_submitted_response": {

--- a/data/en/stocks_0033.json
+++ b/data/en/stocks_0033.json
@@ -104,7 +104,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4751",
-                            "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] }} to {{ metadata['ref_p_end_date'] }}?",
+                            "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] | format_date }} to {{ metadata['ref_p_end_date'] | format_date }}?",
                             "type": "General",
                             "answers": [{
                                 "id": "answer6029",

--- a/data/en/stocks_0034.json
+++ b/data/en/stocks_0034.json
@@ -690,14 +690,6 @@
         {
             "name": "ref_p_end_date",
             "validator": "string"
-        },
-        {
-            "name": "trad_as",
-            "validator": "string"
-        },
-        {
-            "name": "employment_date",
-            "validator": "date"
         }
     ],
     "view_submitted_response": {

--- a/data/en/stocks_0034.json
+++ b/data/en/stocks_0034.json
@@ -545,8 +545,8 @@
                             "type": "Question",
                             "questions": [{
                                 "id": "question4804",
-                                "title": "Did any significant changes occur to the total value of stocks for {{ metadata['trad_as'] }}?",
-                                "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ metadata['trad_as'] }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
+                                "title": "Did any significant changes occur to the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                                "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
                                 "type": "General",
                                 "answers": [{
                                     "id": "answer6098",
@@ -588,7 +588,7 @@
                             "type": "Question",
                             "questions": [{
                                 "id": "question4805",
-                                "title": "Please indicate the reasons for any changes in the total value of stocks for {{ metadata['trad_as'] }}",
+                                "title": "Please indicate the reasons for any changes in the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                                 "type": "General",
                                 "answers": [{
                                     "id": "answer6099",
@@ -690,6 +690,10 @@
         {
             "name": "ref_p_end_date",
             "validator": "string"
+        },
+        {
+            "name": "trad_as",
+            "validator": "optional_string"
         }
     ],
     "view_submitted_response": {

--- a/data/en/stocks_0034.json
+++ b/data/en/stocks_0034.json
@@ -104,7 +104,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4751",
-                            "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] }} to {{ metadata['ref_p_end_date'] }}?",
+                            "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] | format_date }} to {{ metadata['ref_p_end_date'] | format_date }}?",
                             "type": "General",
                             "answers": [{
                                 "id": "answer6029",

--- a/data/en/stocks_0051.json
+++ b/data/en/stocks_0051.json
@@ -229,8 +229,8 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4808",
-                            "title": "Did any significant changes occur to the total value of stocks for {{ metadata['trad_as'] }}?",
-                            "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ metadata['trad_as'] }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
+                            "title": "Did any significant changes occur to the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                            "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
                             "type": "General",
                             "answers": [{
                                 "id": "answer6102",
@@ -272,7 +272,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4809",
-                            "title": "Please indicate the reasons for any changes in the total value of stocks for {{ metadata['trad_as'] }}",
+                            "title": "Please indicate the reasons for any changes in the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                             "type": "General",
                             "answers": [{
                                 "id": "answer6103",
@@ -373,6 +373,10 @@
         {
             "name": "ref_p_end_date",
             "validator": "string"
+        },
+        {
+            "name": "trad_as",
+            "validator": "optional_string"
         }
     ],
     "view_submitted_response": {

--- a/data/en/stocks_0051.json
+++ b/data/en/stocks_0051.json
@@ -373,14 +373,6 @@
         {
             "name": "ref_p_end_date",
             "validator": "string"
-        },
-        {
-            "name": "trad_as",
-            "validator": "string"
-        },
-        {
-            "name": "employment_date",
-            "validator": "date"
         }
     ],
     "view_submitted_response": {

--- a/data/en/stocks_0051.json
+++ b/data/en/stocks_0051.json
@@ -69,7 +69,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4783",
-                            "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] }} to {{ metadata['ref_p_end_date'] }}?",
+                            "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] | format_date }} to {{ metadata['ref_p_end_date'] | format_date }}?",
                             "type": "General",
                             "answers": [{
                                 "id": "answer6073",

--- a/data/en/stocks_0052.json
+++ b/data/en/stocks_0052.json
@@ -229,8 +229,8 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4808",
-                            "title": "Did any significant changes occur to the total value of stocks for {{ metadata['trad_as'] }}?",
-                            "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ metadata['trad_as'] }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
+                            "title": "Did any significant changes occur to the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                            "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
                             "type": "General",
                             "answers": [{
                                 "id": "answer6102",
@@ -272,7 +272,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4809",
-                            "title": "Please indicate the reasons for any changes in the total value of stocks for {{ metadata['trad_as'] }}",
+                            "title": "Please indicate the reasons for any changes in the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                             "type": "General",
                             "answers": [{
                                 "id": "answer6103",
@@ -373,6 +373,10 @@
         {
             "name": "ref_p_end_date",
             "validator": "string"
+        },
+        {
+            "name": "trad_as",
+            "validator": "optional_string"
         }
     ],
     "view_submitted_response": {

--- a/data/en/stocks_0052.json
+++ b/data/en/stocks_0052.json
@@ -69,7 +69,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4783",
-                            "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] }} to {{ metadata['ref_p_end_date'] }}?",
+                            "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] | format_date }} to {{ metadata['ref_p_end_date'] | format_date }}?",
                             "type": "General",
                             "answers": [{
                                 "id": "answer6073",

--- a/data/en/stocks_0057.json
+++ b/data/en/stocks_0057.json
@@ -122,7 +122,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4667",
-                            "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] }} to {{ metadata['ref_p_end_date'] }}?",
+                            "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] | format_date }} to {{ metadata['ref_p_end_date'] | format_date }}?",
                             "type": "General",
                             "answers": [{
                                 "id": "answer5917",

--- a/data/en/stocks_0057.json
+++ b/data/en/stocks_0057.json
@@ -581,14 +581,6 @@
         {
             "name": "ref_p_end_date",
             "validator": "string"
-        },
-        {
-            "name": "trad_as",
-            "validator": "string"
-        },
-        {
-            "name": "employment_date",
-            "validator": "date"
         }
     ],
     "view_submitted_response": {

--- a/data/en/stocks_0057.json
+++ b/data/en/stocks_0057.json
@@ -438,8 +438,8 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4790",
-                            "title": "Did any significant changes occur to the total value of stocks for {{ metadata['trad_as'] }}?",
-                            "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ metadata['trad_as'] }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
+                            "title": "Did any significant changes occur to the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                            "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
                             "type": "General",
                             "answers": [{
                                 "id": "answer6083",
@@ -481,7 +481,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4791",
-                            "title": "Please indicate the reasons for any changes in the total value of stocks for {{ metadata['trad_as'] }}",
+                            "title": "Please indicate the reasons for any changes in the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                             "type": "General",
                             "answers": [{
                                 "id": "answer6084",
@@ -581,6 +581,10 @@
         {
             "name": "ref_p_end_date",
             "validator": "string"
+        },
+        {
+            "name": "trad_as",
+            "validator": "optional_string"
         }
     ],
     "view_submitted_response": {

--- a/data/en/stocks_0058.json
+++ b/data/en/stocks_0058.json
@@ -122,7 +122,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4667",
-                            "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] }} to {{ metadata['ref_p_end_date'] }}?",
+                            "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] | format_date }} to {{ metadata['ref_p_end_date'] | format_date }}?",
                             "type": "General",
                             "answers": [{
                                 "id": "answer5917",

--- a/data/en/stocks_0058.json
+++ b/data/en/stocks_0058.json
@@ -581,14 +581,6 @@
         {
             "name": "ref_p_end_date",
             "validator": "string"
-        },
-        {
-            "name": "trad_as",
-            "validator": "string"
-        },
-        {
-            "name": "employment_date",
-            "validator": "date"
         }
     ],
     "view_submitted_response": {

--- a/data/en/stocks_0058.json
+++ b/data/en/stocks_0058.json
@@ -438,8 +438,8 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4790",
-                            "title": "Did any significant changes occur to the total value of stocks for {{ metadata['trad_as'] }}?",
-                            "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ metadata['trad_as'] }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
+                            "title": "Did any significant changes occur to the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                            "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
                             "type": "General",
                             "answers": [{
                                 "id": "answer6083",
@@ -481,7 +481,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4791",
-                            "title": "Please indicate the reasons for any changes in the total value of stocks for {{ metadata['trad_as'] }}",
+                            "title": "Please indicate the reasons for any changes in the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                             "type": "General",
                             "answers": [{
                                 "id": "answer6084",
@@ -581,6 +581,10 @@
         {
             "name": "ref_p_end_date",
             "validator": "string"
+        },
+        {
+            "name": "trad_as",
+            "validator": "optional_string"
         }
     ],
     "view_submitted_response": {

--- a/data/en/stocks_0061.json
+++ b/data/en/stocks_0061.json
@@ -373,14 +373,6 @@
         {
             "name": "ref_p_end_date",
             "validator": "string"
-        },
-        {
-            "name": "trad_as",
-            "validator": "string"
-        },
-        {
-            "name": "employmentDate",
-            "validator": "date"
         }
     ],
     "view_submitted_response": {

--- a/data/en/stocks_0061.json
+++ b/data/en/stocks_0061.json
@@ -69,7 +69,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question379",
-                            "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] }} to {{ metadata['ref_p_end_date'] }}?",
+                            "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] | format_date }} to {{ metadata['ref_p_end_date'] | format_date }}?",
                             "type": "General",
                             "answers": [{
                                 "id": "answer434",

--- a/data/en/stocks_0061.json
+++ b/data/en/stocks_0061.json
@@ -229,8 +229,8 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4952",
-                            "title": "Did any significant changes occur to the total value of stocks for {{ metadata['trad_as'] }}?",
-                            "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ metadata['trad_as'] }}{{ metadata['trad_as'] }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
+                            "title": "Did any significant changes occur to the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                            "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}{{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
                             "type": "General",
                             "answers": [{
                                 "id": "answer6287",
@@ -272,7 +272,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4953",
-                            "title": "Please indicate the reasons for any changes in the total value of stocks for {{ metadata['trad_as'] }}",
+                            "title": "Please indicate the reasons for any changes in the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                             "type": "General",
                             "answers": [{
                                 "id": "answer6288",
@@ -373,6 +373,10 @@
         {
             "name": "ref_p_end_date",
             "validator": "string"
+        },
+        {
+            "name": "trad_as",
+            "validator": "optional_string"
         }
     ],
     "view_submitted_response": {

--- a/data/en/stocks_0070.json
+++ b/data/en/stocks_0070.json
@@ -237,8 +237,8 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4952",
-                            "title": "Did any significant changes occur to the total value of stocks for {{ metadata['trad_as'] }}?",
-                            "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ metadata['trad_as'] }}{{ metadata['trad_as'] }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
+                            "title": "Did any significant changes occur to the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                            "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}{{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
                             "type": "General",
                             "answers": [{
                                 "id": "answer6287",
@@ -280,7 +280,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question4953",
-                            "title": "Please indicate the reasons for any changes in the total value of stocks for {{ metadata['trad_as'] }}",
+                            "title": "Please indicate the reasons for any changes in the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
                             "type": "General",
                             "answers": [{
                                 "id": "answer6288",
@@ -381,6 +381,10 @@
         {
             "name": "ref_p_end_date",
             "validator": "string"
+        },
+        {
+            "name": "trad_as",
+            "validator": "optional_string"
         }
     ],
     "view_submitted_response": {

--- a/data/en/stocks_0070.json
+++ b/data/en/stocks_0070.json
@@ -69,7 +69,7 @@
                         "type": "Question",
                         "questions": [{
                             "id": "question379",
-                            "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] }} to {{ metadata['ref_p_end_date'] }}?",
+                            "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] | format_date }} to {{ metadata['ref_p_end_date'] | format_date }}?",
                             "type": "General",
                             "answers": [{
                                 "id": "answer434",

--- a/data/en/stocks_0070.json
+++ b/data/en/stocks_0070.json
@@ -1,15 +1,15 @@
 {
-    "eq_id": "516",
-    "form_type": "0052",
+    "eq_id": "13fec20d-6144-4dbb-9c00-4eab97d111c5",
+    "form_type": "0070",
     "mime_type": "application/json/ons/eq",
     "schema_version": "0.0.1",
     "data_version": "0.0.1",
     "survey_id": "017",
     "title": "Quarterly Stocks Survey",
     "sections": [{
-        "id": "section1198",
+        "id": "section91",
         "groups": [{
-                "id": "group1198",
+                "id": "group91",
                 "title": "",
                 "blocks": [{
                         "type": "Introduction",
@@ -19,8 +19,8 @@
                             "id": "primary",
                             "content": [{
                                 "list": [
-                                    "This survey covers UK businesses. The business is the individual company partnership, sole proprietorship to which the questionnaire has been sent, unless specified otherwise.",
-                                    "You can provide informed estimates if actual figures aren&#x2019;t available.",
+                                    "Data should relate to all sites in England, Scotland, Wales and Northern Ireland unless otherwise stated.",
+                                    "You can provide info estimates if actual figures aren&#x2019;t available.",
                                     "We will treat your data securely and confidentially."
                                 ]
                             }]
@@ -68,11 +68,11 @@
                         "id": "able-to-report-between",
                         "type": "Question",
                         "questions": [{
-                            "id": "question4783",
+                            "id": "question379",
                             "title": "Are you able to report for the period {{ metadata['ref_p_start_date'] }} to {{ metadata['ref_p_end_date'] }}?",
                             "type": "General",
                             "answers": [{
-                                "id": "answer6073",
+                                "id": "answer434",
                                 "mandatory": true,
                                 "type": "Radio",
                                 "label": "",
@@ -90,17 +90,17 @@
                         }],
                         "routing_rules": [{
                                 "goto": {
-                                    "block": "which-period-report",
+                                    "block": "total-value-stocks-net-progress-payments",
                                     "when": [{
-                                        "id": "answer6073",
+                                        "id": "answer434",
                                         "condition": "equals",
-                                        "value": "No"
+                                        "value": "Yes"
                                     }]
                                 }
                             },
                             {
                                 "goto": {
-                                    "block": "total-value-stocks"
+                                    "block": "which-period-report"
                                 }
                             }
                         ]
@@ -109,11 +109,11 @@
                         "id": "which-period-report",
                         "type": "Question",
                         "questions": [{
-                            "id": "question4784",
+                            "id": "question380",
                             "title": "For which period are you able to report?",
                             "type": "DateRange",
                             "answers": [{
-                                    "id": "answer6074from",
+                                    "id": "answer435from",
                                     "type": "Date",
                                     "mandatory": true,
                                     "label": "Period from",
@@ -126,7 +126,7 @@
                                     }
                                 },
                                 {
-                                    "id": "answer6074to",
+                                    "id": "answer435to",
                                     "type": "Date",
                                     "mandatory": true,
                                     "label": "Period to",
@@ -150,10 +150,10 @@
                         }]
                     },
                     {
-                        "id": "total-value-stocks",
+                        "id": "total-value-stocks-net-progress-payments",
                         "type": "Question",
                         "questions": [{
-                            "id": "question4785",
+                            "id": "question381",
                             "title": "What was the <em>total value</em> of stocks held (net of progress payments on long-term contracts)?",
                             "guidance": {
                                 "content": [{
@@ -161,9 +161,10 @@
                                     },
                                     {
                                         "list": [
-                                            "All stocks owned; whether held by your business in the UK or abroad",
+                                            "All stocks owned, whether held by your business in the UK or abroad",
                                             "Duty for dutiable goods held out of bond",
-                                            "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes"
+                                            "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes",
+                                            "Work in progress"
                                         ]
                                     },
                                     {
@@ -176,42 +177,49 @@
                             },
                             "type": "General",
                             "answers": [{
-                                    "id": "answer6076",
+                                    "id": "answer436",
                                     "mandatory": true,
                                     "type": "Currency",
                                     "label": "Total value of stocks held at start of period",
-                                    "q_code": "498",
                                     "description": "",
+                                    "q_code": "498",
                                     "decimal_places": 2,
                                     "currency": "GBP"
                                 },
                                 {
-                                    "id": "answer6075",
+                                    "id": "answer437",
                                     "mandatory": true,
                                     "type": "Currency",
                                     "label": "Total value of stocks held at end of period",
-                                    "q_code": "499",
                                     "description": "",
+                                    "q_code": "499",
                                     "decimal_places": 2,
-                                    "currency": "GBP"
+                                    "currency": "GBP",
+                                    "guidance": {
+                                        "show_guidance": "What is 'work in progress'?",
+                                        "hide_guidance": "What is 'work in progress'?",
+                                        "content": [{
+                                            "description": "Work in progress consists of goods and services that have been partially completed (e.g. a solicitor working on a legal case over a period of time and being paid at the end of the contract for the services provided i.e. unbilled work)."
+                                        }]
+                                    }
                                 }
                             ]
                         }]
                     },
                     {
-                        "id": "is-eop-figures-estimated",
+                        "id": "figures-estimated",
                         "type": "Question",
                         "questions": [{
-                            "id": "question4788",
+                            "id": "question4616",
                             "title": "Are the end of period figures you have provided estimated?",
                             "type": "General",
                             "answers": [{
-                                "id": "answer6079",
+                                "id": "answer5873",
                                 "mandatory": true,
                                 "type": "Radio",
                                 "label": "",
-                                "q_code": "15",
                                 "description": "",
+                                "q_code": "15",
                                 "options": [{
                                         "label": "Yes",
                                         "value": "Yes"
@@ -225,20 +233,20 @@
                         }]
                     },
                     {
-                        "id": "significant-changes-total-value",
+                        "id": "stocks-significant-changes",
                         "type": "Question",
                         "questions": [{
-                            "id": "question4808",
+                            "id": "question4952",
                             "title": "Did any significant changes occur to the total value of stocks for {{ metadata['trad_as'] }}?",
-                            "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ metadata['trad_as'] }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
+                            "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ metadata['trad_as'] }}{{ metadata['trad_as'] }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
                             "type": "General",
                             "answers": [{
-                                "id": "answer6102",
+                                "id": "answer6287",
                                 "mandatory": true,
                                 "type": "Radio",
                                 "label": "",
-                                "q_code": "146a",
                                 "description": "",
+                                "q_code": "146a",
                                 "options": [{
                                         "label": "Yes",
                                         "value": "Yes"
@@ -252,9 +260,9 @@
                         }],
                         "routing_rules": [{
                                 "goto": {
-                                    "block": "reason-changes-total-value",
+                                    "block": "reasons-for-changes-value",
                                     "when": [{
-                                        "id": "answer6102",
+                                        "id": "answer6287",
                                         "condition": "equals",
                                         "value": "Yes"
                                     }]
@@ -262,20 +270,20 @@
                             },
                             {
                                 "goto": {
-                                    "block": "difference-quarter-open-close-value"
+                                    "block": "differences-between-quarters"
                                 }
                             }
                         ]
                     },
                     {
-                        "id": "reason-changes-total-value",
+                        "id": "reasons-for-changes-value",
                         "type": "Question",
                         "questions": [{
-                            "id": "question4809",
+                            "id": "question4953",
                             "title": "Please indicate the reasons for any changes in the total value of stocks for {{ metadata['trad_as'] }}",
                             "type": "General",
                             "answers": [{
-                                "id": "answer6103",
+                                "id": "answer6288",
                                 "mandatory": true,
                                 "type": "Checkbox",
                                 "label": "",
@@ -320,19 +328,19 @@
                         }]
                     },
                     {
-                        "id": "difference-quarter-open-close-value",
+                        "id": "differences-between-quarters",
                         "type": "Question",
                         "questions": [{
-                            "id": "question4786",
+                            "id": "question383",
                             "title": "Explain any differences between this quarter&apos;s opening value and the previously returned closing value",
                             "description": "<p>  Include any unusual fluctuations in figures  </p>",
                             "type": "General",
                             "answers": [{
-                                "id": "answer6077",
+                                "id": "answer439",
                                 "mandatory": false,
                                 "type": "TextArea",
-                                "q_code": "146",
                                 "label": "Comments",
+                                "q_code": "146",
                                 "description": ""
                             }]
                         }]


### PR DESCRIPTION
### What is the context of this PR?
Added form type 70 and removed trad_as and employment_date metadata from being mandatory 

### How to review 
Check that the forms launch without needing trad_as or employment_date metadata and that form type 70 looks ok and launches without error
