### PR TITLE
Change stocks validations to use metadata values.

### DIFF
--- a/data/en/stocks_0001.json
+++ b/data/en/stocks_0001.json
@@ -173,7 +173,7 @@
                                     "label": "Period from",
                                     "q_code": "11",
                                     "minimum": {
-                                        "value": "2019-03-31",
+                                        "meta": "ref_p_start_date",
                                         "offset_by": {
                                             "days": -31
                                         }
@@ -186,7 +186,7 @@
                                     "label": "Period to",
                                     "q_code": "12",
                                     "maximum": {
-                                        "value": "2019-06-30",
+                                        "meta": "ref_p_end_date",
                                         "offset_by": {
                                             "days": 31
                                         }

--- a/data/en/stocks_0002.json
+++ b/data/en/stocks_0002.json
@@ -173,7 +173,7 @@
                                     "label": "Period from",
                                     "q_code": "11",
                                     "minimum": {
-                                        "value": "2019-03-31",
+                                        "meta": "ref_p_start_date",
                                         "offset_by": {
                                             "days": -31
                                         }
@@ -186,7 +186,7 @@
                                     "label": "Period to",
                                     "q_code": "12",
                                     "maximum": {
-                                        "value": "2019-06-30",
+                                        "meta": "ref_p_end_date",
                                         "offset_by": {
                                             "days": 31
                                         }

--- a/data/en/stocks_0003.json
+++ b/data/en/stocks_0003.json
@@ -153,7 +153,7 @@
                                     "label": "Period from",
                                     "q_code": "11",
                                     "minimum": {
-                                        "value": "2019-03-31",
+                                        "meta": "ref_p_start_date",
                                         "offset_by": {
                                             "days": -31
                                         }
@@ -166,7 +166,7 @@
                                     "label": "Period to",
                                     "q_code": "12",
                                     "maximum": {
-                                        "value": "2019-06-30",
+                                        "meta": "ref_p_end_date",
                                         "offset_by": {
                                             "days": 31
                                         }

--- a/data/en/stocks_0004.json
+++ b/data/en/stocks_0004.json
@@ -153,7 +153,7 @@
                                     "label": "Period from",
                                     "q_code": "11",
                                     "minimum": {
-                                        "value": "2019-03-31",
+                                        "meta": "ref_p_start_date",
                                         "offset_by": {
                                             "days": -31
                                         }
@@ -166,7 +166,7 @@
                                     "label": "Period to",
                                     "q_code": "12",
                                     "maximum": {
-                                        "value": "2019-06-30",
+                                        "meta": "ref_p_end_date",
                                         "offset_by": {
                                             "days": 31
                                         }

--- a/data/en/stocks_0005.json
+++ b/data/en/stocks_0005.json
@@ -219,7 +219,7 @@
                                     "label": "Period from",
                                     "q_code": "11",
                                     "minimum": {
-                                        "value": "2019-03-31",
+                                        "meta": "ref_p_start_date",
                                         "offset_by": {
                                             "days": -31
                                         }
@@ -232,7 +232,7 @@
                                     "label": "Period to",
                                     "q_code": "12",
                                     "maximum": {
-                                        "value": "2019-06-30",
+                                        "meta": "ref_p_end_date",
                                         "offset_by": {
                                             "days": 31
                                         }

--- a/data/en/stocks_0006.json
+++ b/data/en/stocks_0006.json
@@ -219,7 +219,7 @@
                                     "label": "Period from",
                                     "q_code": "11",
                                     "minimum": {
-                                        "value": "2019-03-31",
+                                        "meta": "ref_p_start_date",
                                         "offset_by": {
                                             "days": -31
                                         }
@@ -232,7 +232,7 @@
                                     "label": "Period to",
                                     "q_code": "12",
                                     "maximum": {
-                                        "value": "2019-06-30",
+                                        "meta": "ref_p_end_date",
                                         "offset_by": {
                                             "days": 31
                                         }

--- a/data/en/stocks_0007.json
+++ b/data/en/stocks_0007.json
@@ -178,7 +178,7 @@
                                     "label": "Period from",
                                     "q_code": "11",
                                     "minimum": {
-                                        "value": "2019-03-31",
+                                        "meta": "ref_p_start_date",
                                         "offset_by": {
                                             "days": -31
                                         }
@@ -191,7 +191,7 @@
                                     "label": "Period to",
                                     "q_code": "12",
                                     "maximum": {
-                                        "value": "2019-06-30",
+                                        "meta": "ref_p_end_date",
                                         "offset_by": {
                                             "days": 31
                                         }

--- a/data/en/stocks_0008.json
+++ b/data/en/stocks_0008.json
@@ -178,7 +178,7 @@
                                     "label": "Period from",
                                     "q_code": "11",
                                     "minimum": {
-                                        "value": "2019-03-31",
+                                        "meta": "ref_p_start_date",
                                         "offset_by": {
                                             "days": -31
                                         }
@@ -191,7 +191,7 @@
                                     "label": "Period to",
                                     "q_code": "12",
                                     "maximum": {
-                                        "value": "2019-06-30",
+                                        "meta": "ref_p_end_date",
                                         "offset_by": {
                                             "days": 31
                                         }

--- a/data/en/stocks_0009.json
+++ b/data/en/stocks_0009.json
@@ -99,7 +99,7 @@
                                     "label": "Period from",
                                     "q_code": "11",
                                     "minimum": {
-                                        "value": "2019-03-31",
+                                        "meta": "ref_p_start_date",
                                         "offset_by": {
                                             "days": -31
                                         }
@@ -112,7 +112,7 @@
                                     "label": "Period to",
                                     "q_code": "12",
                                     "maximum": {
-                                        "value": "2019-06-30",
+                                        "meta": "ref_p_end_date",
                                         "offset_by": {
                                             "days": 31
                                         }

--- a/data/en/stocks_0010.json
+++ b/data/en/stocks_0010.json
@@ -99,7 +99,7 @@
                                     "label": "Period from",
                                     "q_code": "11",
                                     "minimum": {
-                                        "value": "2019-03-31",
+                                        "meta": "ref_p_start_date",
                                         "offset_by": {
                                             "days": -31
                                         }
@@ -112,7 +112,7 @@
                                     "label": "Period to",
                                     "q_code": "12",
                                     "maximum": {
-                                        "value": "2019-06-30",
+                                        "meta": "ref_p_end_date",
                                         "offset_by": {
                                             "days": 31
                                         }

--- a/data/en/stocks_0011.json
+++ b/data/en/stocks_0011.json
@@ -151,7 +151,7 @@
                                     "label": "Period from",
                                     "q_code": "11",
                                     "minimum": {
-                                        "value": "2019-03-31",
+                                        "meta": "ref_p_start_date",
                                         "offset_by": {
                                             "days": -31
                                         }
@@ -164,7 +164,7 @@
                                     "label": "Period to",
                                     "q_code": "12",
                                     "maximum": {
-                                        "value": "2019-06-30",
+                                        "meta": "ref_p_end_date",
                                         "offset_by": {
                                             "days": 31
                                         }

--- a/data/en/stocks_0012.json
+++ b/data/en/stocks_0012.json
@@ -151,7 +151,7 @@
                                     "label": "Period from",
                                     "q_code": "11",
                                     "minimum": {
-                                        "value": "2019-03-31",
+                                        "meta": "ref_p_start_date",
                                         "offset_by": {
                                             "days": -31
                                         }
@@ -164,7 +164,7 @@
                                     "label": "Period to",
                                     "q_code": "12",
                                     "maximum": {
-                                        "value": "2019-06-30",
+                                        "meta": "ref_p_end_date",
                                         "offset_by": {
                                             "days": 31
                                         }

--- a/data/en/stocks_0013.json
+++ b/data/en/stocks_0013.json
@@ -99,7 +99,7 @@
                                     "label": "Period from",
                                     "q_code": "11",
                                     "minimum": {
-                                        "value": "2019-03-31",
+                                        "meta": "ref_p_start_date",
                                         "offset_by": {
                                             "days": -31
                                         }
@@ -112,7 +112,7 @@
                                     "label": "Period to",
                                     "q_code": "12",
                                     "maximum": {
-                                        "value": "2019-06-30",
+                                        "meta": "ref_p_end_date",
                                         "offset_by": {
                                             "days": 31
                                         }

--- a/data/en/stocks_0014.json
+++ b/data/en/stocks_0014.json
@@ -99,7 +99,7 @@
                                     "label": "Period from",
                                     "q_code": "11",
                                     "minimum": {
-                                        "value": "2019-03-31",
+                                        "meta": "ref_p_start_date",
                                         "offset_by": {
                                             "days": -31
                                         }
@@ -112,7 +112,7 @@
                                     "label": "Period to",
                                     "q_code": "12",
                                     "maximum": {
-                                        "value": "2019-06-30",
+                                        "meta": "ref_p_end_date",
                                         "offset_by": {
                                             "days": 31
                                         }

--- a/data/en/stocks_0033.json
+++ b/data/en/stocks_0033.json
@@ -154,7 +154,7 @@
                                     "label": "Period from",
                                     "q_code": "11",
                                     "minimum": {
-                                        "value": "2019-03-31",
+                                        "meta": "ref_p_start_date",
                                         "offset_by": {
                                             "days": -31
                                         }
@@ -167,7 +167,7 @@
                                     "label": "Period to",
                                     "q_code": "12",
                                     "maximum": {
-                                        "value": "2019-06-30",
+                                        "meta": "ref_p_end_date",
                                         "offset_by": {
                                             "days": 31
                                         }

--- a/data/en/stocks_0034.json
+++ b/data/en/stocks_0034.json
@@ -154,7 +154,7 @@
                                     "label": "Period from",
                                     "q_code": "11",
                                     "minimum": {
-                                        "value": "2019-03-31",
+                                        "meta": "ref_p_start_date",
                                         "offset_by": {
                                             "days": -31
                                         }
@@ -167,7 +167,7 @@
                                     "label": "Period to",
                                     "q_code": "12",
                                     "maximum": {
-                                        "value": "2019-06-30",
+                                        "meta": "ref_p_end_date",
                                         "offset_by": {
                                             "days": 31
                                         }

--- a/data/en/stocks_0051.json
+++ b/data/en/stocks_0051.json
@@ -119,7 +119,7 @@
                                     "label": "Period from",
                                     "q_code": "11",
                                     "minimum": {
-                                        "value": "2019-03-31",
+                                        "meta": "ref_p_start_date",
                                         "offset_by": {
                                             "days": -31
                                         }
@@ -132,7 +132,7 @@
                                     "label": "Period to",
                                     "q_code": "12",
                                     "maximum": {
-                                        "value": "2019-06-30",
+                                        "meta": "ref_p_end_date",
                                         "offset_by": {
                                             "days": 31
                                         }

--- a/data/en/stocks_0052.json
+++ b/data/en/stocks_0052.json
@@ -119,7 +119,7 @@
                                     "label": "Period from",
                                     "q_code": "11",
                                     "minimum": {
-                                        "value": "2019-03-31",
+                                        "meta": "ref_p_start_date",
                                         "offset_by": {
                                             "days": -31
                                         }
@@ -132,7 +132,7 @@
                                     "label": "Period to",
                                     "q_code": "12",
                                     "maximum": {
-                                        "value": "2019-06-30",
+                                        "meta": "ref_p_end_date",
                                         "offset_by": {
                                             "days": 31
                                         }

--- a/data/en/stocks_0057.json
+++ b/data/en/stocks_0057.json
@@ -172,7 +172,7 @@
                                     "label": "Period from",
                                     "q_code": "11",
                                     "minimum": {
-                                        "value": "2019-03-31",
+                                        "meta": "ref_p_start_date",
                                         "offset_by": {
                                             "days": -31
                                         }
@@ -185,7 +185,7 @@
                                     "label": "Period to",
                                     "q_code": "12",
                                     "maximum": {
-                                        "value": "2019-06-30",
+                                        "meta": "ref_p_end_date",
                                         "offset_by": {
                                             "days": 31
                                         }

--- a/data/en/stocks_0058.json
+++ b/data/en/stocks_0058.json
@@ -172,7 +172,7 @@
                                     "label": "Period from",
                                     "q_code": "11",
                                     "minimum": {
-                                        "value": "2019-03-31",
+                                        "meta": "ref_p_start_date",
                                         "offset_by": {
                                             "days": -31
                                         }
@@ -185,7 +185,7 @@
                                     "label": "Period to",
                                     "q_code": "12",
                                     "maximum": {
-                                        "value": "2019-06-30",
+                                        "meta": "ref_p_end_date",
                                         "offset_by": {
                                             "days": 31
                                         }

--- a/data/en/stocks_0061.json
+++ b/data/en/stocks_0061.json
@@ -119,7 +119,7 @@
                                     "label": "Period from",
                                     "q_code": "11",
                                     "minimum": {
-                                        "value": "2019-03-31",
+                                        "meta": "ref_p_start_date",
                                         "offset_by": {
                                             "days": -31
                                         }
@@ -132,7 +132,7 @@
                                     "label": "Period to",
                                     "q_code": "12",
                                     "maximum": {
-                                        "value": "2019-06-30",
+                                        "meta": "ref_p_end_date",
                                         "offset_by": {
                                             "days": 31
                                         }

--- a/data/en/stocks_0070.json
+++ b/data/en/stocks_0070.json
@@ -119,7 +119,7 @@
                                     "label": "Period from",
                                     "q_code": "11",
                                     "minimum": {
-                                        "value": "2019-03-31",
+                                        "meta": "ref_p_start_date",
                                         "offset_by": {
                                             "days": -31
                                         }
@@ -132,7 +132,7 @@
                                     "label": "Period to",
                                     "q_code": "12",
                                     "maximum": {
-                                        "value": "2019-06-30",
+                                        "meta": "ref_p_end_date",
                                         "offset_by": {
                                             "days": 31
                                         }


### PR DESCRIPTION
### What is the context of this PR?
The validation that has been set up for the stocks schemas was using hard coded date values.
This commit changes the validations to reference the start and end dates supplied in the metadata.

### How to review 
Validation changes are correct.
Should be able to launch the schemas and test that validation is triggered off the metadata values.
