### PR TITLE
Add missing routing rules for stocks 0013 and 0014.

### DIFF
--- a/data/en/stocks_0013.json
+++ b/data/en/stocks_0013.json
@@ -140,7 +140,23 @@
                                     }
                                 ]
                             }]
-                        }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "value-stocks-materials",
+                                    "when": [{
+                                        "id": "answer6197",
+                                        "condition": "equals",
+                                        "value": "Yes"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "which-report-period"
+                                }
+                            }
+                        ]
                     },
                     {
                         "id": "which-report-period",

--- a/data/en/stocks_0014.json
+++ b/data/en/stocks_0014.json
@@ -140,7 +140,23 @@
                                     }
                                 ]
                             }]
-                        }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "value-stocks-materials",
+                                    "when": [{
+                                        "id": "answer6197",
+                                        "condition": "equals",
+                                        "value": "Yes"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "which-report-period"
+                                }
+                            }
+                        ]
                     },
                     {
                         "id": "which-report-period",


### PR DESCRIPTION
### What is the context of this PR?
The routing rules for the first question of the survey were removed incorrectly.
This change re-introduces the routing rules.

### How to review 
1. Launch stocks 0013 survey.
1. Answer yes for the first question.
1. Should be routed to the other questions.
1. Answer no for the first question.
1. Should be prompted for the reporting dates.

Repeat the above test for 0014.
