### PR TITLE
Remove block title and description

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -35,5 +35,5 @@ insert_final_newline = true
 [*.{json}]
 insert_final_newline = false
 
-[*.{js,scss,html}]
+[*.{js,scss,html,jsonnet}]
 indent_size = 2

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ test-unit:
 test-functional:
 	pipenv run ./scripts/run_tests_functional.sh
 
+test-schemas:
+	pipenv run ./scripts/test_schemas.sh
+
 load_templates:
 	pipenv run ./scripts/load_templates.sh
 

--- a/data-source/json/test_big_list_naughty_strings.json
+++ b/data-source/json/test_big_list_naughty_strings.json
@@ -15,7 +15,6 @@
         "groups": [{
             "blocks": [{
                 "type": "Question",
-                "description": "Test schema for known bad text combinations.",
                 "routing_rules": [],
                 "question": {
                     "answers": [{
@@ -3066,7 +3065,6 @@
                     "description": "",
                     "id": "question"
                 },
-                "title": "Textarea Test",
                 "id": "textarea-block"
             }, {
                 "type": "Summary",

--- a/data-source/json/test_calculated_summary.json
+++ b/data-source/json/test_calculated_summary.json
@@ -7,18 +7,15 @@
     "theme": "default",
     "description": "A survey that tests grouped and calculated answers against a total",
     "metadata": [{
-            "name": "user_id",
-            "type": "string"
-        },
-        {
-            "name": "period_id",
-            "type": "string"
-        },
-        {
-            "name": "ru_name",
-            "type": "string"
-        }
-    ],
+        "name": "user_id",
+        "type": "string"
+    }, {
+        "name": "period_id",
+        "type": "string"
+    }, {
+        "name": "ru_name",
+        "type": "string"
+    }],
     "view_submitted_response": {
         "enabled": true,
         "duration": 5
@@ -29,319 +26,258 @@
             "id": "group",
             "title": "Total a range of values",
             "blocks": [{
-                    "type": "Question",
-                    "title": "First Number Block Title",
-                    "id": "first-number-block",
-                    "description": "",
-                    "question": {
-                        "id": "first-number-question",
-                        "title": "First Number Question Title",
-                        "type": "General",
-                        "answers": [{
-                            "id": "first-number-answer",
-                            "label": "First answer label",
-                            "mandatory": true,
-                            "type": "Currency",
-                            "currency": "GBP",
-                            "decimal_places": 2
-                        }]
-                    }
-                },
-                {
-                    "type": "Question",
-                    "title": "Second Number Block Title",
-                    "id": "second-number-block",
-                    "description": "",
-                    "question": {
-                        "id": "second-number-question",
-                        "title": "Second Number Question Title",
-                        "type": "General",
-                        "answers": [{
-                                "id": "second-number-answer",
-                                "label": "Second answer in currency label",
-                                "mandatory": true,
-                                "type": "Currency",
-                                "currency": "GBP",
-                                "decimal_places": 2
-                            },
-                            {
-                                "id": "second-number-answer-unit-total",
-                                "label": "Second answer label in unit total",
-                                "mandatory": true,
-                                "type": "Unit",
-                                "unit_length": "short",
-                                "unit": "length-centimeter"
-                            },
-                            {
-                                "id": "second-number-answer-also-in-total",
-                                "label": "Second answer label also in currency total (optional)",
-                                "mandatory": false,
-                                "type": "Currency",
-                                "currency": "GBP",
-                                "decimal_places": 2
-                            }
-                        ]
-                    }
-                },
-                {
-                    "type": "Question",
-                    "title": "Third Number Block Title",
-                    "id": "third-number-block",
-                    "description": "",
-                    "question": {
-                        "id": "third-number-question",
-                        "title": "Third Number Question Title",
-                        "type": "General",
-                        "answers": [{
-                            "id": "third-number-answer",
-                            "label": "Third answer label",
-                            "mandatory": true,
-                            "type": "Currency",
-                            "currency": "GBP",
-                            "decimal_places": 2
-                        }]
-                    }
-                },
-                {
-                    "type": "Question",
-                    "title": "Third Number Block Title",
-                    "id": "third-and-a-half-number-block",
-                    "description": "",
-                    "question": {
-                        "id": "third-and-a-half-number-question-unit-total",
-                        "title": "Third Number Question Title Unit Total",
-                        "type": "General",
-                        "answers": [{
-                            "id": "third-and-a-half-number-answer-unit-total",
-                            "label": "Third answer label in unit total",
-                            "mandatory": true,
-                            "type": "Unit",
-                            "unit_length": "short",
-                            "unit": "length-centimeter"
-                        }]
-                    }
-                },
-                {
-                    "type": "Question",
-                    "id": "skip-fourth-block",
-                    "question": {
-                        "type": "General",
-                        "id": "skip-fourth-block-question",
-                        "title": "Skip Fourth Block so it doesn't appear in Total?",
-                        "answers": [{
-                            "type": "Radio",
-                            "id": "skip-fourth-block-answer",
-                            "mandatory": false,
-                            "options": [{
-                                    "label": "Yes",
-                                    "value": "Yes"
-                                },
-                                {
-                                    "label": "No",
-                                    "value": "No"
-                                }
-                            ]
-                        }]
-                    }
-                },
-                {
-                    "skip_conditions": [{
-                        "when": [{
-                            "id": "skip-fourth-block-answer",
-                            "condition": "equals",
+                "type": "Question",
+                "id": "first-number-block",
+                "question": {
+                    "id": "first-number-question",
+                    "title": "First Number Question Title",
+                    "type": "General",
+                    "answers": [{
+                        "id": "first-number-answer",
+                        "label": "First answer label",
+                        "mandatory": true,
+                        "type": "Currency",
+                        "currency": "GBP",
+                        "decimal_places": 2
+                    }]
+                }
+            }, {
+                "type": "Question",
+                "id": "second-number-block",
+                "question": {
+                    "id": "second-number-question",
+                    "title": "Second Number Question Title",
+                    "type": "General",
+                    "answers": [{
+                        "id": "second-number-answer",
+                        "label": "Second answer in currency label",
+                        "mandatory": true,
+                        "type": "Currency",
+                        "currency": "GBP",
+                        "decimal_places": 2
+                    }, {
+                        "id": "second-number-answer-unit-total",
+                        "label": "Second answer label in unit total",
+                        "mandatory": true,
+                        "type": "Unit",
+                        "unit_length": "short",
+                        "unit": "length-centimeter"
+                    }, {
+                        "id": "second-number-answer-also-in-total",
+                        "label": "Second answer label also in currency total (optional)",
+                        "mandatory": false,
+                        "type": "Currency",
+                        "currency": "GBP",
+                        "decimal_places": 2
+                    }]
+                }
+            }, {
+                "type": "Question",
+                "id": "third-number-block",
+                "question": {
+                    "id": "third-number-question",
+                    "title": "Third Number Question Title",
+                    "type": "General",
+                    "answers": [{
+                        "id": "third-number-answer",
+                        "label": "Third answer label",
+                        "mandatory": true,
+                        "type": "Currency",
+                        "currency": "GBP",
+                        "decimal_places": 2
+                    }]
+                }
+            }, {
+                "type": "Question",
+                "id": "third-and-a-half-number-block",
+                "question": {
+                    "id": "third-and-a-half-number-question-unit-total",
+                    "title": "Third Number Question Title Unit Total",
+                    "type": "General",
+                    "answers": [{
+                        "id": "third-and-a-half-number-answer-unit-total",
+                        "label": "Third answer label in unit total",
+                        "mandatory": true,
+                        "type": "Unit",
+                        "unit_length": "short",
+                        "unit": "length-centimeter"
+                    }]
+                }
+            }, {
+                "type": "Question",
+                "id": "skip-fourth-block",
+                "question": {
+                    "type": "General",
+                    "id": "skip-fourth-block-question",
+                    "title": "Skip Fourth Block so it doesn't appear in Total?",
+                    "answers": [{
+                        "type": "Radio",
+                        "id": "skip-fourth-block-answer",
+                        "mandatory": false,
+                        "options": [{
+                            "label": "Yes",
                             "value": "Yes"
-                        }]
-                    }],
-                    "type": "Question",
-                    "title": "Fourth Number Block Title",
-                    "id": "fourth-number-block",
-                    "description": "",
-                    "question": {
-                        "id": "fourth-number-question",
-                        "title": "Fourth Number Question Title",
-                        "type": "General",
-                        "answers": [{
-                            "id": "fourth-number-answer",
-                            "label": "Fourth answer label (optional)",
-                            "mandatory": false,
-                            "type": "Currency",
-                            "currency": "GBP",
-                            "decimal_places": 2
-                        }]
-                    }
-                },
-                {
-                    "skip_conditions": [{
-                        "when": [{
-                            "id": "skip-fourth-block-answer",
-                            "condition": "equals",
-                            "value": "Yes"
-                        }]
-                    }],
-                    "type": "Question",
-                    "title": "Fourth Number Block Title",
-                    "id": "fourth-and-a-half-number-block",
-                    "description": "",
-                    "question": {
-                        "id": "fourth-and-a-half-number-question-also-in-total",
-                        "title": "Fourth Number Additional Question Title",
-                        "type": "General",
-                        "answers": [{
-                            "id": "fourth-and-a-half-number-answer-also-in-total",
-                            "label": "Fourth answer label also in total (optional)",
-                            "mandatory": false,
-                            "type": "Currency",
-                            "currency": "GBP",
-                            "decimal_places": 2
-                        }]
-                    }
-                },
-                {
-                    "type": "Question",
-                    "title": "Fifth Number Block Title",
-                    "id": "fifth-number-block",
-                    "description": "",
-                    "question": {
-                        "id": "fifth-number-question",
-                        "title": "Fifth Number Question Title Percentage",
-                        "type": "General",
-                        "answers": [{
-                                "id": "fifth-percent-answer",
-                                "label": "Fifth answer label percentage total",
-                                "mandatory": true,
-                                "type": "Percentage",
-                                "max_value": {
-                                    "value": 100
-                                }
-                            },
-                            {
-                                "id": "fifth-number-answer",
-                                "label": "Fifth answer label number total",
-                                "mandatory": false,
-                                "type": "Number",
-                                "decimal_places": 2
-                            }
-                        ]
-                    }
-                },
-                {
-                    "type": "Question",
-                    "title": "Sixth Number Block Title",
-                    "id": "sixth-number-block",
-                    "description": "",
-                    "question": {
-                        "id": "sixth-number-question",
-                        "title": "Sixth Number Question Title Percentage",
-                        "type": "General",
-                        "answers": [{
-                                "id": "sixth-percent-answer",
-                                "label": "Sixth answer label percentage total",
-                                "mandatory": true,
-                                "type": "Percentage",
-                                "max_value": {
-                                    "value": 100
-                                }
-                            },
-                            {
-                                "id": "sixth-number-answer",
-                                "label": "Sixth answer label number total",
-                                "mandatory": false,
-                                "type": "Number",
-                                "decimal_places": 2
-                            }
-                        ]
-                    }
-                },
-                {
-                    "type": "CalculatedSummary",
-                    "id": "currency-total-playback-skipped-fourth",
-                    "title": "We calculate the total of currency values entered to be %(total)s. Is this correct? (Skipped Fourth)",
-                    "calculation": {
-                        "calculation_type": "sum",
-                        "answers_to_calculate": [
-                            "first-number-answer",
-                            "second-number-answer",
-                            "second-number-answer-also-in-total",
-                            "third-number-answer"
-                        ],
-                        "title": "Grand total of previous values"
-                    },
-                    "skip_conditions": [{
-                        "when": [{
-                            "id": "skip-fourth-block-answer",
-                            "condition": "equals",
+                        }, {
+                            "label": "No",
                             "value": "No"
                         }]
                     }]
-                },
-                {
-                    "type": "CalculatedSummary",
-                    "id": "currency-total-playback-with-fourth",
-                    "title": "We calculate the total of currency values entered to be %(total)s. Is this correct? (With Fourth)",
-                    "calculation": {
-                        "calculation_type": "sum",
-                        "answers_to_calculate": [
-                            "first-number-answer",
-                            "second-number-answer",
-                            "second-number-answer-also-in-total",
-                            "third-number-answer",
-                            "fourth-number-answer",
-                            "fourth-and-a-half-number-answer-also-in-total"
-                        ],
-                        "title": "Grand total of previous values"
-                    },
-                    "skip_conditions": [{
-                        "when": [{
-                            "id": "skip-fourth-block-answer",
-                            "condition": "equals",
-                            "value": "Yes"
-                        }]
-                    }]
-                },
-                {
-                    "type": "CalculatedSummary",
-                    "id": "unit-total-playback",
-                    "title": "We calculate the total of unit values entered to be %(total)s. Is this correct?",
-                    "calculation": {
-                        "calculation_type": "sum",
-                        "answers_to_calculate": [
-                            "second-number-answer-unit-total",
-                            "third-and-a-half-number-answer-unit-total"
-                        ],
-                        "title": "Grand total of previous values"
-                    }
-                },
-                {
-                    "type": "CalculatedSummary",
-                    "id": "percentage-total-playback",
-                    "title": "We calculate the total of percentage values entered to be %(total)s. Is this correct?",
-                    "calculation": {
-                        "calculation_type": "sum",
-                        "answers_to_calculate": [
-                            "fifth-percent-answer",
-                            "sixth-percent-answer"
-                        ],
-                        "title": "Grand total of previous values"
-                    }
-                },
-                {
-                    "type": "CalculatedSummary",
-                    "id": "number-total-playback",
-                    "title": "We calculate the total of number values entered to be %(total)s. Is this correct?",
-                    "calculation": {
-                        "calculation_type": "sum",
-                        "answers_to_calculate": [
-                            "fifth-number-answer",
-                            "sixth-number-answer"
-                        ],
-                        "title": "Grand total of previous values"
-                    }
-                },
-                {
-                    "type": "Summary",
-                    "id": "summary"
                 }
-            ]
+            }, {
+                "skip_conditions": [{
+                    "when": [{
+                        "id": "skip-fourth-block-answer",
+                        "condition": "equals",
+                        "value": "Yes"
+                    }]
+                }],
+                "type": "Question",
+                "id": "fourth-number-block",
+                "question": {
+                    "id": "fourth-number-question",
+                    "title": "Fourth Number Question Title",
+                    "type": "General",
+                    "answers": [{
+                        "id": "fourth-number-answer",
+                        "label": "Fourth answer label (optional)",
+                        "mandatory": false,
+                        "type": "Currency",
+                        "currency": "GBP",
+                        "decimal_places": 2
+                    }]
+                }
+            }, {
+                "skip_conditions": [{
+                    "when": [{
+                        "id": "skip-fourth-block-answer",
+                        "condition": "equals",
+                        "value": "Yes"
+                    }]
+                }],
+                "type": "Question",
+                "id": "fourth-and-a-half-number-block",
+                "question": {
+                    "id": "fourth-and-a-half-number-question-also-in-total",
+                    "title": "Fourth Number Additional Question Title",
+                    "type": "General",
+                    "answers": [{
+                        "id": "fourth-and-a-half-number-answer-also-in-total",
+                        "label": "Fourth answer label also in total (optional)",
+                        "mandatory": false,
+                        "type": "Currency",
+                        "currency": "GBP",
+                        "decimal_places": 2
+                    }]
+                }
+            }, {
+                "type": "Question",
+                "id": "fifth-number-block",
+                "question": {
+                    "id": "fifth-number-question",
+                    "title": "Fifth Number Question Title Percentage",
+                    "type": "General",
+                    "answers": [{
+                        "id": "fifth-percent-answer",
+                        "label": "Fifth answer label percentage total",
+                        "mandatory": true,
+                        "type": "Percentage",
+                        "max_value": {
+                            "value": 100
+                        }
+                    }, {
+                        "id": "fifth-number-answer",
+                        "label": "Fifth answer label number total",
+                        "mandatory": false,
+                        "type": "Number",
+                        "decimal_places": 2
+                    }]
+                }
+            }, {
+                "type": "Question",
+                "id": "sixth-number-block",
+                "question": {
+                    "id": "sixth-number-question",
+                    "title": "Sixth Number Question Title Percentage",
+                    "type": "General",
+                    "answers": [{
+                        "id": "sixth-percent-answer",
+                        "label": "Sixth answer label percentage total",
+                        "mandatory": true,
+                        "type": "Percentage",
+                        "max_value": {
+                            "value": 100
+                        }
+                    }, {
+                        "id": "sixth-number-answer",
+                        "label": "Sixth answer label number total",
+                        "mandatory": false,
+                        "type": "Number",
+                        "decimal_places": 2
+                    }]
+                }
+            }, {
+                "type": "CalculatedSummary",
+                "id": "currency-total-playback-skipped-fourth",
+                "title": "We calculate the total of currency values entered to be %(total)s. Is this correct? (Skipped Fourth)",
+                "calculation": {
+                    "calculation_type": "sum",
+                    "answers_to_calculate": ["first-number-answer", "second-number-answer", "second-number-answer-also-in-total", "third-number-answer"],
+                    "title": "Grand total of previous values"
+                },
+                "skip_conditions": [{
+                    "when": [{
+                        "id": "skip-fourth-block-answer",
+                        "condition": "equals",
+                        "value": "No"
+                    }]
+                }]
+            }, {
+                "type": "CalculatedSummary",
+                "id": "currency-total-playback-with-fourth",
+                "title": "We calculate the total of currency values entered to be %(total)s. Is this correct? (With Fourth)",
+                "calculation": {
+                    "calculation_type": "sum",
+                    "answers_to_calculate": ["first-number-answer", "second-number-answer", "second-number-answer-also-in-total", "third-number-answer", "fourth-number-answer", "fourth-and-a-half-number-answer-also-in-total"],
+                    "title": "Grand total of previous values"
+                },
+                "skip_conditions": [{
+                    "when": [{
+                        "id": "skip-fourth-block-answer",
+                        "condition": "equals",
+                        "value": "Yes"
+                    }]
+                }]
+            }, {
+                "type": "CalculatedSummary",
+                "id": "unit-total-playback",
+                "title": "We calculate the total of unit values entered to be %(total)s. Is this correct?",
+                "calculation": {
+                    "calculation_type": "sum",
+                    "answers_to_calculate": ["second-number-answer-unit-total", "third-and-a-half-number-answer-unit-total"],
+                    "title": "Grand total of previous values"
+                }
+            }, {
+                "type": "CalculatedSummary",
+                "id": "percentage-total-playback",
+                "title": "We calculate the total of percentage values entered to be %(total)s. Is this correct?",
+                "calculation": {
+                    "calculation_type": "sum",
+                    "answers_to_calculate": ["fifth-percent-answer", "sixth-percent-answer"],
+                    "title": "Grand total of previous values"
+                }
+            }, {
+                "type": "CalculatedSummary",
+                "id": "number-total-playback",
+                "title": "We calculate the total of number values entered to be %(total)s. Is this correct?",
+                "calculation": {
+                    "calculation_type": "sum",
+                    "answers_to_calculate": ["fifth-number-answer", "sixth-number-answer"],
+                    "title": "Grand total of previous values"
+                }
+            }, {
+                "type": "Summary",
+                "id": "summary"
+            }]
         }]
     }]
 }

--- a/data-source/json/test_checkbox.json
+++ b/data-source/json/test_checkbox.json
@@ -27,7 +27,6 @@
             "blocks": [{
                 "type": "Question",
                 "id": "mandatory-checkbox",
-                "description": "",
                 "question": {
                     "answers": [{
                         "id": "mandatory-checkbox-answer",
@@ -79,12 +78,10 @@
                     "title": "Which pizza toppings would you like?",
                     "type": "General"
                 },
-                "title": "Mandatory other option",
                 "routing_rules": []
             }, {
                 "type": "Question",
                 "id": "non-mandatory-checkbox",
-                "description": "",
                 "question": {
                     "answers": [{
                         "id": "non-mandatory-checkbox-answer",
@@ -130,7 +127,6 @@
                     "title": "What extra toppings would you like?",
                     "type": "General"
                 },
-                "title": "Non mandatory other option",
                 "routing_rules": []
             }, {
                 "type": "Summary",

--- a/data-source/json/test_checkbox_multiple_detail_answers.json
+++ b/data-source/json/test_checkbox_multiple_detail_answers.json
@@ -12,102 +12,88 @@
         "INVALID_NUMBER": "Please enter an integer"
     },
     "metadata": [{
-            "name": "user_id",
-            "type": "string"
-        },
-        {
-            "name": "period_id",
-            "type": "string"
-        },
-        {
-            "name": "ru_name",
-            "type": "string"
-        }
-    ],
+        "name": "user_id",
+        "type": "string"
+    }, {
+        "name": "period_id",
+        "type": "string"
+    }, {
+        "name": "ru_name",
+        "type": "string"
+    }],
     "sections": [{
         "id": "default-section",
         "groups": [{
             "blocks": [{
-                    "type": "Question",
-                    "id": "mandatory-checkbox",
-                    "description": "",
-                    "question": {
-                        "answers": [{
-                            "id": "mandatory-checkbox-answer",
-                            "label": "",
-                            "mandatory": false,
-                            "options": [{
-                                    "label": "None",
-                                    "value": "None",
-                                    "q_code": "0"
-                                },
-                                {
-                                    "label": "Cheese",
-                                    "value": "Cheese",
-                                    "q_code": "1",
-                                    "detail_answer": {
-                                        "mandatory": false,
-                                        "id": "cheese-type-answer",
-                                        "label": "Type specific cheese if cheddar isn't wanted",
-                                        "type": "TextField"
-                                    }
-                                },
-                                {
-                                    "label": "Ham",
-                                    "value": "Ham",
-                                    "q_code": "2"
-                                },
-                                {
-                                    "label": "Pineapple",
-                                    "value": "Pineapple",
-                                    "q_code": "3"
-                                },
-                                {
-                                    "label": "Tuna",
-                                    "value": "Tuna",
-                                    "q_code": "4"
-                                },
-                                {
-                                    "label": "Pepperoni",
-                                    "value": "Pepperoni",
-                                    "q_code": "5"
-                                },
-                                {
-                                    "label": "Your choice",
-                                    "q_code": "6",
-                                    "description": "Choose any other topping",
-                                    "value": "Your choice",
-                                    "detail_answer": {
-                                        "mandatory": true,
-                                        "id": "your-choice-answer-mandatory",
-                                        "label": "Please specify your topping",
-                                        "type": "TextField",
-                                        "validation": {
-                                            "messages": {
-                                                "MANDATORY_TEXTFIELD": "Enter your topping choice to continue"
-                                            }
-                                        }
+                "type": "Question",
+                "id": "mandatory-checkbox",
+                "question": {
+                    "answers": [{
+                        "id": "mandatory-checkbox-answer",
+                        "label": "",
+                        "mandatory": false,
+                        "options": [{
+                            "label": "None",
+                            "value": "None",
+                            "q_code": "0"
+                        }, {
+                            "label": "Cheese",
+                            "value": "Cheese",
+                            "q_code": "1",
+                            "detail_answer": {
+                                "mandatory": false,
+                                "id": "cheese-type-answer",
+                                "label": "Type specific cheese if cheddar isn't wanted",
+                                "type": "TextField"
+                            }
+                        }, {
+                            "label": "Ham",
+                            "value": "Ham",
+                            "q_code": "2"
+                        }, {
+                            "label": "Pineapple",
+                            "value": "Pineapple",
+                            "q_code": "3"
+                        }, {
+                            "label": "Tuna",
+                            "value": "Tuna",
+                            "q_code": "4"
+                        }, {
+                            "label": "Pepperoni",
+                            "value": "Pepperoni",
+                            "q_code": "5"
+                        }, {
+                            "label": "Your choice",
+                            "q_code": "6",
+                            "description": "Choose any other topping",
+                            "value": "Your choice",
+                            "detail_answer": {
+                                "mandatory": true,
+                                "id": "your-choice-answer-mandatory",
+                                "label": "Please specify your topping",
+                                "type": "TextField",
+                                "validation": {
+                                    "messages": {
+                                        "MANDATORY_TEXTFIELD": "Enter your topping choice to continue"
                                     }
                                 }
-                            ],
-                            "type": "Checkbox",
-                            "validation": {
-                                "messages": {}
                             }
                         }],
-                        "description": "",
-                        "id": "mandatory-checkbox-question",
-                        "title": "Which pizza toppings would you like?",
-                        "type": "General"
-                    },
-                    "title": "Mandatory other option",
-                    "routing_rules": []
+                        "type": "Checkbox",
+                        "validation": {
+                            "messages": {}
+                        }
+                    }],
+                    "description": "",
+                    "id": "mandatory-checkbox-question",
+                    "title": "Which pizza toppings would you like?",
+                    "type": "General"
                 },
-                {
-                    "type": "Summary",
-                    "id": "summary"
-                }
-            ],
+                "routing_rules": []
+            }, {
+                "type": "Summary",
+                "id": "summary"
+            }],
             "id": "checkboxes",
             "title": ""
         }]

--- a/data-source/json/test_conditional_combined_routing.json
+++ b/data-source/json/test_conditional_combined_routing.json
@@ -22,8 +22,6 @@
             "blocks": [{
                 "type": "Question",
                 "id": "conditional-routing-block",
-                "title": "Conditional Routing Test",
-                "description": "",
                 "question": {
                     "id": "conditional-routing-question",
                     "title": "Do you drink coffee?",
@@ -79,8 +77,6 @@
             }, {
                 "type": "Question",
                 "id": "response-any",
-                "title": "Yes/Sometimes, I do drink coffee",
-                "description": "",
                 "question": {
                     "id": "response-any-question",
                     "title": "How many cups of coffee do you drink a day?",
@@ -97,8 +93,6 @@
             }, {
                 "type": "Question",
                 "id": "response-not-any",
-                "title": "No, I prefer tea",
-                "description": "",
                 "question": {
                     "id": "response-not-any-question",
                     "title": "How many cups of tea do you drink a day?",

--- a/data-source/json/test_confirmation_question.json
+++ b/data-source/json/test_confirmation_question.json
@@ -28,150 +28,145 @@
         "optional": true
     }],
     "sections": [{
-            "id": "default-section",
-            "title": "Questions",
-            "groups": [{
-                "id": "confirmation-block",
-                "title": "Confirmation Question Test",
-                "blocks": [{
-                        "id": "number-of-employees-total-block",
-                        "question": {
-                            "answers": [{
-                                "id": "number-of-employees-total",
-                                "q_code": "50",
-                                "label": "Total number of employees",
-                                "mandatory": false,
-                                "type": "Number",
-                                "default": 0
-                            }],
-                            "id": "number-of-employees-total-question",
-                            "title": {
-                                "text": "How many employees work at {company_name}?",
-                                "placeholders": [{
-                                    "placeholder": "company_name",
-                                    "transforms": [{
-                                        "transform": "first_non_empty_item",
-                                        "arguments": {
-                                            "items": {
-                                                "source": "metadata",
-                                                "identifier": ["trad_as", "ru_name"]
-                                            }
-                                        }
-                                    }]
-                                }]
-                            },
-                            "type": "General"
-                        },
-                        "type": "Question"
-                    }, {
-                        "type": "ConfirmationQuestion",
-                        "title": "Employees",
-                        "id": "confirm-zero-employees-block",
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "number-of-employees-total",
-                                "condition": "greater than",
-                                "value": 0
+        "id": "default-section",
+        "title": "Questions",
+        "groups": [{
+            "id": "confirmation-block",
+            "title": "Confirmation Question Test",
+            "blocks": [{
+                "id": "number-of-employees-total-block",
+                "question": {
+                    "answers": [{
+                        "id": "number-of-employees-total",
+                        "q_code": "50",
+                        "label": "Total number of employees",
+                        "mandatory": false,
+                        "type": "Number",
+                        "default": 0
+                    }],
+                    "id": "number-of-employees-total-question",
+                    "title": {
+                        "text": "How many employees work at {company_name}?",
+                        "placeholders": [{
+                            "placeholder": "company_name",
+                            "transforms": [{
+                                "transform": "first_non_empty_item",
+                                "arguments": {
+                                    "items": {
+                                        "source": "metadata",
+                                        "identifier": ["trad_as", "ru_name"]
+                                    }
+                                }
                             }]
-                        }],
-                        "question": {
-                            "type": "General",
-                            "answers": [{
-                                "type": "Radio",
-                                "id": "confirm-zero-employees-answer",
-                                "options": [{
-                                    "label": "Yes this is correct",
-                                    "value": "Yes"
-                                }, {
-                                    "label": "No I need to change this",
-                                    "value": "No"
-                                }],
-                                "mandatory": true,
-                                "q_code": "d50"
-                            }],
-                            "id": "confirm-zero-employees-question",
-                            "title": {
-                                "text": "The current number of employees for {company_name} is <em>0</em>, is this correct?",
-                                "placeholders": [{
-                                    "placeholder": "company_name",
-                                    "transforms": [{
-                                        "transform": "first_non_empty_item",
-                                        "arguments": {
-                                            "items": {
-                                                "source": "metadata",
-                                                "identifier": ["trad_as", "ru_name"]
-                                            }
-                                        }
-                                    }]
-                                }]
-                            }
-                        },
-                        "routing_rules": [{
-                            "goto": {
-                                "when": [{
-                                    "value": "No",
-                                    "id": "confirm-zero-employees-answer",
-                                    "condition": "equals"
-                                }],
-                                "block": "number-of-employees-total-block"
-                            }
+                        }]
+                    },
+                    "type": "General"
+                },
+                "type": "Question"
+            }, {
+                "type": "ConfirmationQuestion",
+                "id": "confirm-zero-employees-block",
+                "skip_conditions": [{
+                    "when": [{
+                        "id": "number-of-employees-total",
+                        "condition": "greater than",
+                        "value": 0
+                    }]
+                }],
+                "question": {
+                    "type": "General",
+                    "answers": [{
+                        "type": "Radio",
+                        "id": "confirm-zero-employees-answer",
+                        "options": [{
+                            "label": "Yes this is correct",
+                            "value": "Yes"
                         }, {
-                            "goto": {
-                                "group": "summary-group"
+                            "label": "No I need to change this",
+                            "value": "No"
+                        }],
+                        "mandatory": true,
+                        "q_code": "d50"
+                    }],
+                    "id": "confirm-zero-employees-question",
+                    "title": {
+                        "text": "The current number of employees for {company_name} is <em>0</em>, is this correct?",
+                        "placeholders": [{
+                            "placeholder": "company_name",
+                            "transforms": [{
+                                "transform": "first_non_empty_item",
+                                "arguments": {
+                                    "items": {
+                                        "source": "metadata",
+                                        "identifier": ["trad_as", "ru_name"]
+                                    }
+                                }
+                            }]
+                        }]
+                    }
+                },
+                "routing_rules": [{
+                    "goto": {
+                        "when": [{
+                            "value": "No",
+                            "id": "confirm-zero-employees-answer",
+                            "condition": "equals"
+                        }],
+                        "block": "number-of-employees-total-block"
+                    }
+                }, {
+                    "goto": {
+                        "group": "summary-group"
+                    }
+                }]
+            }, {
+                "id": "number-of-employees-split-block",
+                "type": "Question",
+                "question": {
+                    "answers": [{
+                        "id": "number-of-employees-male-more-30-hours",
+                        "label": "Number of male employees working more than 30 hours per week",
+                        "mandatory": false,
+                        "q_code": "51",
+                        "type": "Number",
+                        "max_value": {
+                            "answer_id": "number-of-employees-total"
+                        }
+                    }, {
+                        "id": "number-of-employees-female-more-30-hours",
+                        "label": "Number of female employees working more than 30 hours per week",
+                        "mandatory": false,
+                        "q_code": "52",
+                        "type": "Number",
+                        "max_value": {
+                            "answer_id": "number-of-employees-total"
+                        }
+                    }],
+                    "id": "number-of-employees-split-question",
+                    "title": {
+                        "text": "Of the <em>{number_of_employees_total}</em> total employees employed, how many male and female employees worked the following hours?",
+                        "placeholders": [{
+                            "placeholder": "number_of_employees_total",
+                            "value": {
+                                "source": "answers",
+                                "identifier": "number-of-employees-total"
                             }
                         }]
                     },
-                    {
-                        "id": "number-of-employees-split-block",
-                        "type": "Question",
-                        "question": {
-                            "answers": [{
-                                "id": "number-of-employees-male-more-30-hours",
-                                "label": "Number of male employees working more than 30 hours per week",
-                                "mandatory": false,
-                                "q_code": "51",
-                                "type": "Number",
-                                "max_value": {
-                                    "answer_id": "number-of-employees-total"
-                                }
-                            }, {
-                                "id": "number-of-employees-female-more-30-hours",
-                                "label": "Number of female employees working more than 30 hours per week",
-                                "mandatory": false,
-                                "q_code": "52",
-                                "type": "Number",
-                                "max_value": {
-                                    "answer_id": "number-of-employees-total"
-                                }
-                            }],
-                            "id": "number-of-employees-split-question",
-                            "title": {
-                                "text": "Of the <em>{number_of_employees_total}</em> total employees employed, how many male and female employees worked the following hours?",
-                                "placeholders": [{
-                                    "placeholder": "number_of_employees_total",
-                                    "value": {
-                                        "source": "answers",
-                                        "identifier": "number-of-employees-total"
-                                    }
-                                }]
-                            },
-                            "type": "General"
-                        }
-                    }
-                ]
+                    "type": "General"
+                }
             }]
-        },
-        {
-            "id": "summary-section",
-            "title": "Summary",
-            "groups": [{
-                "blocks": [{
-                    "id": "summary",
-                    "type": "Summary"
-                }],
-                "id": "summary-group",
-                "title": "Summary"
-            }]
-        }
-    ]
+        }]
+    }, {
+        "id": "summary-section",
+        "title": "Summary",
+        "groups": [{
+            "blocks": [{
+                "id": "summary",
+                "type": "Summary"
+            }],
+            "id": "summary-group",
+            "title": "Summary"
+        }]
+    }]
 }

--- a/data-source/json/test_currency.json
+++ b/data-source/json/test_currency.json
@@ -32,7 +32,6 @@
             "blocks": [{
                 "type": "Question",
                 "id": "block",
-                "description": "",
                 "question": {
                     "answers": [{
                         "id": "answer",
@@ -68,10 +67,9 @@
                     }],
                     "description": "",
                     "id": "question",
-                    "title": "",
+                    "title": "Currency Input Test",
                     "type": "General"
                 },
-                "title": "Currency Input Test",
                 "routing_rules": []
             }, {
                 "type": "Summary",

--- a/data-source/json/test_date_range.json
+++ b/data-source/json/test_date_range.json
@@ -22,7 +22,6 @@
             "blocks": [{
                 "type": "Question",
                 "id": "date-block",
-                "description": "",
                 "question": {
                     "answers": [{
                         "id": "date-range-from-answer",
@@ -41,8 +40,7 @@
                     "id": "date-range-question",
                     "title": "Date range",
                     "type": "DateRange"
-                },
-                "title": "Date Examples"
+                }
             }, {
                 "type": "Summary",
                 "id": "summary"

--- a/data-source/json/test_date_validation_combined.json
+++ b/data-source/json/test_date_validation_combined.json
@@ -30,49 +30,51 @@
             "blocks": [{
                 "type": "Question",
                 "id": "date-range-block",
-                "title": "Date Range",
                 "question": {
                     "id": "date-range-question",
                     "title": "Enter Date Range",
                     "type": "DateRange",
                     "guidance": {
-                        "content": [{
-                            "description": "Dates between 10 and 50 days apart"
-                        }, {
-                            "description": {
-                                "text": "Period from date greater than 19 days before {date}",
-                                "placeholders": [{
-                                    "placeholder": "date",
-                                    "transforms": [{
-                                        "transform": "format_date",
-                                        "arguments": {
-                                            "date_to_format": {
-                                                "source": "metadata",
-                                                "identifier": "ref_p_start_date"
-                                            },
-                                            "date_format": "d MMMM YYYY"
-                                        }
+                        "contents": [{
+                                "description": "Dates between 10 and 50 days apart"
+                            },
+                            {
+                                "description": {
+                                    "text": "Period from date greater than 19 days before {date}",
+                                    "placeholders": [{
+                                        "placeholder": "date",
+                                        "transforms": [{
+                                            "transform": "format_date",
+                                            "arguments": {
+                                                "date_to_format": {
+                                                    "source": "metadata",
+                                                    "identifier": "ref_p_start_date"
+                                                },
+                                                "date_format": "d MMMM YYYY"
+                                            }
+                                        }]
                                     }]
-                                }]
-                            }
-                        }, {
-                            "description": {
-                                "text": "Period to date no greater than 20 days after {date}",
-                                "placeholders": [{
-                                    "placeholder": "date",
-                                    "transforms": [{
-                                        "transform": "format_date",
-                                        "arguments": {
-                                            "date_to_format": {
-                                                "source": "metadata",
-                                                "identifier": "ref_p_end_date"
-                                            },
-                                            "date_format": "d MMMM YYYY"
-                                        }
+                                }
+                            },
+                            {
+                                "description": {
+                                    "text": "Period to date no greater than 20 days after {date}",
+                                    "placeholders": [{
+                                        "placeholder": "date",
+                                        "transforms": [{
+                                            "transform": "format_date",
+                                            "arguments": {
+                                                "date_to_format": {
+                                                    "source": "metadata",
+                                                    "identifier": "ref_p_end_date"
+                                                },
+                                                "date_format": "d MMMM YYYY"
+                                            }
+                                        }]
                                     }]
-                                }]
+                                }
                             }
-                        }]
+                        ]
                     },
                     "period_limits": {
                         "minimum": {

--- a/data-source/json/test_date_validation_mm_yyyy_combined.json
+++ b/data-source/json/test_date_validation_mm_yyyy_combined.json
@@ -30,49 +30,52 @@
             "blocks": [{
                 "type": "Question",
                 "id": "date-range-block",
-                "title": "Date Range",
                 "question": {
                     "id": "date-range-question",
                     "title": "Enter Date Range",
                     "type": "DateRange",
                     "guidance": {
-                        "content": [{
-                            "description": "Dates between 2 and 3 months apart"
-                        }, {
-                            "description": {
-                                "text": "Period from date greater than 1 month before {date}",
-                                "placeholders": [{
-                                    "placeholder": "date",
-                                    "transforms": [{
-                                        "transform": "format_date",
-                                        "arguments": {
-                                            "date_to_format": {
-                                                "source": "metadata",
-                                                "identifier": "ref_p_start_date"
-                                            },
-                                            "date_format": "d MMMM YYYY"
-                                        }
+                        "contents": [{
+                                "description": "Dates between 2 and 3 months apart"
+                            },
+                            {
+                                "description": {
+                                    "text": "Period from date greater than 1 month before {date}",
+                                    "placeholders": [{
+                                        "placeholder": "date",
+                                        "transforms": [{
+                                            "transform": "format_date",
+                                            "arguments": {
+                                                "date_to_format": {
+                                                    "source": "metadata",
+                                                    "identifier": "ref_p_start_date"
+                                                },
+                                                "date_format": "d MMMM YYYY"
+                                            }
+                                        }]
                                     }]
-                                }]
-                            }
-                        }, {
-                            "description": {
-                                "text": "Period to date no greater than 3 months after {date}",
-                                "placeholders": [{
-                                    "placeholder": "date",
-                                    "transforms": [{
-                                        "transform": "format_date",
-                                        "arguments": {
-                                            "date_to_format": {
-                                                "source": "metadata",
-                                                "identifier": "ref_p_end_date"
-                                            },
-                                            "date_format": "d MMMM YYYY"
-                                        }
+                                }
+                            },
+                            {
+                                "description": {
+                                    "text": "Period to date no greater than 3 months after {date}",
+                                    "placeholders": [{
+                                        "placeholder": "date",
+                                        "transforms": [{
+                                            "transform": "format_date",
+                                            "arguments": {
+                                                "date_to_format": {
+                                                    "source": "metadata",
+                                                    "identifier": "ref_p_end_date"
+                                                },
+                                                "date_format": "d MMMM YYYY"
+                                            }
+                                        }]
                                     }]
-                                }]
+                                }
                             }
-                        }]
+                        ]
+
                     },
                     "period_limits": {
                         "minimum": {

--- a/data-source/json/test_date_validation_range.json
+++ b/data-source/json/test_date_validation_range.json
@@ -24,14 +24,15 @@
             "blocks": [{
                 "type": "Question",
                 "id": "date-range-block",
-                "title": "Date Range",
                 "question": {
                     "id": "date-range-question",
                     "title": "Enter Date Range",
                     "type": "DateRange",
                     "guidance": {
-                        "content": [{
-                            "list": ["Enter a date range between 23 days and 1 month and 20 days apart"]
+                        "contents": [{
+                            "list": [
+                                "Enter a date range between 23 days and 1 month and 20 days apart"
+                            ]
                         }]
                     },
                     "period_limits": {

--- a/data-source/json/test_date_validation_single.json
+++ b/data-source/json/test_date_validation_single.json
@@ -27,8 +27,6 @@
             "blocks": [{
                 "type": "Question",
                 "id": "date-block",
-                "title": "Date",
-                "description": "This date will be used as a minimum date for the 'To' date in the next question",
                 "question": {
                     "id": "date-question",
                     "title": "Enter Date",
@@ -43,49 +41,51 @@
             }, {
                 "type": "Question",
                 "id": "date-range-block",
-                "title": "Date Range",
                 "question": {
                     "id": "date-range-question",
                     "title": "Enter Date Range",
                     "type": "DateRange",
                     "guidance": {
-                        "content": [{
-                            "description": {
-                                "text": "Period 'from' date should be greater than 19 days before {date}",
-                                "placeholders": [{
-                                    "placeholder": "date",
-                                    "transforms": [{
-                                        "transform": "format_date",
-                                        "arguments": {
-                                            "date_to_format": {
-                                                "source": "metadata",
-                                                "identifier": "ref_p_start_date"
-                                            },
-                                            "date_format": "d MMMM YYYY"
-                                        }
+                        "contents": [{
+                                "description": {
+                                    "text": "Period 'from' date should be greater than 19 days before {date}",
+                                    "placeholders": [{
+                                        "placeholder": "date",
+                                        "transforms": [{
+                                            "transform": "format_date",
+                                            "arguments": {
+                                                "date_to_format": {
+                                                    "source": "metadata",
+                                                    "identifier": "ref_p_start_date"
+                                                },
+                                                "date_format": "d MMMM YYYY"
+                                            }
+                                        }]
                                     }]
-                                }]
-                            }
-                        }, {
-                            "description": "Period 'from' should also be no greater than 20 days after 11 June 2017"
-                        }, {
-                            "description": {
-                                "text": "Period 'to' date should be greater than 1 month 10 days after {date}",
-                                "placeholders": [{
-                                    "placeholder": "date",
-                                    "transforms": [{
-                                        "transform": "format_date",
-                                        "arguments": {
-                                            "date_to_format": {
-                                                "source": "answers",
-                                                "identifier": "date"
-                                            },
-                                            "date_format": "d MMMM YYYY"
-                                        }
+                                }
+                            },
+                            {
+                                "description": "Period 'from' should also be no greater than 20 days after 11 June 2017"
+                            },
+                            {
+                                "description": {
+                                    "text": "Period 'to' date should be greater than 1 month 10 days after {date}",
+                                    "placeholders": [{
+                                        "placeholder": "date",
+                                        "transforms": [{
+                                            "transform": "format_date",
+                                            "arguments": {
+                                                "date_to_format": {
+                                                    "source": "answers",
+                                                    "identifier": "date"
+                                                },
+                                                "date_format": "d MMMM YYYY"
+                                            }
+                                        }]
                                     }]
-                                }]
+                                }
                             }
-                        }]
+                        ]
                     },
                     "answers": [{
                         "id": "date-range-from",

--- a/data-source/json/test_date_validation_yyyy_combined.json
+++ b/data-source/json/test_date_validation_yyyy_combined.json
@@ -30,49 +30,51 @@
             "blocks": [{
                 "type": "Question",
                 "id": "date-range-block",
-                "title": "Date Range",
                 "question": {
                     "id": "date-range-question",
                     "title": "Enter Date Range",
                     "type": "DateRange",
                     "guidance": {
-                        "content": [{
-                            "description": "Dates between 2 and 3 years apart"
-                        }, {
-                            "description": {
-                                "text": "Period from date greater than 1 year before {date}",
-                                "placeholders": [{
-                                    "placeholder": "date",
-                                    "transforms": [{
-                                        "transform": "format_date",
-                                        "arguments": {
-                                            "date_to_format": {
-                                                "source": "metadata",
-                                                "identifier": "ref_p_start_date"
-                                            },
-                                            "date_format": "d MMMM YYYY"
-                                        }
+                        "contents": [{
+                                "description": "Dates between 2 and 3 years apart"
+                            },
+                            {
+                                "description": {
+                                    "text": "Period from date greater than 1 year before {date}",
+                                    "placeholders": [{
+                                        "placeholder": "date",
+                                        "transforms": [{
+                                            "transform": "format_date",
+                                            "arguments": {
+                                                "date_to_format": {
+                                                    "source": "metadata",
+                                                    "identifier": "ref_p_start_date"
+                                                },
+                                                "date_format": "d MMMM YYYY"
+                                            }
+                                        }]
                                     }]
-                                }]
-                            }
-                        }, {
-                            "description": {
-                                "text": "Period to date no greater than 3 years after {date}",
-                                "placeholders": [{
-                                    "placeholder": "date",
-                                    "transforms": [{
-                                        "transform": "format_date",
-                                        "arguments": {
-                                            "date_to_format": {
-                                                "source": "metadata",
-                                                "identifier": "ref_p_end_date"
-                                            },
-                                            "date_format": "d MMMM YYYY"
-                                        }
+                                }
+                            },
+                            {
+                                "description": {
+                                    "text": "Period to date no greater than 3 years after {date}",
+                                    "placeholders": [{
+                                        "placeholder": "date",
+                                        "transforms": [{
+                                            "transform": "format_date",
+                                            "arguments": {
+                                                "date_to_format": {
+                                                    "source": "metadata",
+                                                    "identifier": "ref_p_end_date"
+                                                },
+                                                "date_format": "d MMMM YYYY"
+                                            }
+                                        }]
                                     }]
-                                }]
+                                }
                             }
-                        }]
+                        ]
                     },
                     "period_limits": {
                         "minimum": {

--- a/data-source/json/test_dates.json
+++ b/data-source/json/test_dates.json
@@ -7,18 +7,15 @@
     "description": "A test schema for different date formats",
     "theme": "default",
     "metadata": [{
-            "name": "user_id",
-            "type": "string"
-        },
-        {
-            "name": "period_id",
-            "type": "string"
-        },
-        {
-            "name": "ru_name",
-            "type": "string"
-        }
-    ],
+        "name": "user_id",
+        "type": "string"
+    }, {
+        "name": "period_id",
+        "type": "string"
+    }, {
+        "name": "ru_name",
+        "type": "string"
+    }],
     "sections": [{
         "id": "default-section",
         "title": "Date Examples",
@@ -26,108 +23,95 @@
             "id": "dates",
             "title": "",
             "blocks": [{
-                    "type": "Question",
-                    "id": "date-range-block",
+                "type": "Question",
+                "id": "date-range-block",
+                "question": {
+                    "answers": [{
+                        "id": "date-range-from-answer",
+                        "label": "Period from",
+                        "mandatory": true,
+                        "q_code": "11",
+                        "type": "Date"
+                    }, {
+                        "id": "date-range-to-answer",
+                        "label": "Period to",
+                        "mandatory": true,
+                        "q_code": "12",
+                        "type": "Date"
+                    }],
                     "description": "",
-                    "question": {
-                        "answers": [{
-                                "id": "date-range-from-answer",
-                                "label": "Period from",
-                                "mandatory": true,
-                                "q_code": "11",
-                                "type": "Date"
-                            },
-                            {
-                                "id": "date-range-to-answer",
-                                "label": "Period to",
-                                "mandatory": true,
-                                "q_code": "12",
-                                "type": "Date"
-                            }
-                        ],
-                        "description": "",
-                        "id": "date-range-question",
-                        "title": "Date range",
-                        "type": "DateRange"
-                    }
-                },
-                {
-                    "type": "Question",
-                    "id": "date-month-year-block",
-                    "description": "",
-                    "question": {
-                        "answers": [{
-                            "id": "month-year-answer",
-                            "label": "Date",
-                            "mandatory": true,
-                            "q_code": "11",
-                            "type": "MonthYearDate"
-                        }],
-                        "description": "",
-                        "id": "month-year-question",
-                        "title": "Date with month and year",
-                        "type": "General"
-                    }
-                },
-                {
-                    "type": "Question",
-                    "id": "date-single-block",
-                    "description": "",
-                    "question": {
-                        "answers": [{
-                            "id": "single-date-answer",
-                            "label": "Date",
-                            "mandatory": true,
-                            "q_code": "11",
-                            "type": "Date"
-                        }],
-                        "description": "",
-                        "id": "single-date-question",
-                        "title": "Single date type",
-                        "type": "General"
-                    }
-                },
-                {
-                    "type": "Question",
-                    "id": "date-non-mandatory-block",
-                    "description": "",
-                    "question": {
-                        "answers": [{
-                            "id": "non-mandatory-date-answer",
-                            "label": "Date",
-                            "mandatory": false,
-                            "q_code": "17",
-                            "type": "Date"
-                        }],
-                        "description": "",
-                        "id": "non-mandatory-date-question",
-                        "title": "Non Mandatory",
-                        "type": "General"
-                    }
-                },
-                {
-                    "type": "Question",
-                    "id": "date-year-date-block",
-                    "description": "",
-                    "question": {
-                        "answers": [{
-                            "id": "year-date-answer",
-                            "label": "Date",
-                            "mandatory": false,
-                            "q_code": "18",
-                            "type": "YearDate"
-                        }],
-                        "description": "",
-                        "id": "year-date-question",
-                        "title": "Year (YYYY)",
-                        "type": "General"
-                    }
-                },
-                {
-                    "type": "Summary",
-                    "id": "summary"
+                    "id": "date-range-question",
+                    "title": "Date range",
+                    "type": "DateRange"
                 }
-            ]
+            }, {
+                "type": "Question",
+                "id": "date-month-year-block",
+                "question": {
+                    "answers": [{
+                        "id": "month-year-answer",
+                        "label": "Date",
+                        "mandatory": true,
+                        "q_code": "11",
+                        "type": "MonthYearDate"
+                    }],
+                    "description": "",
+                    "id": "month-year-question",
+                    "title": "Date with month and year",
+                    "type": "General"
+                }
+            }, {
+                "type": "Question",
+                "id": "date-single-block",
+                "question": {
+                    "answers": [{
+                        "id": "single-date-answer",
+                        "label": "Date",
+                        "mandatory": true,
+                        "q_code": "11",
+                        "type": "Date"
+                    }],
+                    "description": "",
+                    "id": "single-date-question",
+                    "title": "Single date type",
+                    "type": "General"
+                }
+            }, {
+                "type": "Question",
+                "id": "date-non-mandatory-block",
+                "question": {
+                    "answers": [{
+                        "id": "non-mandatory-date-answer",
+                        "label": "Date",
+                        "mandatory": false,
+                        "q_code": "17",
+                        "type": "Date"
+                    }],
+                    "description": "",
+                    "id": "non-mandatory-date-question",
+                    "title": "Non Mandatory",
+                    "type": "General"
+                }
+            }, {
+                "type": "Question",
+                "id": "date-year-date-block",
+                "question": {
+                    "answers": [{
+                        "id": "year-date-answer",
+                        "label": "Date",
+                        "mandatory": false,
+                        "q_code": "18",
+                        "type": "YearDate"
+                    }],
+                    "description": "",
+                    "id": "year-date-question",
+                    "title": "Year (YYYY)",
+                    "type": "General"
+                }
+            }, {
+                "type": "Summary",
+                "id": "summary"
+            }]
         }]
     }]
 }

--- a/data-source/json/test_default.json
+++ b/data-source/json/test_default.json
@@ -22,8 +22,6 @@
             "blocks": [{
                 "type": "Question",
                 "id": "number-question",
-                "description": "",
-                "title": "Zero Default",
                 "question": {
                     "answers": [{
                         "id": "answer",

--- a/data-source/json/test_difference_in_years.json
+++ b/data-source/json/test_difference_in_years.json
@@ -24,7 +24,6 @@
             "blocks": [{
                 "type": "Question",
                 "id": "age-block",
-                "title": "Calculate Age",
                 "question": {
                     "id": "date-pipe-question",
                     "title": "What is your date of birth?",
@@ -39,7 +38,6 @@
             }, {
                 "type": "ConfirmationQuestion",
                 "id": "age-test",
-                "title": "Confirm Your Age",
                 "question": {
                     "id": "confirm-dob-question",
                     "title": {

--- a/data-source/json/test_difference_in_years_month_year.json
+++ b/data-source/json/test_difference_in_years_month_year.json
@@ -24,7 +24,6 @@
             "blocks": [{
                 "type": "Question",
                 "id": "age-block",
-                "title": "Calculate Difference",
                 "question": {
                     "id": "date-pipe-question",
                     "title": "When did you last go on holiday?",
@@ -39,7 +38,6 @@
             }, {
                 "type": "ConfirmationQuestion",
                 "id": "age-test",
-                "title": "Confirm Duration",
                 "question": {
                     "id": "confirm-dob-question",
                     "title": {

--- a/data-source/json/test_difference_in_years_month_year_range.json
+++ b/data-source/json/test_difference_in_years_month_year_range.json
@@ -24,7 +24,6 @@
             "blocks": [{
                 "type": "Question",
                 "id": "date-block",
-                "title": "Calculate Difference Between Two Dates",
                 "question": {
                     "id": "date-pipe-question",
                     "title": "How long were you outside the UK?",
@@ -44,7 +43,6 @@
             }, {
                 "type": "ConfirmationQuestion",
                 "id": "age-test",
-                "title": "Confirm Dates",
                 "question": {
                     "id": "confirm-dob-question",
                     "title": {

--- a/data-source/json/test_difference_in_years_range.json
+++ b/data-source/json/test_difference_in_years_range.json
@@ -24,7 +24,6 @@
             "blocks": [{
                 "type": "Question",
                 "id": "date-block",
-                "title": "Calculate Difference Between Two Dates",
                 "question": {
                     "id": "date-pipe-question",
                     "title": "How long were you outside the UK?",
@@ -44,7 +43,6 @@
             }, {
                 "type": "ConfirmationQuestion",
                 "id": "age-test",
-                "title": "Confirm Dates",
                 "question": {
                     "id": "confirm-dob-question",
                     "title": {

--- a/data-source/json/test_dob_date.json
+++ b/data-source/json/test_dob_date.json
@@ -19,166 +19,157 @@
     "sections": [{
         "id": "default-section",
         "groups": [{
-                "blocks": [{
-                        "type": "Question",
-                        "id": "date-of-birth",
-                        "question": {
-                            "id": "date-of-birth-question",
-                            "title": "What is your date of birth?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "date-of-birth-answer",
-                                "mandatory": false,
-                                "type": "Date",
-                                "maximum": {
-                                    "value": "now"
-                                },
-                                "minimum": {
-                                    "value": "1900-01-01"
-                                }
-                            }]
+            "blocks": [{
+                "type": "Question",
+                "id": "date-of-birth",
+                "question": {
+                    "id": "date-of-birth-question",
+                    "title": "What is your date of birth?",
+                    "type": "General",
+                    "answers": [{
+                        "id": "date-of-birth-answer",
+                        "mandatory": false,
+                        "type": "Date",
+                        "maximum": {
+                            "value": "now"
                         },
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "over-sixteen",
-                                    "when": [{
-                                        "id": "date-of-birth-answer",
-                                        "condition": "less than",
-                                        "date_comparison": {
-                                            "value": "now",
-                                            "offset_by": {
-                                                "years": -16
-                                            }
-                                        }
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "under-sixteen",
-                                    "when": [{
-                                        "id": "date-of-birth-answer",
-                                        "condition": "greater than or equal to",
-                                        "date_comparison": {
-                                            "value": "now",
-                                            "offset_by": {
-                                                "years": -16
-                                            }
-                                        }
-                                    }]
-                                }
-                            }, {
-                                "goto": {
-                                    "block": "dob-age"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "dob-age",
-                        "question": {
-                            "id": "dob-age-question",
-                            "title": "What is your age?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "dob-age-answer",
-                                "unit": "duration-year",
-                                "type": "Unit",
-                                "label": "Your age",
-                                "unit_length": "long",
-                                "mandatory": true,
-                                "max_value": {
-                                    "value": 118
-                                }
-                            }]
-                        },
-                        "routing_rules": [{
-                            "goto": {
-                                "block": "over-sixteen",
-                                "when": [{
-                                    "id": "dob-age-answer",
-                                    "condition": "greater than or equal to",
-                                    "value": 16
-                                }]
-                            }
-                        }, {
-                            "goto": {
-                                "block": "under-sixteen"
-                            }
-                        }]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "over-sixteen",
-                        "question": {
-                            "id": "over-sixteen-question",
-                            "title": "You are over 16!",
-                            "type": "General",
-                            "answers": [{
-                                "id": "over-sixteen-answer",
-                                "mandatory": false,
-                                "type": "Date",
-                                "maximum": {
-                                    "value": "now"
-                                },
-                                "minimum": {
-                                    "value": "1900-01-01"
-                                }
-                            }]
+                        "minimum": {
+                            "value": "1900-01-01"
                         }
-                    },
-                    {
-                        "type": "Question",
-                        "id": "under-sixteen",
-                        "question": {
-                            "id": "under-sixteen-question",
-                            "title": "You are under 16!",
-                            "type": "General",
-                            "answers": [{
-                                "id": "under-sixteen-answer",
-                                "mandatory": false,
-                                "type": "Date",
-                                "maximum": {
-                                    "value": "now"
-                                },
-                                "minimum": {
-                                    "value": "1900-01-01"
+                    }]
+                },
+                "routing_rules": [{
+                    "goto": {
+                        "block": "over-sixteen",
+                        "when": [{
+                            "id": "date-of-birth-answer",
+                            "condition": "less than",
+                            "date_comparison": {
+                                "value": "now",
+                                "offset_by": {
+                                    "years": -16
                                 }
-                            }]
-                        },
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "dob-age-answer",
-                                "condition": "greater than or equal to",
-                                "value": 16
-                            }]
-                        }, {
-                            "when": [{
-                                "id": "date-of-birth-answer",
-                                "condition": "less than",
-                                "date_comparison": {
-                                    "value": "now",
-                                    "offset_by": {
-                                        "years": -16
-                                    }
-                                }
-                            }]
+                            }
                         }]
                     }
-                ],
-                "id": "test",
-                "title": ""
-            },
-
-            {
-                "blocks": [{
-                    "type": "Summary",
-                    "id": "summary"
-                }],
-                "id": "summary-group",
-                "title": "Summary"
-            }
-        ]
+                }, {
+                    "goto": {
+                        "block": "under-sixteen",
+                        "when": [{
+                            "id": "date-of-birth-answer",
+                            "condition": "greater than or equal to",
+                            "date_comparison": {
+                                "value": "now",
+                                "offset_by": {
+                                    "years": -16
+                                }
+                            }
+                        }]
+                    }
+                }, {
+                    "goto": {
+                        "block": "dob-age"
+                    }
+                }]
+            }, {
+                "type": "Question",
+                "id": "dob-age",
+                "question": {
+                    "id": "dob-age-question",
+                    "title": "What is your age?",
+                    "type": "General",
+                    "answers": [{
+                        "id": "dob-age-answer",
+                        "unit": "duration-year",
+                        "type": "Unit",
+                        "label": "Your age",
+                        "unit_length": "long",
+                        "mandatory": true,
+                        "max_value": {
+                            "value": 118
+                        }
+                    }]
+                },
+                "routing_rules": [{
+                    "goto": {
+                        "block": "over-sixteen",
+                        "when": [{
+                            "id": "dob-age-answer",
+                            "condition": "greater than or equal to",
+                            "value": 16
+                        }]
+                    }
+                }, {
+                    "goto": {
+                        "block": "under-sixteen"
+                    }
+                }]
+            }, {
+                "type": "Question",
+                "id": "over-sixteen",
+                "question": {
+                    "id": "over-sixteen-question",
+                    "title": "You are over 16!",
+                    "type": "General",
+                    "answers": [{
+                        "id": "over-sixteen-answer",
+                        "mandatory": false,
+                        "type": "Date",
+                        "maximum": {
+                            "value": "now"
+                        },
+                        "minimum": {
+                            "value": "1900-01-01"
+                        }
+                    }]
+                }
+            }, {
+                "type": "Question",
+                "id": "under-sixteen",
+                "question": {
+                    "id": "under-sixteen-question",
+                    "title": "You are under 16!",
+                    "type": "General",
+                    "answers": [{
+                        "id": "under-sixteen-answer",
+                        "mandatory": false,
+                        "type": "Date",
+                        "maximum": {
+                            "value": "now"
+                        },
+                        "minimum": {
+                            "value": "1900-01-01"
+                        }
+                    }]
+                },
+                "skip_conditions": [{
+                    "when": [{
+                        "id": "dob-age-answer",
+                        "condition": "greater than or equal to",
+                        "value": 16
+                    }]
+                }, {
+                    "when": [{
+                        "id": "date-of-birth-answer",
+                        "condition": "less than",
+                        "date_comparison": {
+                            "value": "now",
+                            "offset_by": {
+                                "years": -16
+                            }
+                        }
+                    }]
+                }]
+            }],
+            "id": "test",
+            "title": ""
+        }, {
+            "blocks": [{
+                "type": "Summary",
+                "id": "summary"
+            }],
+            "id": "summary-group",
+            "title": "Summary"
+        }]
     }]
 }

--- a/data-source/json/test_durations.json
+++ b/data-source/json/test_durations.json
@@ -22,7 +22,6 @@
             "blocks": [{
                 "type": "Question",
                 "id": "duration-block",
-                "description": "",
                 "question": {
                     "answers": [{
                         "id": "year-month-answer",
@@ -71,8 +70,7 @@
                     "id": "duration-question",
                     "title": "Durations",
                     "type": "General"
-                },
-                "title": "Duration Examples"
+                }
             }, {
                 "type": "Summary",
                 "id": "summary"

--- a/data-source/json/test_error_messages.json
+++ b/data-source/json/test_error_messages.json
@@ -22,7 +22,6 @@
             "blocks": [{
                 "type": "Question",
                 "id": "test-errors",
-                "description": "",
                 "question": {
                     "answers": [{
                         "id": "test-number",
@@ -52,8 +51,7 @@
                     "id": "test-min-max-range-question",
                     "title": "Please enter test values (none mandatory)",
                     "type": "General"
-                },
-                "title": ""
+                }
             }],
             "id": "test",
             "title": ""

--- a/data-source/json/test_final_confirmation.json
+++ b/data-source/json/test_final_confirmation.json
@@ -30,14 +30,10 @@
         "groups": [{
             "blocks": [{
                 "type": "Introduction",
-                "id": "introduction",
-                "title": "Introduction",
-                "description": ""
+                "id": "introduction"
             }, {
                 "type": "Question",
                 "id": "breakfast",
-                "description": "",
-                "title": "What is your favourite breakfast food",
                 "question": {
                     "answers": [{
                         "id": "breakfast-answer",
@@ -63,10 +59,9 @@
             "blocks": [{
                 "type": "Confirmation",
                 "id": "confirmation",
-                "title": "Submit answers",
-                "content": [{
+                "content": {
                     "title": "Thank you for your answers, do you wish to submit"
-                }]
+                }
             }],
             "id": "confirmation-group",
             "title": "Submit answers"

--- a/data-source/json/test_interstitial_page.json
+++ b/data-source/json/test_interstitial_page.json
@@ -26,13 +26,10 @@
         "groups": [{
             "blocks": [{
                 "type": "Introduction",
-                "id": "introduction",
-                "title": "Introduction",
-                "description": ""
+                "id": "introduction"
             }, {
                 "type": "Question",
                 "id": "breakfast-block",
-                "description": "",
                 "question": {
                     "answers": [{
                         "id": "favourite-breakfast",
@@ -46,19 +43,19 @@
                     "title": "What is your favourite breakfast food",
                     "type": "General"
                 },
-                "title": "What is your favourite breakfast food",
                 "routing_rules": []
             }, {
                 "id": "breakfast-interstitial",
-                "title": "Breakfast Interstitial Page",
-                "content": [{
-                    "description": "You have successfully completed the breakfast section. Next we want to know about your lunch."
-                }],
+                "content": {
+                    "title": "Breakfast interstitial",
+                    "contents": [{
+                        "description": "You have successfully completed the breakfast section. Next we want to know about your lunch."
+                    }]
+                },
                 "type": "Interstitial"
             }, {
                 "type": "Question",
                 "id": "lunch-block",
-                "description": "",
                 "question": {
                     "answers": [{
                         "id": "favourite-lunch",
@@ -72,14 +69,13 @@
                     "title": "",
                     "type": "General"
                 },
-                "title": "What is your favourite lunchtime food",
                 "routing_rules": []
             }, {
                 "type": "Confirmation",
                 "id": "confirmation",
-                "content": [{
+                "content": {
                     "title": "Thank you for your answers, do you wish to submit"
-                }]
+                }
             }],
             "id": "favourite-foods",
             "title": "Favourite food"

--- a/data-source/json/test_introduction.json
+++ b/data-source/json/test_introduction.json
@@ -26,32 +26,34 @@
                 "id": "introduction",
                 "type": "Introduction",
                 "primary_content": [{
-                    "type": "Basic",
                     "id": "use-of-information",
                     "title": "What you need to do next",
-                    "content": [{
-                        "list": [
-                            "Data should relate to all sites in England, Scotland and Wales unless otherwise stated.",
-                            "You can provide informed estimates if actual figures aren’t available.",
-                            "We will treat your data securely and confidentially."
-                        ]
-                    }, {
-                        "description": "To take part, all you need to do is check that you have the information you need to answer the survey questions."
-                    }]
+                    "contents": [{
+                            "list": [
+                                "Data should relate to all sites in England, Scotland and Wales unless otherwise stated.",
+                                "You can provide informed estimates if actual figures aren’t available.",
+                                "We will treat your data securely and confidentially."
+                            ]
+                        },
+                        {
+                            "description": "To take part, all you need to do is check that you have the information you need to answer the survey questions."
+                        }
+                    ]
                 }],
                 "preview_content": {
                     "id": "preview",
                     "title": "Information you need",
-                    "content": [{
-                        "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
-                    }, {
-                        "description": "<a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/surveys/informationforbusinesses/aboutonsbusinesssurveys/detailedguidancetohelpcompletethequarterlyacquisitionsanddisposalsofcapitalassetssurvey'>Read the detailed guidance for completing this survey</a>"
-                    }],
+                    "contents": [{
+                            "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
+                        },
+                        {
+                            "description": "<a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/surveys/informationforbusinesses/aboutonsbusinesssurveys/detailedguidancetohelpcompletethequarterlyacquisitionsanddisposalsofcapitalassetssurvey'>Read the detailed guidance for completing this survey</a>"
+                        }
+                    ],
                     "questions": [{
                         "id": "employee-pay-frequency",
-                        "type": "Basic",
                         "question": "Employee pay frequency",
-                        "content": [{
+                        "contents": [{
                             "list": [
                                 "You will need to indicate how frequently employees are paid i.e weekly, fortnightly, calendar monthly, four weekly or five weekly.",
                                 "You will be asked to answer the questions below for all of your selected pay patterns."
@@ -59,9 +61,8 @@
                         }]
                     }, {
                         "id": "what-you-need-to-know",
-                        "type": "Basic",
                         "question": "What you need to know",
-                        "content": [{
+                        "contents": [{
                             "list": [
                                 "You can provide informed estimates if actual figures aren't available",
                                 "All information you provide is strictly confidential"
@@ -69,48 +70,49 @@
                         }]
                     }, {
                         "id": "definition-of-innovation",
-                        "type": "Definition",
                         "question": "Definition of innovation",
-                        "content": [{
-                            "description": {
-                                "text": "Innovation, for the purpose of this survey, is defined as <strong>new</strong> or <strong>significantly improved goods or services</strong> as well as <strong>processes</strong> used to produce or supply all goods or services that {ru_name} has introduced, regardless of their origin.",
-                                "placeholders": [{
-                                    "placeholder": "ru_name",
-                                    "value": {
-                                        "source": "metadata",
-                                        "identifier": "ru_name"
-                                    }
-                                }]
+                        "contents": [{
+                                "description": {
+                                    "text": "Innovation, for the purpose of this survey, is defined as <strong>new</strong> or <strong>significantly improved goods or services</strong> as well as <strong>processes</strong> used to produce or supply all goods or services that {ru_name} has introduced, regardless of their origin.",
+                                    "placeholders": [{
+                                        "placeholder": "ru_name",
+                                        "value": {
+                                            "source": "metadata",
+                                            "identifier": "ru_name"
+                                        }
+                                    }]
+                                }
+                            },
+                            {
+                                "description": {
+                                    "text": "These innovations may be new to {ru_name} or new to the market",
+                                    "placeholders": [{
+                                        "placeholder": "ru_name",
+                                        "value": {
+                                            "source": "metadata",
+                                            "identifier": "ru_name"
+                                        }
+                                    }]
+                                }
+                            },
+                            {
+                                "description": {
+                                    "text": "Investments for future innovation and changes that {ru_name} has introduced at a <strong>strategic</strong> level (in organisation and practices) are also covered",
+                                    "placeholders": [{
+                                        "placeholder": "ru_name",
+                                        "value": {
+                                            "source": "metadata",
+                                            "identifier": "ru_name"
+                                        }
+                                    }]
+                                }
                             }
-                        }, {
-                            "description": {
-                                "text": "These innovations may be new to {ru_name} or new to the market",
-                                "placeholders": [{
-                                    "placeholder": "ru_name",
-                                    "value": {
-                                        "source": "metadata",
-                                        "identifier": "ru_name"
-                                    }
-                                }]
-                            }
-                        }, {
-                            "description": {
-                                "text": "Investments for future innovation and changes that {ru_name} has introduced at a <strong>strategic</strong> level (in organisation and practices) are also covered",
-                                "placeholders": [{
-                                    "placeholder": "ru_name",
-                                    "value": {
-                                        "source": "metadata",
-                                        "identifier": "ru_name"
-                                    }
-                                }]
-                            }
-                        }]
+                        ]
                     }]
                 },
                 "secondary_content": [{
                     "id": "how-we-use-your-data",
-                    "type": "Basic",
-                    "content": [{
+                    "contents": [{
                         "title": "How we use your data",
                         "list": [
                             "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy",
@@ -120,26 +122,29 @@
                     }]
                 }]
             }, {
+                "type": "Interstitial",
                 "id": "general-business-information-completed",
-                "section_number": "1",
-                "title": "General Business Information",
-                "content": [{
-                    "description": "<p>You have successfully completed this section</p><p>The next section covers changes in <em>business strategy and practices</em>, for example, implementing changes to marketing concepts or strategies.</p>"
-                }],
-                "type": "Interstitial"
+                "content": {
+                    "title": "Section complete",
+                    "contents": [{
+                        "description": "<p>You have successfully completed this section</p><p>The next section covers changes in <em>business strategy and practices</em>, for example, implementing changes to marketing concepts or strategies.</p>"
+                    }]
+                }
             }]
         }, {
             "blocks": [{
                 "id": "confirmation",
-                "title": "You are now ready to submit this survey",
                 "type": "Confirmation",
-                "content": [{
-                    "title": "Submission",
-                    "list": [
-                        "You will not be able to access or change your answers on submitting the questionnaire",
-                        "If you wish to review your answers please select the relevant completed sections"
-                    ]
-                }]
+                "content": {
+                    "title": "You are now ready to submit this survey",
+                    "contents": [{
+                        "title": "Submission",
+                        "list": [
+                            "You will not be able to access or change your answers on submitting the questionnaire",
+                            "If you wish to review your answers please select the relevant completed sections"
+                        ]
+                    }]
+                }
             }],
             "id": "ready-to-submit",
             "title": "Submit answers"

--- a/data-source/json/test_is_skipping_to_end.json
+++ b/data-source/json/test_is_skipping_to_end.json
@@ -13,195 +13,165 @@
         "duration": 900
     },
     "metadata": [{
-            "name": "user_id",
-            "type": "string"
-        },
-        {
-            "name": "period_id",
-            "type": "string"
-        },
-        {
-            "name": "ru_name",
-            "type": "string"
-        }
-    ],
+        "name": "user_id",
+        "type": "string"
+    }, {
+        "name": "period_id",
+        "type": "string"
+    }, {
+        "name": "ru_name",
+        "type": "string"
+    }],
     "sections": [{
-            "id": "test-skipping-section",
-            "title": "Section 1",
-            "groups": [{
-                    "blocks": [{
-                            "id": "test-skipping-forced",
-                            "question": {
-                                "answers": [{
-                                    "id": "test-skipping-answer",
-                                    "mandatory": true,
-                                    "options": [{
-                                            "label": "Yes",
-                                            "value": "Yes"
-                                        },
-                                        {
-                                            "label": "No",
-                                            "value": "No"
-                                        }
-                                    ],
-                                    "type": "Radio"
-                                }],
-                                "description": "",
-                                "id": "test-skipping-question",
-                                "title": "Were you forced to complete section 1?",
-                                "type": "General"
-                            },
-                            "title": "This is section 1",
-                            "type": "Question",
-                            "routing_rules": [{
-                                    "goto": {
-                                        "block": "test-skipping-optional",
-                                        "when": [{
-                                            "id": "test-skipping-answer",
-                                            "condition": "equals",
-                                            "value": "Yes"
-                                        }]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "group": "test-skipping-section-summary-group"
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "id": "test-skipping-optional",
-                            "title": "This is section 1",
-                            "type": "Question",
-                            "question": {
-                                "answers": [{
-                                    "id": "test-skipping-optional-answer",
-                                    "mandatory": true,
-                                    "options": [{
-                                            "label": "£5 Cash",
-                                            "value": "fiver"
-                                        },
-                                        {
-                                            "label": "£10 Amazon Voucher",
-                                            "value": "tenner"
-                                        }
-                                    ],
-                                    "type": "Checkbox"
-                                }],
-                                "id": "test-skipping-optional-question",
-                                "title": "What would incentivise you to complete this section?",
-                                "type": "General"
-                            }
-                        }
-                    ],
-                    "id": "test-skipping-group",
-                    "title": "Section 1"
+        "id": "test-skipping-section",
+        "title": "Section 1",
+        "groups": [{
+            "blocks": [{
+                "id": "test-skipping-forced",
+                "question": {
+                    "title": "Were you forced to complete section 1?",
+                    "answers": [{
+                        "id": "test-skipping-answer",
+                        "mandatory": true,
+                        "options": [{
+                            "label": "Yes",
+                            "value": "Yes"
+                        }, {
+                            "label": "No",
+                            "value": "No"
+                        }],
+                        "type": "Radio"
+                    }],
+                    "description": "",
+                    "id": "test-skipping-question",
+                    "type": "General"
                 },
-                {
-                    "id": "test-skipping-section-summary-group",
-                    "title": "Section 1 Summary",
-                    "blocks": [{
-                        "id": "test-skipping-section-summary",
-                        "type": "SectionSummary"
-                    }]
+                "type": "Question",
+                "routing_rules": [{
+                    "goto": {
+                        "block": "test-skipping-optional",
+                        "when": [{
+                            "id": "test-skipping-answer",
+                            "condition": "equals",
+                            "value": "Yes"
+                        }]
+                    }
+                }, {
+                    "goto": {
+                        "group": "test-skipping-section-summary-group"
+                    }
+                }]
+            }, {
+                "id": "test-skipping-optional",
+                "type": "Question",
+                "question": {
+                    "answers": [{
+                        "id": "test-skipping-optional-answer",
+                        "mandatory": true,
+                        "options": [{
+                            "label": "£5 Cash",
+                            "value": "fiver"
+                        }, {
+                            "label": "£10 Amazon Voucher",
+                            "value": "tenner"
+                        }],
+                        "type": "Checkbox"
+                    }],
+                    "id": "test-skipping-optional-question",
+                    "title": "What would incentivise you to complete this section?",
+                    "type": "General"
                 }
-            ]
-        },
-        {
-            "id": "test-skipping-section-2",
-            "title": "Section 2",
-            "groups": [{
-                    "blocks": [{
-                            "id": "test-skipping-forced-2",
-                            "question": {
-                                "answers": [{
-                                    "id": "test-skipping-answer-2",
-                                    "mandatory": true,
-                                    "options": [{
-                                            "label": "Yes",
-                                            "value": "Yes"
-                                        },
-                                        {
-                                            "label": "No",
-                                            "value": "No"
-                                        }
-                                    ],
-                                    "type": "Radio"
-                                }],
-                                "description": "",
-                                "id": "test-skipping-question-2",
-                                "title": "Were you forced to complete section 2?",
-                                "type": "General"
-                            },
-                            "title": "This is section 2",
-                            "type": "Question",
-                            "routing_rules": [{
-                                    "goto": {
-                                        "block": "test-skipping-optional-2",
-                                        "when": [{
-                                            "id": "test-skipping-answer-2",
-                                            "condition": "equals",
-                                            "value": "Yes"
-                                        }]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "group": "test-skipping-section-summary-group-2"
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "id": "test-skipping-optional-2",
-                            "title": "This is section 2",
-                            "type": "Question",
-                            "question": {
-                                "answers": [{
-                                    "id": "test-skipping-optional-answer-2",
-                                    "mandatory": true,
-                                    "options": [{
-                                            "label": "£5 Cash",
-                                            "value": "fiver"
-                                        },
-                                        {
-                                            "label": "£10 Amazon Voucher",
-                                            "value": "tenner"
-                                        }
-                                    ],
-                                    "type": "Checkbox"
-                                }],
-                                "id": "test-skipping-optional-question-2",
-                                "title": "What would incentivise you to complete this section?",
-                                "type": "General"
-                            }
-                        }
-                    ],
-                    "id": "test-skipping-group-2",
-                    "title": "Section 2"
-                },
-                {
-                    "id": "test-skipping-section-summary-group-2",
-                    "title": "Section 2 Summary",
-                    "blocks": [{
-                        "id": "test-skipping-section-summary-2",
-                        "type": "SectionSummary"
-                    }]
-                }
-            ]
-        },
-        {
-            "id": "summary-section",
-            "title": "Summary",
-            "groups": [{
-                "blocks": [{
-                    "type": "Summary",
-                    "id": "summary"
-                }],
-                "id": "summary-group",
-                "title": "Summary"
+            }],
+            "id": "test-skipping-group",
+            "title": "Section 1"
+        }, {
+            "id": "test-skipping-section-summary-group",
+            "title": "Section 1 Summary",
+            "blocks": [{
+                "id": "test-skipping-section-summary",
+                "type": "SectionSummary"
             }]
-        }
-    ]
+        }]
+    }, {
+        "id": "test-skipping-section-2",
+        "title": "Section 2",
+        "groups": [{
+            "blocks": [{
+                "id": "test-skipping-forced-2",
+                "question": {
+                    "answers": [{
+                        "id": "test-skipping-answer-2",
+                        "mandatory": true,
+                        "options": [{
+                            "label": "Yes",
+                            "value": "Yes"
+                        }, {
+                            "label": "No",
+                            "value": "No"
+                        }],
+                        "type": "Radio"
+                    }],
+                    "description": "",
+                    "id": "test-skipping-question-2",
+                    "title": "Were you forced to complete section 2?",
+                    "type": "General"
+                },
+                "type": "Question",
+                "routing_rules": [{
+                    "goto": {
+                        "block": "test-skipping-optional-2",
+                        "when": [{
+                            "id": "test-skipping-answer-2",
+                            "condition": "equals",
+                            "value": "Yes"
+                        }]
+                    }
+                }, {
+                    "goto": {
+                        "group": "test-skipping-section-summary-group-2"
+                    }
+                }]
+            }, {
+                "id": "test-skipping-optional-2",
+                "type": "Question",
+                "question": {
+                    "answers": [{
+                        "id": "test-skipping-optional-answer-2",
+                        "mandatory": true,
+                        "options": [{
+                            "label": "£5 Cash",
+                            "value": "fiver"
+                        }, {
+                            "label": "£10 Amazon Voucher",
+                            "value": "tenner"
+                        }],
+                        "type": "Checkbox"
+                    }],
+                    "id": "test-skipping-optional-question-2",
+                    "title": "What would incentivise you to complete this section?",
+                    "type": "General"
+                }
+            }],
+            "id": "test-skipping-group-2",
+            "title": "Section 2"
+        }, {
+            "id": "test-skipping-section-summary-group-2",
+            "title": "Section 2 Summary",
+            "blocks": [{
+                "id": "test-skipping-section-summary-2",
+                "type": "SectionSummary"
+            }]
+        }]
+    }, {
+        "id": "summary-section",
+        "title": "Summary",
+        "groups": [{
+            "blocks": [{
+                "type": "Summary",
+                "id": "summary"
+            }],
+            "id": "summary-group",
+            "title": "Summary"
+        }]
+    }]
 }

--- a/data-source/json/test_language.json
+++ b/data-source/json/test_language.json
@@ -21,7 +21,6 @@
             "blocks": [{
                 "type": "Question",
                 "id": "language-block",
-                "description": "",
                 "question": {
                     "answers": [{
                         "id": "month-year-answer",
@@ -32,10 +31,9 @@
                     }],
                     "description": "",
                     "id": "month-year-question",
-                    "title": "Date with month and year",
+                    "title": "English Questionnaire - Date with month and year",
                     "type": "General"
-                },
-                "title": "English Questionnaire"
+                }
             }, {
                 "type": "Summary",
                 "id": "summary"

--- a/data-source/json/test_list_collector.json
+++ b/data-source/json/test_list_collector.json
@@ -7,239 +7,217 @@
     "theme": "default",
     "description": "A questionnaire to test ListCollector",
     "metadata": [{
-            "name": "user_id",
-            "type": "string"
-        },
-        {
-            "name": "period_id",
-            "type": "string"
-        },
-        {
-            "name": "ru_name",
-            "type": "string"
-        }
-    ],
+        "name": "user_id",
+        "type": "string"
+    }, {
+        "name": "period_id",
+        "type": "string"
+    }, {
+        "name": "ru_name",
+        "type": "string"
+    }],
     "sections": [{
         "id": "section",
         "groups": [{
-                "id": "group",
-                "title": "List",
-                "blocks": [{
-                    "id": "list-collector",
-                    "type": "ListCollector",
-                    "populates_list": "people",
-                    "add_answer": {
+            "id": "group",
+            "title": "List",
+            "blocks": [{
+                "id": "list-collector",
+                "type": "ListCollector",
+                "populates_list": "people",
+                "add_answer": {
+                    "id": "anyone-else",
+                    "value": "Yes"
+                },
+                "remove_answer": {
+                    "id": "remove-confirmation",
+                    "value": "Yes"
+                },
+                "question": {
+                    "id": "confirmation-question",
+                    "type": "General",
+                    "title": "Does anyone else live here?",
+                    "answers": [{
                         "id": "anyone-else",
-                        "value": "Yes"
-                    },
-                    "remove_answer": {
-                        "id": "remove-confirmation",
-                        "value": "Yes"
-                    },
+                        "mandatory": true,
+                        "type": "Radio",
+                        "options": [{
+                            "label": "Yes",
+                            "value": "Yes"
+                        }, {
+                            "label": "No",
+                            "value": "No"
+                        }]
+                    }]
+                },
+                "add_block": {
+                    "id": "add-person",
+                    "type": "ListAddQuestion",
                     "question": {
-                        "id": "confirmation-question",
+                        "id": "add-question",
                         "type": "General",
-                        "title": "Does anyone else live here?",
+                        "title": "What is the name of the person?",
                         "answers": [{
-                            "id": "anyone-else",
+                            "id": "first-name",
+                            "label": "First name",
+                            "mandatory": true,
+                            "type": "TextField"
+                        }, {
+                            "id": "last-name",
+                            "label": "Last name",
+                            "mandatory": true,
+                            "type": "TextField"
+                        }]
+                    }
+                },
+                "edit_block": {
+                    "id": "edit-person",
+                    "type": "ListEditQuestion",
+                    "question": {
+                        "id": "edit-question",
+                        "type": "General",
+                        "title": "What is the name of the person?",
+                        "answers": [{
+                            "id": "first-name",
+                            "label": "First name",
+                            "mandatory": true,
+                            "type": "TextField"
+                        }, {
+                            "id": "last-name",
+                            "label": "Last name",
+                            "mandatory": true,
+                            "type": "TextField"
+                        }]
+                    }
+                },
+                "remove_block": {
+                    "id": "remove-person",
+                    "type": "ListRemoveQuestion",
+                    "question": {
+                        "id": "remove-question",
+                        "type": "General",
+                        "title": "Are you sure you want to remove this person?",
+                        "answers": [{
+                            "id": "remove-confirmation",
                             "mandatory": true,
                             "type": "Radio",
                             "options": [{
-                                    "label": "Yes",
-                                    "value": "Yes"
-                                },
-                                {
-                                    "label": "No",
-                                    "value": "No"
-                                }
-                            ]
+                                "label": "Yes",
+                                "value": "Yes"
+                            }, {
+                                "label": "No",
+                                "value": "No"
+                            }]
                         }]
-                    },
-                    "add_block": {
-                        "id": "add-person",
-                        "type": "ListAddQuestion",
-                        "question": {
-                            "id": "add-question",
-                            "type": "General",
-                            "title": "What is the name of the person?",
-                            "answers": [{
-                                    "id": "first-name",
-                                    "label": "First name",
-                                    "mandatory": true,
-                                    "type": "TextField"
-                                },
-                                {
-                                    "id": "last-name",
-                                    "label": "Last name",
-                                    "mandatory": true,
-                                    "type": "TextField"
-                                }
-                            ]
-                        }
-                    },
-                    "edit_block": {
-                        "id": "edit-person",
-                        "type": "ListEditQuestion",
-                        "question": {
-                            "id": "edit-question",
-                            "type": "General",
-                            "title": "What is the name of the person?",
-                            "answers": [{
-                                    "id": "first-name",
-                                    "label": "First name",
-                                    "mandatory": true,
-                                    "type": "TextField"
-                                },
-                                {
-                                    "id": "last-name",
-                                    "label": "Last name",
-                                    "mandatory": true,
-                                    "type": "TextField"
-                                }
-                            ]
-                        }
-                    },
-                    "remove_block": {
-                        "id": "remove-person",
-                        "type": "ListRemoveQuestion",
-                        "question": {
-                            "id": "remove-question",
-                            "type": "General",
-                            "title": "Are you sure you want to remove this person?",
-                            "answers": [{
-                                "id": "remove-confirmation",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "options": [{
-                                        "label": "Yes",
-                                        "value": "Yes"
-                                    },
-                                    {
-                                        "label": "No",
-                                        "value": "No"
-                                    }
-                                ]
-                            }]
-                        }
                     }
-                }]
-            },
-            {
-                "id": "extra-list-group",
-                "title": "Another List",
-                "blocks": [{
-                        "id": "next-interstitial",
-                        "title": "What's next",
-                        "content": [{
-                            "description": "You have added some people to the 'people' list. Next we'll test another list collector adding to the same list. This should still have the same list of people."
-                        }],
-                        "type": "Interstitial"
-                    },
-                    {
-                        "id": "another-list-collector-block",
-                        "type": "ListCollector",
-                        "populates_list": "people",
-                        "add_answer": {
-                            "id": "another-anyone-else",
+                }
+            }]
+        }, {
+            "id": "extra-list-group",
+            "title": "Another List",
+            "blocks": [{
+                "id": "next-interstitial",
+                "content": {
+                    "title": "Another list",
+                    "contents": [{
+                        "description": "You have added some people to the 'people' list. Next we'll test another list collector adding to the same list. This should still have the same list of people."
+                    }]
+                },
+                "type": "Interstitial"
+            }, {
+                "id": "another-list-collector-block",
+                "type": "ListCollector",
+                "populates_list": "people",
+                "add_answer": {
+                    "id": "another-anyone-else",
+                    "value": "Yes"
+                },
+                "remove_answer": {
+                    "id": "another-remove-confirmation",
+                    "value": "Yes"
+                },
+                "question": {
+                    "id": "another-confirmation-question",
+                    "type": "General",
+                    "title": "This list collector will add to the same 'people' list. Add someone else?",
+                    "answers": [{
+                        "id": "another-anyone-else",
+                        "mandatory": true,
+                        "type": "Radio",
+                        "options": [{
+                            "label": "Yes",
                             "value": "Yes"
-                        },
-                        "remove_answer": {
+                        }, {
+                            "label": "No",
+                            "value": "No"
+                        }]
+                    }]
+                },
+                "add_block": {
+                    "id": "another-add-person",
+                    "type": "ListAddQuestion",
+                    "question": {
+                        "id": "another-add-question",
+                        "type": "General",
+                        "title": "What is the name of the person?",
+                        "answers": [{
+                            "id": "first-name",
+                            "label": "First name",
+                            "mandatory": true,
+                            "type": "TextField"
+                        }, {
+                            "id": "last-name",
+                            "label": "Last name",
+                            "mandatory": true,
+                            "type": "TextField"
+                        }]
+                    }
+                },
+                "edit_block": {
+                    "id": "another-edit-person",
+                    "type": "ListEditQuestion",
+                    "question": {
+                        "id": "another-edit-question",
+                        "type": "General",
+                        "title": "What is the name of the person?",
+                        "answers": [{
+                            "id": "first-name",
+                            "label": "First name",
+                            "mandatory": true,
+                            "type": "TextField"
+                        }, {
+                            "id": "last-name",
+                            "label": "Last name",
+                            "mandatory": true,
+                            "type": "TextField"
+                        }]
+                    }
+                },
+                "remove_block": {
+                    "id": "another-remove-person",
+                    "type": "ListRemoveQuestion",
+                    "question": {
+                        "id": "another-remove-question",
+                        "type": "General",
+                        "title": "Are you sure you want to remove this person?",
+                        "answers": [{
                             "id": "another-remove-confirmation",
-                            "value": "Yes"
-                        },
-                        "question": {
-                            "id": "another-confirmation-question",
-                            "type": "General",
-                            "title": "This list collector will add to the same 'people' list. Add someone else?",
-                            "answers": [{
-                                "id": "another-anyone-else",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "options": [{
-                                        "label": "Yes",
-                                        "value": "Yes"
-                                    },
-                                    {
-                                        "label": "No",
-                                        "value": "No"
-                                    }
-                                ]
+                            "mandatory": true,
+                            "type": "Radio",
+                            "options": [{
+                                "label": "Yes",
+                                "value": "Yes"
+                            }, {
+                                "label": "No",
+                                "value": "No"
                             }]
-                        },
-                        "add_block": {
-                            "id": "another-add-person",
-                            "type": "ListAddQuestion",
-                            "question": {
-                                "id": "another-add-question",
-                                "type": "General",
-                                "title": "What is the name of the person?",
-                                "answers": [{
-                                        "id": "first-name",
-                                        "label": "First name",
-                                        "mandatory": true,
-                                        "type": "TextField"
-                                    },
-                                    {
-                                        "id": "last-name",
-                                        "label": "Last name",
-                                        "mandatory": true,
-                                        "type": "TextField"
-                                    }
-                                ]
-                            }
-                        },
-                        "edit_block": {
-                            "id": "another-edit-person",
-                            "type": "ListEditQuestion",
-                            "question": {
-                                "id": "another-edit-question",
-                                "type": "General",
-                                "title": "What is the name of the person?",
-                                "answers": [{
-                                        "id": "first-name",
-                                        "label": "First name",
-                                        "mandatory": true,
-                                        "type": "TextField"
-                                    },
-                                    {
-                                        "id": "last-name",
-                                        "label": "Last name",
-                                        "mandatory": true,
-                                        "type": "TextField"
-                                    }
-                                ]
-                            }
-                        },
-                        "remove_block": {
-                            "id": "another-remove-person",
-                            "type": "ListRemoveQuestion",
-                            "question": {
-                                "id": "another-remove-question",
-                                "type": "General",
-                                "title": "Are you sure you want to remove this person?",
-                                "answers": [{
-                                    "id": "another-remove-confirmation",
-                                    "mandatory": true,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "Yes",
-                                            "value": "Yes"
-                                        },
-                                        {
-                                            "label": "No",
-                                            "value": "No"
-                                        }
-                                    ]
-                                }]
-                            }
-                        }
-                    },
-                    {
-                        "id": "summary",
-                        "type": "Summary"
+                        }]
                     }
-                ]
-            }
-        ]
+                }
+            }, {
+                "id": "summary",
+                "type": "Summary"
+            }]
+        }]
     }]
 }

--- a/data-source/json/test_list_collector_variants.json
+++ b/data-source/json/test_list_collector_variants.json
@@ -7,287 +7,255 @@
     "theme": "default",
     "description": "A questionnaire to test ListCollector",
     "metadata": [{
-            "name": "user_id",
-            "type": "string"
-        },
-        {
-            "name": "period_id",
-            "type": "string"
-        },
-        {
-            "name": "ru_name",
-            "type": "string"
-        }
-    ],
+        "name": "user_id",
+        "type": "string"
+    }, {
+        "name": "period_id",
+        "type": "string"
+    }, {
+        "name": "ru_name",
+        "type": "string"
+    }],
     "sections": [{
         "id": "section",
         "groups": [{
             "id": "group",
             "title": "List",
             "blocks": [{
-                    "type": "Question",
-                    "id": "you-live-here-block",
-                    "question": {
-                        "type": "General",
-                        "id": "you-live-here-question",
-                        "title": "Do you live at 1 Pleasant Lane?",
-                        "answers": [{
-                            "type": "Radio",
-                            "id": "you-live-here-answer",
-                            "mandatory": true,
-                            "options": [{
-                                    "label": "Yes",
-                                    "value": "Yes"
-                                },
-                                {
-                                    "label": "No",
-                                    "value": "No"
-                                }
-                            ]
+                "type": "Question",
+                "id": "you-live-here-block",
+                "question": {
+                    "type": "General",
+                    "id": "you-live-here-question",
+                    "title": "Do you live at 1 Pleasant Lane?",
+                    "answers": [{
+                        "type": "Radio",
+                        "id": "you-live-here-answer",
+                        "mandatory": true,
+                        "options": [{
+                            "label": "Yes",
+                            "value": "Yes"
+                        }, {
+                            "label": "No",
+                            "value": "No"
                         }]
-                    }
-                },
-                {
-                    "id": "list-collector",
-                    "type": "ListCollector",
-                    "populates_list": "people",
-                    "add_answer": {
-                        "id": "anyone-else",
-                        "value": "Yes"
-                    },
-                    "remove_answer": {
-                        "id": "remove-confirmation",
-                        "value": "Yes"
-                    },
-                    "question_variants": [{
-                            "question": {
-                                "id": "confirmation-question",
-                                "type": "General",
-                                "title": "Does anyone else live at 1 Pleasant Lane?",
-                                "answers": [{
-                                    "id": "anyone-else",
-                                    "mandatory": true,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "Yes",
-                                            "value": "Yes"
-                                        },
-                                        {
-                                            "label": "No",
-                                            "value": "No"
-                                        }
-                                    ]
-                                }]
-                            },
-                            "when": [{
-                                "id": "you-live-here-answer",
-                                "condition": "equals",
-                                "value": "Yes"
-                            }]
-                        },
-                        {
-                            "question": {
-                                "id": "confirmation-question",
-                                "type": "General",
-                                "title": "Does anyone live at 1 Pleasant Lane?",
-                                "answers": [{
-                                    "id": "anyone-else",
-                                    "mandatory": true,
-                                    "type": "Radio",
-                                    "options": [{
-                                            "label": "Yes",
-                                            "value": "Yes"
-                                        },
-                                        {
-                                            "label": "No",
-                                            "value": "No"
-                                        }
-                                    ]
-                                }]
-                            },
-                            "when": [{
-                                "id": "you-live-here-answer",
-                                "condition": "equals",
-                                "value": "No"
-                            }]
-                        }
-                    ],
-                    "add_block": {
-                        "id": "add-person",
-                        "type": "ListAddQuestion",
-                        "question_variants": [{
-                                "question": {
-                                    "id": "add-question",
-                                    "type": "General",
-                                    "title": "What is the name of the person who isn't you?",
-                                    "answers": [{
-                                            "id": "first-name",
-                                            "label": "First name",
-                                            "mandatory": true,
-                                            "type": "TextField"
-                                        },
-                                        {
-                                            "id": "last-name",
-                                            "label": "Last name",
-                                            "mandatory": true,
-                                            "type": "TextField"
-                                        }
-                                    ]
-                                },
-                                "when": [{
-                                    "id": "you-live-here-answer",
-                                    "condition": "equals",
-                                    "value": "No"
-                                }]
-                            },
-                            {
-                                "question": {
-                                    "id": "add-question",
-                                    "type": "General",
-                                    "title": "What is the name of the person?",
-                                    "answers": [{
-                                            "id": "first-name",
-                                            "label": "First name",
-                                            "mandatory": true,
-                                            "type": "TextField"
-                                        },
-                                        {
-                                            "id": "last-name",
-                                            "label": "Last name",
-                                            "mandatory": true,
-                                            "type": "TextField"
-                                        }
-                                    ]
-                                },
-                                "when": [{
-                                    "id": "you-live-here-answer",
-                                    "condition": "equals",
-                                    "value": "Yes"
-                                }]
-                            }
-                        ]
-                    },
-                    "edit_block": {
-                        "id": "edit-person",
-                        "type": "ListEditQuestion",
-                        "question_variants": [{
-                                "question": {
-                                    "id": "edit-question",
-                                    "type": "General",
-                                    "title": "What is the name of the person?",
-                                    "answers": [{
-                                            "id": "first-name",
-                                            "label": "First name",
-                                            "mandatory": true,
-                                            "type": "TextField"
-                                        },
-                                        {
-                                            "id": "last-name",
-                                            "label": "Last name",
-                                            "mandatory": true,
-                                            "type": "TextField"
-                                        }
-                                    ]
-                                },
-                                "when": [{
-                                    "id": "you-live-here-answer",
-                                    "condition": "equals",
-                                    "value": "Yes"
-                                }]
-                            },
-                            {
-                                "question": {
-                                    "id": "edit-question",
-                                    "type": "General",
-                                    "title": "What is the name of the person who isn't you?",
-                                    "answers": [{
-                                            "id": "first-name",
-                                            "label": "First name",
-                                            "mandatory": true,
-                                            "type": "TextField"
-                                        },
-                                        {
-                                            "id": "last-name",
-                                            "label": "Last name",
-                                            "mandatory": true,
-                                            "type": "TextField"
-                                        }
-                                    ]
-                                },
-                                "when": [{
-                                    "id": "you-live-here-answer",
-                                    "condition": "equals",
-                                    "value": "No"
-                                }]
-                            }
-                        ]
-                    },
-                    "remove_block": {
-                        "id": "remove-person",
-                        "type": "ListRemoveQuestion",
-                        "question_variants": [{
-                                "question": {
-                                    "id": "remove-question",
-                                    "type": "General",
-                                    "title": "Are you sure you want to remove this person?",
-                                    "answers": [{
-                                        "id": "remove-confirmation",
-                                        "mandatory": true,
-                                        "type": "Radio",
-                                        "options": [{
-                                                "label": "Yes",
-                                                "value": "Yes"
-                                            },
-                                            {
-                                                "label": "No",
-                                                "value": "No"
-                                            }
-                                        ]
-                                    }]
-                                },
-                                "when": [{
-                                    "id": "you-live-here-answer",
-                                    "condition": "equals",
-                                    "value": "Yes"
-                                }]
-                            },
-                            {
-                                "question": {
-                                    "id": "remove-question",
-                                    "type": "General",
-                                    "title": "Are you sure you want to remove this person who isn't you?",
-                                    "answers": [{
-                                        "id": "remove-confirmation",
-                                        "mandatory": true,
-                                        "type": "Radio",
-                                        "options": [{
-                                                "label": "Yes",
-                                                "value": "Yes"
-                                            },
-                                            {
-                                                "label": "No",
-                                                "value": "No"
-                                            }
-                                        ]
-                                    }]
-                                },
-                                "when": [{
-                                    "id": "you-live-here-answer",
-                                    "condition": "equals",
-                                    "value": "No"
-                                }]
-                            }
-                        ]
-                    }
-                },
-                {
-                    "type": "Confirmation",
-                    "id": "confirmation",
-                    "content": [{
-                        "title": "Thank you for your answers, do you wish to submit"
                     }]
                 }
-            ]
+            }, {
+                "id": "list-collector",
+                "type": "ListCollector",
+                "populates_list": "people",
+                "add_answer": {
+                    "id": "anyone-else",
+                    "value": "Yes"
+                },
+                "remove_answer": {
+                    "id": "remove-confirmation",
+                    "value": "Yes"
+                },
+                "question_variants": [{
+                    "question": {
+                        "id": "confirmation-question",
+                        "type": "General",
+                        "title": "Does anyone else live at 1 Pleasant Lane?",
+                        "answers": [{
+                            "id": "anyone-else",
+                            "mandatory": true,
+                            "type": "Radio",
+                            "options": [{
+                                "label": "Yes",
+                                "value": "Yes"
+                            }, {
+                                "label": "No",
+                                "value": "No"
+                            }]
+                        }]
+                    },
+                    "when": [{
+                        "id": "you-live-here-answer",
+                        "condition": "equals",
+                        "value": "Yes"
+                    }]
+                }, {
+                    "question": {
+                        "id": "confirmation-question",
+                        "type": "General",
+                        "title": "Does anyone live at 1 Pleasant Lane?",
+                        "answers": [{
+                            "id": "anyone-else",
+                            "mandatory": true,
+                            "type": "Radio",
+                            "options": [{
+                                "label": "Yes",
+                                "value": "Yes"
+                            }, {
+                                "label": "No",
+                                "value": "No"
+                            }]
+                        }]
+                    },
+                    "when": [{
+                        "id": "you-live-here-answer",
+                        "condition": "equals",
+                        "value": "No"
+                    }]
+                }],
+                "add_block": {
+                    "id": "add-person",
+                    "type": "ListAddQuestion",
+                    "question_variants": [{
+                        "question": {
+                            "id": "add-question",
+                            "type": "General",
+                            "title": "What is the name of the person who isn't you?",
+                            "answers": [{
+                                "id": "first-name",
+                                "label": "First name",
+                                "mandatory": true,
+                                "type": "TextField"
+                            }, {
+                                "id": "last-name",
+                                "label": "Last name",
+                                "mandatory": true,
+                                "type": "TextField"
+                            }]
+                        },
+                        "when": [{
+                            "id": "you-live-here-answer",
+                            "condition": "equals",
+                            "value": "No"
+                        }]
+                    }, {
+                        "question": {
+                            "id": "add-question",
+                            "type": "General",
+                            "title": "What is the name of the person?",
+                            "answers": [{
+                                "id": "first-name",
+                                "label": "First name",
+                                "mandatory": true,
+                                "type": "TextField"
+                            }, {
+                                "id": "last-name",
+                                "label": "Last name",
+                                "mandatory": true,
+                                "type": "TextField"
+                            }]
+                        },
+                        "when": [{
+                            "id": "you-live-here-answer",
+                            "condition": "equals",
+                            "value": "Yes"
+                        }]
+                    }]
+                },
+                "edit_block": {
+                    "id": "edit-person",
+                    "type": "ListEditQuestion",
+                    "question_variants": [{
+                        "question": {
+                            "id": "edit-question",
+                            "type": "General",
+                            "title": "What is the name of the person?",
+                            "answers": [{
+                                "id": "first-name",
+                                "label": "First name",
+                                "mandatory": true,
+                                "type": "TextField"
+                            }, {
+                                "id": "last-name",
+                                "label": "Last name",
+                                "mandatory": true,
+                                "type": "TextField"
+                            }]
+                        },
+                        "when": [{
+                            "id": "you-live-here-answer",
+                            "condition": "equals",
+                            "value": "Yes"
+                        }]
+                    }, {
+                        "question": {
+                            "id": "edit-question",
+                            "type": "General",
+                            "title": "What is the name of the person who isn't you?",
+                            "answers": [{
+                                "id": "first-name",
+                                "label": "First name",
+                                "mandatory": true,
+                                "type": "TextField"
+                            }, {
+                                "id": "last-name",
+                                "label": "Last name",
+                                "mandatory": true,
+                                "type": "TextField"
+                            }]
+                        },
+                        "when": [{
+                            "id": "you-live-here-answer",
+                            "condition": "equals",
+                            "value": "No"
+                        }]
+                    }]
+                },
+                "remove_block": {
+                    "id": "remove-person",
+                    "type": "ListRemoveQuestion",
+                    "question_variants": [{
+                        "question": {
+                            "id": "remove-question",
+                            "type": "General",
+                            "title": "Are you sure you want to remove this person?",
+                            "answers": [{
+                                "id": "remove-confirmation",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "options": [{
+                                    "label": "Yes",
+                                    "value": "Yes"
+                                }, {
+                                    "label": "No",
+                                    "value": "No"
+                                }]
+                            }]
+                        },
+                        "when": [{
+                            "id": "you-live-here-answer",
+                            "condition": "equals",
+                            "value": "Yes"
+                        }]
+                    }, {
+                        "question": {
+                            "id": "remove-question",
+                            "type": "General",
+                            "title": "Are you sure you want to remove this person who isn't you?",
+                            "answers": [{
+                                "id": "remove-confirmation",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "options": [{
+                                    "label": "Yes",
+                                    "value": "Yes"
+                                }, {
+                                    "label": "No",
+                                    "value": "No"
+                                }]
+                            }]
+                        },
+                        "when": [{
+                            "id": "you-live-here-answer",
+                            "condition": "equals",
+                            "value": "No"
+                        }]
+                    }]
+                }
+            }, {
+                "type": "Confirmation",
+                "id": "confirmation",
+                "content": {
+                    "title": "Thank you for your answers, do you wish to submit"
+                }
+            }]
         }]
     }]
 }

--- a/data-source/json/test_markup.json
+++ b/data-source/json/test_markup.json
@@ -24,13 +24,12 @@
             "blocks": [{
                 "type": "Question",
                 "id": "emphasis-block",
-                "title": "Emphasis",
                 "question": {
                     "answers": [{
                         "guidance": {
                             "show_guidance": "Show lorem ipsum guidance",
                             "hide_guidance": "hide lorem ipsum guidance",
-                            "content": [{
+                            "contents": [{
                                 "description": "Lorem ipsum dolor sit amet, <em>consectetur adipiscing elit</em>. Nulla vitae elit libero, a pharetra augue. Vestibulum id ligula porta felis euismod semper. Integer posuere erat a ante venenatis dapibus posuere velit aliquet."
                             }]
                         },

--- a/data-source/json/test_metadata_routing.json
+++ b/data-source/json/test_metadata_routing.json
@@ -24,7 +24,6 @@
             "blocks": [{
                 "type": "Question",
                 "id": "block1",
-                "title": "Question 1",
                 "question": {
                     "id": "block1-question",
                     "title": "Question 1",
@@ -54,7 +53,6 @@
             }, {
                 "type": "Question",
                 "id": "block2",
-                "title": "Question 2",
                 "question": {
                     "id": "block2-question",
                     "title": "Question 2",
@@ -70,7 +68,6 @@
             }, {
                 "type": "Question",
                 "id": "block3",
-                "title": "Question 3",
                 "question": {
                     "id": "block3-question",
                     "title": "Question 3",

--- a/data-source/json/test_multiple_answers.json
+++ b/data-source/json/test_multiple_answers.json
@@ -41,8 +41,7 @@
                     "id": "personal-details-question",
                     "title": "Tell me about yourself",
                     "type": "General"
-                },
-                "title": "Multiple questions"
+                }
             }, {
                 "type": "Summary",
                 "id": "summary"

--- a/data-source/json/test_mutually_exclusive.json
+++ b/data-source/json/test_mutually_exclusive.json
@@ -20,481 +20,465 @@
         "visible": true
     },
     "sections": [{
-            "id": "mutually-exclusive-checkbox-section",
-            "title": "Checkbox",
-            "groups": [{
-                "id": "mutually-exclusive-mandatory-group",
-                "title": "Mutually Exclusive With Single Checkbox Override - Mandatory",
-                "blocks": [{
-                    "type": "Question",
-                    "id": "mutually-exclusive-checkbox",
-                    "title": "Mutually Exclusive With Single Checkbox Override - Mandatory",
-                    "question": {
-                        "id": "mutually-exclusive-checkbox-question",
-                        "type": "MutuallyExclusive",
-                        "title": "What is your nationality?",
-                        "mandatory": true,
-                        "answers": [{
-                            "id": "checkbox-answer",
-                            "label": "Select an answer",
-                            "type": "Checkbox",
-                            "mandatory": false,
-                            "options": [{
-                                    "label": "British",
-                                    "value": "British"
-                                }, {
-                                    "label": "Irish",
-                                    "value": "Irish"
-                                },
-                                {
-                                    "label": "Other",
-                                    "description": "Choose any other topping",
-                                    "value": "Other",
-                                    "detail_answer": {
-                                        "mandatory": false,
-                                        "id": "checkbox-child-other-answer",
-                                        "label": "Please specify other",
-                                        "type": "TextField"
-                                    }
-                                }
-                            ]
-                        }, {
-                            "id": "checkbox-exclusive-answer",
-                            "mandatory": false,
-                            "type": "Checkbox",
-                            "options": [{
-                                "label": "I prefer not to say",
-                                "description": "Some description",
-                                "value": "I prefer not to say"
-                            }]
-                        }]
-                    }
-                }]
-            }, {
-                "id": "mandatory-mutually-exclusive-summary-group",
-                "title": "",
-                "blocks": [{
-                    "type": "SectionSummary",
-                    "id": "mandatory-section-summary"
-                }]
-            }]
-        },
-        {
-            "id": "mutually-exclusive-date-section",
-            "title": "Date",
-            "groups": [{
-                "id": "mutually-exclusive-date-group",
-                "title": "Mutually Exclusive With Single Checkbox Override - Optional",
-                "blocks": [{
-                    "type": "Question",
-                    "id": "mutually-exclusive-date",
-                    "title": "Mutually Exclusive With Single Checkbox Override - Optional",
-                    "question": {
-                        "id": "mutually-exclusive-date-question",
-                        "type": "MutuallyExclusive",
-                        "title": "When did you leave your last paid job?",
+        "id": "mutually-exclusive-checkbox-section",
+        "title": "Checkbox",
+        "groups": [{
+            "id": "mutually-exclusive-mandatory-group",
+            "title": "Mutually Exclusive With Single Checkbox Override - Mandatory",
+            "blocks": [{
+                "type": "Question",
+                "id": "mutually-exclusive-checkbox",
+                "question": {
+                    "id": "mutually-exclusive-checkbox-question",
+                    "type": "MutuallyExclusive",
+                    "title": "What is your nationality?",
+                    "mandatory": true,
+                    "answers": [{
+                        "id": "checkbox-answer",
+                        "label": "Select an answer",
+                        "type": "Checkbox",
                         "mandatory": false,
-                        "answers": [{
-                            "id": "date-answer",
-                            "label": "Enter a date",
-                            "mandatory": false,
-                            "type": "Date"
+                        "options": [{
+                            "label": "British",
+                            "value": "British"
                         }, {
-                            "id": "date-exclusive-answer",
-                            "mandatory": false,
-                            "type": "Checkbox",
-                            "options": [{
-                                "label": "I prefer not to say",
-                                "value": "I prefer not to say"
-                            }]
-                        }]
-                    }
-                }]
-            }, {
-                "id": "mutually-exclusive-date-section-summary",
-                "title": "",
-                "blocks": [{
-                    "type": "SectionSummary",
-                    "id": "optional-date-section-summary"
-                }]
-            }]
-        }, {
-            "id": "mutually-exclusive-currency-section",
-            "title": "Currency",
-            "groups": [{
-                "id": "mutually-exclusive-currency-group",
-                "title": "Mutually Exclusive With Single Checkbox Override - Optional",
-                "blocks": [{
-                    "type": "Question",
-                    "id": "mutually-exclusive-currency",
-                    "title": "Mutually Exclusive With Single Checkbox Override - Optional",
-                    "question": {
-                        "id": "mutually-exclusive-currency-question",
-                        "type": "MutuallyExclusive",
-                        "title": "What is your annual income before tax?",
-                        "mandatory": false,
-                        "answers": [{
-                            "id": "currency-answer",
-                            "label": "Enter your income",
-                            "mandatory": false,
-                            "type": "Currency",
-                            "currency": "GBP"
+                            "label": "Irish",
+                            "value": "Irish"
                         }, {
-                            "id": "currency-exclusive-answer",
-                            "mandatory": false,
-                            "type": "Checkbox",
-                            "options": [{
-                                "label": "I prefer not to say",
-                                "value": "I prefer not to say"
-                            }]
-                        }]
-                    }
-                }]
-            }, {
-                "id": "mutually-exclusive-currency-section-summary",
-                "title": "",
-                "blocks": [{
-                    "type": "SectionSummary",
-                    "id": "optional-currency-section-summary"
-                }]
-            }]
-        }, {
-            "id": "mutually-exclusive-number-section",
-            "title": "Number",
-            "groups": [{
-                "id": "mutually-exclusive-number-group",
-                "title": "Mutually Exclusive With Single Checkbox Override - Optional",
-                "blocks": [{
-                    "type": "Question",
-                    "id": "mutually-exclusive-number",
-                    "title": "Mutually Exclusive With Single Checkbox Override - Optional",
-                    "question": {
-                        "id": "mutually-exclusive-number-question",
-                        "type": "MutuallyExclusive",
-                        "title": "What is your favourite number?",
-                        "mandatory": false,
-                        "answers": [{
-                            "id": "number-answer",
-                            "label": "Enter your favourite number",
-                            "mandatory": false,
-                            "type": "Number",
-                            "decimal_places": 2
-                        }, {
-                            "id": "number-exclusive-answer",
-                            "mandatory": false,
-                            "type": "Checkbox",
-                            "options": [{
-                                "label": "I prefer not to say",
-                                "value": "I prefer not to say"
-                            }]
-                        }]
-                    }
-                }]
-            }, {
-                "id": "mutually-exclusive-number-section-summary",
-                "title": "",
-                "blocks": [{
-                    "type": "SectionSummary",
-                    "id": "optional-number-section-summary"
-                }]
-            }]
-        },
-        {
-            "id": "mutually-exclusive-percentage-section",
-            "title": "Percentage",
-            "groups": [{
-                "id": "mutually-exclusive-percentage-group",
-                "title": "Mutually Exclusive With Single Checkbox Override - Optional",
-                "blocks": [{
-                    "type": "Question",
-                    "id": "mutually-exclusive-percentage",
-                    "title": "Mutually Exclusive With Single Checkbox Override - Optional",
-                    "question": {
-                        "id": "mutually-exclusive-percentage-question",
-                        "type": "MutuallyExclusive",
-                        "title": "What was the percentage increase in your annual income this tax year?",
-                        "mandatory": false,
-                        "answers": [{
-                            "id": "percentage-answer",
-                            "label": "Enter the percentage increase of your income",
-                            "mandatory": false,
-                            "type": "Percentage",
-                            "max_value": {
-                                "value": 100
+                            "label": "Other",
+                            "description": "Choose any other topping",
+                            "value": "Other",
+                            "detail_answer": {
+                                "mandatory": false,
+                                "id": "checkbox-child-other-answer",
+                                "label": "Please specify other",
+                                "type": "TextField"
                             }
-                        }, {
-                            "id": "percentage-exclusive-answer",
-                            "mandatory": false,
-                            "type": "Checkbox",
-                            "options": [{
-                                "label": "I prefer not to say",
-                                "value": "I prefer not to say"
-                            }]
                         }]
-                    }
-                }]
-            }, {
-                "id": "mutually-exclusive-percentage-section-summary",
-                "title": "",
-                "blocks": [{
-                    "type": "SectionSummary",
-                    "id": "optional-percentage-section-summary"
-                }]
-            }]
-        }, {
-            "id": "mutually-exclusive-textfield-section",
-            "title": "Textfield",
-            "groups": [{
-                "id": "mutually-exclusive-textfield-group",
-                "title": "Mutually Exclusive With Single Checkbox Override - Optional",
-                "blocks": [{
-                    "type": "Question",
-                    "id": "mutually-exclusive-textfield",
-                    "title": "Mutually Exclusive With Single Checkbox Override - Optional",
-                    "question": {
-                        "id": "mutually-exclusive-textfield-question",
-                        "type": "MutuallyExclusive",
-                        "title": "What is your favourite colour?",
+                    }, {
+                        "id": "checkbox-exclusive-answer",
                         "mandatory": false,
-                        "answers": [{
-                            "id": "textfield-answer",
-                            "label": "Enter your favourite colour",
-                            "mandatory": false,
-                            "type": "TextField"
-                        }, {
-                            "id": "textfield-exclusive-answer",
-                            "mandatory": false,
-                            "type": "Checkbox",
-                            "options": [{
-                                "label": "I prefer not to say",
-                                "value": "I prefer not to say"
-                            }]
+                        "type": "Checkbox",
+                        "options": [{
+                            "label": "I prefer not to say",
+                            "description": "Some description",
+                            "value": "I prefer not to say"
                         }]
-                    }
-                }]
-            }, {
-                "id": "mutually-exclusive-textfield-section-summary",
-                "title": "",
-                "blocks": [{
-                    "type": "SectionSummary",
-                    "id": "optional-textfield-section-summary"
-                }]
+                    }]
+                }
             }]
         }, {
-            "id": "mutually-exclusive-month-year-date-section",
-            "title": "Month Year Date",
-            "groups": [{
-                "id": "mutually-exclusive-month-year-date-group",
-                "title": "Mutually Exclusive With Single Checkbox Override - Optional",
-                "blocks": [{
-                    "type": "Question",
-                    "id": "mutually-exclusive-month-year-date",
-                    "title": "Mutually Exclusive With Single Checkbox Override - Optional",
-                    "question": {
-                        "id": "mutually-exclusive-month-year-date-question",
-                        "type": "MutuallyExclusive",
-                        "title": "When did you leave your last paid job?",
+            "id": "mandatory-mutually-exclusive-summary-group",
+            "title": "",
+            "blocks": [{
+                "type": "SectionSummary",
+                "id": "mandatory-section-summary"
+            }]
+        }]
+    }, {
+        "id": "mutually-exclusive-date-section",
+        "title": "Date",
+        "groups": [{
+            "id": "mutually-exclusive-date-group",
+            "title": "Mutually Exclusive With Single Checkbox Override - Optional",
+            "blocks": [{
+                "type": "Question",
+                "id": "mutually-exclusive-date",
+                "question": {
+                    "id": "mutually-exclusive-date-question",
+                    "type": "MutuallyExclusive",
+                    "title": "When did you leave your last paid job?",
+                    "mandatory": false,
+                    "answers": [{
+                        "id": "date-answer",
+                        "label": "Enter a date",
                         "mandatory": false,
-                        "answers": [{
-                            "id": "month-year-date-answer",
-                            "label": "Enter a date",
-                            "mandatory": false,
-                            "type": "MonthYearDate",
-                            "maximum": {
-                                "value": "now"
-                            }
-                        }, {
-                            "id": "month-year-date-exclusive-answer",
-                            "mandatory": false,
-                            "type": "Checkbox",
-                            "options": [{
-                                "label": "I prefer not to say",
-                                "value": "I prefer not to say"
-                            }]
-                        }]
-                    }
-                }]
-            }, {
-                "id": "mutually-exclusive-month-year-section-summary",
-                "title": "",
-                "blocks": [{
-                    "type": "SectionSummary",
-                    "id": "optional-month-year-section-summary"
-                }]
-            }]
-        }, {
-            "id": "mutually-exclusive-year-date-section",
-            "title": "Year Date",
-            "groups": [{
-                "id": "mutually-exclusive-year-date-group",
-                "title": "Mutually Exclusive With Single Checkbox Override - Optional",
-                "blocks": [{
-                    "type": "Question",
-                    "id": "mutually-exclusive-year-date",
-                    "title": "Mutually Exclusive With Single Checkbox Override - Optional",
-                    "question": {
-                        "id": "mutually-exclusive-year-date-question",
-                        "type": "MutuallyExclusive",
-                        "title": "When did you leave your last paid job?",
+                        "type": "Date"
+                    }, {
+                        "id": "date-exclusive-answer",
                         "mandatory": false,
-                        "answers": [{
-                            "id": "year-date-answer",
-                            "label": "Enter a date",
-                            "mandatory": false,
-                            "type": "YearDate",
-                            "maximum": {
-                                "value": "now"
-                            }
-                        }, {
-                            "id": "year-date-exclusive-answer",
-                            "mandatory": false,
-                            "type": "Checkbox",
-                            "options": [{
-                                "label": "I prefer not to say",
-                                "value": "I prefer not to say"
-                            }]
+                        "type": "Checkbox",
+                        "options": [{
+                            "label": "I prefer not to say",
+                            "value": "I prefer not to say"
                         }]
-                    }
-                }]
-            }, {
-                "id": "mutually-exclusive-year-section-summary",
-                "title": "",
-                "blocks": [{
-                    "type": "SectionSummary",
-                    "id": "optional-year-section-summary"
-                }]
+                    }]
+                }
             }]
         }, {
-            "id": "mutually-exclusive-unit-section",
-            "title": "Unit",
-            "groups": [{
-                "id": "mutually-exclusive-unit-group",
-                "title": "Mutually Exclusive With Single Checkbox Override - Optional",
-                "blocks": [{
-                    "type": "Question",
-                    "id": "mutually-exclusive-unit",
-                    "title": "Mutually Exclusive With Single Checkbox Override - Optional",
-                    "question": {
-                        "id": "mutually-exclusive-unit-question",
-                        "type": "MutuallyExclusive",
-                        "title": "How many years have you been in the UK?",
+            "id": "mutually-exclusive-date-section-summary",
+            "title": "",
+            "blocks": [{
+                "type": "SectionSummary",
+                "id": "optional-date-section-summary"
+            }]
+        }]
+    }, {
+        "id": "mutually-exclusive-currency-section",
+        "title": "Currency",
+        "groups": [{
+            "id": "mutually-exclusive-currency-group",
+            "title": "Mutually Exclusive With Single Checkbox Override - Optional",
+            "blocks": [{
+                "type": "Question",
+                "id": "mutually-exclusive-currency",
+                "question": {
+                    "id": "mutually-exclusive-currency-question",
+                    "type": "MutuallyExclusive",
+                    "title": "What is your annual income before tax?",
+                    "mandatory": false,
+                    "answers": [{
+                        "id": "currency-answer",
+                        "label": "Enter your income",
                         "mandatory": false,
-                        "answers": [{
-                            "id": "unit-answer",
-                            "label": "Enter the number of years you have lived in the UK",
-                            "unit": "duration-year",
-                            "type": "Unit",
-                            "unit_length": "long",
-                            "mandatory": false
-                        }, {
-                            "id": "unit-exclusive-answer",
-                            "mandatory": false,
-                            "type": "Checkbox",
-                            "options": [{
-                                "label": "I prefer not to say",
-                                "value": "I prefer not to say"
-                            }]
-                        }]
-                    }
-                }]
-            }, {
-                "id": "mutually-exclusive-unit-section-summary",
-                "title": "",
-                "blocks": [{
-                    "type": "SectionSummary",
-                    "id": "optional-unit-section-summary"
-                }]
-            }]
-        }, {
-            "id": "mutually-exclusive-duration-section",
-            "title": "Duration",
-            "groups": [{
-                "id": "mutually-exclusive-duration-group",
-                "title": "Mutually Exclusive With Single Checkbox Override - Optional",
-                "blocks": [{
-                    "type": "Question",
-                    "id": "mutually-exclusive-duration",
-                    "title": "Mutually Exclusive With Single Checkbox Override - Optional",
-                    "question": {
-                        "id": "mutually-exclusive-duration-question",
-                        "type": "MutuallyExclusive",
-                        "title": "How long have you been employed for?",
+                        "type": "Currency",
+                        "currency": "GBP"
+                    }, {
+                        "id": "currency-exclusive-answer",
                         "mandatory": false,
-                        "answers": [{
-                            "id": "duration-answer",
-                            "label": "Years and Months",
-                            "mandatory": false,
-                            "units": ["years", "months"],
-                            "type": "Duration"
-                        }, {
-                            "id": "duration-exclusive-answer",
-                            "mandatory": false,
-                            "type": "Checkbox",
-                            "options": [{
-                                "label": "I prefer not to say",
-                                "value": "I prefer not to say"
-                            }]
+                        "type": "Checkbox",
+                        "options": [{
+                            "label": "I prefer not to say",
+                            "value": "I prefer not to say"
                         }]
-                    }
-                }]
-            }, {
-                "id": "mutually-exclusive-duration-section-summary",
-                "title": "",
-                "blocks": [{
-                    "type": "SectionSummary",
-                    "id": "optional-duration-section-summary"
-                }]
+                    }]
+                }
             }]
         }, {
-            "id": "mutually-exclusive-textarea-section",
-            "title": "TextArea",
-            "groups": [{
-                "id": "mutually-exclusive-textarea-group",
-                "title": "Mutually Exclusive With Single Checkbox Override - Optional",
-                "blocks": [{
-                    "type": "Question",
-                    "id": "mutually-exclusive-textarea",
-                    "title": "Mutually Exclusive With Single Checkbox Override - Optional",
-                    "question": {
-                        "id": "mutually-exclusive-textarea-question",
-                        "type": "MutuallyExclusive",
-                        "title": "Why did you leave you last job?",
+            "id": "mutually-exclusive-currency-section-summary",
+            "title": "",
+            "blocks": [{
+                "type": "SectionSummary",
+                "id": "optional-currency-section-summary"
+            }]
+        }]
+    }, {
+        "id": "mutually-exclusive-number-section",
+        "title": "Number",
+        "groups": [{
+            "id": "mutually-exclusive-number-group",
+            "title": "Mutually Exclusive With Single Checkbox Override - Optional",
+            "blocks": [{
+                "type": "Question",
+                "id": "mutually-exclusive-number",
+                "question": {
+                    "id": "mutually-exclusive-number-question",
+                    "type": "MutuallyExclusive",
+                    "title": "What is your favourite number?",
+                    "mandatory": false,
+                    "answers": [{
+                        "id": "number-answer",
+                        "label": "Enter your favourite number",
                         "mandatory": false,
-                        "answers": [{
-                            "id": "textarea-answer",
-                            "mandatory": false,
-                            "type": "TextArea"
-                        }, {
-                            "id": "textarea-exclusive-answer",
-                            "mandatory": false,
-                            "type": "Checkbox",
-                            "options": [{
-                                "label": "I prefer not to say",
-                                "value": "I prefer not to say"
-                            }]
+                        "type": "Number",
+                        "decimal_places": 2
+                    }, {
+                        "id": "number-exclusive-answer",
+                        "mandatory": false,
+                        "type": "Checkbox",
+                        "options": [{
+                            "label": "I prefer not to say",
+                            "value": "I prefer not to say"
                         }]
-                    }
-                }]
-            }, {
-                "id": "mutually-exclusive-textarea-section-summary",
-                "title": "",
-                "blocks": [{
-                    "type": "SectionSummary",
-                    "id": "optional-textarea-section-summary"
-                }]
+                    }]
+                }
             }]
         }, {
-            "id": "summary-section",
+            "id": "mutually-exclusive-number-section-summary",
+            "title": "",
+            "blocks": [{
+                "type": "SectionSummary",
+                "id": "optional-number-section-summary"
+            }]
+        }]
+    }, {
+        "id": "mutually-exclusive-percentage-section",
+        "title": "Percentage",
+        "groups": [{
+            "id": "mutually-exclusive-percentage-group",
+            "title": "Mutually Exclusive With Single Checkbox Override - Optional",
+            "blocks": [{
+                "type": "Question",
+                "id": "mutually-exclusive-percentage",
+                "question": {
+                    "id": "mutually-exclusive-percentage-question",
+                    "type": "MutuallyExclusive",
+                    "title": "What was the percentage increase in your annual income this tax year?",
+                    "mandatory": false,
+                    "answers": [{
+                        "id": "percentage-answer",
+                        "label": "Enter the percentage increase of your income",
+                        "mandatory": false,
+                        "type": "Percentage",
+                        "max_value": {
+                            "value": 100
+                        }
+                    }, {
+                        "id": "percentage-exclusive-answer",
+                        "mandatory": false,
+                        "type": "Checkbox",
+                        "options": [{
+                            "label": "I prefer not to say",
+                            "value": "I prefer not to say"
+                        }]
+                    }]
+                }
+            }]
+        }, {
+            "id": "mutually-exclusive-percentage-section-summary",
+            "title": "",
+            "blocks": [{
+                "type": "SectionSummary",
+                "id": "optional-percentage-section-summary"
+            }]
+        }]
+    }, {
+        "id": "mutually-exclusive-textfield-section",
+        "title": "Textfield",
+        "groups": [{
+            "id": "mutually-exclusive-textfield-group",
+            "title": "Mutually Exclusive With Single Checkbox Override - Optional",
+            "blocks": [{
+                "type": "Question",
+                "id": "mutually-exclusive-textfield",
+                "question": {
+                    "id": "mutually-exclusive-textfield-question",
+                    "type": "MutuallyExclusive",
+                    "title": "What is your favourite colour?",
+                    "mandatory": false,
+                    "answers": [{
+                        "id": "textfield-answer",
+                        "label": "Enter your favourite colour",
+                        "mandatory": false,
+                        "type": "TextField"
+                    }, {
+                        "id": "textfield-exclusive-answer",
+                        "mandatory": false,
+                        "type": "Checkbox",
+                        "options": [{
+                            "label": "I prefer not to say",
+                            "value": "I prefer not to say"
+                        }]
+                    }]
+                }
+            }]
+        }, {
+            "id": "mutually-exclusive-textfield-section-summary",
+            "title": "",
+            "blocks": [{
+                "type": "SectionSummary",
+                "id": "optional-textfield-section-summary"
+            }]
+        }]
+    }, {
+        "id": "mutually-exclusive-month-year-date-section",
+        "title": "Month Year Date",
+        "groups": [{
+            "id": "mutually-exclusive-month-year-date-group",
+            "title": "Mutually Exclusive With Single Checkbox Override - Optional",
+            "blocks": [{
+                "type": "Question",
+                "id": "mutually-exclusive-month-year-date",
+                "question": {
+                    "id": "mutually-exclusive-month-year-date-question",
+                    "type": "MutuallyExclusive",
+                    "title": "When did you leave your last paid job?",
+                    "mandatory": false,
+                    "answers": [{
+                        "id": "month-year-date-answer",
+                        "label": "Enter a date",
+                        "mandatory": false,
+                        "type": "MonthYearDate",
+                        "maximum": {
+                            "value": "now"
+                        }
+                    }, {
+                        "id": "month-year-date-exclusive-answer",
+                        "mandatory": false,
+                        "type": "Checkbox",
+                        "options": [{
+                            "label": "I prefer not to say",
+                            "value": "I prefer not to say"
+                        }]
+                    }]
+                }
+            }]
+        }, {
+            "id": "mutually-exclusive-month-year-section-summary",
+            "title": "",
+            "blocks": [{
+                "type": "SectionSummary",
+                "id": "optional-month-year-section-summary"
+            }]
+        }]
+    }, {
+        "id": "mutually-exclusive-year-date-section",
+        "title": "Year Date",
+        "groups": [{
+            "id": "mutually-exclusive-year-date-group",
+            "title": "Mutually Exclusive With Single Checkbox Override - Optional",
+            "blocks": [{
+                "type": "Question",
+                "id": "mutually-exclusive-year-date",
+                "question": {
+                    "id": "mutually-exclusive-year-date-question",
+                    "type": "MutuallyExclusive",
+                    "title": "When did you leave your last paid job?",
+                    "mandatory": false,
+                    "answers": [{
+                        "id": "year-date-answer",
+                        "label": "Enter a date",
+                        "mandatory": false,
+                        "type": "YearDate",
+                        "maximum": {
+                            "value": "now"
+                        }
+                    }, {
+                        "id": "year-date-exclusive-answer",
+                        "mandatory": false,
+                        "type": "Checkbox",
+                        "options": [{
+                            "label": "I prefer not to say",
+                            "value": "I prefer not to say"
+                        }]
+                    }]
+                }
+            }]
+        }, {
+            "id": "mutually-exclusive-year-section-summary",
+            "title": "",
+            "blocks": [{
+                "type": "SectionSummary",
+                "id": "optional-year-section-summary"
+            }]
+        }]
+    }, {
+        "id": "mutually-exclusive-unit-section",
+        "title": "Unit",
+        "groups": [{
+            "id": "mutually-exclusive-unit-group",
+            "title": "Mutually Exclusive With Single Checkbox Override - Optional",
+            "blocks": [{
+                "type": "Question",
+                "id": "mutually-exclusive-unit",
+                "question": {
+                    "id": "mutually-exclusive-unit-question",
+                    "type": "MutuallyExclusive",
+                    "title": "How many years have you been in the UK?",
+                    "mandatory": false,
+                    "answers": [{
+                        "id": "unit-answer",
+                        "label": "Enter the number of years you have lived in the UK",
+                        "unit": "duration-year",
+                        "type": "Unit",
+                        "unit_length": "long",
+                        "mandatory": false
+                    }, {
+                        "id": "unit-exclusive-answer",
+                        "mandatory": false,
+                        "type": "Checkbox",
+                        "options": [{
+                            "label": "I prefer not to say",
+                            "value": "I prefer not to say"
+                        }]
+                    }]
+                }
+            }]
+        }, {
+            "id": "mutually-exclusive-unit-section-summary",
+            "title": "",
+            "blocks": [{
+                "type": "SectionSummary",
+                "id": "optional-unit-section-summary"
+            }]
+        }]
+    }, {
+        "id": "mutually-exclusive-duration-section",
+        "title": "Duration",
+        "groups": [{
+            "id": "mutually-exclusive-duration-group",
+            "title": "Mutually Exclusive With Single Checkbox Override - Optional",
+            "blocks": [{
+                "type": "Question",
+                "id": "mutually-exclusive-duration",
+                "question": {
+                    "id": "mutually-exclusive-duration-question",
+                    "type": "MutuallyExclusive",
+                    "title": "How long have you been employed for?",
+                    "mandatory": false,
+                    "answers": [{
+                        "id": "duration-answer",
+                        "label": "Years and Months",
+                        "mandatory": false,
+                        "units": ["years", "months"],
+                        "type": "Duration"
+                    }, {
+                        "id": "duration-exclusive-answer",
+                        "mandatory": false,
+                        "type": "Checkbox",
+                        "options": [{
+                            "label": "I prefer not to say",
+                            "value": "I prefer not to say"
+                        }]
+                    }]
+                }
+            }]
+        }, {
+            "id": "mutually-exclusive-duration-section-summary",
+            "title": "",
+            "blocks": [{
+                "type": "SectionSummary",
+                "id": "optional-duration-section-summary"
+            }]
+        }]
+    }, {
+        "id": "mutually-exclusive-textarea-section",
+        "title": "TextArea",
+        "groups": [{
+            "id": "mutually-exclusive-textarea-group",
+            "title": "Mutually Exclusive With Single Checkbox Override - Optional",
+            "blocks": [{
+                "type": "Question",
+                "id": "mutually-exclusive-textarea",
+                "question": {
+                    "id": "mutually-exclusive-textarea-question",
+                    "type": "MutuallyExclusive",
+                    "title": "Why did you leave you last job?",
+                    "mandatory": false,
+                    "answers": [{
+                        "id": "textarea-answer",
+                        "mandatory": false,
+                        "type": "TextArea"
+                    }, {
+                        "id": "textarea-exclusive-answer",
+                        "mandatory": false,
+                        "type": "Checkbox",
+                        "options": [{
+                            "label": "I prefer not to say",
+                            "value": "I prefer not to say"
+                        }]
+                    }]
+                }
+            }]
+        }, {
+            "id": "mutually-exclusive-textarea-section-summary",
+            "title": "",
+            "blocks": [{
+                "type": "SectionSummary",
+                "id": "optional-textarea-section-summary"
+            }]
+        }]
+    }, {
+        "id": "summary-section",
+        "title": "Summary",
+        "groups": [{
+            "id": "summary-group",
             "title": "Summary",
-            "groups": [{
-                "id": "summary-group",
-                "title": "Summary",
-                "blocks": [{
-                    "id": "summary",
-                    "type": "Summary",
-                    "collapsible": true
-                }]
+            "blocks": [{
+                "id": "summary",
+                "type": "Summary",
+                "collapsible": true
             }]
-        }
-    ]
+        }]
+    }]
 }

--- a/data-source/json/test_numbers.json
+++ b/data-source/json/test_numbers.json
@@ -7,264 +7,237 @@
     "description": "Test Description",
     "theme": "default",
     "metadata": [{
-            "name": "user_id",
-            "type": "string"
-        },
-        {
-            "name": "period_id",
-            "type": "string"
-        },
-        {
-            "name": "ru_name",
-            "type": "string"
-        }
-    ],
+        "name": "user_id",
+        "type": "string"
+    }, {
+        "name": "period_id",
+        "type": "string"
+    }, {
+        "name": "ru_name",
+        "type": "string"
+    }],
     "sections": [{
         "id": "default-section",
         "groups": [{
-                "blocks": [{
-                        "type": "Question",
-                        "id": "set-min-max-block",
-                        "description": "",
-                        "question": {
-                            "answers": [{
-                                    "id": "set-minimum",
-                                    "label": "Minimum Value",
-                                    "description": "This is a description of the minimum value",
-                                    "mandatory": true,
-                                    "type": "Number",
-                                    "decimal_places": 2,
-                                    "min_value": {
-                                        "value": 0
-                                    },
-                                    "max_value": {
-                                        "value": 1000
-                                    }
-                                },
-                                {
-                                    "id": "set-maximum",
-                                    "description": "This is a description of the maximum value",
-                                    "label": "Maximum Value",
-                                    "mandatory": true,
-                                    "type": "Number",
-                                    "decimal_places": 2,
-                                    "min_value": {
-                                        "value": 1001
-                                    },
-                                    "max_value": {
-                                        "value": 10000
-                                    }
-                                }
-                            ],
-                            "description": "",
-                            "id": "set-min-question",
-                            "title": "Please set the minimum and maximum used for future questions",
-                            "type": "General"
+            "blocks": [{
+                "type": "Question",
+                "id": "set-min-max-block",
+                "question": {
+                    "answers": [{
+                        "id": "set-minimum",
+                        "label": "Minimum Value",
+                        "description": "This is a description of the minimum value",
+                        "mandatory": true,
+                        "type": "Number",
+                        "decimal_places": 2,
+                        "min_value": {
+                            "value": 0
                         },
-                        "title": ""
-                    },
-                    {
-                        "type": "Question",
-                        "id": "test-min-max-block",
-                        "description": "",
-                        "question": {
-                            "answers": [{
-                                    "id": "test-range",
-                                    "label": "",
-                                    "description": {
-                                        "text": "Range Test ({minimum} to {maximum})",
-                                        "placeholders": [{
-                                                "placeholder": "minimum",
-                                                "transforms": [{
-                                                    "transform": "format_number",
-                                                    "arguments": {
-                                                        "number": {
-                                                            "source": "answers",
-                                                            "identifier": "set-minimum"
-                                                        }
-                                                    }
-                                                }]
-                                            },
-                                            {
-                                                "placeholder": "maximum",
-                                                "transforms": [{
-                                                    "transform": "format_number",
-                                                    "arguments": {
-                                                        "number": {
-                                                            "source": "answers",
-                                                            "identifier": "set-maximum"
-                                                        }
-                                                    }
-                                                }]
-                                            }
-                                        ]
-                                    },
-                                    "mandatory": false,
-                                    "type": "Number",
-                                    "decimal_places": 2,
-                                    "max_value": {
-                                        "answer_id": "set-maximum"
-                                    },
-                                    "min_value": {
-                                        "answer_id": "set-minimum"
-                                    }
-                                },
-                                {
-                                    "id": "test-range-exclusive",
-                                    "label": "",
-                                    "description": {
-                                        "text": "Range Exclusive Test ({minimum} to {maximum} Exclusive)",
-                                        "placeholders": [{
-                                                "placeholder": "minimum",
-                                                "transforms": [{
-                                                    "transform": "format_number",
-                                                    "arguments": {
-                                                        "number": {
-                                                            "source": "answers",
-                                                            "identifier": "set-minimum"
-                                                        }
-                                                    }
-                                                }]
-                                            },
-                                            {
-                                                "placeholder": "maximum",
-                                                "transforms": [{
-                                                    "transform": "format_number",
-                                                    "arguments": {
-                                                        "number": {
-                                                            "source": "answers",
-                                                            "identifier": "set-maximum"
-                                                        }
-                                                    }
-                                                }]
-                                            }
-                                        ]
-                                    },
-                                    "mandatory": false,
-                                    "type": "Number",
-                                    "decimal_places": 2,
-                                    "max_value": {
-                                        "answer_id": "set-maximum",
-                                        "exclusive": true
-                                    },
-                                    "min_value": {
-                                        "answer_id": "set-minimum",
-                                        "exclusive": true
-                                    }
-                                },
-                                {
-                                    "id": "test-min",
-                                    "description": "",
-                                    "label": "Min Test (123 to 9,999,999,999)",
-                                    "mandatory": false,
-                                    "type": "Number",
-                                    "min_value": {
-                                        "value": 123
-                                    }
-                                },
-                                {
-                                    "id": "test-max",
-                                    "description": "",
-                                    "label": "Max Test (0 to 1,234)",
-                                    "mandatory": false,
-                                    "type": "Number",
-                                    "max_value": {
-                                        "value": 1234
-                                    }
-                                },
-                                {
-                                    "id": "test-min-exclusive",
-                                    "description": "",
-                                    "label": "Min Exclusive Test (124 to 9,999,999,999 - 123 Exclusive)",
-                                    "mandatory": false,
-                                    "type": "Number",
-                                    "min_value": {
-                                        "value": 123,
-                                        "exclusive": true
-                                    }
-                                },
-                                {
-                                    "id": "test-max-exclusive",
-                                    "description": "",
-                                    "label": "Max Exclusive Test (0 to 1,233 - 1,234 Exclusive)",
-                                    "mandatory": false,
-                                    "type": "Number",
-                                    "max_value": {
-                                        "value": 1234,
-                                        "exclusive": true
-                                    }
-                                },
-                                {
-                                    "id": "test-percent",
-                                    "description": "",
-                                    "label": "Percent Test (0 to 100)",
-                                    "mandatory": false,
-                                    "type": "Percentage",
-                                    "max_value": {
-                                        "value": 100
-                                    }
-                                },
-                                {
-                                    "id": "test-decimal",
-                                    "label": "",
-                                    "description": {
-                                        "text": "Range Exclusive Test ({minimum} to {maximum} Exclusive)",
-                                        "placeholders": [{
-                                                "placeholder": "minimum",
-                                                "transforms": [{
-                                                    "transform": "format_number",
-                                                    "arguments": {
-                                                        "number": {
-                                                            "source": "answers",
-                                                            "identifier": "set-minimum"
-                                                        }
-                                                    }
-                                                }]
-                                            },
-                                            {
-                                                "placeholder": "maximum",
-                                                "transforms": [{
-                                                    "transform": "format_number",
-                                                    "arguments": {
-                                                        "number": {
-                                                            "source": "answers",
-                                                            "identifier": "set-maximum"
-                                                        }
-                                                    }
-                                                }]
-                                            }
-                                        ]
-                                    },
-                                    "mandatory": false,
-                                    "type": "Currency",
-                                    "currency": "GBP",
-                                    "decimal_places": 2,
-                                    "max_value": {
-                                        "answer_id": "set-maximum"
-                                    },
-                                    "min_value": {
-                                        "answer_id": "set-minimum"
-                                    }
-                                }
-                            ],
-                            "id": "test-min-max-range-question",
-                            "title": "Please enter test values (none mandatory)",
-                            "type": "General"
+                        "max_value": {
+                            "value": 1000
+                        }
+                    }, {
+                        "id": "set-maximum",
+                        "description": "This is a description of the maximum value",
+                        "label": "Maximum Value",
+                        "mandatory": true,
+                        "type": "Number",
+                        "decimal_places": 2,
+                        "min_value": {
+                            "value": 1001
                         },
-                        "title": ""
-                    }
-                ],
-                "id": "test",
-                "title": ""
-            },
-            {
-                "blocks": [{
-                    "type": "Summary",
-                    "id": "summary"
-                }],
-                "id": "summary-group",
-                "title": "Summary"
-            }
-        ]
+                        "max_value": {
+                            "value": 10000
+                        }
+                    }],
+                    "description": "",
+                    "id": "set-min-question",
+                    "title": "Please set the minimum and maximum used for future questions",
+                    "type": "General"
+                }
+            }, {
+                "type": "Question",
+                "id": "test-min-max-block",
+                "question": {
+                    "answers": [{
+                        "id": "test-range",
+                        "label": "",
+                        "description": {
+                            "text": "Range Test ({minimum} to {maximum})",
+                            "placeholders": [{
+                                "placeholder": "minimum",
+                                "transforms": [{
+                                    "transform": "format_number",
+                                    "arguments": {
+                                        "number": {
+                                            "source": "answers",
+                                            "identifier": "set-minimum"
+                                        }
+                                    }
+                                }]
+                            }, {
+                                "placeholder": "maximum",
+                                "transforms": [{
+                                    "transform": "format_number",
+                                    "arguments": {
+                                        "number": {
+                                            "source": "answers",
+                                            "identifier": "set-maximum"
+                                        }
+                                    }
+                                }]
+                            }]
+                        },
+                        "mandatory": false,
+                        "type": "Number",
+                        "decimal_places": 2,
+                        "max_value": {
+                            "answer_id": "set-maximum"
+                        },
+                        "min_value": {
+                            "answer_id": "set-minimum"
+                        }
+                    }, {
+                        "id": "test-range-exclusive",
+                        "label": "",
+                        "description": {
+                            "text": "Range Exclusive Test ({minimum} to {maximum} Exclusive)",
+                            "placeholders": [{
+                                "placeholder": "minimum",
+                                "transforms": [{
+                                    "transform": "format_number",
+                                    "arguments": {
+                                        "number": {
+                                            "source": "answers",
+                                            "identifier": "set-minimum"
+                                        }
+                                    }
+                                }]
+                            }, {
+                                "placeholder": "maximum",
+                                "transforms": [{
+                                    "transform": "format_number",
+                                    "arguments": {
+                                        "number": {
+                                            "source": "answers",
+                                            "identifier": "set-maximum"
+                                        }
+                                    }
+                                }]
+                            }]
+                        },
+                        "mandatory": false,
+                        "type": "Number",
+                        "decimal_places": 2,
+                        "max_value": {
+                            "answer_id": "set-maximum",
+                            "exclusive": true
+                        },
+                        "min_value": {
+                            "answer_id": "set-minimum",
+                            "exclusive": true
+                        }
+                    }, {
+                        "id": "test-min",
+                        "description": "",
+                        "label": "Min Test (123 to 9,999,999,999)",
+                        "mandatory": false,
+                        "type": "Number",
+                        "min_value": {
+                            "value": 123
+                        }
+                    }, {
+                        "id": "test-max",
+                        "description": "",
+                        "label": "Max Test (0 to 1,234)",
+                        "mandatory": false,
+                        "type": "Number",
+                        "max_value": {
+                            "value": 1234
+                        }
+                    }, {
+                        "id": "test-min-exclusive",
+                        "description": "",
+                        "label": "Min Exclusive Test (124 to 9,999,999,999 - 123 Exclusive)",
+                        "mandatory": false,
+                        "type": "Number",
+                        "min_value": {
+                            "value": 123,
+                            "exclusive": true
+                        }
+                    }, {
+                        "id": "test-max-exclusive",
+                        "description": "",
+                        "label": "Max Exclusive Test (0 to 1,233 - 1,234 Exclusive)",
+                        "mandatory": false,
+                        "type": "Number",
+                        "max_value": {
+                            "value": 1234,
+                            "exclusive": true
+                        }
+                    }, {
+                        "id": "test-percent",
+                        "description": "",
+                        "label": "Percent Test (0 to 100)",
+                        "mandatory": false,
+                        "type": "Percentage",
+                        "max_value": {
+                            "value": 100
+                        }
+                    }, {
+                        "id": "test-decimal",
+                        "label": "",
+                        "description": {
+                            "text": "Range Exclusive Test ({minimum} to {maximum} Exclusive)",
+                            "placeholders": [{
+                                "placeholder": "minimum",
+                                "transforms": [{
+                                    "transform": "format_number",
+                                    "arguments": {
+                                        "number": {
+                                            "source": "answers",
+                                            "identifier": "set-minimum"
+                                        }
+                                    }
+                                }]
+                            }, {
+                                "placeholder": "maximum",
+                                "transforms": [{
+                                    "transform": "format_number",
+                                    "arguments": {
+                                        "number": {
+                                            "source": "answers",
+                                            "identifier": "set-maximum"
+                                        }
+                                    }
+                                }]
+                            }]
+                        },
+                        "mandatory": false,
+                        "type": "Currency",
+                        "currency": "GBP",
+                        "decimal_places": 2,
+                        "max_value": {
+                            "answer_id": "set-maximum"
+                        },
+                        "min_value": {
+                            "answer_id": "set-minimum"
+                        }
+                    }],
+                    "id": "test-min-max-range-question",
+                    "title": "Please enter test values (none mandatory)",
+                    "type": "General"
+                }
+            }],
+            "id": "test",
+            "title": ""
+        }, {
+            "blocks": [{
+                "type": "Summary",
+                "id": "summary"
+            }],
+            "id": "summary-group",
+            "title": "Summary"
+        }]
     }]
 }

--- a/data-source/json/test_percentage.json
+++ b/data-source/json/test_percentage.json
@@ -26,7 +26,6 @@
             "blocks": [{
                 "type": "Question",
                 "id": "block",
-                "description": "",
                 "question": {
                     "answers": [{
                         "description": "Enter percentage of growth",
@@ -44,7 +43,6 @@
                     "title": "",
                     "type": "General"
                 },
-                "title": "Percentage Input Test",
                 "routing_rules": []
             }],
             "id": "group",

--- a/data-source/json/test_placeholder_full.json
+++ b/data-source/json/test_placeholder_full.json
@@ -20,94 +20,121 @@
         "type": "string"
     }],
     "sections": [{
-            "id": "name-section",
-            "title": "Name Input",
-            "groups": [{
-                "id": "name-group",
-                "title": "",
-                "blocks": [{
-                    "type": "Question",
-                    "id": "name-question",
-                    "title": "What is your name?",
-                    "question": {
+        "id": "name-section",
+        "title": "Name Input",
+        "groups": [{
+            "id": "name-group",
+            "title": "",
+            "blocks": [{
+                "type": "Question",
+                "id": "name-question",
+                "question": {
+                    "description": "",
+                    "id": "primary-name-question",
+                    "title": "Please enter your name",
+                    "type": "General",
+                    "answers": [{
+                        "id": "first-name",
                         "description": "",
-                        "id": "primary-name-question",
-                        "title": "Please enter your name",
-                        "type": "General",
-                        "answers": [{
-                                "id": "first-name",
-                                "description": "",
-                                "label": "First Name",
-                                "mandatory": true,
-                                "type": "TextField"
-                            },
-                            {
-                                "id": "last-name",
-                                "description": "",
-                                "label": "Last Name",
-                                "mandatory": false,
-                                "type": "TextField"
-                            }
-                        ]
-                    }
-                }]
+                        "label": "First Name",
+                        "mandatory": true,
+                        "type": "TextField"
+                    }, {
+                        "id": "last-name",
+                        "description": "",
+                        "label": "Last Name",
+                        "mandatory": false,
+                        "type": "TextField"
+                    }]
+                }
             }]
-        },
-        {
-            "id": "age-input-section",
-            "title": "Age Input",
-            "groups": [{
-                "id": "dob-input-group",
-                "title": "",
-                "blocks": [{
-                    "type": "Question",
-                    "id": "dob-question-block",
-                    "question": {
-                        "description": "",
-                        "id": "dob-question",
-                        "title": {
-                            "text": "What is the date of birth for {person_name}?",
-                            "placeholders": [{
-                                "placeholder": "person_name",
-                                "transforms": [{
-                                    "transform": "concatenate_list",
-                                    "arguments": {
-                                        "list_to_concatenate": {
-                                            "source": "answers",
-                                            "identifier": [
-                                                "first-name",
-                                                "last-name"
-                                            ]
-                                        },
-                                        "delimiter": " "
-                                    }
-                                }]
+        }]
+    }, {
+        "id": "age-input-section",
+        "title": "Age Input",
+        "groups": [{
+            "id": "dob-input-group",
+            "title": "",
+            "blocks": [{
+                "type": "Question",
+                "id": "dob-question-block",
+                "question": {
+                    "description": "",
+                    "id": "dob-question",
+                    "title": {
+                        "text": "What is the date of birth for {person_name}?",
+                        "placeholders": [{
+                            "placeholder": "person_name",
+                            "transforms": [{
+                                "transform": "concatenate_list",
+                                "arguments": {
+                                    "list_to_concatenate": {
+                                        "source": "answers",
+                                        "identifier": ["first-name", "last-name"]
+                                    },
+                                    "delimiter": " "
+                                }
                             }]
-                        },
-                        "type": "General",
-                        "answers": [{
-                            "id": "date-of-birth-answer",
-                            "description": "Enter your date of birth",
-                            "label": "Date of Birth",
-                            "mandatory": true,
-                            "type": "Date"
                         }]
-                    }
-                }]
+                    },
+                    "type": "General",
+                    "answers": [{
+                        "id": "date-of-birth-answer",
+                        "description": "Enter your date of birth",
+                        "label": "Date of Birth",
+                        "mandatory": true,
+                        "type": "Date"
+                    }]
+                }
             }]
-        },
-        {
-            "id": "age-confirmation-section",
-            "title": "Age Confirmation",
-            "groups": [{
-                "blocks": [{
-                    "type": "ConfirmationQuestion",
-                    "id": "confirm-dob-proxy",
-                    "question": {
-                        "id": "confirm-date-of-birth-proxy",
-                        "title": {
-                            "text": "{person_name} is {age_in_years} years old. Is this correct?",
-                            "placeholders": [{
+        }]
+    }, {
+        "id": "age-confirmation-section",
+        "title": "Age Confirmation",
+        "groups": [{
+            "blocks": [{
+                "type": "ConfirmationQuestion",
+                "id": "confirm-dob-proxy",
+                "question": {
+                    "id": "confirm-date-of-birth-proxy",
+                    "title": {
+                        "text": "{person_name} is {age_in_years} years old. Is this correct?",
+                        "placeholders": [{
+                            "placeholder": "person_name",
+                            "transforms": [{
+                                "transform": "concatenate_list",
+                                "arguments": {
+                                    "list_to_concatenate": {
+                                        "source": "answers",
+                                        "identifier": ["first-name", "last-name"]
+                                    },
+                                    "delimiter": " "
+                                }
+                            }]
+                        }, {
+                            "placeholder": "age_in_years",
+                            "transforms": [{
+                                "transform": "calculate_years_difference",
+                                "arguments": {
+                                    "first_date": {
+                                        "source": "answers",
+                                        "identifier": "date-of-birth-answer"
+                                    },
+                                    "second_date": {
+                                        "value": "now"
+                                    }
+                                }
+                            }]
+                        }]
+                    },
+                    "type": "General",
+                    "answers": [{
+                        "id": "confirm-date-of-birth-answer-proxy",
+                        "mandatory": true,
+                        "options": [{
+                            "label": {
+                                "text": "Yes, {person_name} is {age_in_years} years old.",
+                                "placeholders": [{
                                     "placeholder": "person_name",
                                     "transforms": [{
                                         "transform": "concatenate_list",
@@ -119,8 +146,7 @@
                                             "delimiter": " "
                                         }
                                     }]
-                                },
-                                {
+                                }, {
                                     "placeholder": "age_in_years",
                                     "transforms": [{
                                         "transform": "calculate_years_difference",
@@ -134,86 +160,44 @@
                                             }
                                         }
                                     }]
-                                }
-                            ]
-                        },
-                        "type": "General",
-                        "answers": [{
-                            "id": "confirm-date-of-birth-answer-proxy",
-                            "mandatory": true,
-                            "options": [{
-                                    "label": {
-                                        "text": "Yes, {person_name} is {age_in_years} years old.",
-                                        "placeholders": [{
-                                                "placeholder": "person_name",
-                                                "transforms": [{
-                                                    "transform": "concatenate_list",
-                                                    "arguments": {
-                                                        "list_to_concatenate": {
-                                                            "source": "answers",
-                                                            "identifier": ["first-name", "last-name"]
-                                                        },
-                                                        "delimiter": " "
-                                                    }
-                                                }]
-                                            },
-                                            {
-                                                "placeholder": "age_in_years",
-                                                "transforms": [{
-                                                    "transform": "calculate_years_difference",
-                                                    "arguments": {
-                                                        "first_date": {
-                                                            "source": "answers",
-                                                            "identifier": "date-of-birth-answer"
-                                                        },
-                                                        "second_date": {
-                                                            "value": "now"
-                                                        }
-                                                    }
-                                                }]
-                                            }
-                                        ]
-                                    },
-                                    "value": "Yes"
-                                },
-                                {
-                                    "label": "No, I need to change their date of birth",
-                                    "value": "No"
-                                }
-                            ],
-                            "type": "Radio"
-                        }]
-                    },
-                    "routing_rules": [{
-                        "goto": {
-                            "group": "dob-input-group",
-                            "when": [{
-                                "id": "confirm-date-of-birth-answer-proxy",
-                                "condition": "equals",
-                                "value": "No"
-                            }]
-                        }
-                    }, {
-                        "goto": {
-                            "group": "summary-group"
-                        }
+                                }]
+                            },
+                            "value": "Yes"
+                        }, {
+                            "label": "No, I need to change their date of birth",
+                            "value": "No"
+                        }],
+                        "type": "Radio"
                     }]
-                }],
-                "id": "group",
-                "title": ""
-            }]
-        },
-        {
-            "id": "summary-section",
-            "title": "Summary",
-            "groups": [{
-                "blocks": [{
-                    "type": "Summary",
-                    "id": "summary"
-                }],
-                "id": "summary-group",
-                "title": "Summary"
-            }]
-        }
-    ]
+                },
+                "routing_rules": [{
+                    "goto": {
+                        "group": "dob-input-group",
+                        "when": [{
+                            "id": "confirm-date-of-birth-answer-proxy",
+                            "condition": "equals",
+                            "value": "No"
+                        }]
+                    }
+                }, {
+                    "goto": {
+                        "group": "summary-group"
+                    }
+                }]
+            }],
+            "id": "group",
+            "title": ""
+        }]
+    }, {
+        "id": "summary-section",
+        "title": "Summary",
+        "groups": [{
+            "blocks": [{
+                "type": "Summary",
+                "id": "summary"
+            }],
+            "id": "summary-group",
+            "title": "Summary"
+        }]
+    }]
 }

--- a/data-source/json/test_placeholder_metadata.json
+++ b/data-source/json/test_placeholder_metadata.json
@@ -26,16 +26,6 @@
             "blocks": [{
                 "type": "Question",
                 "id": "block",
-                "description": {
-                    "text": "What was the <em>total gross weekly pay</em> paid to employees in the last week of {period}?",
-                    "placeholders": [{
-                        "placeholder": "period",
-                        "value": {
-                            "source": "metadata",
-                            "identifier": "period_id"
-                        }
-                    }]
-                },
                 "question": {
                     "answers": [{
                         "description": "Enter the total gross weekly pay",
@@ -48,7 +38,6 @@
                     "title": "",
                     "type": "General"
                 },
-                "title": "Metadata Placeholder Test",
                 "routing_rules": []
             }],
             "id": "group",

--- a/data-source/json/test_placeholder_transform.json
+++ b/data-source/json/test_placeholder_transform.json
@@ -20,86 +20,81 @@
         "type": "string"
     }],
     "sections": [{
-            "id": "retail-turnover-section",
-            "title": "Retail Turnover Input",
-            "groups": [{
-                "id": "retail-turnover-group",
-                "title": "",
-                "blocks": [{
-                    "type": "Question",
-                    "id": "total-retail-turnover-block",
-                    "title": "What was the total retail turnover?",
-                    "question": {
+        "id": "retail-turnover-section",
+        "title": "Retail Turnover Input",
+        "groups": [{
+            "id": "retail-turnover-group",
+            "title": "",
+            "blocks": [{
+                "type": "Question",
+                "id": "total-retail-turnover-block",
+                "question": {
+                    "description": "",
+                    "id": "total-retail-turnover-question",
+                    "title": "Please enter the total retail turnover",
+                    "type": "General",
+                    "answers": [{
+                        "id": "total-retail-turnover-answer",
                         "description": "",
-                        "id": "total-retail-turnover-question",
-                        "title": "Please enter the total retail turnover",
-                        "type": "General",
-                        "answers": [{
-                            "id": "total-retail-turnover-answer",
-                            "description": "",
-                            "label": "Total Retail Turnover",
-                            "mandatory": true,
-                            "type": "Currency",
-                            "currency": "GBP",
-                            "decimal_places": 2
-                        }]
-                    }
-                }]
+                        "label": "Total Retail Turnover",
+                        "mandatory": true,
+                        "type": "Currency",
+                        "currency": "GBP",
+                        "decimal_places": 2
+                    }]
+                }
             }]
-        },
-        {
-            "id": "percent-input-section",
-            "title": "Reporting Confirmation",
-            "groups": [{
-                "blocks": [{
-                    "type": "Question",
-                    "id": "report-period",
-                    "title": "What was the value of internet sales?",
-                    "question": {
-                        "type": "General",
-                        "id": "total-retail-turnover-confirmation-question",
-                        "title": "Please enter the value of internet sales",
-                        "description": {
-                            "text": "Of the <em>{total_turnover}</em> total retail turnover, what was the value of internet sales?",
-                            "placeholders": [{
-                                "placeholder": "total_turnover",
-                                "transforms": [{
-                                    "transform": "format_currency",
-                                    "arguments": {
-                                        "number": {
-                                            "source": "answers",
-                                            "identifier": "total-retail-turnover-answer"
-                                        }
+        }]
+    }, {
+        "id": "percent-input-section",
+        "title": "Reporting Confirmation",
+        "groups": [{
+            "blocks": [{
+                "type": "Question",
+                "id": "report-period",
+                "question": {
+                    "type": "General",
+                    "id": "total-retail-turnover-confirmation-question",
+                    "title": "Please enter the value of internet sales",
+                    "description": {
+                        "text": "Of the <em>{total_turnover}</em> total retail turnover, what was the value of internet sales?",
+                        "placeholders": [{
+                            "placeholder": "total_turnover",
+                            "transforms": [{
+                                "transform": "format_currency",
+                                "arguments": {
+                                    "number": {
+                                        "source": "answers",
+                                        "identifier": "total-retail-turnover-answer"
                                     }
-                                }]
+                                }
                             }]
-                        },
-                        "answers": [{
-                            "id": "total-retail-turnover-internet-sales-answer",
-                            "description": "",
-                            "label": "Value of Internet Sales",
-                            "mandatory": true,
-                            "type": "Currency",
-                            "currency": "GBP",
-                            "decimal_places": 2
                         }]
-                    }
-                }],
-                "id": "retail-confirmation-group",
-                "title": ""
-            }]
-        },
-        {
-            "id": "summary-section",
-            "title": "Summary",
-            "groups": [{
-                "blocks": [{
-                    "type": "Summary",
-                    "id": "summary"
-                }],
-                "id": "summary-group",
-                "title": "Summary"
-            }]
-        }
-    ]
+                    },
+                    "answers": [{
+                        "id": "total-retail-turnover-internet-sales-answer",
+                        "description": "",
+                        "label": "Value of Internet Sales",
+                        "mandatory": true,
+                        "type": "Currency",
+                        "currency": "GBP",
+                        "decimal_places": 2
+                    }]
+                }
+            }],
+            "id": "retail-confirmation-group",
+            "title": ""
+        }]
+    }, {
+        "id": "summary-section",
+        "title": "Summary",
+        "groups": [{
+            "blocks": [{
+                "type": "Summary",
+                "id": "summary"
+            }],
+            "id": "summary-group",
+            "title": "Summary"
+        }]
+    }]
 }

--- a/data-source/json/test_question_definition.json
+++ b/data-source/json/test_question_definition.json
@@ -24,30 +24,29 @@
             "blocks": [{
                 "type": "Question",
                 "id": "definition-block",
-                "description": "",
                 "question": {
                     "id": "question",
                     "title": "Do you connect a LiFePO4 battery to your <em>photovoltaic system</em> to store surplus energy?",
                     "type": "General",
                     "definitions": [{
-                            "title": "What is a photovoltaic system?",
-                            "content": [{
-                                "description": "A typical photovoltaic system employs solar panels, each comprising a number of solar cells, which generate electrical power. PV installations may be ground-mounted, rooftop mounted or wall mounted. The mount may be fixed, or use a solar tracker to follow the sun across the sky."
-                            }]
-                        },
-                        {
-                            "title": "Why use LiFePO4 batteries?",
-                            "content": [{
+                        "title": "What is a photovoltaic system?",
+                        "contents": [{
+                            "description": "A typical photovoltaic system employs solar panels, each comprising a number of solar cells, which generate electrical power. PV installations may be ground-mounted, rooftop mounted or wall mounted. The mount may be fixed, or use a solar tracker to follow the sun across the sky."
+                        }]
+                    }, {
+                        "title": "Why use LiFePO4 batteries?",
+                        "contents": [{
                                 "title": "3 Benefits of LifePO4 batteries."
-                            }, {
+                            },
+                            {
                                 "list": [
                                     "LifePO4 batteries have a life span 10 times longer than that of traditional lead acid batteries. This dramatically reduces the need for battery changes.",
                                     "Lithium iron phosphate batteries operate with much lower resistance and consequently recharge at a faster rate.",
                                     "LifeP04 lightweight batteries are lighter than lead acid batteries, usually weighing about 1/4 less."
                                 ]
-                            }]
-                        }
-                    ],
+                            }
+                        ]
+                    }],
                     "answers": [{
                         "type": "Radio",
                         "id": "radio-mandatory-answer",
@@ -56,14 +55,11 @@
                             "label": "Yes, I do connect a battery",
                             "value": "yes"
                         }, {
-
                             "label": "No, I don't connect a battery",
                             "value": "no"
-
                         }]
                     }]
-                },
-                "title": "Definition Test"
+                }
             }, {
                 "type": "Summary",
                 "id": "definition-summary"

--- a/data-source/json/test_question_guidance.json
+++ b/data-source/json/test_question_guidance.json
@@ -23,28 +23,28 @@
             "title": "",
             "blocks": [{
                 "type": "Introduction",
-                "id": "introduction",
-                "title": "Introduction",
-                "description": ""
+                "id": "introduction"
             }, {
                 "type": "Question",
                 "id": "block-test-guidance-title",
-                "title": "Section: Test guidance title",
-                "description": "",
                 "question": {
                     "id": "question-test-guidance-title",
                     "title": "Question: Test guidance title",
                     "description": "Testing combinations of the title within guidance",
                     "guidance": {
-                        "content": [{
-                            "title": "This one has a description but no list"
-                        }, {
-                            "description": "No list items below this text"
-                        }, {
-                            "title": "This one has no list or description"
-                        }, {
-                            "description": "title, description, title, description"
-                        }]
+                        "contents": [{
+                                "title": "This one has a description but no list"
+                            },
+                            {
+                                "description": "No list items below this text"
+                            },
+                            {
+                                "title": "This one has no list or description"
+                            },
+                            {
+                                "description": "title, description, title, description"
+                            }
+                        ]
                     },
                     "type": "General",
                     "answers": [{
@@ -58,20 +58,26 @@
             }, {
                 "type": "Question",
                 "id": "block-test-guidance-description",
-                "title": "Section: Test guidance descriptions",
-                "description": "",
                 "question": {
                     "id": "question-test-guidance-description",
                     "title": "Question: Test guidance descriptions",
                     "description": "Tests the descriptions within guidance",
                     "guidance": {
-                        "content": [{
-                            "description": "No title above this text, list below"
-                        }, {
-                            "list": ["Item Include 1", "Item Include 2", "Item Include 3", "Item Include 4"]
-                        }, {
-                            "description": "Just description, no title above this text, no list below"
-                        }]
+                        "contents": [{
+                                "description": "No title above this text, list below"
+                            },
+                            {
+                                "list": [
+                                    "Item Include 1",
+                                    "Item Include 2",
+                                    "Item Include 3",
+                                    "Item Include 4"
+                                ]
+                            },
+                            {
+                                "description": "Just description, no title above this text, no list below"
+                            }
+                        ]
                     },
                     "type": "General",
                     "answers": [{
@@ -85,18 +91,28 @@
             }, {
                 "type": "Question",
                 "id": "block-test-guidance-lists",
-                "title": "Section: Test guidance lists",
-                "description": "",
                 "question": {
                     "id": "question-test-guidance-lists",
                     "title": "Question: Test guidance lists (with no question description below)",
                     "guidance": {
-                        "content": [{
-                            "title": "Title, no description, list follows",
-                            "list": ["Item Include 1", "Item Include 2", "Item Include 3", "Item Include 4"]
-                        }, {
-                            "list": ["List with no title or description 1", "List with no title or description 2", "List with no title or description 3", "List with no title or description 4"]
-                        }]
+                        "contents": [{
+                                "title": "Title, no description, list follows",
+                                "list": [
+                                    "Item Include 1",
+                                    "Item Include 2",
+                                    "Item Include 3",
+                                    "Item Include 4"
+                                ]
+                            },
+                            {
+                                "list": [
+                                    "List with no title or description 1",
+                                    "List with no title or description 2",
+                                    "List with no title or description 3",
+                                    "List with no title or description 4"
+                                ]
+                            }
+                        ]
                     },
                     "type": "General",
                     "answers": [{
@@ -110,13 +126,11 @@
             }, {
                 "type": "Question",
                 "id": "block-test-guidance-content-description",
-                "title": "Section: Test show guidance content description",
-                "description": "",
                 "question": {
                     "id": "question-test-guidance-content-description",
                     "title": "Question: Test show guidance content description",
                     "guidance": {
-                        "content": [{
+                        "contents": [{
                             "description": "Guidance with content description"
                         }]
                     },
@@ -125,7 +139,7 @@
                         "guidance": {
                             "show_guidance": "Show test guidance.",
                             "hide_guidance": "Hide test guidance.",
-                            "content": [{
+                            "contents": [{
                                 "description": "The text here is for description"
                             }]
                         },
@@ -139,13 +153,11 @@
             }, {
                 "type": "Question",
                 "id": "block-test-guidance-content-title",
-                "title": "Section: Test show guidance content title",
-                "description": "",
                 "question": {
                     "id": "question-test-guidance-content-title",
                     "title": "Question: Test show guidance content title",
                     "guidance": {
-                        "content": [{
+                        "contents": [{
                             "description": "Guidance with content title"
                         }]
                     },
@@ -154,7 +166,7 @@
                         "guidance": {
                             "show_guidance": "Show test guidance.",
                             "hide_guidance": "Hide test guidance.",
-                            "content": [{
+                            "contents": [{
                                 "title": "The text here is for a title"
                             }]
                         },
@@ -168,13 +180,11 @@
             }, {
                 "type": "Question",
                 "id": "block-test-guidance-content-list",
-                "title": "Section: Test show guidance content list",
-                "description": "",
                 "question": {
                     "id": "question-test-guidance-content-list",
                     "title": "Question: Test show guidance content list",
                     "guidance": {
-                        "content": [{
+                        "contents": [{
                             "title": "Guidance with content list"
                         }]
                     },
@@ -183,8 +193,12 @@
                         "guidance": {
                             "show_guidance": "Show test guidance.",
                             "hide_guidance": "Hide test guidance.",
-                            "content": [{
-                                "list": ["The text here is for a list", "Another list item", "One more"]
+                            "contents": [{
+                                "list": [
+                                    "The text here is for a list",
+                                    "Another list item",
+                                    "One more"
+                                ]
                             }]
                         },
                         "id": "answer-test-guidance-content-list",
@@ -197,46 +211,75 @@
             }, {
                 "type": "Question",
                 "id": "block-test-guidance-all",
-                "title": "Section: Test guidance all",
-                "description": "",
                 "question": {
                     "id": "question-test-guidance-all",
                     "title": "Question: Test guidance all",
                     "description": "Testing all features of the guidance block enabled together",
                     "guidance": {
-                        "content": [{
-                            "title": "Include"
-                        }, {
-                            "description": "<p>Guidance <b>include</b> description text</p>"
-                        }, {
-                            "list": ["Item Include 1", "Item Include 2", "Item Include 3", "Item Include 4"]
-                        }, {
-                            "title": "Exclude"
-                        }, {
-                            "description": "<p>Guidance <b>exclude</b> description text</p>"
-                        }, {
-                            "list": ["Item Exclude 1", "Item Exclude 2", "Item Exclude 3", "Item Exclude 4"]
-                        }, {
-                            "title": "Other"
-                        }, {
-                            "description": "<p>Guidance <b>other</b> description text</p>"
-                        }, {
-                            "list": ["Item Other 1", "Item Other 2", "Item Other 3", "Item Other 4"]
-                        }]
+                        "contents": [{
+                                "title": "Include"
+                            },
+                            {
+                                "description": "<p>Guidance <b>include</b> description text</p>"
+                            },
+                            {
+                                "list": [
+                                    "Item Include 1",
+                                    "Item Include 2",
+                                    "Item Include 3",
+                                    "Item Include 4"
+                                ]
+                            },
+                            {
+                                "title": "Exclude"
+                            },
+                            {
+                                "description": "<p>Guidance <b>exclude</b> description text</p>"
+                            },
+                            {
+                                "list": [
+                                    "Item Exclude 1",
+                                    "Item Exclude 2",
+                                    "Item Exclude 3",
+                                    "Item Exclude 4"
+                                ]
+                            },
+                            {
+                                "title": "Other"
+                            },
+                            {
+                                "description": "<p>Guidance <b>other</b> description text</p>"
+                            },
+                            {
+                                "list": [
+                                    "Item Other 1",
+                                    "Item Other 2",
+                                    "Item Other 3",
+                                    "Item Other 4"
+                                ]
+                            }
+                        ]
                     },
                     "type": "General",
                     "answers": [{
                         "guidance": {
                             "show_guidance": "Show test guidance.",
                             "hide_guidance": "Hide test guidance.",
-                            "content": [{
-                                "description": "The text here is for a description"
-                            }, {
-                                "description": "Here's some more description text"
-                            }, {
-                                "title": "This text here is the title for the list",
-                                "list": ["The text here is for a list", "Another list item", "One more"]
-                            }]
+                            "contents": [{
+                                    "description": "The text here is for a description"
+                                },
+                                {
+                                    "description": "Here's some more description text"
+                                },
+                                {
+                                    "title": "This text here is the title for the list",
+                                    "list": [
+                                        "The text here is for a list",
+                                        "Another list item",
+                                        "One more"
+                                    ]
+                                }
+                            ]
                         },
                         "id": "answer-test-guidance-all",
                         "label": "Text question",

--- a/data-source/json/test_radio_checkbox_descriptions.json
+++ b/data-source/json/test_radio_checkbox_descriptions.json
@@ -24,8 +24,6 @@
             "blocks": [{
                 "type": "Question",
                 "id": "checkbox-block",
-                "title": "Did this business make major changes in the following areas?",
-                "description": "<p>Include all <strong>new</strong> and <strong>significantly improved</strong> forms of organisation, business structures or practices aimed at raising internal efficiency or the effectiveness of approaching markets and customers.</p>",
                 "question": {
                     "answers": [{
                         "id": "checkbox-answer",
@@ -60,7 +58,6 @@
             }, {
                 "type": "Question",
                 "id": "radio-block",
-                "description": "",
                 "question": {
                     "answers": [{
                         "id": "radio-answer",
@@ -92,8 +89,7 @@
                     "id": "radio-question",
                     "title": "Did this business make major changes in the following areas?",
                     "type": "General"
-                },
-                "title": "Business Strategy and Practices Part Two"
+                }
             }, {
                 "type": "Summary",
                 "id": "summary"

--- a/data-source/json/test_radio_mandatory_with_mandatory_other.json
+++ b/data-source/json/test_radio_mandatory_with_mandatory_other.json
@@ -6,58 +6,51 @@
     "title": "Radio Mandatory with Mandatory Other",
     "theme": "default",
     "metadata": [{
-            "name": "user_id",
-            "type": "string"
-        },
-        {
-            "name": "period_id",
-            "type": "string"
-        },
-        {
-            "name": "ru_name",
-            "type": "string"
-        }
-    ],
+        "name": "user_id",
+        "type": "string"
+    }, {
+        "name": "period_id",
+        "type": "string"
+    }, {
+        "name": "ru_name",
+        "type": "string"
+    }],
     "sections": [{
         "id": "default-section",
         "groups": [{
             "id": "radio",
             "title": "Radio Mandatory with Mandatory Other",
             "blocks": [{
-                    "type": "Question",
-                    "id": "radio-mandatory",
-                    "question": {
-                        "type": "General",
-                        "id": "radio-mandatory-question",
-                        "title": "What is you favourite breakfast item?",
-                        "answers": [{
-                            "type": "Radio",
-                            "id": "radio-mandatory-answer",
-                            "mandatory": true,
-                            "options": [{
-                                    "label": "Toast",
-                                    "value": "Toast"
-                                },
-                                {
-                                    "label": "Other",
-                                    "description": "An answer is required.",
-                                    "value": "Other",
-                                    "detail_answer": {
-                                        "mandatory": true,
-                                        "id": "other-answer-mandatory",
-                                        "label": "Please specify other",
-                                        "type": "TextField"
-                                    }
-                                }
-                            ]
+                "type": "Question",
+                "id": "radio-mandatory",
+                "question": {
+                    "type": "General",
+                    "id": "radio-mandatory-question",
+                    "title": "What is you favourite breakfast item?",
+                    "answers": [{
+                        "type": "Radio",
+                        "id": "radio-mandatory-answer",
+                        "mandatory": true,
+                        "options": [{
+                            "label": "Toast",
+                            "value": "Toast"
+                        }, {
+                            "label": "Other",
+                            "description": "An answer is required.",
+                            "value": "Other",
+                            "detail_answer": {
+                                "mandatory": true,
+                                "id": "other-answer-mandatory",
+                                "label": "Please specify other",
+                                "type": "TextField"
+                            }
                         }]
-                    }
-                },
-                {
-                    "type": "Summary",
-                    "id": "summary"
+                    }]
                 }
-            ]
+            }, {
+                "type": "Summary",
+                "id": "summary"
+            }]
         }]
     }]
 }

--- a/data-source/json/test_radio_multiple_detail_answers.json
+++ b/data-source/json/test_radio_multiple_detail_answers.json
@@ -21,55 +21,50 @@
             "id": "radio",
             "title": "Radio Mandatory with Mandatory Other Overridden Error",
             "blocks": [{
-                    "type": "Question",
-                    "id": "radio-mandatory",
-                    "question": {
-                        "type": "General",
-                        "id": "radio-mandatory-question",
-                        "title": "What is you favourite breakfast item?",
-                        "answers": [{
-                            "type": "Radio",
-                            "id": "radio-mandatory-answer",
-                            "mandatory": true,
-                            "options": [{
-                                    "label": "Toast",
-                                    "value": "Toast"
-                                },
-                                {
-                                    "label": "Eggs",
-                                    "value": "Eggs",
-                                    "detail_answer": {
-                                        "mandatory": false,
-                                        "id": "eggs-answer",
-                                        "label": "Please write your favourite egg type",
-                                        "type": "TextField"
-                                    }
-                                },
-                                {
-                                    "label": "Favourite not listed",
-                                    "description": "An answer is required.",
-                                    "value": "Favourite not listed",
-                                    "detail_answer": {
-                                        "mandatory": true,
-                                        "id": "alternate-answer",
-                                        "label": "Please write your favourite",
-                                        "type": "TextField",
-                                        "validation": {
-                                            "messages": {
-                                                "MANDATORY_TEXTFIELD": "Enter your favourite to continue"
-                                            }
-                                        }
+                "type": "Question",
+                "id": "radio-mandatory",
+                "question": {
+                    "type": "General",
+                    "id": "radio-mandatory-question",
+                    "title": "What is you favourite breakfast item?",
+                    "answers": [{
+                        "type": "Radio",
+                        "id": "radio-mandatory-answer",
+                        "mandatory": true,
+                        "options": [{
+                            "label": "Toast",
+                            "value": "Toast"
+                        }, {
+                            "label": "Eggs",
+                            "value": "Eggs",
+                            "detail_answer": {
+                                "mandatory": false,
+                                "id": "eggs-answer",
+                                "label": "Please write your favourite egg type",
+                                "type": "TextField"
+                            }
+                        }, {
+                            "label": "Favourite not listed",
+                            "description": "An answer is required.",
+                            "value": "Favourite not listed",
+                            "detail_answer": {
+                                "mandatory": true,
+                                "id": "alternate-answer",
+                                "label": "Please write your favourite",
+                                "type": "TextField",
+                                "validation": {
+                                    "messages": {
+                                        "MANDATORY_TEXTFIELD": "Enter your favourite to continue"
                                     }
                                 }
-                            ]
+                            }
                         }]
-                    }
-                },
-                {
-                    "type": "Summary",
-                    "id": "summary"
+                    }]
                 }
-            ]
+            }, {
+                "type": "Summary",
+                "id": "summary"
+            }]
         }]
     }]
 }

--- a/data-source/json/test_routing_answer_comparison.json
+++ b/data-source/json/test_routing_answer_comparison.json
@@ -25,7 +25,6 @@
             "blocks": [{
                 "type": "Question",
                 "id": "route-comparison-1",
-                "description": "",
                 "question": {
                     "answers": [{
                         "id": "route-comparison-1-answer",
@@ -41,7 +40,6 @@
             }, {
                 "type": "Question",
                 "id": "route-comparison-2",
-                "description": "",
                 "question": {
                     "answers": [{
                         "id": "route-comparison-2-answer",
@@ -71,17 +69,21 @@
             }, {
                 "type": "Interstitial",
                 "id": "route-comparison-3",
-                "title": "Your second number was lower or equal",
-                "content": [{
-                    "description": "This page should be skipped if your second answer was higher than your first"
-                }]
+                "content": {
+                    "title": "Your second number was lower or equal",
+                    "contents": [{
+                        "description": "This page should be skipped if your second answer was higher than your first"
+                    }]
+                }
             }, {
                 "type": "Interstitial",
                 "id": "route-comparison-4",
-                "title": "Your second number was higher",
-                "content": [{
-                    "description": "This page should never be skipped"
-                }]
+                "content": {
+                    "title": "Your second number was higher",
+                    "contents": [{
+                        "description": "This page should never be skipped"
+                    }]
+                }
             }]
         }, {
             "id": "summary-group",

--- a/data-source/json/test_routing_checkbox_contains.json
+++ b/data-source/json/test_routing_checkbox_contains.json
@@ -7,108 +7,90 @@
     "theme": "default",
     "description": "A questionnaire to demo checkbox field combined contains routing",
     "metadata": [{
-            "name": "user_id",
-            "type": "string"
-        },
-        {
-            "name": "period_id",
-            "type": "string"
-        },
-        {
-            "name": "ru_name",
-            "type": "string"
-        }
-    ],
+        "name": "user_id",
+        "type": "string"
+    }, {
+        "name": "period_id",
+        "type": "string"
+    }, {
+        "name": "ru_name",
+        "type": "string"
+    }],
     "sections": [{
         "id": "default-section",
         "groups": [{
             "blocks": [{
-                    "type": "Question",
-                    "id": "country-checkbox",
-                    "title": "Country question",
-                    "question": {
-                        "id": "country-checkbox-question",
-                        "title": "Have you visited any of the following countries?",
-                        "type": "General",
-                        "answers": [{
-                            "id": "country-checkbox-answer",
-                            "label": "",
-                            "mandatory": false,
-                            "type": "Checkbox",
-                            "options": [{
-                                    "label": "India",
-                                    "value": "India"
-                                },
-                                {
-                                    "label": "Azerbaijan",
-                                    "value": "Azerbaijan"
-                                },
-                                {
-                                    "label": "Liechtenstein",
-                                    "value": "Liechtenstein"
-                                },
-                                {
-                                    "label": "Malta",
-                                    "value": "Malta"
-                                }
-                            ]
+                "type": "Question",
+                "id": "country-checkbox",
+                "question": {
+                    "id": "country-checkbox-question",
+                    "title": "Have you visited any of the following countries?",
+                    "type": "General",
+                    "answers": [{
+                        "id": "country-checkbox-answer",
+                        "label": "",
+                        "mandatory": false,
+                        "type": "Checkbox",
+                        "options": [{
+                            "label": "India",
+                            "value": "India"
+                        }, {
+                            "label": "Azerbaijan",
+                            "value": "Azerbaijan"
+                        }, {
+                            "label": "Liechtenstein",
+                            "value": "Liechtenstein"
+                        }, {
+                            "label": "Malta",
+                            "value": "Malta"
                         }]
-                    },
-                    "routing_rules": [{
-                            "goto": {
-                                "block": "country-interstitial-all",
-                                "when": [{
-                                    "id": "country-checkbox-answer",
-                                    "condition": "contains all",
-                                    "values": [
-                                        "India",
-                                        "Azerbaijan",
-                                        "Liechtenstein"
-                                    ]
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "country-interstitial-any",
-                                "when": [{
-                                    "id": "country-checkbox-answer",
-                                    "condition": "contains any",
-                                    "values": [
-                                        "India",
-                                        "Azerbaijan"
-                                    ]
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "summary"
-                            }
-                        }
-                    ]
+                    }]
                 },
-                {
-                    "id": "country-interstitial-any",
+                "routing_rules": [{
+                    "goto": {
+                        "block": "country-interstitial-all",
+                        "when": [{
+                            "id": "country-checkbox-answer",
+                            "condition": "contains all",
+                            "values": ["India", "Azerbaijan", "Liechtenstein"]
+                        }]
+                    }
+                }, {
+                    "goto": {
+                        "block": "country-interstitial-any",
+                        "when": [{
+                            "id": "country-checkbox-answer",
+                            "condition": "contains any",
+                            "values": ["India", "Azerbaijan"]
+                        }]
+                    }
+                }, {
+                    "goto": {
+                        "block": "summary"
+                    }
+                }]
+            }, {
+                "id": "country-interstitial-any",
+                "type": "Interstitial",
+                "content": {
                     "title": "Condition: Contains Any",
-                    "type": "Interstitial",
-                    "content": [{
+                    "contents": [{
                         "description": "You chose India or Azerbaijan."
                     }]
-                },
-                {
-                    "id": "country-interstitial-all",
+                }
+            }, {
+                "id": "country-interstitial-all",
+                "type": "Interstitial",
+                "content": {
                     "title": "Condition: Contains All",
-                    "type": "Interstitial",
-                    "content": [{
+                    "contents": [{
                         "description": "You chose India, Azerbaijan and Liechtenstein."
                     }]
-                },
-                {
-                    "type": "Summary",
-                    "id": "summary"
                 }
-            ],
+            }, {
+                "type": "Summary",
+                "id": "summary"
+            }],
             "id": "checkboxes",
             "title": ""
         }]

--- a/data-source/json/test_routing_checkbox_set_not_set.json
+++ b/data-source/json/test_routing_checkbox_set_not_set.json
@@ -20,143 +20,140 @@
         "id": "default-section",
         "groups": [{
             "blocks": [{
-                    "type": "Question",
-                    "id": "topping-checkbox",
-                    "description": "",
-                    "question": {
-                        "answers": [{
-                            "id": "topping-checkbox-answer",
-                            "label": "",
-                            "mandatory": false,
-                            "options": [{
-                                "label": "None",
-                                "value": "None"
-                            }, {
-                                "label": "Cheese",
-                                "value": "Cheese"
-                            }, {
-                                "label": "Ham",
-                                "value": "Ham"
-                            }, {
-                                "label": "Pineapple",
-                                "value": "Pineapple"
-                            }, {
-                                "label": "Tuna",
-                                "value": "Tuna"
-                            }, {
-                                "label": "Pepperoni",
-                                "value": "Pepperoni"
-                            }, {
-                                "label": "Other",
-                                "value": "Other",
-                                "description": "Choose any other topping",
-                                "detail_answer": {
-                                    "mandatory": false,
-                                    "id": "other-answer-topping",
-                                    "label": "Please specify other",
-                                    "type": "TextField"
-                                }
-                            }],
-                            "type": "Checkbox",
-                            "validation": {
-                                "messages": {}
+                "type": "Question",
+                "id": "topping-checkbox",
+                "question": {
+                    "answers": [{
+                        "id": "topping-checkbox-answer",
+                        "label": "",
+                        "mandatory": false,
+                        "options": [{
+                            "label": "None",
+                            "value": "None"
+                        }, {
+                            "label": "Cheese",
+                            "value": "Cheese"
+                        }, {
+                            "label": "Ham",
+                            "value": "Ham"
+                        }, {
+                            "label": "Pineapple",
+                            "value": "Pineapple"
+                        }, {
+                            "label": "Tuna",
+                            "value": "Tuna"
+                        }, {
+                            "label": "Pepperoni",
+                            "value": "Pepperoni"
+                        }, {
+                            "label": "Other",
+                            "value": "Other",
+                            "description": "Choose any other topping",
+                            "detail_answer": {
+                                "mandatory": false,
+                                "id": "other-answer-topping",
+                                "label": "Please specify other",
+                                "type": "TextField"
                             }
                         }],
-                        "description": "",
-                        "id": "topping-checkbox-question",
-                        "title": "What extra toppings would you like?",
-                        "type": "General"
-                    },
-                    "title": "Topping question",
-                    "routing_rules": []
+                        "type": "Checkbox",
+                        "validation": {
+                            "messages": {}
+                        }
+                    }],
+                    "description": "",
+                    "id": "topping-checkbox-question",
+                    "title": "What extra toppings would you like?",
+                    "type": "General"
                 },
-                {
-                    "id": "topping-interstitial-set",
-                    "title": "Topping Interstitial Page",
-                    "content": [{
+                "routing_rules": []
+            }, {
+                "id": "topping-interstitial-set",
+                "content": {
+                    "title": "Topping selected",
+                    "contents": [{
                         "description": "You selected a topping"
-                    }],
-                    "type": "Interstitial",
-                    "skip_conditions": [{
-                        "when": [{
-                            "id": "topping-checkbox-answer",
-                            "condition": "not set"
-                        }]
                     }]
                 },
-                {
-                    "id": "topping-interstitial-not-set",
-                    "title": "Topping Interstitial Page",
-                    "content": [{
+                "type": "Interstitial",
+                "skip_conditions": [{
+                    "when": [{
+                        "id": "topping-checkbox-answer",
+                        "condition": "not set"
+                    }]
+                }]
+            }, {
+                "id": "topping-interstitial-not-set",
+                "content": {
+                    "title": "Topping not selected",
+                    "contents": [{
                         "description": "You did not select a topping"
-                    }],
-                    "type": "Interstitial",
-                    "skip_conditions": [{
-                        "when": [{
-                            "id": "topping-checkbox-answer",
-                            "condition": "set"
-                        }]
                     }]
                 },
-                {
-                    "type": "Question",
-                    "id": "optional-mutually-exclusive",
-                    "question": {
-                        "answers": [{
-                            "id": "optional-mutually-exclusive-answer",
-                            "mandatory": false,
-                            "options": [{
-                                    "label": "Cheddar",
-                                    "value": "Cheddar"
-                                },
-                                {
-                                    "label": "Mozzarella",
-                                    "value": "Mozzarella"
-                                },
-                                {
-                                    "label": "I don't like cheese",
-                                    "value": "No cheese"
-                                }
-                            ],
-                            "type": "Checkbox"
+                "type": "Interstitial",
+                "skip_conditions": [{
+                    "when": [{
+                        "id": "topping-checkbox-answer",
+                        "condition": "set"
+                    }]
+                }]
+            }, {
+                "type": "Question",
+                "id": "optional-mutually-exclusive",
+                "question": {
+                    "answers": [{
+                        "id": "optional-mutually-exclusive-answer",
+                        "mandatory": false,
+                        "options": [{
+                            "label": "Cheddar",
+                            "value": "Cheddar"
+                        }, {
+                            "label": "Mozzarella",
+                            "value": "Mozzarella"
+                        }, {
+                            "label": "I don't like cheese",
+                            "value": "No cheese"
                         }],
-                        "id": "optional-mutually-exclusive-question",
-                        "title": "What is your favourite cheese?",
-                        "type": "General"
-                    },
-                    "title": "Optional question"
-                },
-                {
-                    "id": "cheese-interstitial-set",
-                    "title": "Cheese Interstitial Page",
-                    "type": "Interstitial",
-                    "content": [{
-                        "description": "You selected an option for the cheese question"
+                        "type": "Checkbox"
                     }],
-                    "skip_conditions": [{
-                        "when": [{
-                            "id": "optional-mutually-exclusive-answer",
-                            "condition": "not set"
-                        }]
-                    }]
-                }, {
-                    "id": "cheese-interstitial-not-set",
-                    "title": "Cheese Interstitial Page",
-                    "type": "Interstitial",
-                    "content": [{
-                        "description": "You did not select an option for the cheese question"
-                    }],
-                    "skip_conditions": [{
-                        "when": [{
-                            "id": "optional-mutually-exclusive-answer",
-                            "condition": "set"
-                        }]
-                    }]
-                }, {
-                    "type": "Summary",
-                    "id": "summary"
+                    "id": "optional-mutually-exclusive-question",
+                    "title": "What is your favourite cheese?",
+                    "type": "General"
                 }
-            ],
+            }, {
+                "id": "cheese-interstitial-set",
+                "type": "Interstitial",
+                "content": {
+                    "title": "Cheese selected",
+                    "contents": [{
+                        "description": "You selected an option for the cheese question"
+                    }]
+                },
+                "skip_conditions": [{
+                    "when": [{
+                        "id": "optional-mutually-exclusive-answer",
+                        "condition": "not set"
+                    }]
+                }]
+            }, {
+                "id": "cheese-interstitial-not-set",
+                "type": "Interstitial",
+                "content": {
+                    "title": "Cheese not selected",
+                    "contents": [{
+                        "description": "You did not select an option for the cheese question"
+                    }]
+                },
+                "skip_conditions": [{
+                    "when": [{
+                        "id": "optional-mutually-exclusive-answer",
+                        "condition": "set"
+                    }]
+                }]
+            }, {
+                "type": "Summary",
+                "id": "summary"
+            }],
             "id": "checkboxes",
             "title": ""
         }]

--- a/data-source/json/test_routing_date_equals.json
+++ b/data-source/json/test_routing_date_equals.json
@@ -22,7 +22,6 @@
             "blocks": [{
                 "type": "Question",
                 "id": "comparison-date-block",
-                "description": "",
                 "question": {
                     "answers": [{
                         "id": "comparison-date-answer",
@@ -36,17 +35,23 @@
                     "title": "",
                     "type": "General",
                     "guidance": {
-                        "content": [{
+                        "contents": [{
                             "title": "If you enter 31/03/2018 the following dates will be valid",
-                            "list": ["Yesterday 30/03/2018", "Today 31/03/2018", "Tomorrow 01/04/2018", "Last Month 28/02/2018 (28th as no 31st February)", "Next Month 30/04/2018 (30th as no 31st April)", "Last Year 31/03/2017", "Next Year 31/03/2019"]
+                            "list": [
+                                "Yesterday 30/03/2018",
+                                "Today 31/03/2018",
+                                "Tomorrow 01/04/2018",
+                                "Last Month 28/02/2018 (28th as no 31st February)",
+                                "Next Month 30/04/2018 (30th as no 31st April)",
+                                "Last Year 31/03/2017",
+                                "Next Year 31/03/2019"
+                            ]
                         }]
                     }
-                },
-                "title": "Date To Compare"
+                }
             }, {
                 "type": "Question",
                 "id": "date-question",
-                "description": "",
                 "question": {
                     "answers": [{
                         "id": "single-date-answer",
@@ -74,7 +79,6 @@
                     },
                     "type": "General"
                 },
-                "title": "",
                 "routing_rules": [{
                     "goto": {
                         "block": "correct-answer",
@@ -178,10 +182,12 @@
             }, {
                 "type": "Interstitial",
                 "id": "incorrect-answer",
-                "title": "Incorrect Date",
-                "content": [{
-                    "description": "You entered an incorrect date"
-                }],
+                "content": {
+                    "title": "Incorrect Date",
+                    "contents": [{
+                        "description": "You entered an incorrect date"
+                    }]
+                },
                 "routing_rules": [{
                     "goto": {
                         "block": "summary"
@@ -190,10 +196,12 @@
             }, {
                 "type": "Interstitial",
                 "id": "correct-answer",
-                "title": "Correct Date",
-                "content": [{
-                    "description": "You entered a correct date."
-                }]
+                "content": {
+                    "title": "Correct Date",
+                    "contents": [{
+                        "description": "You entered a correct date."
+                    }]
+                }
             }, {
                 "type": "Summary",
                 "id": "summary"

--- a/data-source/json/test_routing_date_greater_than.json
+++ b/data-source/json/test_routing_date_greater_than.json
@@ -70,25 +70,27 @@
             }, {
                 "type": "Interstitial",
                 "id": "incorrect-answer",
-                "title": "Incorrect Date",
-                "content": [{
-                    "description": {
-                        "text": "You entered a return date earlier than {date}",
-                        "placeholders": [{
-                            "placeholder": "date",
-                            "transforms": [{
-                                "transform": "format_date",
-                                "arguments": {
-                                    "date_to_format": {
-                                        "source": "metadata",
-                                        "identifier": "return_by"
-                                    },
-                                    "date_format": "d MMMM YYYY"
-                                }
+                "content": {
+                    "title": "Incorrect answer",
+                    "contents": [{
+                        "description": {
+                            "text": "You entered a return date earlier than {date}",
+                            "placeholders": [{
+                                "placeholder": "date",
+                                "transforms": [{
+                                    "transform": "format_date",
+                                    "arguments": {
+                                        "date_to_format": {
+                                            "source": "metadata",
+                                            "identifier": "return_by"
+                                        },
+                                        "date_format": "d MMMM YYYY"
+                                    }
+                                }]
                             }]
-                        }]
-                    }
-                }],
+                        }
+                    }]
+                },
                 "routing_rules": [{
                     "goto": {
                         "block": "summary"
@@ -97,25 +99,27 @@
             }, {
                 "type": "Interstitial",
                 "id": "correct-answer",
-                "title": "Correct Date",
-                "content": [{
-                    "description": {
-                        "text": "You entered a return date later than {date}",
-                        "placeholders": [{
-                            "placeholder": "date",
-                            "transforms": [{
-                                "transform": "format_date",
-                                "arguments": {
-                                    "date_to_format": {
-                                        "source": "metadata",
-                                        "identifier": "return_by"
-                                    },
-                                    "date_format": "d MMMM YYYY"
-                                }
+                "content": {
+                    "title": "Correct answer",
+                    "contents": [{
+                        "description": {
+                            "text": "You entered a return date later than {date}",
+                            "placeholders": [{
+                                "placeholder": "date",
+                                "transforms": [{
+                                    "transform": "format_date",
+                                    "arguments": {
+                                        "date_to_format": {
+                                            "source": "metadata",
+                                            "identifier": "return_by"
+                                        },
+                                        "date_format": "d MMMM YYYY"
+                                    }
+                                }]
                             }]
-                        }]
-                    }
-                }]
+                        }
+                    }]
+                }
             }, {
                 "type": "Summary",
                 "id": "summary"

--- a/data-source/json/test_routing_date_less_than.json
+++ b/data-source/json/test_routing_date_less_than.json
@@ -22,7 +22,6 @@
             "blocks": [{
                 "type": "Question",
                 "id": "date-question",
-                "description": "",
                 "question": {
                     "answers": [{
                         "id": "single-date-answer",
@@ -35,7 +34,6 @@
                     "title": "Enter a date less than Today",
                     "type": "General"
                 },
-                "title": "",
                 "routing_rules": [{
                     "goto": {
                         "block": "correct-answer",
@@ -55,10 +53,12 @@
             }, {
                 "type": "Interstitial",
                 "id": "incorrect-answer",
-                "title": "Incorrect Date",
-                "content": [{
-                    "description": "You entered a date later than yesterday."
-                }],
+                "content": {
+                    "title": "Incorrect answer",
+                    "contents": [{
+                        "description": "You entered a date later than yesterday."
+                    }]
+                },
                 "routing_rules": [{
                     "goto": {
                         "block": "summary"
@@ -67,10 +67,12 @@
             }, {
                 "type": "Interstitial",
                 "id": "correct-answer",
-                "title": "Correct Date",
-                "content": [{
-                    "description": "You entered a date older than Today."
-                }]
+                "content": {
+                    "title": "Correct answer",
+                    "contents": [{
+                        "description": "You entered a date older than Today."
+                    }]
+                }
             }, {
                 "type": "Summary",
                 "id": "summary"

--- a/data-source/json/test_routing_date_not_equals.json
+++ b/data-source/json/test_routing_date_not_equals.json
@@ -22,7 +22,6 @@
             "blocks": [{
                 "type": "Question",
                 "id": "date-question",
-                "description": "",
                 "question": {
                     "answers": [{
                         "id": "single-date-answer",
@@ -35,7 +34,6 @@
                     "title": "Enter a date other than 28 February 2018",
                     "type": "General"
                 },
-                "title": "",
                 "routing_rules": [{
                     "goto": {
                         "block": "correct-answer",
@@ -55,10 +53,12 @@
             }, {
                 "type": "Interstitial",
                 "id": "incorrect-answer",
-                "title": "Incorrect Date",
-                "content": [{
-                    "description": "You entered 28 February 2018."
-                }],
+                "content": {
+                    "title": "Incorrect Date",
+                    "contents": [{
+                        "description": "You entered 28 February 2018."
+                    }]
+                },
                 "routing_rules": [{
                     "goto": {
                         "block": "summary"
@@ -67,10 +67,12 @@
             }, {
                 "type": "Interstitial",
                 "id": "correct-answer",
-                "title": "Correct Date",
-                "content": [{
-                    "description": "You entered a date other than 28 February 2018."
-                }]
+                "content": {
+                    "title": "Correct Date",
+                    "contents": [{
+                        "description": "You entered a date other than 28 February 2018."
+                    }]
+                }
             }, {
                 "type": "Summary",
                 "id": "summary"

--- a/data-source/json/test_routing_group.json
+++ b/data-source/json/test_routing_group.json
@@ -23,8 +23,6 @@
             "blocks": [{
                 "type": "Question",
                 "id": "which-group-block",
-                "description": "",
-                "title": "Pick your next group?",
                 "question": {
                     "description": "",
                     "id": "which-group-question",
@@ -69,8 +67,6 @@
                 "type": "Question",
                 "id": "group1-block",
                 "routing_rules": [],
-                "description": "",
-                "title": "Did you want Group 1?",
                 "question": {
                     "description": "",
                     "id": "group1-question",
@@ -91,8 +87,6 @@
                 "type": "Question",
                 "id": "group2-block",
                 "routing_rules": [],
-                "description": "",
-                "title": "Did you want Group 2?",
                 "question": {
                     "description": "",
                     "id": "group2-question",

--- a/data-source/json/test_routing_not_affected_by_answers_not_on_path.json
+++ b/data-source/json/test_routing_not_affected_by_answers_not_on_path.json
@@ -25,7 +25,7 @@
                 "question": {
                     "type": "General",
                     "id": "initial-choice-question",
-                    "title": "Answer First, then, after answering a quesiton, go back to this question and answer Second",
+                    "title": "Answer First, then, after answering a question, go back to this question and answer Second",
                     "answers": [{
                         "type": "Radio",
                         "id": "initial-choice-answer",
@@ -40,26 +40,22 @@
                     }]
                 },
                 "routing_rules": [{
-                        "goto": {
-                            "block": "valid-path",
-                            "when": [{
-                                "id": "initial-choice-answer",
-                                "condition": "equals",
-                                "value": "Second"
-                            }]
-                        }
-                    },
-                    {
-                        "goto": {
-                            "block": "invalid-path"
-                        }
+                    "goto": {
+                        "block": "valid-path",
+                        "when": [{
+                            "id": "initial-choice-answer",
+                            "condition": "equals",
+                            "value": "Second"
+                        }]
                     }
-                ]
+                }, {
+                    "goto": {
+                        "block": "invalid-path"
+                    }
+                }]
             }, {
                 "type": "Question",
                 "id": "invalid-path",
-                "title": "",
-                "description": "Enter an answer and continue",
                 "question": {
                     "answers": [{
                         "id": "invalid-path-answer",
@@ -74,10 +70,12 @@
             }, {
                 "type": "Interstitial",
                 "id": "invalid-path-interstitial",
-                "title": "You now have an answer that could be invalid in the store.",
-                "content": [{
-                    "description": "Go back to the first question and choose the second path."
-                }],
+                "content": {
+                    "title": "You now have an answer that could be invalid in the store.",
+                    "contents": [{
+                        "description": "Go back to the first question and choose the second path."
+                    }]
+                },
                 "routing_rules": [{
                     "goto": {
                         "block": "summary"
@@ -86,8 +84,6 @@
             }, {
                 "type": "Question",
                 "id": "valid-path",
-                "title": "Route page",
-                "description": "This page should take you to the valid page. If it takes you to the invalid page then routing is using an answer that isn't on the routing path",
                 "question": {
                     "answers": [{
                         "id": "valid-path-answer",
@@ -115,10 +111,12 @@
             }, {
                 "type": "Interstitial",
                 "id": "valid-skipped-interstitial",
-                "title": "This page should have been skipped!",
-                "content": [{
-                    "description": ""
-                }],
+                "content": {
+                    "title": "This page should have been skipped!",
+                    "contents": [{
+                        "description": ""
+                    }]
+                },
                 "skip_conditions": [{
                     "when": [{
                         "id": "invalid-path-answer",
@@ -128,10 +126,12 @@
             }, {
                 "type": "Interstitial",
                 "id": "valid-final-interstitial",
-                "title": "You were routed correctly!",
-                "content": [{
-                    "description": ""
-                }],
+                "content": {
+                    "title": "You were routed correctly!",
+                    "contents": [{
+                        "description": ""
+                    }]
+                },
                 "routing_rules": [{
                     "goto": {
                         "block": "summary"
@@ -140,10 +140,12 @@
             }, {
                 "type": "Interstitial",
                 "id": "invalid-final-interstitial",
-                "title": "You were routed incorrectly.",
-                "content": [{
-                    "description": ""
-                }],
+                "content": {
+                    "title": "You were routed incorrectly!",
+                    "contents": [{
+                        "description": ""
+                    }]
+                },
                 "routing_rules": [{
                     "goto": {
                         "block": "summary"

--- a/data-source/json/test_routing_number_equals.json
+++ b/data-source/json/test_routing_number_equals.json
@@ -22,7 +22,6 @@
             "blocks": [{
                 "type": "Question",
                 "id": "number-question",
-                "description": "",
                 "question": {
                     "answers": [{
                         "id": "answer",
@@ -34,7 +33,6 @@
                     "title": "Enter the number 123",
                     "type": "General"
                 },
-                "title": "Number Routing Equals",
                 "routing_rules": [{
                     "goto": {
                         "block": "correct-answer",
@@ -52,19 +50,21 @@
             }, {
                 "type": "Interstitial",
                 "id": "incorrect-answer",
-                "title": "You did not enter 123",
-                "content": [{
-                    "description": {
-                        "text": "You were asked to enter <em>123</em> but you actually entered <em>{answer}</em>.",
-                        "placeholders": [{
-                            "placeholder": "answer",
-                            "value": {
-                                "source": "answers",
-                                "identifier": "answer"
-                            }
-                        }]
-                    }
-                }],
+                "content": {
+                    "title": "You did not enter 123",
+                    "contents": [{
+                        "description": {
+                            "text": "You were asked to enter <em>123</em> but you actually entered <em>{answer}</em>.",
+                            "placeholders": [{
+                                "placeholder": "answer",
+                                "value": {
+                                    "source": "answers",
+                                    "identifier": "answer"
+                                }
+                            }]
+                        }
+                    }]
+                },
                 "routing_rules": [{
                     "goto": {
                         "block": "summary"
@@ -73,19 +73,21 @@
             }, {
                 "type": "Interstitial",
                 "id": "correct-answer",
-                "title": "You entered 123",
-                "content": [{
-                    "description": {
-                        "text": "You were asked to enter <em>123</em> and you entered <em>{answer}</em>.",
-                        "placeholders": [{
-                            "placeholder": "answer",
-                            "value": {
-                                "source": "answers",
-                                "identifier": "answer"
-                            }
-                        }]
-                    }
-                }]
+                "content": {
+                    "title": "Correct",
+                    "contents": [{
+                        "description": {
+                            "text": "You were asked to enter <em>123</em> and you entered <em>{answer}</em>.",
+                            "placeholders": [{
+                                "placeholder": "answer",
+                                "value": {
+                                    "source": "answers",
+                                    "identifier": "answer"
+                                }
+                            }]
+                        }
+                    }]
+                }
             }, {
                 "type": "Summary",
                 "id": "summary"

--- a/data-source/json/test_routing_number_greater_than.json
+++ b/data-source/json/test_routing_number_greater_than.json
@@ -22,7 +22,6 @@
             "blocks": [{
                 "type": "Question",
                 "id": "number-question",
-                "description": "",
                 "question": {
                     "answers": [{
                         "id": "answer",
@@ -34,7 +33,6 @@
                     "title": "Enter the number greater than 123",
                     "type": "General"
                 },
-                "title": "Number Routing Greater Than",
                 "routing_rules": [{
                     "goto": {
                         "block": "correct-answer",
@@ -52,19 +50,21 @@
             }, {
                 "type": "Interstitial",
                 "id": "incorrect-answer",
-                "title": "You entered a number that was not greater than 123",
-                "content": [{
-                    "description": {
-                        "text": "You were asked to enter a number greater than <em>123</em> but you entered <em>{answer}</em>.",
-                        "placeholders": [{
-                            "placeholder": "answer",
-                            "value": {
-                                "source": "answers",
-                                "identifier": "answer"
-                            }
-                        }]
-                    }
-                }],
+                "content": {
+                    "title": "Incorrect answer",
+                    "contents": [{
+                        "description": {
+                            "text": "You were asked to enter a number greater than <em>123</em> but you entered <em>{answer}</em>.",
+                            "placeholders": [{
+                                "placeholder": "answer",
+                                "value": {
+                                    "source": "answers",
+                                    "identifier": "answer"
+                                }
+                            }]
+                        }
+                    }]
+                },
                 "routing_rules": [{
                     "goto": {
                         "block": "summary"
@@ -73,19 +73,21 @@
             }, {
                 "type": "Interstitial",
                 "id": "correct-answer",
-                "title": "You entered a number greater than 123",
-                "content": [{
-                    "description": {
-                        "text": "You were asked to enter a number greater than <em>123</em> and you entered <em>{answer}</em>.",
-                        "placeholders": [{
-                            "placeholder": "answer",
-                            "value": {
-                                "source": "answers",
-                                "identifier": "answer"
-                            }
-                        }]
-                    }
-                }]
+                "content": {
+                    "title": "Correct answer",
+                    "contents": [{
+                        "description": {
+                            "text": "You were asked to enter a number greater than <em>123</em> and you entered <em>{answer}</em>.",
+                            "placeholders": [{
+                                "placeholder": "answer",
+                                "value": {
+                                    "source": "answers",
+                                    "identifier": "answer"
+                                }
+                            }]
+                        }
+                    }]
+                }
             }, {
                 "type": "Summary",
                 "id": "summary"

--- a/data-source/json/test_routing_number_greater_than_or_equal.json
+++ b/data-source/json/test_routing_number_greater_than_or_equal.json
@@ -22,7 +22,6 @@
             "blocks": [{
                 "type": "Question",
                 "id": "number-question",
-                "description": "",
                 "question": {
                     "answers": [{
                         "id": "answer",
@@ -34,7 +33,6 @@
                     "title": "Enter the number greater than or equal to 123",
                     "type": "General"
                 },
-                "title": "Number Routing Greater Than or Equal",
                 "routing_rules": [{
                     "goto": {
                         "block": "correct-answer",
@@ -61,19 +59,21 @@
             }, {
                 "type": "Interstitial",
                 "id": "incorrect-answer",
-                "title": "You entered a number that was not greater than or equal 123",
-                "content": [{
-                    "description": {
-                        "text": "You were asked to enter a number greater than or equal to <em>123</em> but you entered <em>{answer}</em>.",
-                        "placeholders": [{
-                            "placeholder": "answer",
-                            "value": {
-                                "source": "answers",
-                                "identifier": "answer"
-                            }
-                        }]
-                    }
-                }],
+                "content": {
+                    "title": "Incorrect answer",
+                    "contents": [{
+                        "description": {
+                            "text": "You were asked to enter a number greater than or equal to <em>123</em> but you entered <em>{answer}</em>.",
+                            "placeholders": [{
+                                "placeholder": "answer",
+                                "value": {
+                                    "source": "answers",
+                                    "identifier": "answer"
+                                }
+                            }]
+                        }
+                    }]
+                },
                 "routing_rules": [{
                     "goto": {
                         "block": "summary"
@@ -82,19 +82,21 @@
             }, {
                 "type": "Interstitial",
                 "id": "correct-answer",
-                "title": "You entered a number greater than or equal to 123",
-                "content": [{
-                    "description": {
-                        "text": "You were asked to enter a number greater than or equal to <em>123</em> and you entered <em>{answer}</em>.",
-                        "placeholders": [{
-                            "placeholder": "answer",
-                            "value": {
-                                "source": "answers",
-                                "identifier": "answer"
-                            }
-                        }]
-                    }
-                }]
+                "content": {
+                    "title": "Correct answer",
+                    "contents": [{
+                        "description": {
+                            "text": "You were asked to enter a number greater than or equal to <em>123</em> and you entered <em>{answer}</em>.",
+                            "placeholders": [{
+                                "placeholder": "answer",
+                                "value": {
+                                    "source": "answers",
+                                    "identifier": "answer"
+                                }
+                            }]
+                        }
+                    }]
+                }
             }, {
                 "type": "Summary",
                 "id": "summary"

--- a/data-source/json/test_routing_number_greater_than_or_equal_single_condition.json
+++ b/data-source/json/test_routing_number_greater_than_or_equal_single_condition.json
@@ -7,59 +7,52 @@
     "theme": "default",
     "description": "A test survey for routing based on a number greater than or equal",
     "metadata": [{
-            "name": "user_id",
-            "type": "string"
-        },
-        {
-            "name": "period_id",
-            "type": "string"
-        },
-        {
-            "name": "ru_name",
-            "type": "string"
-        }
-    ],
+        "name": "user_id",
+        "type": "string"
+    }, {
+        "name": "period_id",
+        "type": "string"
+    }, {
+        "name": "ru_name",
+        "type": "string"
+    }],
     "sections": [{
         "id": "default-section",
         "groups": [{
             "blocks": [{
-                    "type": "Question",
-                    "id": "number-question",
-                    "description": "",
-                    "question": {
-                        "answers": [{
-                            "id": "answer",
-                            "mandatory": true,
-                            "type": "Number",
-                            "label": "123 or greater"
-                        }],
-                        "id": "question",
-                        "title": "Enter the number greater than or equal to 123",
-                        "type": "General"
-                    },
-                    "title": "Number Routing Greater Than or Equal",
-                    "routing_rules": [{
-                            "goto": {
-                                "block": "correct-answer",
-                                "when": [{
-                                    "id": "answer",
-                                    "condition": "greater than or equal to",
-                                    "value": 123
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "incorrect-answer"
-                            }
-                        }
-                    ]
+                "type": "Question",
+                "id": "number-question",
+                "question": {
+                    "answers": [{
+                        "id": "answer",
+                        "mandatory": true,
+                        "type": "Number",
+                        "label": "123 or greater"
+                    }],
+                    "id": "question",
+                    "title": "Enter the number greater than or equal to 123",
+                    "type": "General"
                 },
-                {
-                    "type": "Interstitial",
-                    "id": "incorrect-answer",
-                    "title": "You entered a number that was not greater than or equal 123",
-                    "content": [{
+                "routing_rules": [{
+                    "goto": {
+                        "block": "correct-answer",
+                        "when": [{
+                            "id": "answer",
+                            "condition": "greater than or equal to",
+                            "value": 123
+                        }]
+                    }
+                }, {
+                    "goto": {
+                        "block": "incorrect-answer"
+                    }
+                }]
+            }, {
+                "type": "Interstitial",
+                "id": "incorrect-answer",
+                "content": {
+                    "title": "Incorrect answer",
+                    "contents": [{
                         "description": {
                             "text": "You were asked to enter a number greater than or equal to <em>123</em> but you entered <em>{answer}</em>.",
                             "placeholders": [{
@@ -70,18 +63,19 @@
                                 }
                             }]
                         }
-                    }],
-                    "routing_rules": [{
-                        "goto": {
-                            "block": "summary"
-                        }
                     }]
                 },
-                {
-                    "type": "Interstitial",
-                    "id": "correct-answer",
-                    "title": "You entered a number greater than or equal to 123",
-                    "content": [{
+                "routing_rules": [{
+                    "goto": {
+                        "block": "summary"
+                    }
+                }]
+            }, {
+                "type": "Interstitial",
+                "id": "correct-answer",
+                "content": {
+                    "title": "Correct answer",
+                    "contents": [{
                         "description": {
                             "text": "You were asked to enter a number greater than or equal to <em>123</em> and you entered <em>{answer}</em>.",
                             "placeholders": [{
@@ -93,12 +87,11 @@
                             }]
                         }
                     }]
-                },
-                {
-                    "type": "Summary",
-                    "id": "summary"
                 }
-            ],
+            }, {
+                "type": "Summary",
+                "id": "summary"
+            }],
             "id": "group",
             "title": ""
         }]

--- a/data-source/json/test_routing_number_less_than.json
+++ b/data-source/json/test_routing_number_less_than.json
@@ -22,7 +22,6 @@
             "blocks": [{
                 "type": "Question",
                 "id": "number-question",
-                "description": "",
                 "question": {
                     "answers": [{
                         "id": "answer",
@@ -34,7 +33,6 @@
                     "title": "Enter the number less than 123",
                     "type": "General"
                 },
-                "title": "Number Routing Less Than",
                 "routing_rules": [{
                     "goto": {
                         "block": "correct-answer",
@@ -52,19 +50,21 @@
             }, {
                 "type": "Interstitial",
                 "id": "incorrect-answer",
-                "title": "You entered a number that was not less than 123",
-                "content": [{
-                    "description": {
-                        "text": "You were asked to enter a number less than <em>123</em> but you entered <em>{answer}</em>.",
-                        "placeholders": [{
-                            "placeholder": "answer",
-                            "value": {
-                                "source": "answers",
-                                "identifier": "answer"
-                            }
-                        }]
-                    }
-                }],
+                "content": {
+                    "title": "Incorrect answer",
+                    "contents": [{
+                        "description": {
+                            "text": "You were asked to enter a number less than <em>123</em> but you entered <em>{answer}</em>.",
+                            "placeholders": [{
+                                "placeholder": "answer",
+                                "value": {
+                                    "source": "answers",
+                                    "identifier": "answer"
+                                }
+                            }]
+                        }
+                    }]
+                },
                 "routing_rules": [{
                     "goto": {
                         "block": "summary"
@@ -73,19 +73,21 @@
             }, {
                 "type": "Interstitial",
                 "id": "correct-answer",
-                "title": "You entered a number less than 123",
-                "content": [{
-                    "description": {
-                        "text": "You were asked to enter a number less than <em>123</em> and you entered <em>{answer}</em>.",
-                        "placeholders": [{
-                            "placeholder": "answer",
-                            "value": {
-                                "source": "answers",
-                                "identifier": "answer"
-                            }
-                        }]
-                    }
-                }]
+                "content": {
+                    "title": "Correct answer",
+                    "contents": [{
+                        "description": {
+                            "text": "You were asked to enter a number less than <em>123</em> and you entered <em>{answer}</em>.",
+                            "placeholders": [{
+                                "placeholder": "answer",
+                                "value": {
+                                    "source": "answers",
+                                    "identifier": "answer"
+                                }
+                            }]
+                        }
+                    }]
+                }
             }, {
                 "type": "Summary",
                 "id": "summary"

--- a/data-source/json/test_routing_number_less_than_or_equal.json
+++ b/data-source/json/test_routing_number_less_than_or_equal.json
@@ -22,7 +22,6 @@
             "blocks": [{
                 "type": "Question",
                 "id": "number-question",
-                "description": "",
                 "question": {
                     "answers": [{
                         "id": "answer",
@@ -34,7 +33,6 @@
                     "title": "Enter the number less than or equal to 123",
                     "type": "General"
                 },
-                "title": "Number Routing Less Than or Equal",
                 "routing_rules": [{
                     "goto": {
                         "block": "correct-answer",
@@ -61,19 +59,21 @@
             }, {
                 "type": "Interstitial",
                 "id": "incorrect-answer",
-                "title": "You entered a number that was not less than or equal 123",
-                "content": [{
-                    "description": {
-                        "text": "You were asked to enter a number less than or equal to <em>123</em> but you entered <em>{answer}</em>.",
-                        "placeholders": [{
-                            "placeholder": "answer",
-                            "value": {
-                                "source": "answers",
-                                "identifier": "answer"
-                            }
-                        }]
-                    }
-                }],
+                "content": {
+                    "title": "Incorrect answer",
+                    "contents": [{
+                        "description": {
+                            "text": "You were asked to enter a number less than or equal to <em>123</em> but you entered <em>{answer}</em>.",
+                            "placeholders": [{
+                                "placeholder": "answer",
+                                "value": {
+                                    "source": "answers",
+                                    "identifier": "answer"
+                                }
+                            }]
+                        }
+                    }]
+                },
                 "routing_rules": [{
                     "goto": {
                         "block": "summary"
@@ -82,19 +82,21 @@
             }, {
                 "type": "Interstitial",
                 "id": "correct-answer",
-                "title": "You entered a number less than or equal to 123",
-                "content": [{
-                    "description": {
-                        "text": "You were asked to enter a number less than or equal to <em>123</em> and you entered <em>{answer}</em>.",
-                        "placeholders": [{
-                            "placeholder": "answer",
-                            "value": {
-                                "source": "answers",
-                                "identifier": "answer"
-                            }
-                        }]
-                    }
-                }]
+                "content": {
+                    "title": "correct answer",
+                    "contents": [{
+                        "description": {
+                            "text": "You were asked to enter a number less than or equal to <em>123</em> and you entered <em>{answer}</em>.",
+                            "placeholders": [{
+                                "placeholder": "answer",
+                                "value": {
+                                    "source": "answers",
+                                    "identifier": "answer"
+                                }
+                            }]
+                        }
+                    }]
+                }
             }, {
                 "type": "Summary",
                 "id": "summary"

--- a/data-source/json/test_routing_number_less_than_or_equal_single_condition.json
+++ b/data-source/json/test_routing_number_less_than_or_equal_single_condition.json
@@ -7,59 +7,52 @@
     "theme": "default",
     "description": "A test survey for routing based on a number less than or equal",
     "metadata": [{
-            "name": "user_id",
-            "type": "string"
-        },
-        {
-            "name": "period_id",
-            "type": "string"
-        },
-        {
-            "name": "ru_name",
-            "type": "string"
-        }
-    ],
+        "name": "user_id",
+        "type": "string"
+    }, {
+        "name": "period_id",
+        "type": "string"
+    }, {
+        "name": "ru_name",
+        "type": "string"
+    }],
     "sections": [{
         "id": "default-section",
         "groups": [{
             "blocks": [{
-                    "type": "Question",
-                    "id": "number-question",
-                    "description": "",
-                    "question": {
-                        "answers": [{
-                            "id": "answer",
-                            "mandatory": true,
-                            "type": "Number",
-                            "label": "Number"
-                        }],
-                        "id": "question",
-                        "title": "Enter the number less than or equal to 123",
-                        "type": "General"
-                    },
-                    "title": "Number Routing Less Than or Equal",
-                    "routing_rules": [{
-                            "goto": {
-                                "block": "correct-answer",
-                                "when": [{
-                                    "id": "answer",
-                                    "condition": "less than or equal to",
-                                    "value": 123
-                                }]
-                            }
-                        },
-                        {
-                            "goto": {
-                                "block": "incorrect-answer"
-                            }
-                        }
-                    ]
+                "type": "Question",
+                "id": "number-question",
+                "question": {
+                    "answers": [{
+                        "id": "answer",
+                        "mandatory": true,
+                        "type": "Number",
+                        "label": "Number"
+                    }],
+                    "id": "question",
+                    "title": "Enter the number less than or equal to 123",
+                    "type": "General"
                 },
-                {
-                    "type": "Interstitial",
-                    "id": "incorrect-answer",
-                    "title": "You entered a number that was not less than or equal 123",
-                    "content": [{
+                "routing_rules": [{
+                    "goto": {
+                        "block": "correct-answer",
+                        "when": [{
+                            "id": "answer",
+                            "condition": "less than or equal to",
+                            "value": 123
+                        }]
+                    }
+                }, {
+                    "goto": {
+                        "block": "incorrect-answer"
+                    }
+                }]
+            }, {
+                "type": "Interstitial",
+                "id": "incorrect-answer",
+                "content": {
+                    "title": "Incorrect answer",
+                    "contents": [{
                         "description": {
                             "text": "You were asked to enter a number less than or equal to <em>123</em> but you entered <em>{answer}</em>.",
                             "placeholders": [{
@@ -70,18 +63,19 @@
                                 }
                             }]
                         }
-                    }],
-                    "routing_rules": [{
-                        "goto": {
-                            "block": "summary"
-                        }
                     }]
                 },
-                {
-                    "type": "Interstitial",
-                    "id": "correct-answer",
-                    "title": "You entered a number less than or equal to 123",
-                    "content": [{
+                "routing_rules": [{
+                    "goto": {
+                        "block": "summary"
+                    }
+                }]
+            }, {
+                "type": "Interstitial",
+                "id": "correct-answer",
+                "content": {
+                    "title": "Correct answer",
+                    "contents": [{
                         "description": {
                             "text": "You were asked to enter a number less than or equal to <em>123</em> and you entered <em>{answer}</em>.",
                             "placeholders": [{
@@ -93,12 +87,11 @@
                             }]
                         }
                     }]
-                },
-                {
-                    "type": "Summary",
-                    "id": "summary"
                 }
-            ],
+            }, {
+                "type": "Summary",
+                "id": "summary"
+            }],
             "id": "group",
             "title": ""
         }]

--- a/data-source/json/test_routing_number_not_equals.json
+++ b/data-source/json/test_routing_number_not_equals.json
@@ -22,7 +22,6 @@
             "blocks": [{
                 "type": "Question",
                 "id": "number-question",
-                "description": "",
                 "question": {
                     "answers": [{
                         "id": "answer",
@@ -34,7 +33,6 @@
                     "title": "Enter the number that isn't 123",
                     "type": "General"
                 },
-                "title": "Number Routing Not Equals",
                 "routing_rules": [{
                     "goto": {
                         "block": "correct-answer",
@@ -52,19 +50,21 @@
             }, {
                 "type": "Interstitial",
                 "id": "incorrect-answer",
-                "title": "You entered 123, which is wrong",
-                "content": [{
-                    "description": {
-                        "text": "You were asked not to enter <em>123</em> but you entered <em>{answer}</em>.",
-                        "placeholders": [{
-                            "placeholder": "answer",
-                            "value": {
-                                "source": "answers",
-                                "identifier": "answer"
-                            }
-                        }]
-                    }
-                }],
+                "content": {
+                    "title": "Incorrect answer",
+                    "contents": [{
+                        "description": {
+                            "text": "You were asked not to enter <em>123</em> but you entered <em>{answer}</em>.",
+                            "placeholders": [{
+                                "placeholder": "answer",
+                                "value": {
+                                    "source": "answers",
+                                    "identifier": "answer"
+                                }
+                            }]
+                        }
+                    }]
+                },
                 "routing_rules": [{
                     "goto": {
                         "block": "summary"
@@ -73,19 +73,21 @@
             }, {
                 "type": "Interstitial",
                 "id": "correct-answer",
-                "title": "You did not enter 123",
-                "content": [{
-                    "description": {
-                        "text": "You were asked not to enter <em>123</em> and you entered <em>{answer}</em>.",
-                        "placeholders": [{
-                            "placeholder": "answer",
-                            "value": {
-                                "source": "answers",
-                                "identifier": "answer"
-                            }
-                        }]
-                    }
-                }]
+                "content": {
+                    "title": "Correct answer",
+                    "contents": [{
+                        "description": {
+                            "text": "You were asked not to enter <em>123</em> and you entered <em>{answer}</em>.",
+                            "placeholders": [{
+                                "placeholder": "answer",
+                                "value": {
+                                    "source": "answers",
+                                    "identifier": "answer"
+                                }
+                            }]
+                        }
+                    }]
+                }
             }, {
                 "type": "Summary",
                 "id": "summary"

--- a/data-source/json/test_routing_on_multiple_select.json
+++ b/data-source/json/test_routing_on_multiple_select.json
@@ -21,7 +21,6 @@
             "blocks": [{
                 "type": "Question",
                 "id": "block1",
-                "title": "Question 1",
                 "question": {
                     "id": "block1-question",
                     "title": "Question 1",
@@ -60,7 +59,6 @@
             }, {
                 "type": "Question",
                 "id": "block2",
-                "title": "Question 2",
                 "question": {
                     "id": "block2-question",
                     "title": "Question 2",
@@ -76,7 +74,6 @@
             }, {
                 "type": "Question",
                 "id": "block3",
-                "title": "Question 3",
                 "question": {
                     "id": "block3-question",
                     "title": "Question 3",

--- a/data-source/json/test_section_summary.json
+++ b/data-source/json/test_section_summary.json
@@ -24,178 +24,163 @@
         "type": "string"
     }],
     "sections": [{
-            "id": "property-details-section",
-            "title": "Property Details Section",
-            "groups": [{
-                "id": "property-details",
-                "title": "Property Details",
-                "blocks": [{
-                    "id": "insurance-type",
-                    "title": "Property Details",
-                    "type": "Question",
-                    "question": {
-                        "id": "insurance-type-question",
-                        "title": "What kind of insurance would you like?",
-                        "type": "General",
-                        "answers": [{
-                            "id": "insurance-type-answer",
-                            "type": "Radio",
-                            "label": "",
-                            "mandatory": false,
-                            "options": [{
-                                "label": "Buildings",
-                                "value": "Buildings"
-                            }, {
-                                "label": "Contents",
-                                "value": "Contents"
-                            }, {
-                                "label": "Both",
-                                "value": "Both"
-                            }]
-                        }]
-                    }
-                }, {
-                    "id": "insurance-address",
-                    "title": "Property Details",
-                    "type": "Question",
-                    "question": {
-                        "id": "insurance-address-question",
-                        "title": "What is the address you would like to insure?",
-                        "type": "General",
-                        "answers": [{
-                            "id": "insurance-address-answer",
-                            "type": "TextArea",
-                            "label": "",
-                            "mandatory": false
-                        }]
-                    }
-                }]
-            }, {
-                "id": "address-length",
-                "title": "Address Duration",
-                "blocks": [{
-                    "id": "address-duration",
-                    "title": "Address Duration",
-                    "type": "Question",
-                    "question": {
-                        "id": "address-duration-question",
-                        "title": "Have you been living at this address for over 5 years?",
-                        "type": "General",
-                        "answers": [{
-                            "id": "address-duration-answer",
-                            "type": "Radio",
-                            "mandatory": false,
-                            "options": [{
-                                "label": "Yes",
-                                "value": "Yes"
-                            }, {
-                                "label": "No",
-                                "value": "No"
-                            }]
-                        }]
-                    },
-                    "skip_conditions": [{
-                        "when": [{
-                            "id": "insurance-type-answer",
-                            "condition": "equals",
+        "id": "property-details-section",
+        "title": "Property Details Section",
+        "groups": [{
+            "id": "property-details",
+            "title": "Property Details",
+            "blocks": [{
+                "id": "insurance-type",
+                "type": "Question",
+                "question": {
+                    "id": "insurance-type-question",
+                    "title": "What kind of insurance would you like?",
+                    "type": "General",
+                    "answers": [{
+                        "id": "insurance-type-answer",
+                        "type": "Radio",
+                        "label": "",
+                        "mandatory": false,
+                        "options": [{
+                            "label": "Buildings",
+                            "value": "Buildings"
+                        }, {
+                            "label": "Contents",
+                            "value": "Contents"
+                        }, {
+                            "label": "Both",
                             "value": "Both"
                         }]
                     }]
-                }]
+                }
             }, {
-                "id": "property-details-summary-group",
-                "title": "Property Details Summary",
-                "blocks": [{
-                    "id": "property-details-summary",
-                    "type": "SectionSummary"
-                }]
-            }]
-        },
-        {
-            "id": "house-details-section",
-            "title": "House Details Section",
-            "groups": [{
-                    "id": "house-details",
-                    "title": "House Details",
-                    "skip_conditions": [{
-                            "when": [{
-                                "id": "insurance-type-answer",
-                                "condition": "equals",
-                                "value": "Contents"
-                            }]
-                        },
-                        {
-                            "when": [{
-                                "id": "insurance-type-answer",
-                                "condition": "not set"
-                            }]
-                        }
-                    ],
-                    "blocks": [{
-                        "id": "house-type",
-                        "title": "House Details",
-                        "type": "Question",
-                        "question": {
-                            "id": "house-type-question",
-                            "title": "What kind of house is it?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "house-type-answer",
-                                "type": "Radio",
-                                "label": "",
-                                "mandatory": false,
-                                "options": [{
-                                        "label": "Detached",
-                                        "value": "Detached"
-                                    },
-                                    {
-                                        "label": "Semi-detached",
-                                        "value": "Semi-detached"
-                                    },
-                                    {
-                                        "label": "Terrace",
-                                        "value": "Terrace"
-                                    }
-                                ]
-                            }]
-                        }
-                    }]
-                },
-                {
-                    "id": "household-details-summary-group",
-                    "title": "Household Details Summary",
-                    "skip_conditions": [{
-                            "when": [{
-                                "id": "insurance-type-answer",
-                                "condition": "equals",
-                                "value": "Contents"
-                            }]
-                        },
-                        {
-                            "when": [{
-                                "id": "insurance-type-answer",
-                                "condition": "not set"
-                            }]
-                        }
-                    ],
-                    "blocks": [{
-                        "id": "household-details-summary",
-                        "type": "SectionSummary"
+                "id": "insurance-address",
+                "type": "Question",
+                "question": {
+                    "id": "insurance-address-question",
+                    "title": "What is the address you would like to insure?",
+                    "type": "General",
+                    "answers": [{
+                        "id": "insurance-address-answer",
+                        "type": "TextArea",
+                        "label": "",
+                        "mandatory": false
                     }]
                 }
-            ]
+            }]
         }, {
-            "id": "summary-section",
-            "title": "Summary",
-            "groups": [{
-                "id": "summary-group",
-                "title": "Summary",
-                "blocks": [{
-                    "id": "summary",
-                    "type": "Summary",
-                    "collapsible": true
+            "id": "address-length",
+            "title": "Address Duration",
+            "blocks": [{
+                "id": "address-duration",
+                "type": "Question",
+                "question": {
+                    "id": "address-duration-question",
+                    "title": "Have you been living at this address for over 5 years?",
+                    "type": "General",
+                    "answers": [{
+                        "id": "address-duration-answer",
+                        "type": "Radio",
+                        "mandatory": false,
+                        "options": [{
+                            "label": "Yes",
+                            "value": "Yes"
+                        }, {
+                            "label": "No",
+                            "value": "No"
+                        }]
+                    }]
+                },
+                "skip_conditions": [{
+                    "when": [{
+                        "id": "insurance-type-answer",
+                        "condition": "equals",
+                        "value": "Both"
+                    }]
                 }]
             }]
-        }
-    ]
+        }, {
+            "id": "property-details-summary-group",
+            "title": "Property Details Summary",
+            "blocks": [{
+                "id": "property-details-summary",
+                "type": "SectionSummary"
+            }]
+        }]
+    }, {
+        "id": "house-details-section",
+        "title": "House Details Section",
+        "groups": [{
+            "id": "house-details",
+            "title": "House Details",
+            "skip_conditions": [{
+                "when": [{
+                    "id": "insurance-type-answer",
+                    "condition": "equals",
+                    "value": "Contents"
+                }]
+            }, {
+                "when": [{
+                    "id": "insurance-type-answer",
+                    "condition": "not set"
+                }]
+            }],
+            "blocks": [{
+                "id": "house-type",
+                "type": "Question",
+                "question": {
+                    "id": "house-type-question",
+                    "title": "What kind of house is it?",
+                    "type": "General",
+                    "answers": [{
+                        "id": "house-type-answer",
+                        "type": "Radio",
+                        "label": "",
+                        "mandatory": false,
+                        "options": [{
+                            "label": "Detached",
+                            "value": "Detached"
+                        }, {
+                            "label": "Semi-detached",
+                            "value": "Semi-detached"
+                        }, {
+                            "label": "Terrace",
+                            "value": "Terrace"
+                        }]
+                    }]
+                }
+            }]
+        }, {
+            "id": "household-details-summary-group",
+            "title": "Household Details Summary",
+            "skip_conditions": [{
+                "when": [{
+                    "id": "insurance-type-answer",
+                    "condition": "equals",
+                    "value": "Contents"
+                }]
+            }, {
+                "when": [{
+                    "id": "insurance-type-answer",
+                    "condition": "not set"
+                }]
+            }],
+            "blocks": [{
+                "id": "household-details-summary",
+                "type": "SectionSummary"
+            }]
+        }]
+    }, {
+        "id": "summary-section",
+        "title": "Summary",
+        "groups": [{
+            "id": "summary-group",
+            "title": "Summary",
+            "blocks": [{
+                "id": "summary",
+                "type": "Summary",
+                "collapsible": true
+            }]
+        }]
+    }]
 }

--- a/data-source/json/test_skip_condition.json
+++ b/data-source/json/test_skip_condition.json
@@ -23,7 +23,6 @@
             "blocks": [{
                 "type": "Question",
                 "id": "food-block",
-                "description": "",
                 "question": {
                     "answers": [{
                         "id": "food-answer",
@@ -44,12 +43,10 @@
                     "title": "",
                     "type": "General"
                 },
-                "title": "What is your favourite breakfast food",
                 "routing_rules": []
             }, {
                 "type": "Question",
                 "id": "drink-block",
-                "description": "",
                 "question": {
                     "answers": [{
                         "id": "drink-answer",
@@ -76,8 +73,7 @@
                             "value": "Eggs"
                         }]
                     }]
-                },
-                "title": ""
+                }
             }, {
                 "type": "Summary",
                 "id": "summary"

--- a/data-source/json/test_skip_condition_answer_comparison.json
+++ b/data-source/json/test_skip_condition_answer_comparison.json
@@ -23,7 +23,6 @@
             "blocks": [{
                 "type": "Question",
                 "id": "comparison-1",
-                "description": "",
                 "question": {
                     "answers": [{
                         "id": "comparison-1-answer",
@@ -39,7 +38,6 @@
             }, {
                 "type": "Question",
                 "id": "comparison-2",
-                "description": "",
                 "question": {
                     "answers": [{
                         "id": "comparison-2-answer",
@@ -55,10 +53,12 @@
             }, {
                 "type": "Interstitial",
                 "id": "equals-answers",
-                "title": "Second equal first",
-                "content": [{
-                    "description": "Your second number was equal to your first number"
-                }],
+                "content": {
+                    "title": "Answers equal",
+                    "contents": [{
+                        "description": "Your second number was equal to your first number"
+                    }]
+                },
                 "skip_conditions": [{
                     "when": [{
                         "id": "comparison-1-answer",
@@ -69,10 +69,12 @@
             }, {
                 "type": "Interstitial",
                 "id": "less-than-answers",
-                "title": "First less than second",
-                "content": [{
-                    "description": "Your first answer was less than your second number"
-                }],
+                "content": {
+                    "title": "First less than second",
+                    "contents": [{
+                        "description": "Your first answer was less than your second number"
+                    }]
+                },
                 "skip_conditions": [{
                     "when": [{
                         "id": "comparison-1-answer",
@@ -89,10 +91,12 @@
             }, {
                 "type": "Interstitial",
                 "id": "greater-than-answers",
-                "title": "First greater than second",
-                "content": [{
-                    "description": "Your first answer was greater than your second number"
-                }],
+                "content": {
+                    "title": "First greater than second",
+                    "contents": [{
+                        "description": "Your first answer was greater than your second number"
+                    }]
+                },
                 "skip_conditions": [{
                     "when": [{
                         "id": "comparison-1-answer",

--- a/data-source/json/test_skip_condition_block.json
+++ b/data-source/json/test_skip_condition_block.json
@@ -24,8 +24,6 @@
                 "type": "Question",
                 "id": "do-you-want-to-skip",
                 "routing_rules": [],
-                "description": "",
-                "title": "Do you want to skip?",
                 "question": {
                     "description": "",
                     "id": "do-you-want-to-skip-question",
@@ -52,8 +50,6 @@
                 "type": "Question",
                 "id": "should-skip",
                 "routing_rules": [],
-                "description": "",
-                "title": "Why didn't you skip the block?",
                 "question": {
                     "description": "",
                     "id": "should-skip-question",
@@ -76,8 +72,6 @@
             }, {
                 "type": "Question",
                 "id": "a-non-skipped-block",
-                "description": "an additional question within the same group",
-                "title": "Additional Question",
                 "question": {
                     "id": "will-not-be-skipped-question",
                     "title": "Always ask this question",

--- a/data-source/json/test_skip_condition_group.json
+++ b/data-source/json/test_skip_condition_group.json
@@ -24,8 +24,6 @@
                 "type": "Question",
                 "id": "do-you-want-to-skip",
                 "routing_rules": [],
-                "description": "",
-                "title": "Do you want to skip?",
                 "question": {
                     "description": "",
                     "id": "do-you-want-to-skip-question",
@@ -63,8 +61,6 @@
                 "type": "Question",
                 "id": "should-skip",
                 "routing_rules": [],
-                "description": "",
-                "title": "Why didn't you skip the group?",
                 "question": {
                     "description": "",
                     "id": "should-skip-question",
@@ -85,8 +81,6 @@
                 "type": "Question",
                 "id": "last-group-block",
                 "routing_rules": [],
-                "description": "",
-                "title": "This group is required as a skipped group can't be the last group",
                 "question": {
                     "description": "",
                     "id": "last-group-question",

--- a/data-source/json/test_skip_condition_not_set.json
+++ b/data-source/json/test_skip_condition_not_set.json
@@ -23,7 +23,6 @@
             "blocks": [{
                 "type": "Question",
                 "id": "food-block",
-                "description": "",
                 "question": {
                     "answers": [{
                         "id": "food-answer",
@@ -44,12 +43,10 @@
                     "title": "",
                     "type": "General"
                 },
-                "title": "What is your favourite breakfast food",
                 "routing_rules": []
             }, {
                 "type": "Question",
                 "id": "drink-block",
-                "description": "",
                 "question": {
                     "answers": [{
                         "id": "drink-answer",
@@ -70,7 +67,6 @@
                     "title": "What beverage would you like to accompany your choice of breakfast?",
                     "type": "General"
                 },
-                "title": "",
                 "skip_conditions": [{
                     "when": [{
                         "id": "food-answer",

--- a/data-source/json/test_skip_condition_set.json
+++ b/data-source/json/test_skip_condition_set.json
@@ -23,7 +23,6 @@
             "blocks": [{
                 "type": "Question",
                 "id": "food-block",
-                "description": "",
                 "question": {
                     "answers": [{
                         "id": "food-answer",
@@ -44,12 +43,10 @@
                     "title": "",
                     "type": "General"
                 },
-                "title": "What is your favourite breakfast food",
                 "routing_rules": []
             }, {
                 "type": "Question",
                 "id": "drink-block",
-                "description": "",
                 "question": {
                     "answers": [{
                         "id": "drink-answer",
@@ -70,7 +67,6 @@
                     "title": "What beverage would you like to accompany your choice of breakfast?",
                     "type": "General"
                 },
-                "title": "",
                 "skip_conditions": [{
                     "when": [{
                         "id": "food-answer",

--- a/data-source/json/test_sum_equal_or_less_validation_against_total.json
+++ b/data-source/json/test_sum_equal_or_less_validation_against_total.json
@@ -23,9 +23,7 @@
             "title": "Validate sum against total",
             "blocks": [{
                 "type": "Question",
-                "title": "Target total",
                 "id": "total-block",
-                "description": "",
                 "question": {
                     "id": "total-question",
                     "title": "Total",
@@ -40,7 +38,6 @@
                 }
             }, {
                 "type": "Question",
-                "title": "Calculated total",
                 "id": "breakdown-block",
                 "question": {
                     "id": "breakdown-question",

--- a/data-source/json/test_sum_equal_validation_against_total.json
+++ b/data-source/json/test_sum_equal_validation_against_total.json
@@ -23,9 +23,7 @@
             "title": "Validate sum against total",
             "blocks": [{
                 "type": "Question",
-                "title": "Target total",
                 "id": "total-block",
-                "description": "",
                 "question": {
                     "id": "total-question",
                     "title": "Total",
@@ -40,7 +38,6 @@
                 }
             }, {
                 "type": "Question",
-                "title": "Calculated total",
                 "id": "breakdown-block",
                 "question": {
                     "id": "breakdown-question",

--- a/data-source/json/test_sum_less_validation_against_total.json
+++ b/data-source/json/test_sum_less_validation_against_total.json
@@ -23,9 +23,7 @@
             "title": "Validate sum against total",
             "blocks": [{
                 "type": "Question",
-                "title": "Target total",
                 "id": "total-block",
-                "description": "",
                 "question": {
                     "id": "total-question",
                     "title": "Total",
@@ -41,7 +39,6 @@
                 }
             }, {
                 "type": "Question",
-                "title": "Calculated total",
                 "id": "breakdown-block",
                 "question": {
                     "id": "breakdown-question",

--- a/data-source/json/test_sum_multi_validation_against_total.json
+++ b/data-source/json/test_sum_multi_validation_against_total.json
@@ -23,9 +23,7 @@
             "title": "Validate sum against total",
             "blocks": [{
                 "type": "Question",
-                "title": "Target total",
                 "id": "total-block",
-                "description": "",
                 "question": {
                     "id": "total-question",
                     "title": "Total",
@@ -44,7 +42,6 @@
                 }
             }, {
                 "type": "Question",
-                "title": "Calculated total",
                 "id": "breakdown-block",
                 "question": {
                     "id": "breakdown-question",

--- a/data-source/json/test_summary.json
+++ b/data-source/json/test_summary.json
@@ -22,7 +22,6 @@
             "blocks": [{
                 "type": "Question",
                 "id": "radio",
-                "description": "",
                 "question": {
                     "answers": [{
                         "id": "radio-answer",
@@ -60,12 +59,10 @@
                     "title": "",
                     "type": "General"
                 },
-                "title": "What is your favourite breakfast food",
                 "routing_rules": []
             }, {
                 "type": "Question",
                 "id": "test-number-block",
-                "description": "",
                 "question": {
                     "answers": [{
                         "id": "test-currency",
@@ -94,14 +91,12 @@
                     "id": "test-number-range-question",
                     "title": "Please enter test values (none mandatory)",
                     "type": "General"
-                },
-                "title": ""
+                }
             }],
             "id": "summary-group",
             "title": ""
         }, {
             "blocks": [{
-                "description": "",
                 "type": "Question",
                 "id": "dessert-block",
                 "question": {

--- a/data-source/json/test_textarea.json
+++ b/data-source/json/test_textarea.json
@@ -27,7 +27,6 @@
             "blocks": [{
                 "type": "Question",
                 "id": "textarea-block",
-                "description": "",
                 "question": {
                     "answers": [{
                         "id": "answer",
@@ -45,8 +44,7 @@
                     "id": "question",
                     "title": "",
                     "type": "General"
-                },
-                "title": "Textarea Test"
+                }
             }, {
                 "type": "Summary",
                 "id": "textarea-summary"

--- a/data-source/json/test_textfield.json
+++ b/data-source/json/test_textfield.json
@@ -27,7 +27,6 @@
             "blocks": [{
                 "type": "Question",
                 "id": "name-block",
-                "description": "",
                 "question": {
                     "answers": [{
                         "id": "name-answer",
@@ -41,7 +40,6 @@
                     "title": "",
                     "type": "General"
                 },
-                "title": "Text Field Test",
                 "routing_rules": []
             }, {
                 "type": "Summary",

--- a/data-source/json/test_theme_northernireland.json
+++ b/data-source/json/test_theme_northernireland.json
@@ -26,7 +26,6 @@
             "blocks": [{
                 "type": "Question",
                 "id": "radio",
-                "description": "",
                 "question": {
                     "answers": [{
                         "id": "radio-answer",
@@ -47,8 +46,7 @@
                     "id": "radio-question",
                     "title": "What is your favourite breakfast food?",
                     "type": "General"
-                },
-                "title": "Favourite breakfast food"
+                }
             }, {
                 "type": "Summary",
                 "id": "summary"

--- a/data-source/json/test_theme_social.json
+++ b/data-source/json/test_theme_social.json
@@ -26,7 +26,6 @@
             "blocks": [{
                 "type": "Question",
                 "id": "radio",
-                "description": "",
                 "question": {
                     "answers": [{
                         "id": "radio-answer",
@@ -47,8 +46,7 @@
                     "id": "radio-question",
                     "title": "What is your favourite breakfast food?",
                     "type": "General"
-                },
-                "title": "Favourite breakfast food"
+                }
             }, {
                 "type": "Summary",
                 "id": "summary"

--- a/data-source/json/test_timeout.json
+++ b/data-source/json/test_timeout.json
@@ -25,7 +25,6 @@
             "blocks": [{
                 "type": "Question",
                 "id": "timeout-block",
-                "title": "Timeout",
                 "question": {
                     "answers": [{
                         "id": "timeout-answer",

--- a/data-source/json/test_title.json
+++ b/data-source/json/test_title.json
@@ -24,7 +24,6 @@
             "blocks": [{
                 "type": "Question",
                 "id": "single-title-block",
-                "title": "Single question title",
                 "question": {
                     "id": "single-title-question",
                     "title": "How are you feeling??",

--- a/data-source/json/test_titles_radio_and_checkbox.json
+++ b/data-source/json/test_titles_radio_and_checkbox.json
@@ -7,287 +7,248 @@
     "description": "",
     "theme": "default",
     "metadata": [{
-            "name": "user_id",
-            "type": "string"
-        },
-        {
-            "name": "period_id",
-            "type": "string"
-        },
-        {
-            "name": "ru_name",
-            "type": "string"
-        }
-    ],
+        "name": "user_id",
+        "type": "string"
+    }, {
+        "name": "period_id",
+        "type": "string"
+    }, {
+        "name": "ru_name",
+        "type": "string"
+    }],
     "sections": [{
         "id": "default-section",
         "groups": [{
             "id": "radio-checkbox-group",
             "title": "",
             "blocks": [{
-                    "id": "preamble-block",
-                    "type": "Question",
+                "id": "preamble-block",
+                "type": "Question",
+                "question": {
+                    "id": "name-question",
+                    "title": "What is your name?",
+                    "type": "General",
+                    "guidance": {
+                        "contents": [{
+                            "description": "The answer you write will have an effect on question titles in next question",
+                            "list": [
+                                "If you type 'Peter', the question will be aimed for Peter",
+                                "If you type 'Mary', the question will be aimed for Mary",
+                                "If you type anything else the question will be the default question"
+                            ]
+                        }]
+                    },
+                    "answers": [{
+                        "id": "name-answer",
+                        "label": "Your name",
+                        "type": "TextField",
+                        "mandatory": true
+                    }]
+                }
+            }, {
+                "type": "Question",
+                "id": "checkbox-block",
+                "question_variants": [{
+                    "when": [{
+                        "id": "name-answer",
+                        "condition": "equals",
+                        "value": "Peter"
+                    }],
                     "question": {
-                        "id": "name-question",
-                        "title": "What is your name?",
+                        "id": "checkbox-question",
                         "type": "General",
-                        "guidance": {
-                            "content": [{
-                                "description": "The answer you write will have an effect on question titles in next question",
-                                "list": [
-                                    "If you type 'Peter', the question will be aimed for Peter",
-                                    "If you type 'Mary', the question will be aimed for Mary",
-                                    "If you type anything else the question will be the default question"
-                                ]
+                        "title": "Did <em>Peter</em> make changes to this business?",
+                        "answers": [{
+                            "id": "checkbox-answer",
+                            "type": "Checkbox",
+                            "mandatory": true,
+                            "options": [{
+                                "label": "New business practices for organising procedures",
+                                "value": "New business practices for organising procedures"
+                            }, {
+                                "label": "New methods of organising work responsibilities and decision making",
+                                "value": "New methods of organising work responsibilities and decision making"
+                            }, {
+                                "label": "New methods of organising external relationships with other firms or public institutions",
+                                "value": "New methods of organising external relationships with other firms or public institutions"
+                            }, {
+                                "label": "Implementation of changes to marketing concepts or strategies",
+                                "value": "Implementation of changes to marketing concepts or strategies"
+                            }]
+                        }]
+                    }
+                }, {
+                    "when": [{
+                        "id": "name-answer",
+                        "condition": "equals",
+                        "value": "Mary"
+                    }],
+                    "question": {
+                        "id": "checkbox-question",
+                        "type": "General",
+                        "title": "Did <em>Mary</em> make changes to this business?",
+                        "answers": [{
+                            "id": "checkbox-answer",
+                            "type": "Checkbox",
+                            "mandatory": true,
+                            "options": [{
+                                "label": "New business practices for organising procedures",
+                                "value": "New business practices for organising procedures"
+                            }, {
+                                "label": "New methods of organising work responsibilities and decision making",
+                                "value": "New methods of organising work responsibilities and decision making"
+                            }, {
+                                "label": "New methods of organising external relationships with other firms or public institutions",
+                                "value": "New methods of organising external relationships with other firms or public institutions"
+                            }, {
+                                "label": "Implementation of changes to marketing concepts or strategies",
+                                "value": "Implementation of changes to marketing concepts or strategies"
+                            }]
+                        }]
+                    }
+                }, {
+                    "when": [{
+                        "id": "name-answer",
+                        "condition": "not equals",
+                        "value": "Mary"
+                    }],
+                    "question": {
+                        "id": "checkbox-question",
+                        "type": "General",
+                        "title": "Did this business make major changes in the following areas?",
+                        "answers": [{
+                            "id": "checkbox-answer",
+                            "type": "Checkbox",
+                            "mandatory": true,
+                            "options": [{
+                                "label": "New business practices for organising procedures",
+                                "value": "New business practices for organising procedures"
+                            }, {
+                                "label": "New methods of organising work responsibilities and decision making",
+                                "value": "New methods of organising work responsibilities and decision making"
+                            }, {
+                                "label": "New methods of organising external relationships with other firms or public institutions",
+                                "value": "New methods of organising external relationships with other firms or public institutions"
+                            }, {
+                                "label": "Implementation of changes to marketing concepts or strategies",
+                                "value": "Implementation of changes to marketing concepts or strategies"
+                            }]
+                        }]
+                    }
+                }]
+            }, {
+                "type": "Question",
+                "id": "radio-block",
+                "question_variants": [{
+                    "when": [{
+                        "id": "name-answer",
+                        "condition": "equals",
+                        "value": "Peter"
+                    }],
+                    "question": {
+                        "id": "radio-question",
+                        "type": "General",
+                        "title": "Is <em>Peter</em> the boss?",
+                        "answers": [{
+                            "id": "radio-answer",
+                            "mandatory": true,
+                            "type": "Radio",
+                            "options": [{
+                                "label": "Yes",
+                                "value": "yes"
+                            }, {
+                                "label": "No",
+                                "value": "no"
+                            }, {
+                                "label": "Maybe",
+                                "value": "maybe"
+                            }, {
+                                "label": "I don't know",
+                                "value": "know"
+                            }, {
+                                "label": "Can you repeat the question",
+                                "value": "repeat"
+                            }]
+                        }]
+                    }
+                }, {
+                    "when": [{
+                        "id": "name-answer",
+                        "condition": "equals",
+                        "value": "Mary"
+                    }],
+                    "question": {
+                        "id": "radio-question",
+                        "type": "General",
+                        "title": "Is <em>Mary</em> the boss?",
+                        "answers": [{
+                            "id": "radio-answer",
+                            "mandatory": true,
+                            "type": "Radio",
+                            "options": [{
+                                "label": "Yes",
+                                "value": "yes"
+                            }, {
+                                "label": "No",
+                                "value": "no"
+                            }, {
+                                "label": "Maybe",
+                                "value": "maybe"
+                            }, {
+                                "label": "I don't know",
+                                "value": "know"
+                            }, {
+                                "label": "Can you repeat the question",
+                                "value": "repeat"
+                            }]
+                        }]
+                    }
+                }, {
+                    "when": [{
+                        "id": "name-answer",
+                        "condition": "not equals",
+                        "value": "Mary"
+                    }],
+                    "question": {
+                        "id": "radio-question",
+                        "type": "General",
+                        "title": {
+                            "text": "Is <em>{name}</em> the boss?",
+                            "placeholders": [{
+                                "placeholder": "name",
+                                "value": {
+                                    "source": "answers",
+                                    "identifier": "name-answer"
+                                }
                             }]
                         },
                         "answers": [{
-                            "id": "name-answer",
-                            "label": "Your name",
-                            "type": "TextField",
-                            "mandatory": true
+                            "id": "radio-answer",
+                            "mandatory": true,
+                            "type": "Radio",
+                            "options": [{
+                                "label": "Yes",
+                                "value": "yes"
+                            }, {
+                                "label": "No",
+                                "value": "no"
+                            }, {
+                                "label": "Maybe",
+                                "value": "maybe"
+                            }, {
+                                "label": "I don't know",
+                                "value": "know"
+                            }, {
+                                "label": "Can you repeat the question",
+                                "value": "repeat"
+                            }]
                         }]
                     }
-                },
-                {
-                    "type": "Question",
-                    "id": "checkbox-block",
-                    "title": "Checkbox Answer",
-                    "question_variants": [{
-                            "when": [{
-                                "id": "name-answer",
-                                "condition": "equals",
-                                "value": "Peter"
-                            }],
-                            "question": {
-                                "id": "checkbox-question",
-                                "type": "General",
-                                "title": "Did <em>Peter</em> make changes to this business?",
-                                "answers": [{
-                                    "id": "checkbox-answer",
-                                    "type": "Checkbox",
-                                    "mandatory": true,
-                                    "options": [{
-                                            "label": "New business practices for organising procedures",
-                                            "value": "New business practices for organising procedures"
-                                        },
-                                        {
-                                            "label": "New methods of organising work responsibilities and decision making",
-                                            "value": "New methods of organising work responsibilities and decision making"
-                                        },
-                                        {
-                                            "label": "New methods of organising external relationships with other firms or public institutions",
-                                            "value": "New methods of organising external relationships with other firms or public institutions"
-                                        },
-                                        {
-                                            "label": "Implementation of changes to marketing concepts or strategies",
-                                            "value": "Implementation of changes to marketing concepts or strategies"
-                                        }
-                                    ]
-                                }]
-                            }
-                        },
-                        {
-                            "when": [{
-                                "id": "name-answer",
-                                "condition": "equals",
-                                "value": "Mary"
-                            }],
-                            "question": {
-                                "id": "checkbox-question",
-                                "type": "General",
-                                "title": "Did <em>Mary</em> make changes to this business?",
-                                "answers": [{
-                                    "id": "checkbox-answer",
-                                    "type": "Checkbox",
-                                    "mandatory": true,
-                                    "options": [{
-                                            "label": "New business practices for organising procedures",
-                                            "value": "New business practices for organising procedures"
-                                        },
-                                        {
-                                            "label": "New methods of organising work responsibilities and decision making",
-                                            "value": "New methods of organising work responsibilities and decision making"
-                                        },
-                                        {
-                                            "label": "New methods of organising external relationships with other firms or public institutions",
-                                            "value": "New methods of organising external relationships with other firms or public institutions"
-                                        },
-                                        {
-                                            "label": "Implementation of changes to marketing concepts or strategies",
-                                            "value": "Implementation of changes to marketing concepts or strategies"
-                                        }
-                                    ]
-                                }]
-                            }
-                        },
-                        {
-                            "when": [{
-                                "id": "name-answer",
-                                "condition": "not equals",
-                                "value": "Mary"
-                            }],
-                            "question": {
-                                "id": "checkbox-question",
-                                "type": "General",
-                                "title": "Did this business make major changes in the following areas?",
-                                "answers": [{
-                                    "id": "checkbox-answer",
-                                    "type": "Checkbox",
-                                    "mandatory": true,
-                                    "options": [{
-                                            "label": "New business practices for organising procedures",
-                                            "value": "New business practices for organising procedures"
-                                        },
-                                        {
-                                            "label": "New methods of organising work responsibilities and decision making",
-                                            "value": "New methods of organising work responsibilities and decision making"
-                                        },
-                                        {
-                                            "label": "New methods of organising external relationships with other firms or public institutions",
-                                            "value": "New methods of organising external relationships with other firms or public institutions"
-                                        },
-                                        {
-                                            "label": "Implementation of changes to marketing concepts or strategies",
-                                            "value": "Implementation of changes to marketing concepts or strategies"
-                                        }
-                                    ]
-                                }]
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "Question",
-                    "id": "radio-block",
-                    "title": "Radio Block",
-                    "question_variants": [{
-                        "when": [{
-                            "id": "name-answer",
-                            "condition": "equals",
-                            "value": "Peter"
-                        }],
-                        "question": {
-                            "id": "radio-question",
-                            "type": "General",
-                            "title": "Is <em>Peter</em> the boss?",
-                            "answers": [{
-                                "id": "radio-answer",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "options": [{
-                                        "label": "Yes",
-                                        "value": "yes"
-                                    },
-                                    {
-                                        "label": "No",
-                                        "value": "no"
-                                    },
-                                    {
-                                        "label": "Maybe",
-                                        "value": "maybe"
-                                    },
-                                    {
-                                        "label": "I don't know",
-                                        "value": "know"
-                                    },
-                                    {
-                                        "label": "Can you repeat the question",
-                                        "value": "repeat"
-                                    }
-                                ]
-                            }]
-                        }
-                    }, {
-                        "when": [{
-                            "id": "name-answer",
-                            "condition": "equals",
-                            "value": "Mary"
-                        }],
-                        "question": {
-                            "id": "radio-question",
-                            "type": "General",
-                            "title": "Is <em>Mary</em> the boss?",
-                            "answers": [{
-                                "id": "radio-answer",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "options": [{
-                                        "label": "Yes",
-                                        "value": "yes"
-                                    },
-                                    {
-                                        "label": "No",
-                                        "value": "no"
-                                    },
-                                    {
-                                        "label": "Maybe",
-                                        "value": "maybe"
-                                    },
-                                    {
-                                        "label": "I don't know",
-                                        "value": "know"
-                                    },
-                                    {
-                                        "label": "Can you repeat the question",
-                                        "value": "repeat"
-                                    }
-                                ]
-                            }]
-                        }
-                    }, {
-                        "when": [{
-                            "id": "name-answer",
-                            "condition": "not equals",
-                            "value": "Mary"
-                        }],
-                        "question": {
-                            "id": "radio-question",
-                            "type": "General",
-                            "title": {
-                                "text": "Is <em>{name}</em> the boss?",
-                                "placeholders": [{
-                                    "placeholder": "name",
-                                    "value": {
-                                        "source": "answers",
-                                        "identifier": "name-answer"
-                                    }
-                                }]
-                            },
-                            "answers": [{
-                                "id": "radio-answer",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "options": [{
-                                        "label": "Yes",
-                                        "value": "yes"
-                                    },
-                                    {
-                                        "label": "No",
-                                        "value": "no"
-                                    },
-                                    {
-                                        "label": "Maybe",
-                                        "value": "maybe"
-                                    },
-                                    {
-                                        "label": "I don't know",
-                                        "value": "know"
-                                    },
-                                    {
-                                        "label": "Can you repeat the question",
-                                        "value": "repeat"
-                                    }
-                                ]
-                            }]
-                        }
-                    }]
-                },
-                {
-                    "type": "Summary",
-                    "id": "summary"
-                }
-            ]
+                }]
+            }, {
+                "type": "Summary",
+                "id": "summary"
+            }]
         }]
     }]
 }

--- a/data-source/json/test_unit_patterns.json
+++ b/data-source/json/test_unit_patterns.json
@@ -22,7 +22,6 @@
             "blocks": [{
                 "type": "Question",
                 "id": "set-length-units-block",
-                "description": "",
                 "question": {
                     "answers": [{
                         "id": "centimetres",
@@ -61,42 +60,36 @@
                     "id": "set-length-units-question",
                     "title": "Length Units",
                     "type": "General"
-                },
-                "title": "Length Units"
+                }
             }, {
                 "type": "Question",
                 "id": "set-duration-units-block",
-                "description": "",
                 "question": {
                     "answers": [{
-                            "id": "duration-hour",
-                            "description": "",
-                            "label": "Hour",
-                            "mandatory": false,
-                            "type": "Unit",
-                            "unit": "duration-hour",
-                            "unit_length": "long"
-                        },
-                        {
-                            "id": "duration-year",
-                            "description": "",
-                            "label": "Years",
-                            "mandatory": false,
-                            "type": "Unit",
-                            "unit": "duration-year",
-                            "unit_length": "long"
-                        }
-                    ],
+                        "id": "duration-hour",
+                        "description": "",
+                        "label": "Hour",
+                        "mandatory": false,
+                        "type": "Unit",
+                        "unit": "duration-hour",
+                        "unit_length": "long"
+                    }, {
+                        "id": "duration-year",
+                        "description": "",
+                        "label": "Years",
+                        "mandatory": false,
+                        "type": "Unit",
+                        "unit": "duration-year",
+                        "unit_length": "long"
+                    }],
                     "description": "",
                     "id": "set-duration-units-question",
                     "title": "Duration Units",
                     "type": "General"
-                },
-                "title": "Duration Units"
+                }
             }, {
                 "type": "Question",
                 "id": "set-area-units-block",
-                "description": "",
                 "question": {
                     "answers": [{
                         "id": "square-centimetres",
@@ -151,12 +144,10 @@
                     "id": "set-area-unit-questions",
                     "title": "Area Units",
                     "type": "General"
-                },
-                "title": "Area Units"
+                }
             }, {
                 "type": "Question",
                 "id": "set-volume-units-block",
-                "description": "",
                 "question": {
                     "answers": [{
                         "id": "cubic-centimetres",
@@ -203,8 +194,7 @@
                     "id": "set-volume-unit-questions",
                     "title": "Volume Units",
                     "type": "General"
-                },
-                "title": "Volume Units"
+                }
             }],
             "id": "test",
             "title": ""

--- a/data-source/json/test_variants_content.json
+++ b/data-source/json/test_variants_content.json
@@ -7,70 +7,66 @@
     "theme": "default",
     "description": "A questionnaire to test content variants and variant choices",
     "metadata": [{
-            "name": "user_id",
-            "type": "string"
-        },
-        {
-            "name": "period_id",
-            "type": "string"
-        },
-        {
-            "name": "ru_name",
-            "type": "string"
-        }
-    ],
+        "name": "user_id",
+        "type": "string"
+    }, {
+        "name": "period_id",
+        "type": "string"
+    }, {
+        "name": "ru_name",
+        "type": "string"
+    }],
     "sections": [{
         "id": "section",
         "groups": [{
             "id": "group",
             "title": "Variants",
             "blocks": [{
-                    "type": "Question",
-                    "id": "age-question-block",
-                    "title": "questions only",
-                    "question": {
-                        "id": "age-question",
-                        "type": "General",
-                        "title": "What is your age?",
-                        "answers": [{
-                            "id": "age-answer",
-                            "label": "Your age?",
-                            "mandatory": true,
-                            "type": "Number"
-                        }]
-                    }
-                },
-                {
-                    "type": "Interstitial",
-                    "id": "age-display-block",
-                    "title": "variants only",
-                    "content_variants": [{
-                            "content": [{
-                                "title": "You are 16 or older"
-                            }],
-                            "when": [{
-                                "id": "age-answer",
-                                "condition": "greater than",
-                                "value": 16
-                            }]
-                        },
-                        {
-                            "content": [{
-                                "title": "You are 16 or younger"
-                            }],
-                            "when": [{
-                                "id": "age-answer",
-                                "condition": "less than or equal to",
-                                "value": 16
-                            }]
-                        }
-                    ]
-                },
-                {
-                    "type": "Summary",
-                    "id": "summary"
+                "type": "Question",
+                "id": "age-question-block",
+                "question": {
+                    "id": "age-question",
+                    "type": "General",
+                    "title": "What is your age?",
+                    "answers": [{
+                        "id": "age-answer",
+                        "label": "Your age?",
+                        "mandatory": true,
+                        "type": "Number"
+                    }]
                 }
-            ]
+            }, {
+                "type": "Interstitial",
+                "id": "age-display-block",
+                "content_variants": [{
+                    "content": {
+                        "title": "You are 16 or older",
+                        "contents": [{
+                            "description": "According to your answer"
+                        }]
+                    },
+                    "when": [{
+                        "id": "age-answer",
+                        "condition": "greater than",
+                        "value": 16
+                    }]
+                }, {
+                    "content": {
+                        "title": "You are 16 or younger",
+                        "contents": [{
+                            "description": "According to your answer"
+                        }]
+                    },
+                    "when": [{
+                        "id": "age-answer",
+                        "condition": "less than or equal to",
+                        "value": 16
+                    }]
+                }]
+            }, {
+                "type": "Summary",
+                "id": "summary"
+            }]
         }]
     }]
 }

--- a/data-source/json/test_variants_question.json
+++ b/data-source/json/test_variants_question.json
@@ -7,471 +7,421 @@
     "theme": "default",
     "description": "A questionnaire to test question variants",
     "metadata": [{
-            "name": "user_id",
-            "type": "string"
-        },
-        {
-            "name": "period_id",
-            "type": "string"
-        },
-        {
-            "name": "ru_name",
-            "type": "string"
-        }
-    ],
+        "name": "user_id",
+        "type": "string"
+    }, {
+        "name": "period_id",
+        "type": "string"
+    }, {
+        "name": "ru_name",
+        "type": "string"
+    }],
     "sections": [{
-            "id": "variant-proxy-section",
-            "groups": [{
-                "id": "variant-proxy-group",
-                "title": "Variants for proxy",
-                "blocks": [{
-                        "type": "Question",
-                        "id": "name-block",
-                        "question": {
-                            "description": "",
-                            "id": "name-question",
-                            "title": "Who is this questionnaire about?",
-                            "type": "General",
-                            "answers": [{
-                                    "id": "first-name-answer",
-                                    "description": "",
-                                    "label": "First Name",
-                                    "mandatory": true,
-                                    "type": "TextField"
-                                },
-                                {
-                                    "id": "last-name-answer",
-                                    "description": "",
-                                    "label": "Last Name",
-                                    "mandatory": false,
-                                    "type": "TextField"
-                                }
-                            ]
-                        }
-                    },
-                    {
-                        "type": "Question",
-                        "id": "proxy-block",
-                        "question": {
-                            "id": "proxy-question",
-                            "title": {
-                                "text": "Are you <em>{person_name}</em>?",
-                                "placeholders": [{
-                                    "placeholder": "person_name",
-                                    "transforms": [{
-                                        "transform": "concatenate_list",
-                                        "arguments": {
-                                            "list_to_concatenate": {
-                                                "source": "answers",
-                                                "identifier": ["first-name-answer", "last-name-answer"]
-                                            },
-                                            "delimiter": " "
-                                        }
-                                    }]
-                                }]
-                            },
-                            "type": "General",
-                            "answers": [{
-                                "id": "proxy-answer",
-                                "mandatory": true,
-                                "options": [{
-                                        "label": "Yes, I am",
-                                        "value": "non-proxy"
+        "id": "variant-proxy-section",
+        "groups": [{
+            "id": "variant-proxy-group",
+            "title": "Variants for proxy",
+            "blocks": [{
+                "type": "Question",
+                "id": "name-block",
+                "question": {
+                    "description": "",
+                    "id": "name-question",
+                    "title": "Who is this questionnaire about?",
+                    "type": "General",
+                    "answers": [{
+                        "id": "first-name-answer",
+                        "description": "",
+                        "label": "First Name",
+                        "mandatory": true,
+                        "type": "TextField"
+                    }, {
+                        "id": "last-name-answer",
+                        "description": "",
+                        "label": "Last Name",
+                        "mandatory": false,
+                        "type": "TextField"
+                    }]
+                }
+            }, {
+                "type": "Question",
+                "id": "proxy-block",
+                "question": {
+                    "id": "proxy-question",
+                    "title": {
+                        "text": "Are you <em>{person_name}</em>?",
+                        "placeholders": [{
+                            "placeholder": "person_name",
+                            "transforms": [{
+                                "transform": "concatenate_list",
+                                "arguments": {
+                                    "list_to_concatenate": {
+                                        "source": "answers",
+                                        "identifier": ["first-name-answer", "last-name-answer"]
                                     },
-                                    {
-                                        "label": "No, I am answering on their behalf",
-                                        "value": "proxy"
-                                    }
-                                ],
-                                "type": "Radio"
+                                    "delimiter": " "
+                                }
                             }]
-                        }
-                    }
-                ]
-            }]
-        },
-        {
-            "id": "basic-question-variant-section",
-            "groups": [{
-                "id": "basic-question-variant-group",
-                "title": "Variants",
-                "blocks": [{
-                        "type": "Question",
-                        "id": "age-block",
-                        "question_variants": [{
-                                "question": {
-                                    "id": "age-question",
-                                    "type": "General",
-                                    "title": "What is your age?",
-                                    "answers": [{
-                                        "id": "age-answer",
-                                        "mandatory": false,
-                                        "type": "Number",
-                                        "label": "Age"
-                                    }]
-                                },
-                                "when": [{
-                                    "id": "proxy-answer",
-                                    "condition": "equals",
-                                    "value": "non-proxy"
-                                }]
-                            },
-                            {
-                                "question": {
-                                    "id": "age-question",
-                                    "type": "General",
-                                    "title": {
-                                        "text": "What age is <em>{person_name}</em>?",
-                                        "placeholders": [{
-                                            "placeholder": "person_name",
-                                            "transforms": [{
-                                                "transform": "concatenate_list",
-                                                "arguments": {
-                                                    "list_to_concatenate": {
-                                                        "source": "answers",
-                                                        "identifier": ["first-name-answer", "last-name-answer"]
-                                                    },
-                                                    "delimiter": " "
-                                                }
-                                            }]
-                                        }]
-                                    },
-                                    "answers": [{
-                                        "id": "age-answer",
-                                        "mandatory": true,
-                                        "type": "Number",
-                                        "label": "Age"
-                                    }]
-                                },
-                                "when": [{
-                                    "id": "proxy-answer",
-                                    "condition": "equals",
-                                    "value": "proxy"
-                                }]
-                            }
-                        ]
+                        }]
                     },
-                    {
-                        "type": "ConfirmationQuestion",
-                        "id": "age-confirmation-block",
-                        "question_variants": [{
-                                "question": {
-                                    "id": "age-confirmation-question",
-                                    "type": "General",
-                                    "title": "You are over 16?",
-                                    "answers": [{
-                                        "id": "age-confirm-answer",
-                                        "type": "Radio",
-                                        "mandatory": true,
-                                        "options": [{
-                                                "label": "Yes",
-                                                "value": "Yes"
-                                            },
-                                            {
-                                                "label": "No",
-                                                "value": "No"
-                                            }
-                                        ]
-                                    }]
-                                },
-                                "when": [{
-                                        "id": "age-answer",
-                                        "condition": "greater than",
-                                        "value": 16
-                                    },
-                                    {
-                                        "id": "proxy-answer",
-                                        "condition": "not equals",
-                                        "value": "proxy"
-                                    }
-                                ]
-                            },
-                            {
-                                "question": {
-                                    "id": "age-confirmation-question",
-                                    "type": "General",
-                                    "title": "You are under 16?",
-                                    "answers": [{
-                                        "id": "age-confirm-answer",
-                                        "type": "Radio",
-                                        "mandatory": true,
-                                        "options": [{
-                                                "label": "Yes",
-                                                "value": "Yes"
-                                            },
-                                            {
-                                                "label": "No",
-                                                "value": "No"
-                                            }
-                                        ]
-                                    }]
-                                },
-                                "when": [{
-                                        "id": "age-answer",
-                                        "condition": "less than or equal to",
-                                        "value": 16
-                                    },
-                                    {
-                                        "id": "proxy-answer",
-                                        "condition": "not equals",
-                                        "value": "proxy"
-                                    }
-                                ]
-                            },
-                            {
-                                "question": {
-                                    "id": "age-confirmation-question",
-                                    "type": "General",
-                                    "title": {
-                                        "text": "<em>{person_name}</em> is over 16?",
-                                        "placeholders": [{
-                                            "placeholder": "person_name",
-                                            "transforms": [{
-                                                "transform": "concatenate_list",
-                                                "arguments": {
-                                                    "list_to_concatenate": {
-                                                        "source": "answers",
-                                                        "identifier": ["first-name-answer", "last-name-answer"]
-                                                    },
-                                                    "delimiter": " "
-                                                }
-                                            }]
-                                        }]
-                                    },
-                                    "answers": [{
-                                        "id": "age-confirm-answer",
-                                        "type": "Radio",
-                                        "mandatory": true,
-                                        "options": [{
-                                                "label": "Yes",
-                                                "value": "Yes"
-                                            },
-                                            {
-                                                "label": "No",
-                                                "value": "No"
-                                            }
-                                        ]
-                                    }]
-                                },
-                                "when": [{
-                                        "id": "age-answer",
-                                        "condition": "greater than or equal to",
-                                        "value": 16
-                                    },
-                                    {
-                                        "id": "proxy-answer",
-                                        "condition": "equals",
-                                        "value": "proxy"
-                                    }
-                                ]
-                            },
-                            {
-                                "question": {
-                                    "id": "age-confirmation-question",
-                                    "type": "General",
-                                    "title": {
-                                        "text": "<em>{person_name}</em> is under 16?",
-                                        "placeholders": [{
-                                            "placeholder": "person_name",
-                                            "transforms": [{
-                                                "transform": "concatenate_list",
-                                                "arguments": {
-                                                    "list_to_concatenate": {
-                                                        "source": "answers",
-                                                        "identifier": ["first-name-answer", "last-name-answer"]
-                                                    },
-                                                    "delimiter": " "
-                                                }
-                                            }]
-                                        }]
-                                    },
-                                    "answers": [{
-                                        "id": "age-confirm-answer",
-                                        "type": "Radio",
-                                        "mandatory": true,
-                                        "options": [{
-                                                "label": "Yes",
-                                                "value": "Yes"
-                                            },
-                                            {
-                                                "label": "No",
-                                                "value": "No"
-                                            }
-                                        ]
-                                    }]
-                                },
-                                "when": [{
-                                        "id": "age-answer",
-                                        "condition": "less than or equal to",
-                                        "value": 16
-                                    },
-                                    {
-                                        "id": "proxy-answer",
-                                        "condition": "equals",
-                                        "value": "proxy"
-                                    }
-                                ]
-                            }
-                        ],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "age-block",
-                                    "when": [{
-                                        "id": "age-confirm-answer",
-                                        "condition": "equals",
-                                        "value": "no"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "basic-variants-summary"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "id": "basic-variants-summary",
-                        "type": "SectionSummary"
-                    }
-                ]
+                    "type": "General",
+                    "answers": [{
+                        "id": "proxy-answer",
+                        "mandatory": true,
+                        "options": [{
+                            "label": "Yes, I am",
+                            "value": "non-proxy"
+                        }, {
+                            "label": "No, I am answering on their behalf",
+                            "value": "proxy"
+                        }],
+                        "type": "Radio"
+                    }]
+                }
             }]
-        },
-        {
-            "id": "currency-section",
-            "groups": [{
-                "id": "currency-group",
-                "title": "Section Summary With Variants",
-                "blocks": [{
-                        "type": "Question",
-                        "id": "currency-block",
-                        "question": {
-                            "id": "currency-question",
-                            "type": "General",
-                            "title": "What currency would you like",
-                            "answers": [{
-                                "id": "currency-answer",
-                                "type": "Radio",
-                                "mandatory": true,
-                                "options": [{
-                                        "label": "US Dollars",
-                                        "value": "USD"
-                                    },
-                                    {
-                                        "label": "Sterling",
-                                        "value": "GBP"
+        }]
+    }, {
+        "id": "basic-question-variant-section",
+        "groups": [{
+            "id": "basic-question-variant-group",
+            "title": "Variants",
+            "blocks": [{
+                "type": "Question",
+                "id": "age-block",
+                "question_variants": [{
+                    "question": {
+                        "id": "age-question",
+                        "type": "General",
+                        "title": "What is your age?",
+                        "answers": [{
+                            "id": "age-answer",
+                            "mandatory": false,
+                            "type": "Number",
+                            "label": "Age"
+                        }]
+                    },
+                    "when": [{
+                        "id": "proxy-answer",
+                        "condition": "equals",
+                        "value": "non-proxy"
+                    }]
+                }, {
+                    "question": {
+                        "id": "age-question",
+                        "type": "General",
+                        "title": {
+                            "text": "What age is <em>{person_name}</em>?",
+                            "placeholders": [{
+                                "placeholder": "person_name",
+                                "transforms": [{
+                                    "transform": "concatenate_list",
+                                    "arguments": {
+                                        "list_to_concatenate": {
+                                            "source": "answers",
+                                            "identifier": ["first-name-answer", "last-name-answer"]
+                                        },
+                                        "delimiter": " "
                                     }
-                                ]
+                                }]
                             }]
-                        }
+                        },
+                        "answers": [{
+                            "id": "age-answer",
+                            "mandatory": true,
+                            "type": "Number",
+                            "label": "Age"
+                        }]
                     },
-                    {
-                        "type": "Question",
-                        "id": "first-number-block",
-                        "question_variants": [{
-                                "question": {
-                                    "id": "first-number-question",
-                                    "title": "First Number Question Title",
-                                    "type": "General",
-                                    "answers": [{
-                                        "id": "first-number-answer",
-                                        "label": "First answer in GBP",
-                                        "mandatory": true,
-                                        "type": "Currency",
-                                        "currency": "GBP",
-                                        "decimal_places": 2
-                                    }]
-                                },
-                                "when": [{
-                                    "id": "currency-answer",
-                                    "condition": "equals",
-                                    "value": "GBP"
-                                }]
-                            },
-                            {
-                                "question": {
-                                    "id": "first-number-question",
-                                    "title": "First Number Question Title",
-                                    "type": "General",
-                                    "answers": [{
-                                        "id": "first-number-answer",
-                                        "label": "First answer in USD",
-                                        "mandatory": true,
-                                        "type": "Currency",
-                                        "currency": "USD",
-                                        "decimal_places": 2
-                                    }]
-                                },
-                                "when": [{
-                                    "id": "currency-answer",
-                                    "condition": "equals",
-                                    "value": "USD"
-                                }]
-                            }
-                        ]
-                    },
-                    {
-                        "type": "Question",
-                        "id": "second-number-block",
-                        "question_variants": [{
-                                "question": {
-                                    "id": "second-number-question",
-                                    "title": "Second Number Question Title",
-                                    "type": "General",
-                                    "answers": [{
-                                        "id": "second-number-answer",
-                                        "label": "Second answer in GBP",
-                                        "mandatory": true,
-                                        "type": "Currency",
-                                        "currency": "GBP",
-                                        "decimal_places": 2
-                                    }]
-                                },
-                                "when": [{
-                                    "id": "currency-answer",
-                                    "condition": "equals",
-                                    "value": "GBP"
-                                }]
-                            },
-                            {
-                                "question": {
-                                    "id": "second-number-question",
-                                    "title": "Second Number Question Title",
-                                    "type": "General",
-                                    "answers": [{
-                                        "id": "second-number-answer",
-                                        "label": "Second answer in USD",
-                                        "mandatory": true,
-                                        "type": "Currency",
-                                        "currency": "USD",
-                                        "decimal_places": 2
-                                    }]
-                                },
-                                "when": [{
-                                    "id": "currency-answer",
-                                    "condition": "equals",
-                                    "value": "USD"
-                                }]
-                            }
-                        ]
-                    },
-                    {
-                        "type": "SectionSummary",
-                        "id": "currency-section-summary"
-                    }
-                ]
-            }]
-        },
-        {
-            "id": "summary-section",
-            "groups": [{
-                "id": "summary-group",
-                "title": "Final summary",
-                "blocks": [{
-                    "id": "all-summary",
-                    "type": "Summary"
+                    "when": [{
+                        "id": "proxy-answer",
+                        "condition": "equals",
+                        "value": "proxy"
+                    }]
                 }]
+            }, {
+                "type": "ConfirmationQuestion",
+                "id": "age-confirmation-block",
+                "question_variants": [{
+                    "question": {
+                        "id": "age-confirmation-question",
+                        "type": "General",
+                        "title": "You are over 16?",
+                        "answers": [{
+                            "id": "age-confirm-answer",
+                            "type": "Radio",
+                            "mandatory": true,
+                            "options": [{
+                                "label": "Yes",
+                                "value": "Yes"
+                            }, {
+                                "label": "No",
+                                "value": "No"
+                            }]
+                        }]
+                    },
+                    "when": [{
+                        "id": "age-answer",
+                        "condition": "greater than",
+                        "value": 16
+                    }, {
+                        "id": "proxy-answer",
+                        "condition": "not equals",
+                        "value": "proxy"
+                    }]
+                }, {
+                    "question": {
+                        "id": "age-confirmation-question",
+                        "type": "General",
+                        "title": "You are under 16?",
+                        "answers": [{
+                            "id": "age-confirm-answer",
+                            "type": "Radio",
+                            "mandatory": true,
+                            "options": [{
+                                "label": "Yes",
+                                "value": "Yes"
+                            }, {
+                                "label": "No",
+                                "value": "No"
+                            }]
+                        }]
+                    },
+                    "when": [{
+                        "id": "age-answer",
+                        "condition": "less than or equal to",
+                        "value": 16
+                    }, {
+                        "id": "proxy-answer",
+                        "condition": "not equals",
+                        "value": "proxy"
+                    }]
+                }, {
+                    "question": {
+                        "id": "age-confirmation-question",
+                        "type": "General",
+                        "title": {
+                            "text": "<em>{person_name}</em> is over 16?",
+                            "placeholders": [{
+                                "placeholder": "person_name",
+                                "transforms": [{
+                                    "transform": "concatenate_list",
+                                    "arguments": {
+                                        "list_to_concatenate": {
+                                            "source": "answers",
+                                            "identifier": ["first-name-answer", "last-name-answer"]
+                                        },
+                                        "delimiter": " "
+                                    }
+                                }]
+                            }]
+                        },
+                        "answers": [{
+                            "id": "age-confirm-answer",
+                            "type": "Radio",
+                            "mandatory": true,
+                            "options": [{
+                                "label": "Yes",
+                                "value": "Yes"
+                            }, {
+                                "label": "No",
+                                "value": "No"
+                            }]
+                        }]
+                    },
+                    "when": [{
+                        "id": "age-answer",
+                        "condition": "greater than or equal to",
+                        "value": 16
+                    }, {
+                        "id": "proxy-answer",
+                        "condition": "equals",
+                        "value": "proxy"
+                    }]
+                }, {
+                    "question": {
+                        "id": "age-confirmation-question",
+                        "type": "General",
+                        "title": {
+                            "text": "<em>{person_name}</em> is under 16?",
+                            "placeholders": [{
+                                "placeholder": "person_name",
+                                "transforms": [{
+                                    "transform": "concatenate_list",
+                                    "arguments": {
+                                        "list_to_concatenate": {
+                                            "source": "answers",
+                                            "identifier": ["first-name-answer", "last-name-answer"]
+                                        },
+                                        "delimiter": " "
+                                    }
+                                }]
+                            }]
+                        },
+                        "answers": [{
+                            "id": "age-confirm-answer",
+                            "type": "Radio",
+                            "mandatory": true,
+                            "options": [{
+                                "label": "Yes",
+                                "value": "Yes"
+                            }, {
+                                "label": "No",
+                                "value": "No"
+                            }]
+                        }]
+                    },
+                    "when": [{
+                        "id": "age-answer",
+                        "condition": "less than or equal to",
+                        "value": 16
+                    }, {
+                        "id": "proxy-answer",
+                        "condition": "equals",
+                        "value": "proxy"
+                    }]
+                }],
+                "routing_rules": [{
+                    "goto": {
+                        "block": "age-block",
+                        "when": [{
+                            "id": "age-confirm-answer",
+                            "condition": "equals",
+                            "value": "no"
+                        }]
+                    }
+                }, {
+                    "goto": {
+                        "block": "basic-variants-summary"
+                    }
+                }]
+            }, {
+                "id": "basic-variants-summary",
+                "type": "SectionSummary"
             }]
-        }
-    ]
+        }]
+    }, {
+        "id": "currency-section",
+        "groups": [{
+            "id": "currency-group",
+            "title": "Section Summary With Variants",
+            "blocks": [{
+                "type": "Question",
+                "id": "currency-block",
+                "question": {
+                    "id": "currency-question",
+                    "type": "General",
+                    "title": "What currency would you like",
+                    "answers": [{
+                        "id": "currency-answer",
+                        "type": "Radio",
+                        "mandatory": true,
+                        "options": [{
+                            "label": "US Dollars",
+                            "value": "USD"
+                        }, {
+                            "label": "Sterling",
+                            "value": "GBP"
+                        }]
+                    }]
+                }
+            }, {
+                "type": "Question",
+                "id": "first-number-block",
+                "question_variants": [{
+                    "question": {
+                        "id": "first-number-question",
+                        "title": "First Number Question Title",
+                        "type": "General",
+                        "answers": [{
+                            "id": "first-number-answer",
+                            "label": "First answer in GBP",
+                            "mandatory": true,
+                            "type": "Currency",
+                            "currency": "GBP",
+                            "decimal_places": 2
+                        }]
+                    },
+                    "when": [{
+                        "id": "currency-answer",
+                        "condition": "equals",
+                        "value": "GBP"
+                    }]
+                }, {
+                    "question": {
+                        "id": "first-number-question",
+                        "title": "First Number Question Title",
+                        "type": "General",
+                        "answers": [{
+                            "id": "first-number-answer",
+                            "label": "First answer in USD",
+                            "mandatory": true,
+                            "type": "Currency",
+                            "currency": "USD",
+                            "decimal_places": 2
+                        }]
+                    },
+                    "when": [{
+                        "id": "currency-answer",
+                        "condition": "equals",
+                        "value": "USD"
+                    }]
+                }]
+            }, {
+                "type": "Question",
+                "id": "second-number-block",
+                "question_variants": [{
+                    "question": {
+                        "id": "second-number-question",
+                        "title": "Second Number Question Title",
+                        "type": "General",
+                        "answers": [{
+                            "id": "second-number-answer",
+                            "label": "Second answer in GBP",
+                            "mandatory": true,
+                            "type": "Currency",
+                            "currency": "GBP",
+                            "decimal_places": 2
+                        }]
+                    },
+                    "when": [{
+                        "id": "currency-answer",
+                        "condition": "equals",
+                        "value": "GBP"
+                    }]
+                }, {
+                    "question": {
+                        "id": "second-number-question",
+                        "title": "Second Number Question Title",
+                        "type": "General",
+                        "answers": [{
+                            "id": "second-number-answer",
+                            "label": "Second answer in USD",
+                            "mandatory": true,
+                            "type": "Currency",
+                            "currency": "USD",
+                            "decimal_places": 2
+                        }]
+                    },
+                    "when": [{
+                        "id": "currency-answer",
+                        "condition": "equals",
+                        "value": "USD"
+                    }]
+                }]
+            }, {
+                "type": "SectionSummary",
+                "id": "currency-section-summary"
+            }]
+        }]
+    }, {
+        "id": "summary-section",
+        "groups": [{
+            "id": "summary-group",
+            "title": "Final summary",
+            "blocks": [{
+                "id": "all-summary",
+                "type": "Summary"
+            }]
+        }]
+    }]
 }

--- a/data-source/json/test_view_submitted_response.json
+++ b/data-source/json/test_view_submitted_response.json
@@ -31,7 +31,6 @@
             "blocks": [{
                 "type": "Question",
                 "id": "radio",
-                "description": "",
                 "question": {
                     "answers": [{
                         "id": "radio-answer",
@@ -66,14 +65,12 @@
                     }],
                     "description": "",
                     "id": "radio-question",
-                    "title": "",
+                    "title": "What is your favourite breakfast food",
                     "type": "General"
-                },
-                "title": "What is your favourite breakfast food"
+                }
             }, {
                 "type": "Question",
                 "id": "test-number-block",
-                "description": "",
                 "question": {
                     "answers": [{
                         "id": "test-currency",
@@ -103,8 +100,7 @@
                     "id": "test-number-range-question",
                     "title": "Please enter test values (none mandatory)",
                     "type": "General"
-                },
-                "title": ""
+                }
             }, {
                 "type": "Summary",
                 "id": "summary"

--- a/data-source/jsonnet/common/blocks/confirmation.json
+++ b/data-source/jsonnet/common/blocks/confirmation.json
@@ -1,18 +1,20 @@
 {
     "type": "Confirmation",
     "id": "confirmation",
-    "title": "You’re ready to submit your 2019 Census Test",
-    "content": [
-        {
-            "description": "Thank you for taking part in the 2019 Census Test"
-        },
-        {
-            "title": "Please note:",
-            "list": [
-                "by submitting your responses, you are declaring that you have completed to the best of your knowledge and belief.",
-                "if you do not submit, your responses will be automatically submitted when the Census 2019 Test closes.",
-                "after submission you will have an opportunity to provide feedback on your experience."
-            ]
-        }
-    ]
+    "content": {
+        "title": "You’re ready to submit your 2019 Census Test",
+        "contents": [
+            {
+                "description": "Thank you for taking part in the 2019 Census Test"
+            },
+            {
+                "title": "Please note:",
+                "list": [
+                    "by submitting your responses, you are declaring that you have completed to the best of your knowledge and belief.",
+                    "if you do not submit, your responses will be automatically submitted when the Census 2019 Test closes.",
+                    "after submission you will have an opportunity to provide feedback on your experience."
+                ]
+            }
+        ]
+    }
 }

--- a/data-source/jsonnet/common/blocks/individual/employment/employer_address_depot.jsonnet
+++ b/data-source/jsonnet/common/blocks/individual/employment/employer_address_depot.jsonnet
@@ -38,7 +38,7 @@ local question(title) = {
       guidance: {
         show_guidance: 'Why your answer is important',
         hide_guidance: 'Why your answer is important',
-        content: [
+        contents: [
           {
             description: 'The government uses information about workplace address and method of travel to work to form transport policies and plan services. The information helps to work out local transport needs.',
           },

--- a/data-source/jsonnet/common/blocks/individual/employment/employer_address_workplace.jsonnet
+++ b/data-source/jsonnet/common/blocks/individual/employment/employer_address_workplace.jsonnet
@@ -38,7 +38,7 @@ local question(title) = {
       guidance: {
         show_guidance: 'Why your answer is important',
         hide_guidance: 'Why your answer is important',
-        content: [
+        contents: [
           {
             description: 'The government uses information about workplace address and method of travel to work to form transport policies and plan services. The information helps to work out local transport needs.',
           },

--- a/data-source/jsonnet/common/blocks/individual/employment/employment_status.jsonnet
+++ b/data-source/jsonnet/common/blocks/individual/employment/employment_status.jsonnet
@@ -7,7 +7,7 @@ local question(title) = {
   type: 'MutuallyExclusive',
   mandatory: true,
   guidance: {
-    content: [
+    contents: [
       {
         title: 'Include casual or temporary work, even if only for one hour',
       },

--- a/data-source/jsonnet/common/blocks/individual/employment/hours_worked.jsonnet
+++ b/data-source/jsonnet/common/blocks/individual/employment/hours_worked.jsonnet
@@ -5,7 +5,7 @@ local question(title) = {
   title: title,
   id: 'hours-worked-question',
   guidance: {
-    content: [
+    contents: [
       {
         title: 'Include paid and unpaid overtime',
       },

--- a/data-source/jsonnet/common/blocks/individual/employment/jobseeker.jsonnet
+++ b/data-source/jsonnet/common/blocks/individual/employment/jobseeker.jsonnet
@@ -10,7 +10,7 @@ local question(title, guidanceHeader) = {
       guidance: {
         show_guidance: guidanceHeader,
         hide_guidance: guidanceHeader,
-        content: [
+        contents: [
           {
             description: 'To get a true picture of the UK working population, we ask this question of everyone who is not currently working. We ask people who are retired because the number of people continuing to work after retirement age is increasing. We ask people who are long-term sick or disabled because some intend to go back to work.',
           },

--- a/data-source/jsonnet/common/blocks/individual/employment/main_employment_block.jsonnet
+++ b/data-source/jsonnet/common/blocks/individual/employment/main_employment_block.jsonnet
@@ -4,48 +4,55 @@ local rules = import '../../../lib/rules.libsonnet';
 {
   type: 'Interstitial',
   id: 'main-employment-block',
-  title: '',
   content_variants: [
     {
-      content: [
-        {
-          title: 'Main job',
-          description: 'The next set of questions is about your main job. Your main job is the job in which you usually work the most hours',
-        },
-      ],
+      content: {
+        title: 'Main job',
+        contents: [
+          {
+            description: 'The next set of questions is about your main job. Your main job is the job in which you usually work the most hours',
+          },
+        ],
+      },
       when: [rules.proxyNo, rules.mainJob],
     },
     {
-      content: [
-        {
-          title: 'Main job',
-          description: {
-            text: 'The next set of questions is about <em>{person_name_possessive}</em> main job. Their main job is the job in which they usually work the most hours',
-            placeholders: [placeholders.personNamePossessive],
+      content: {
+        title: 'Main job',
+        contents: [
+          {
+            description: {
+              text: 'The next set of questions is about <em>{person_name_possessive}</em> main job. Their main job is the job in which they usually work the most hours',
+              placeholders: [placeholders.personNamePossessive],
+            },
           },
-        },
-      ],
+        ],
+      },
       when: [rules.proxyYes, rules.mainJob],
     },
     {
-      content: [
-        {
-          title: 'Last main job',
-          description: 'The next set of questions is about your last main job. Your main job is the job in which you usually worked the most hours',
-        },
-      ],
+      content: {
+        title: 'Last main job',
+        contents: [
+          {
+            description: 'The next set of questions is about your last main job. Your main job is the job in which you usually worked the most hours',
+          },
+        ],
+      },
       when: [rules.proxyNo, rules.lastMainJob],
     },
     {
-      content: [
-        {
-          title: 'Last main job',
-          description: {
-            text: 'The next set of questions is about <em>{person_name_possessive}</em> last main job. Their main job is the job in which they usually worked the most hours',
-            placeholders: [placeholders.personNamePossessive],
+      content: {
+        title: 'Last main job',
+        contents: [
+          {
+            description: {
+              text: 'The next set of questions is about <em>{person_name_possessive}</em> last main job. Their main job is the job in which they usually worked the most hours',
+              placeholders: [placeholders.personNamePossessive],
+            },
           },
-        },
-      ],
+        ],
+      },
       when: [rules.proxyYes, rules.lastMainJob],
     },
   ],

--- a/data-source/jsonnet/common/blocks/individual/identity-and-health/carer.jsonnet
+++ b/data-source/jsonnet/common/blocks/individual/identity-and-health/carer.jsonnet
@@ -5,7 +5,7 @@ local question(title, guidance) = {
   id: 'carer-question',
   title: title,
   guidance: {
-    content: [
+    contents: [
       {
         title: guidance,
       },

--- a/data-source/jsonnet/common/blocks/individual/personal-details/establishment_position.jsonnet
+++ b/data-source/jsonnet/common/blocks/individual/personal-details/establishment_position.jsonnet
@@ -7,7 +7,7 @@ local question(title) = {
   definitions: [
     {
       title: 'What is an establishment?',
-      content: [
+      contents: [
         {
           description: 'A communal establishment is an establishment providing managed residential accommodation. ‘Managed’ in this context means full-time or part-time supervision of the accommodation. Examples of communal establishments include student halls of residence, boarding schools, armed forces bases, hospitals, care homes and prisons',
         },

--- a/data-source/jsonnet/england-wales/blocks/individual/employment/armed_forces.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/employment/armed_forces.jsonnet
@@ -5,7 +5,7 @@ local question(title) = {
   id: 'armed-forces-question',
   title: title,
   guidance: {
-    content: [
+    contents: [
       {
         title: 'Current serving members should select “No”',
       },
@@ -19,7 +19,7 @@ local question(title) = {
       guidance: {
         show_guidance: 'Why your answer is important',
         hide_guidance: 'Why your answer is important',
-        content: [
+        contents: [
           {
             description: 'We are measuring the number of people who have served in the UK Armed Forces and have now left. Government and councils need this information to carry out their commitments made under the Armed Forces Covenant. This is a promise by the nation ensuring that those who serve or who have served in the armed forces, and their families, are not disadvantaged.',
           },

--- a/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/disability.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/disability.jsonnet
@@ -7,7 +7,7 @@ local question(title, definitionContent) = {
   definitions: [
     {
       title: 'What do we mean by “physical and mental health conditions or illnesses”?',
-      content: definitionContent,
+      contents: definitionContent,
     },
   ],
   type: 'General',

--- a/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/disability_limitation.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/disability_limitation.jsonnet
@@ -32,7 +32,7 @@ local question(title, definition) = {
 local nonProxyTitle = 'Do any of your conditions or illnesses reduce your ability to carry out day-to-day activities?';
 local nonProxyDefinition = {
   title: 'What do we mean by “reduce your ability”?',
-  content: [
+  contents: [
     {
       description: 'We mean whether your health condition or illness currently affects your ability to carry out day-to-day activities.',
     },
@@ -55,7 +55,7 @@ local proxyTitle = {
 };
 local proxyDefinition = {
   title: 'What do we mean by “reduce their ability”?',
-  content: [
+  contents: [
     {
       description: 'We mean whether their health condition or illness currently affects their ability to carry out day-to-day activities.',
     },

--- a/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/ethnic_group.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/ethnic_group.jsonnet
@@ -23,7 +23,7 @@ local question(title, region_code) = (
         guidance: {
           show_guidance: 'Why your answer is important',
           hide_guidance: 'Why your answer is important',
-          content: [
+          contents: [
             {
               description: 'Your answer will help to support equality and fairness in your community. Councils and government use information on ethnic group to make sure they:',
               list: [

--- a/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/ethnic_group_asian.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/ethnic_group_asian.jsonnet
@@ -10,7 +10,7 @@ local question(title) = {
       guidance: {
         show_guidance: 'Why your answer is important',
         hide_guidance: 'Why your answer is important',
-        content: [
+        contents: [
           {
             description: 'How you define your ethnic group is up to you. Sharing this information enables the government and other organisations to provide appropriate resources and policies such as housing, education, health and criminal justice.',
           },

--- a/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/ethnic_group_black.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/ethnic_group_black.jsonnet
@@ -10,7 +10,7 @@ local question(title) = {
       guidance: {
         show_guidance: 'Why your answer is important',
         hide_guidance: 'Why your answer is important',
-        content: [
+        contents: [
           {
             description: 'How you define your ethnic group is up to you. Sharing this information enables the government and other organisations to provide appropriate resources and policies such as housing, education, health and criminal justice.',
           },

--- a/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/ethnic_group_mixed.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/ethnic_group_mixed.jsonnet
@@ -10,7 +10,7 @@ local question(title) = {
       guidance: {
         show_guidance: 'Why your answer is important',
         hide_guidance: 'Why your answer is important',
-        content: [
+        contents: [
           {
             description: 'How you define your ethnic group is up to you. Sharing this information enables the government and other organisations to provide appropriate resources and policies such as housing, education, health and criminal justice.',
           },

--- a/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/ethnic_group_other.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/ethnic_group_other.jsonnet
@@ -10,7 +10,7 @@ local question(title) = {
       guidance: {
         show_guidance: 'Why your answer is important',
         hide_guidance: 'Why your answer is important',
-        content: [
+        contents: [
           {
             description: 'How you define your ethnic group is up to you. Sharing this information enables the government and other organisations to provide appropriate resources and policies such as housing, education, health and criminal justice.',
           },

--- a/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/ethnic_group_white.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/ethnic_group_white.jsonnet
@@ -23,7 +23,7 @@ local question(title, region_code) = (
         guidance: {
           show_guidance: 'Why your answer is important',
           hide_guidance: 'Why your answer is important',
-          content: [
+          contents: [
             {
               description: 'How you define your ethnic group is up to you. Sharing this information enables the government and other organisations to provide appropriate resources and policies such as housing, education, health and criminal justice.',
             },

--- a/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/language.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/language.jsonnet
@@ -30,7 +30,7 @@ local question(title, definitionDescription, region_code) = (
     type: 'General',
     definitions: [{
       title: 'What do we mean by “main language”?',
-      content: [
+      contents: [
         {
           description: definitionDescription,
         },

--- a/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/national_identity.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/national_identity.jsonnet
@@ -61,7 +61,7 @@ local question(title, definitionContent, detailAnswerLabel, region_code) = (
     definitions: [
       {
         title: 'What do we mean by “national identity”?',
-        content: definitionContent,
+        contents: definitionContent,
       },
     ],
     answers: [

--- a/data-source/jsonnet/england-wales/blocks/individual/personal-details/another_address.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/personal-details/another_address.jsonnet
@@ -8,7 +8,7 @@ local question(title) = {
   definitions: [
     {
       title: 'What do we mean by “another address”?',
-      content: [
+      contents: [
         {
           description: "We mean a different address to the one at the start of this survey. This might be another parent or guardian’s address, a term-time address, a partner's address or a holiday home.",
         },

--- a/data-source/jsonnet/england-wales/blocks/individual/personal-details/sex.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/personal-details/sex.jsonnet
@@ -32,7 +32,7 @@ local proxyTitle = {
   ],
 };
 local guidance = {
-  content: [
+  contents: [
     {
       title: 'A question about gender will follow',
     },

--- a/data-source/jsonnet/england-wales/blocks/individual/qualifications/a_level.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/qualifications/a_level.jsonnet
@@ -24,7 +24,7 @@ local question(title, region_code) = (
     id: 'a-level-question',
     title: title,
     guidance: {
-      content: [
+      contents: [
         {
           title: regionGuidanceTitle,
         },

--- a/data-source/jsonnet/england-wales/blocks/individual/qualifications/apprenticeship.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/qualifications/apprenticeship.jsonnet
@@ -22,7 +22,7 @@ local question(title, region_code) = (
     title: title,
     type: 'General',
     guidance: {
-      content: [
+      contents: [
         {
           title: regionGuidanceTitle,
         },

--- a/data-source/jsonnet/england-wales/blocks/individual/qualifications/degree.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/qualifications/degree.jsonnet
@@ -19,7 +19,7 @@ local question(title, region_code) = (
     title: title,
     type: 'General',
     guidance: {
-      content: [
+      contents: [
         {
           title: regionGuidanceTitle,
         },

--- a/data-source/jsonnet/england-wales/blocks/individual/qualifications/gcse.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/qualifications/gcse.jsonnet
@@ -32,7 +32,7 @@ local question(title, region_code) = (
     type: 'MutuallyExclusive',
     mandatory: true,
     guidance: {
-      content: [
+      contents: [
         {
           title: regionGuidanceTitle,
         },

--- a/data-source/jsonnet/england-wales/blocks/individual/qualifications/nvq_level.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/qualifications/nvq_level.jsonnet
@@ -19,7 +19,7 @@ local question(title, region_code) = (
     title: title,
     type: 'MutuallyExclusive',
     guidance: {
-      content: [
+      contents: [
         {
           title: regionGuidanceTitle,
         },

--- a/data-source/jsonnet/england-wales/blocks/individual/qualifications/qualifications.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/qualifications/qualifications.jsonnet
@@ -13,25 +13,30 @@ function(region_code) (
   {
     type: 'Interstitial',
     id: 'qualifications',
-    title: 'Qualifications',
     content_variants: [
       {
-        content: [
-          {
-            description: regionDescriptionNonProxy,
-          },
-        ],
+        content: {
+          title: 'Qualifications',
+          contents: [
+            {
+              description: regionDescriptionNonProxy,
+            },
+          ],
+        },
         when: [rules.proxyNo],
       },
       {
-        content: [
-          {
-            description: {
-              text: regionDescriptionProxy,
-              placeholders: [placeholders.personName],
+        content: {
+          title: 'Qualifications',
+          contents: [
+            {
+              description: {
+                text: regionDescriptionProxy,
+                placeholders: [placeholders.personName],
+              },
             },
-          },
-        ],
+          ],
+        },
         when: [rules.proxyYes],
       },
     ],

--- a/data-source/jsonnet/northern-ireland/blocks/individual/employment/armed_forces.jsonnet
+++ b/data-source/jsonnet/northern-ireland/blocks/individual/employment/armed_forces.jsonnet
@@ -5,7 +5,7 @@ local question(title) = {
   id: 'armed-forces-question',
   title: title,
   guidance: {
-    content: [
+    contents: [
       {
         title: 'Current serving members should select “No”',
       },
@@ -19,7 +19,7 @@ local question(title) = {
       guidance: {
         show_guidance: 'Why your answer is important',
         hide_guidance: 'Why your answer is important',
-        content: [
+        contents: [
           {
             description: 'We are measuring the number of people who have served in the UK Armed Forces and have now left. Government and councils need this information to carry out their commitments made under the Armed Forces Covenant. This is a promise by the nation ensuring that those who serve or who have served in the armed forces, and their families, are not disadvantaged.',
           },

--- a/data-source/jsonnet/northern-ireland/blocks/individual/identity-and-health/disability_limitation.jsonnet
+++ b/data-source/jsonnet/northern-ireland/blocks/individual/identity-and-health/disability_limitation.jsonnet
@@ -5,7 +5,7 @@ local question(title) = {
   id: 'disability-limitation-question',
   title: title,
   guidance: {
-    content: [
+    contents: [
       {
         title: 'Include problems relating to old age',
       },

--- a/data-source/jsonnet/northern-ireland/blocks/individual/identity-and-health/language.jsonnet
+++ b/data-source/jsonnet/northern-ireland/blocks/individual/identity-and-health/language.jsonnet
@@ -18,7 +18,7 @@ local question(title, definitionDescription) = {
   type: 'General',
   definitions: [{
     title: 'What do we mean by “main language”?',
-    content: [
+    contents: [
       {
         description: definitionDescription,
       },

--- a/data-source/jsonnet/northern-ireland/blocks/individual/identity-and-health/national_identity.jsonnet
+++ b/data-source/jsonnet/northern-ireland/blocks/individual/identity-and-health/national_identity.jsonnet
@@ -37,7 +37,7 @@ local question(title, definitionContent, detailAnswerLabel) = {
   definitions: [
     {
       title: 'What do we mean by “national identity”?',
-      content: definitionContent,
+      contents: definitionContent,
     },
   ],
   answers: [

--- a/data-source/jsonnet/northern-ireland/blocks/individual/qualifications/a_level.jsonnet
+++ b/data-source/jsonnet/northern-ireland/blocks/individual/qualifications/a_level.jsonnet
@@ -13,7 +13,7 @@ local question(title) = {
   id: 'a-level-question',
   title: title,
   guidance: {
-    content: [
+    contents: [
       {
         title: 'Include equivalent qualifications achieved anywhere outside Northern Ireland',
       },

--- a/data-source/jsonnet/northern-ireland/blocks/individual/qualifications/apprenticeship.jsonnet
+++ b/data-source/jsonnet/northern-ireland/blocks/individual/qualifications/apprenticeship.jsonnet
@@ -14,7 +14,7 @@ local question(title) = {
   title: title,
   type: 'General',
   guidance: {
-    content: [
+    contents: [
       {
         title: 'Include equivalent apprenticeships completed anywhere outside Northern Ireland',
       },

--- a/data-source/jsonnet/northern-ireland/blocks/individual/qualifications/degree.jsonnet
+++ b/data-source/jsonnet/northern-ireland/blocks/individual/qualifications/degree.jsonnet
@@ -14,7 +14,7 @@ local question(title) = {
   title: title,
   type: 'General',
   guidance: {
-    content: [
+    contents: [
       {
         title: 'Include equivalent qualifications achieved anywhere outside Northern Ireland',
       },

--- a/data-source/jsonnet/northern-ireland/blocks/individual/qualifications/gcse.jsonnet
+++ b/data-source/jsonnet/northern-ireland/blocks/individual/qualifications/gcse.jsonnet
@@ -15,7 +15,7 @@ local question(title) = {
   type: 'MutuallyExclusive',
   mandatory: true,
   guidance: {
-    content: [
+    contents: [
       {
         title: 'Include equivalent qualifications achieved anywhere outside Northern Ireland',
       },

--- a/data-source/jsonnet/northern-ireland/blocks/individual/qualifications/nvq_level.jsonnet
+++ b/data-source/jsonnet/northern-ireland/blocks/individual/qualifications/nvq_level.jsonnet
@@ -14,7 +14,7 @@ local question(title) = {
   title: title,
   type: 'MutuallyExclusive',
   guidance: {
-    content: [
+    contents: [
       {
         title: 'Include equivalent qualifications achieved anywhere outside Northern Ireland',
       },

--- a/data-source/jsonnet/northern-ireland/blocks/individual/qualifications/qualifications.jsonnet
+++ b/data-source/jsonnet/northern-ireland/blocks/individual/qualifications/qualifications.jsonnet
@@ -7,25 +7,30 @@ local descriptionProxy = 'The next set of questions is about the qualifications 
 {
   type: 'Interstitial',
   id: 'qualifications',
-  title: 'Qualifications',
   content_variants: [
     {
-      content: [
-        {
-          description: descriptionNonProxy,
-        },
-      ],
+      content: {
+        title: 'Qualifications',
+        contents: [
+          {
+            description: descriptionNonProxy,
+          },
+        ],
+      },
       when: [rules.proxyNo],
     },
     {
-      content: [
-        {
-          description: {
-            text: descriptionProxy,
-            placeholders: [placeholders.personName],
+      content: {
+        title: 'Qualifications',
+        contents: [
+          {
+            description: {
+              text: descriptionProxy,
+              placeholders: [placeholders.personName],
+            },
           },
-        },
-      ],
+        ],
+      },
       when: [rules.proxyYes],
     },
   ],

--- a/scripts/test_schemas.sh
+++ b/scripts/test_schemas.sh
@@ -27,7 +27,7 @@ until [ "$checks" == 0 ]; do
             sleep 5
         else
             echo -e "Exiting...${default}\\n"
-            exit
+            exit 1
         fi
         (( checks-- ))
     else

--- a/templates/confirmation.html
+++ b/templates/confirmation.html
@@ -28,7 +28,7 @@
     }}
   {% else  %}
     {% if block and block.content %}
-      {% set content_block = content.block.content %}
+      {% set content_block = block.content %}
       {% include 'partials/content-block.html' %}
     {% endif %}
     <p class="u-mt-m">

--- a/templates/interstitial.html
+++ b/templates/interstitial.html
@@ -5,29 +5,9 @@
 {% set continue_button_text = _("Continue") %}
 
 {% block form_content %}
-  {% if block['section_number'] %}
-    <h1>Section {{ block['section_number'] }}: {{ block['title'] }}</h1>
-  {% else %}
-    <h1>{{ block['title'] }}</h1>
+  {% if block.content.title %}
+    <h1 class="u-fs-l">{{ block.content.title }}</h1>
   {% endif %}
-  {% if block['description'] %}
-    <p>{{ block['description'] | safe }}</p>
-  {% endif %}
-
-  {% for item in block.content %}
-    {%- if item.title -%}
-      <h2>{{ item.title }}</h2>
-    {% endif %}
-    {%- if item.description -%}
-      <p>{{ item.description }}</p>
-    {% endif %}
-    {%- if item.list -%}
-      <ul>
-        {%- for list_item in item.list -%}
-          <li>{{ list_item }}</li>
-        {% endfor %}
-      </ul>
-    {% endif %}
-  {% endfor %}
-
+  {% set contents = block.content.contents %}
+  {% include 'partials/contents.html' %}
 {% endblock form_content %}

--- a/templates/introduction.html
+++ b/templates/introduction.html
@@ -29,7 +29,7 @@
 
     {% block intro_content %}
       {% if content.block.primary_content %}
-          {% for intro in content.block.primary_content %}
+          {% for content_block in content.block.primary_content %}
               {% include 'partials/introduction/basic.html' %}
           {% endfor %}
       {% endif %}
@@ -49,7 +49,7 @@
       {% endif %}
 
       {% if content.block.secondary_content %}
-          {% for intro in content.block.secondary_content %}
+          {% for content_block in content.block.secondary_content %}
               {% include 'partials/introduction/basic.html' %}
           {% endfor %}
       {% endif %}

--- a/templates/partials/answer-guidance.html
+++ b/templates/partials/answer-guidance.html
@@ -1,4 +1,3 @@
-{% set content_block = answer_guidance.schema_item.content %}
 {% from "components/details/_macro.njk" import onsDetails %}
 
 {% call onsDetails({
@@ -21,6 +20,7 @@
   }
 }) %}
   <div class="u-mt-s">
+    {% set content_block = answer_guidance.schema_item %}
     {% include 'partials/content-block.html' %}
   </div>
 {% endcall %}

--- a/templates/partials/block.html
+++ b/templates/partials/block.html
@@ -1,13 +1,6 @@
 {% set block = content.block %}
 
 <div class="block" id="{{current_location.block_id}}">
-  {% if block['title'] %}
-    <p class="block__title u-fs-m" data-qa="block-title">{{block['title']}}</p>
-  {% endif %}
-
-  {% if block['description'] %}
-    <div class="block__description" data-qa="block-description">{{ block['description'] }}</div>
-  {% endif %}
 
   {% if 'question' in block %}
       {% set question = block['question'] %}

--- a/templates/partials/content-block.html
+++ b/templates/partials/content-block.html
@@ -1,17 +1,8 @@
 {% import 'macros/helpers.html' as helpers %}
 
-{% for item in content_block %}
-  {%- if item.title -%}
-    <strong class="u-mb-s">{{item.title}}</strong>
+{%- if content_block.title -%}
+    <strong class="u-mb-s">{{content_block.title}}</strong>
   {% endif %}
-  {%- if item.description -%}
-    <p>{{item.description}}</p>
-  {% endif %}
-  {%- if item.list -%}
-    <ul class="u-fs-r">
-      {%- for list_item in item.list -%}
-        <li>{{list_item}}</li>
-      {% endfor %}
-    </ul>
-  {% endif %}
-{% endfor %}
+{% set contents = content_block.contents %}
+{% include 'partials/contents.html' %}
+

--- a/templates/partials/contents.html
+++ b/templates/partials/contents.html
@@ -1,0 +1,15 @@
+{% for item in contents %}
+  {%- if item.title -%}
+    <strong class="u-mb-s">{{item.title}}</strong>
+  {% endif %}
+  {%- if item.description -%}
+    <p>{{item.description}}</p>
+  {% endif %}
+  {%- if item.list -%}
+    <ul>
+      {%- for list_item in item.list -%}
+        <li>{{list_item}}</li>
+      {% endfor %}
+    </ul>
+  {% endif %}
+{% endfor %}

--- a/templates/partials/introduction/basic.html
+++ b/templates/partials/introduction/basic.html
@@ -1,25 +1,7 @@
-<div id="{{intro.id}}" class="u-mb-s">
-  {% if intro.title %}
-    <h2 class="u-fs-l">{{ intro.title }}</h2>
+<div id="{{content_block.id}}" class="u-mb-s">
+  {% if content_block.title %}
+    <h2 class="u-fs-l">{{ content_block.title }}</h2>
   {% endif %}
-
-  {% for content in intro.content  %}
-    {% if content.title %}
-      <h3>{{ content.title }}</h3>
-    {% endif %}
-
-    {% if content.description %}
-      <p class="u-fs-r qa-intro-description" data-qa="intro-basic-description">
-          {{ content.description }}
-      </p>
-    {% endif %}
-
-    {% if content.list %}
-      <ul>
-          {% for li in content.list %}
-            <li>{{ li }}</li>
-          {% endfor %}
-      </ul>
-    {% endif %}
-  {% endfor %}
+  {% set contents = content_block.contents %}
+  {% include 'partials/contents.html' %}
 </div>

--- a/templates/partials/introduction/preview.html
+++ b/templates/partials/introduction/preview.html
@@ -1,21 +1,8 @@
 <h2 class="u-fs-l u-mt-m">{{ intro.title }}</h2>
 
 <div class="collapsible__introduction">
-  {% for content in intro.content %}
-    {% if content.title  %}
-      <h3 class="u-mt-s">{{ content.title }}</h3>
-    {% endif %}
-
-    <p class="qa-intro-description" data-qa="intro-preview-description">{{ content.description }}</p>
-
-    {% if content.list %}
-      <ul>
-          {% for li in content.list %}
-          <li>{{ li }}</li>
-          {% endfor %}
-      </ul>
-    {% endif %}
-  {% endfor %}
+  {% set contents = intro.contents %}
+  {% include "partials/contents.html" %}
 </div>
 
 {% if intro.questions %}
@@ -25,27 +12,8 @@
 
   {% for question in intro.questions %}
     {% set content %}
-      {% if question.content %}
-        {% for item in question.content %}
-          <div class="u-mb-s">
-            {% if item.title %}
-              <div class="u-mb-s u-fs-r--b">{{ item.title }}</div>
-            {% endif %}
-
-            {% if item.description %}
-              <div class="u-mb-s">{{ item.description }}</div>
-            {% endif %}
-
-            {% if item.list %}
-              <ul>
-                  {% for li in item.list %}
-                    <li>{{ li }}</li>
-                  {% endfor %}
-              </ul>
-            {% endif %}
-        </div>
-        {% endfor %}
-      {% endif %}
+      {% set contents = question.contents %}
+      {% include "partials/contents.html" %}
     {% endset %}
 
     {% set item = {

--- a/templates/partials/question-definition.html
+++ b/templates/partials/question-definition.html
@@ -1,7 +1,7 @@
 {% from "components/details/_macro.njk" import onsDetails %}
 
 {% for definition in question.definitions %}
-  {% set content_block = definition.content %}
+  {% set content_block = definition %}
   {% call onsDetails({
       "title": definition.title,
       "classes": "u-mt-s u-mb-s",

--- a/templates/partials/question.html
+++ b/templates/partials/question.html
@@ -16,13 +16,14 @@
 
 {% set question_guidance %}
   {%- if question.guidance -%}
-    {% set content_block = question.guidance.content %}
+    {% set contents = question.guidance.contents %}
     {% from "components/panel/_macro.njk" import onsPanel %}
     {% call onsPanel({
       "id": "question-guidance-" + question.id,
       "classes": "u-mb-m"
     }) %}
-      {% include 'partials/content-block.html' %}
+      {% set contents = question.guidance.contents %}
+      {% include 'partials/contents.html' %}
     {% endcall %}
   {% endif %}
 {% endset %}

--- a/tests/app/questionnaire/test_questionnaire_schema.py
+++ b/tests/app/questionnaire/test_questionnaire_schema.py
@@ -68,9 +68,7 @@ class TestQuestionnaireSchema(AppContextTestCase):
                     'groups': [
                         {
                             'id': 'group1',
-                            'blocks': [
-                                {'id': 'block1', 'type': 'Question', 'title': 'Block 1'}
-                            ],
+                            'blocks': [{'id': 'block1', 'type': 'Question'}],
                         }
                     ],
                 }
@@ -80,7 +78,7 @@ class TestQuestionnaireSchema(AppContextTestCase):
         schema = QuestionnaireSchema(survey_json)
         block = schema.get_block('block1')
 
-        self.assertEqual(block['title'], 'Block 1')
+        self.assertEqual(block['id'], 'block1')
 
     def test_get_groups(self):
         survey_json = {

--- a/tests/functional/base_pages/introduction.page.js
+++ b/tests/functional/base_pages/introduction.page.js
@@ -35,7 +35,7 @@ class IntroductionPage extends BasePage {
   }
 
   introDescription() {
-    return '[data-qa="intro-basic-description"]';
+    return '#use-of-information p';
   }
 
   introTitleDescription() {

--- a/tests/functional/base_pages/question.page.js
+++ b/tests/functional/base_pages/question.page.js
@@ -33,8 +33,6 @@ class QuestionPage extends BasePage {
 
   saveSignOut() { return '[data-qa="btn-save-sign-out"]'; }
 
-  interstitialHeader() { return 'main > h1';}
-
   switchLanguage(language_code) { return 'a[href="?language_code=' + language_code + '"]'; }
 
 }

--- a/tests/functional/spec/content_variants.spec.js
+++ b/tests/functional/spec/content_variants.spec.js
@@ -11,13 +11,13 @@ describe('QuestionVariants', function() {
     return browser
       .setValue(ageQuestionBlock.age(), 12)
       .click(ageQuestionBlock.submit())
-      .getText('main.page__main h2').should.eventually.contain('You are 16 or younger');
+      .getText('main.page__main h1').should.eventually.contain('You are 16 or younger');
   });
 
   it('Given I am completing the survey, then the correct content is shown based on my previous answers when i am under 16', function () {
     return browser
       .setValue(ageQuestionBlock.age(), 22)
       .click(ageQuestionBlock.submit())
-      .getText('main.page__main h2').should.eventually.contain('You are 16 or older');
+      .getText('main.page__main h1').should.eventually.contain('You are 16 or older');
   });
 });

--- a/tests/functional/spec/features/routing/answer_comparison_routing.spec.js
+++ b/tests/functional/spec/features/routing/answer_comparison_routing.spec.js
@@ -2,8 +2,7 @@ const helpers = require('../../../helpers');
 
 const RouteComparison1Page = require('../../../generated_pages/routing_answer_comparison/route-comparison-1.page.js');
 const RouteComparison2Page = require('../../../generated_pages/routing_answer_comparison/route-comparison-2.page.js');
-const RouteComparison3Page = require('../../../generated_pages/routing_answer_comparison/route-comparison-3.page.js');
-const RouteComparison4Page = require('../../../generated_pages/routing_answer_comparison/route-comparison-4.page.js');
+
 
 describe('Test routing skip', function() {
 
@@ -17,7 +16,7 @@ describe('Test routing skip', function() {
       .click(RouteComparison1Page.submit())
       .setValue(RouteComparison2Page.answer(), 2)
       .click(RouteComparison2Page.submit())
-      .getText(RouteComparison4Page.interstitialHeader()).should.eventually.contain('Your second number was higher');
+      .getText('p').should.eventually.contain('This page should never be skipped');
     });
 
   it('Given we start the routing test survey, When we enter a high number then a low number, Then, we should be routed to the third page', function() {
@@ -26,7 +25,7 @@ describe('Test routing skip', function() {
       .click(RouteComparison1Page.submit())
       .setValue(RouteComparison2Page.answer(), 0)
       .click(RouteComparison2Page.submit())
-      .getText(RouteComparison3Page.interstitialHeader()).should.eventually.contain('Your second number was lower or equal');
+      .getText('p').should.eventually.contain('This page should be skipped if your second answer was higher than your first');
     });
 
   it('Given we start the routing test survey, When we enter an equal number on both questions, Then, we should be routed to the third page', function() {
@@ -35,7 +34,7 @@ describe('Test routing skip', function() {
       .click(RouteComparison1Page.submit())
       .setValue(RouteComparison2Page.answer(), 1)
       .click(RouteComparison2Page.submit())
-      .getText(RouteComparison3Page.interstitialHeader()).should.eventually.contain('Your second number was lower or equal');
+      .getText('p').should.eventually.contain('This page should be skipped if your second answer was higher than your first');
     });
 });
 

--- a/tests/functional/spec/features/skipping/answer_comparison_skip_conditions.spec.js
+++ b/tests/functional/spec/features/skipping/answer_comparison_skip_conditions.spec.js
@@ -18,7 +18,7 @@ describe('Test skip condition answer comparisons', function() {
       .click(Comparison1Page.submit())
       .setValue(Comparison2Page.answer(), 1)
       .click(Comparison2Page.submit())
-      .getText(EqualsAnswersPage.interstitialHeader()).should.eventually.contain('Second equal first');
+      .getText('p').should.eventually.contain('Your second number was equal to your first number');
     });
   it('Given we start the skip condition survey, when we enter a high number then a low number, then the interstitial should show that the answers are low then high', function() {
     return browser
@@ -26,7 +26,7 @@ describe('Test skip condition answer comparisons', function() {
       .click(Comparison1Page.submit())
       .setValue(Comparison2Page.answer(), 2)
       .click(Comparison2Page.submit())
-      .getText(LessThanAnswersPage.interstitialHeader()).should.eventually.contain('First greater than second');
+      .getText('p').should.eventually.contain('Your first answer was greater than your second number');
     });
   it('Given we start the skip condition survey, when we enter a low number then a high number, then the interstitial should show that the answers are high then low', function() {
     return browser
@@ -34,7 +34,7 @@ describe('Test skip condition answer comparisons', function() {
       .click(Comparison1Page.submit())
       .setValue(Comparison2Page.answer(), 2)
       .click(Comparison2Page.submit())
-      .getText(GreaterThanAnswersPage.interstitialHeader()).should.eventually.contain('First less than second');
+      .getText('p').should.eventually.contain('Your first answer was less than your second number');
     });
 });
 

--- a/tests/functional/spec/introduction.spec.js
+++ b/tests/functional/spec/introduction.spec.js
@@ -6,7 +6,7 @@ describe('Introduction page', function() {
 
   const introduction_schema = 'test_introduction.json';
 
-  it('Given I start a survey, When I view the introduction page then I should be able to see introduction information', function() {
+  it('@watch Given I start a survey, When I view the introduction page then I should be able to see introduction information', function() {
     return helpers.openQuestionnaire(introduction_schema).then(() => {
       return browser
         .getText(IntroductionPage.useOfData()).should.eventually.contain('How we use your data')

--- a/tests/functional/spec/language_code.spec.js
+++ b/tests/functional/spec/language_code.spec.js
@@ -11,7 +11,7 @@ describe('Language Code', function() {
     return helpers.openQuestionnaire('test_language.json', { language: 'cy' }).then(() => {
 
       return browser
-        .getText(LanguagePage.displayedName()).should.eventually.equal('Holiadur Cymraeg')
+        .getText(LanguagePage.questionText()).should.eventually.contain('Holiadur Cymraeg')
         .setValue(LanguagePage.Month(), 4)
         .setValue(LanguagePage.Year(), 2018)
         .click(LanguagePage.submit())
@@ -31,7 +31,7 @@ describe('Language Code', function() {
     return helpers.openQuestionnaire('test_language.json', { language: 'en' }).then(() => {
 
       return browser
-        .getText(LanguagePage.displayedName()).should.eventually.equal('English Questionnaire')
+        .getText(LanguagePage.questionText()).should.eventually.contain('English Questionnaire')
         .setValue(LanguagePage.Month(), 4)
         .setValue(LanguagePage.Year(), 2018)
         .click(LanguagePage.submit())
@@ -50,9 +50,9 @@ describe('Language Code', function() {
     return helpers.openQuestionnaire('test_language.json', { language: 'en' }).then(() => {
 
       return browser
-        .getText(LanguagePage.displayedName()).should.eventually.equal('English Questionnaire')
+        .getText(LanguagePage.questionText()).should.eventually.contain('English Questionnaire')
         .click(SummaryPage.switchLanguage('cy'))
-        .getText(LanguagePage.displayedName()).should.eventually.equal('Holiadur Cymraeg')
+        .getText(LanguagePage.questionText()).should.eventually.contain('Holiadur Cymraeg')
         .click(SummaryPage.switchLanguage('en'))
         .setValue(LanguagePage.Month(), 4)
         .setValue(LanguagePage.Year(), 2018)
@@ -71,9 +71,9 @@ describe('Language Code', function() {
     return helpers.openQuestionnaire('test_language.json', { language: 'cy' }).then(() => {
 
       return browser
-        .getText(LanguagePage.displayedName()).should.eventually.equal('Holiadur Cymraeg')
+        .getText(LanguagePage.questionText()).should.eventually.contain('Holiadur Cymraeg')
         .click(SummaryPage.switchLanguage('en'))
-        .getText(LanguagePage.displayedName()).should.eventually.equal('English Questionnaire')
+        .getText(LanguagePage.questionText()).should.eventually.contain('English Questionnaire')
         .click(SummaryPage.switchLanguage('cy'))
         .setValue(LanguagePage.Month(), 4)
         .setValue(LanguagePage.Year(), 2018)

--- a/tests/integration/introduction/test_introduction.py
+++ b/tests/integration/introduction/test_introduction.py
@@ -17,7 +17,9 @@ class TestIntroduction(IntegrationTestCase):
 
         # When on the introduction page
         # Then description should be displayed
-        self.assertInBody('qa-intro-description')
+        self.assertInBody(
+            'To take part, all you need to do is check that you have the information you need to answer the survey questions.'
+        )
 
     def test_intro_description_not_displayed(self):
         # Given survey without introduction description

--- a/tests/integration/questionnaire/test_questionnaire_is_skipping_question.py
+++ b/tests/integration/questionnaire/test_questionnaire_is_skipping_question.py
@@ -11,7 +11,6 @@ class TestQuestionnaireChangeAnswer(IntegrationTestCase):
         self.get('questionnaire/summary')
 
         # Then I should be redirected to the first incomplete question in the survey
-        self.assertInBody('This is section 1')
         self.assertInBody('Were you forced to complete section 1?')
 
     def test_final_summary_not_available_after_invalidating_section(self):
@@ -43,5 +42,4 @@ class TestQuestionnaireChangeAnswer(IntegrationTestCase):
         self.get('questionnaire/summary')
 
         # Then I should be redirected to the first incomplete question in the survey
-        self.assertInBody('This is section 1')
         self.assertInBody('What would incentivise you to complete this section?')

--- a/tests/integration/routing/test_answer_comparison.py
+++ b/tests/integration/routing/test_answer_comparison.py
@@ -23,17 +23,17 @@ class TestAnswerComparisonsSkips(IntegrationTestCase):
 
         self.post({'comparison-2-answer': 3})
 
-        self.assertInBody('First less than second')
+        self.assertInBody('Your first answer was less than your second number')
 
         # Go back to the second question and change the answer
         self.post({'comparison-2-answer': 2}, url=second_page)
 
-        self.assertInBody('Second equal first')
+        self.assertInBody('Your second number was equal to your first number')
 
         # Go back to the second question and change the answer
         self.post({'comparison-2-answer': 1}, url=second_page)
 
-        self.assertInBody('First greater than second')
+        self.assertInBody('Your first answer was greater than your second number')
 
 
 class TestAnswerComparisonsRoutes(IntegrationTestCase):
@@ -58,9 +58,11 @@ class TestAnswerComparisonsRoutes(IntegrationTestCase):
         # Enter a higher number
         self.post({'route-comparison-2-answer': 3})
 
-        self.assertInBody('Your second number was higher')
+        self.assertInBody('This page should never be skipped')
 
         # Go back to the second question and change the answer to a lower one
         self.post({'route-comparison-2-answer': 1}, url=second_page)
 
-        self.assertInBody('Your second number was lower or equal')
+        self.assertInBody(
+            'This page should be skipped if your second answer was higher than your first'
+        )


### PR DESCRIPTION
### What is the context of this PR?
Currently, it is not possible to vary block title (page title) without duplicating the block and adjusting any routing rules.

This PR removes this content that is outside of `content_variants` and `question_variants` 

### How to review 
Do current schemas work as expected?