### PR TITLE
Add debug endpoint

### DIFF
--- a/app/data_model/questionnaire_store.py
+++ b/app/data_model/questionnaire_store.py
@@ -53,7 +53,7 @@ class QuestionnaireStore:
         self.completed_blocks = completed_blocks
         self.collection_metadata = json_data.get('COLLECTION_METADATA', {})
 
-    def _serialise(self):
+    def serialise(self):
         data = {
             'METADATA': self._metadata,
             'ANSWERS': list(self.answer_store),
@@ -71,7 +71,7 @@ class QuestionnaireStore:
         self.completed_blocks = []
 
     def add_or_update(self):
-        data = self._serialise()
+        data = self.serialise()
         self._storage.add_or_update(data=data)
 
     def remove_completed_blocks(self, location):

--- a/app/views/dump.py
+++ b/app/views/dump.py
@@ -6,7 +6,7 @@ import simplejson as json
 
 
 from app.authentication.roles import role_required
-from app.globals import get_questionnaire_store, get_session_store, get_answer_store
+from app.globals import get_questionnaire_store, get_session_store
 from app.submitter.converter import convert_answers
 from app.utilities.schema import load_schema_from_session_data
 from app.questionnaire.path_finder import PathFinder
@@ -15,12 +15,14 @@ from app.questionnaire.path_finder import PathFinder
 dump_blueprint = Blueprint('dump', __name__)
 
 
-@dump_blueprint.route('/dump/answers', methods=['GET'])
+@dump_blueprint.route('/dump/debug', methods=['GET'])
 @login_required
 @role_required('dumper')
-def dump_answers():
-    response = {'answers': get_answer_store(current_user).serialise() or []}
-    return json.dumps(response, for_json=True), 200
+def dump_debug():
+    questionnaire_store = get_questionnaire_store(
+        current_user.user_id, current_user.user_ik
+    )
+    return questionnaire_store.serialise()
 
 
 @dump_blueprint.route('/dump/submission', methods=['GET'])
@@ -41,4 +43,4 @@ def dump_submission():
     response = {
         'submission': convert_answers(schema, questionnaire_store, routing_path)
     }
-    return json.dumps(response, for_json=True), 200
+    return json.dumps(response, for_json=True)

--- a/tests/integration/questionnaire/test_questionnaire_csrf.py
+++ b/tests/integration/questionnaire/test_questionnaire_csrf.py
@@ -59,9 +59,9 @@ class TestQuestionnaireCsrf(IntegrationTestCase):
 
         # Then
         self.assertStatusCode(401)
-        self.get('/dump/answers')
+        self.get('/dump/debug')
         answers = json.loads(self.getResponseData())
-        self.assertEqual('Muesli', answers['answers'][0]['value'])
+        self.assertEqual('Muesli', answers['ANSWERS'][0]['value'])
 
     def test_given_valid_answer_when_answer_with_invalid_csrf_token_then_answer_not_saved(
         self
@@ -81,9 +81,9 @@ class TestQuestionnaireCsrf(IntegrationTestCase):
 
         # Then
         self.assertStatusCode(401)
-        self.get('/dump/answers')
+        self.get('/dump/debug')
         answers = json.loads(self.getResponseData())
-        self.assertEqual(2, len(answers['answers']))
+        self.assertEqual(2, len(answers['ANSWERS']))
 
     def test_given_valid_answers_when_save_and_sign_out_with_invalid_csrf_token_then_answers_not_saved(
         self
@@ -99,9 +99,9 @@ class TestQuestionnaireCsrf(IntegrationTestCase):
 
         # Then
         self.assertStatusCode(401)
-        self.get('/dump/answers')
+        self.get('/dump/debug')
         answers = json.loads(self.getResponseData())
-        self.assertEqual(0, len(answers['answers']))
+        self.assertEqual(0, len(answers['ANSWERS']))
 
     def test_given_csrf_attack_when_refresh_then_on_question(self):
         # Given
@@ -115,9 +115,9 @@ class TestQuestionnaireCsrf(IntegrationTestCase):
 
         # Then
         self.assertEqual(self.last_response.status_code, 200)
-        self.get('/dump/answers')
+        self.get('/dump/debug')
         answers = json.loads(self.getResponseData())
-        self.assertEqual(0, len(answers['answers']))
+        self.assertEqual(0, len(answers['ANSWERS']))
 
     def test_given_csrf_attack_when_submit_new_answers_then_answers_saved(self):
         # Given
@@ -132,6 +132,6 @@ class TestQuestionnaireCsrf(IntegrationTestCase):
 
         # Then
         self.assertStatusOK()
-        self.get('/dump/answers')
+        self.get('/dump/debug')
         answers = json.loads(self.getResponseData())
-        self.assertEqual('Pancakes', answers['answers'][0]['value'])
+        self.assertEqual('Pancakes', answers['ANSWERS'][0]['value'])

--- a/tests/integration/questionnaire/test_questionnaire_endpoint_redirects.py
+++ b/tests/integration/questionnaire/test_questionnaire_endpoint_redirects.py
@@ -53,9 +53,9 @@ class TestQuestionnaireEndpointRedirects(IntegrationTestCase):
         self.get('submitted/thank-you')
 
         # Then the answers are not deleted
-        self.get('/dump/answers')
+        self.get('/dump/debug')
         answers = json.loads(self.getResponseData())
-        self.assertEqual(1, len(answers['answers']))
+        self.assertEqual(1, len(answers['ANSWERS']))
 
     def test_given_not_complete_questionnaire_when_get_thank_you_then_redirected_to_latest_location(
         self
@@ -79,9 +79,9 @@ class TestQuestionnaireEndpointRedirects(IntegrationTestCase):
         self.launchSurvey('test', 'percentage', roles=['dumper'])
 
         # Then no answers should have persisted
-        self.get('/dump/answers')
+        self.get('/dump/debug')
         answers = json.loads(self.getResponseData())
-        self.assertEqual(0, len(answers['answers']))
+        self.assertEqual(0, len(answers['ANSWERS']))
 
     def test_when_on_thank_you_get_summary_returns_unauthorised(self):
         # Given we complete the test_percentage survey and are on the thank you page

--- a/tests/integration/views/test_dump.py
+++ b/tests/integration/views/test_dump.py
@@ -3,22 +3,22 @@ import json
 from tests.integration.integration_test_case import IntegrationTestCase
 
 
-class TestDumpAnswers(IntegrationTestCase):
-    def test_dump_answers_not_authenticated(self):
+class TestDumpDebug(IntegrationTestCase):
+    def test_dump_debug_not_authenticated(self):
         # Given I am not an authenticated user
-        # When I attempt to dump the answer store
-        self.get('/dump/answers')
+        # When I attempt to dump the questionnaire store
+        self.get('/dump/debug')
 
         # Then I receive a 401 Unauthorised response code
         self.assertStatusUnauthorised()
 
-    def test_dump_answers_authenticated_missing_role(self):
+    def test_dump_debug_authenticated_missing_role(self):
         # Given I am an authenticated user who has launched a survey
         # but does not have the 'dumper' role in my metadata
         self.launchSurvey('test', 'radio_mandatory_with_mandatory_other')
 
-        # When I attempt to dump the answer store
-        self.get('/dump/answers')
+        # When I attempt to dump the questionnaire store
+        self.get('/dump/debug')
 
         # Then I receive a 403 Forbidden response code
         self.assertStatusForbidden()
@@ -26,54 +26,18 @@ class TestDumpAnswers(IntegrationTestCase):
         # And the response data contains Forbidden
         self.assertInBody('Error 403')
 
-    def test_dump_answers_authenticated_with_role_no_answers(self):
+    def test_dump_debug_authenticated_with_role(self):
         # Given I am an authenticated user who has launched a survey
         # and does have the 'dumper' role in my metadata
         self.launchSurvey(
             'test', 'radio_mandatory_with_mandatory_other', roles=['dumper']
         )
 
-        # When I haven't submitted any answers
-        # And I attempt to dump the answer store
-        self.get('/dump/answers')
+        # And I attempt to dump the questionnaire store
+        self.get('/dump/debug')
 
         # Then I get a 200 OK response
         self.assertStatusOK()
-
-        # And the JSON response contains an empty array
-        actual = json.loads(self.getResponseData())
-        expected = {'answers': []}
-
-        self.assertDictEqual(actual, expected)
-
-    def test_dump_answers_authenticated_with_role_with_answers(self):
-        # Given I am an authenticated user who has launched a survey
-        # and does have the 'dumper' role in my metadata
-        self.launchSurvey(
-            'test', 'radio_mandatory_with_mandatory_other', roles=['dumper']
-        )
-
-        # When I submit an answer
-        self.post(post_data={'radio-mandatory-answer': 'Toast'})
-
-        # And I attempt to dump the answer store
-        self.get('/dump/answers')
-
-        # Then I get a 200 OK response
-        self.assertStatusOK()
-
-        # And the JSON response contains the data I submitted
-        actual = json.loads(self.getResponseData())
-        expected = {
-            'answers': [{'value': 'Toast', 'answer_id': 'radio-mandatory-answer'}]
-        }
-
-        # Enable full dictionary diffs on test failure
-        self.maxDiff = None
-
-        # Data in the answer store doesn't seem to be in a consistent order
-        # between test runs so we have to compare like this.
-        self.assertCountEqual(actual['answers'], expected['answers'])
 
 
 class TestDumpSubmission(IntegrationTestCase):


### PR DESCRIPTION
### What is the context of this PR?
When debugging questionnaires it's useful to know the full state of the questionnaire store. This pull request replaces the `/dump/answers` endpoint with a `/dump/debug` endpoint that dumps the contents of the questionnaire store (metadata, answers, lists and completed blocks).

### How to review 
Test some surveys and open the `/dump/debug` url in another tab