### PR TITLE
Applied question page title style to calculated summary page title

### DIFF
--- a/app/templates/summary.html
+++ b/app/templates/summary.html
@@ -37,8 +37,8 @@
     </div>
 </div>
 {% elif content.summary.summary_type == 'CalculatedSummary' %}
-<div>
-  <h1 class="u-fs-l" data-qa="calculated-summary-title">{{content.summary.title}}</h1>
+<div class="question">
+  <h1 class="u-fs-l question__title" data-qa="calculated-summary-title">{{content.summary.title}}</h1>
   <div class="print__hidden panel panel--simple panel--success u-mb-l">
     <h2 class="u-fs-r--b">{{ _("Please review your answers and confirm these are correct") }}.</h2>
   </div>


### PR DESCRIPTION
### What is the context of this PR?
Calculated Summary Title is not applying highlight styles.

### How to review 
Add a few pages with number answers.
Add a calculated summary page.
In the title of the calculated summary page, use the rich text editor to highlight some of the content.
Preview/launch the questionnaire.
Observe that the highlighting is visible on the calculated summary page.

