### PR TITLE
Push images to GCR from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,11 +45,11 @@ cache:
 script:
     - set -e
     - make travis
-    - export TAG=`if [ "$TRAVIS_PULL_REQUEST_BRANCH" == "" ]; then echo "v3"; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi`
-    - docker build -t onsdigital/eq-survey-runner:$TAG -f Dockerfile .
-    - echo "$DOCKER_PASSWORD" | docker login -u $DOCKER_USERNAME --password-stdin
+    - export TAG="${TRAVIS_PULL_REQUEST_BRANCH:-latest}"
+    - docker build -t eu.gcr.io/census-eq-ci/eq-survey-runner:"$TAG" .
+    - echo "$DOCKER_GCR_PASSWORD" | base64 --decode | docker login -u "$DOCKER_GCR_USERNAME" --password-stdin https://eu.gcr.io
     - echo "Pushing with tag [$TAG]"
-    - docker push onsdigital/eq-survey-runner:$TAG
+    - docker push eu.gcr.io/census-eq-ci/eq-survey-runner:"$TAG"
 after_success:
     - pipenv run bash <(curl -s https://codecov.io/bash)
     - pipenv run pip install codacy-coverage

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ make dev-compose-up
 https://github.com/ONSDigital/eq-questionnaire-launcher
 
 ```
-docker run -e SURVEY_RUNNER_SCHEMA_URL=http://docker.for.mac.host.internal:5000 -it -p 8000:8000 onsdigital/eq-questionnaire-launcher:latest
+docker run -e SURVEY_RUNNER_SCHEMA_URL=http://docker.for.mac.host.internal:5000 -it -p 8000:8000 eu.gcr.io/census-eq-ci/eq-questionnaire-launcher:latest
 ```
 
 ##### Storage backend

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -13,7 +13,7 @@ services:
       - "6379:6379"
 
   eq-questionnaire-launcher:
-    image: onsdigital/eq-questionnaire-launcher:latest
+    image: eu.gcr.io/census-eq-ci/eq-questionnaire-launcher:latest
     environment:
       SURVEY_RUNNER_URL: http://localhost:5000
       SURVEY_RUNNER_SCHEMA_URL: http://docker.for.mac.host.internal:5000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,9 +13,9 @@ services:
       - eq-env
 
   eq-survey-runner:
-    image: onsdigital/eq-survey-runner:v3
+    image: eu.gcr.io/census-eq-ci/eq-survey-runner:v3
     build: ./
-    env_file: 
+    env_file:
       - .development.env
     environment:
       DATASTORE_EMULATOR_HOST: datastore:8432
@@ -30,7 +30,7 @@ services:
       - "5000:5000"
 
   eq-questionnaire-launcher:
-    image: onsdigital/eq-questionnaire-launcher:latest
+    image: eu.gcr.io/census-eq-ci/eq-questionnaire-launcher:latest
     environment:
       SURVEY_RUNNER_URL: http://localhost:5000
       SURVEY_RUNNER_SCHEMA_URL: http://eq-survey-runner:5000


### PR DESCRIPTION
### What is the context of this PR?
Pushes the built docker images from Travis to GCR for easier development workflow.
Have also updated the README to use the GCR registry instead of Docker Hub.

### How to review
- Ensure the images are present in GCR with the correct tag.
- docker-compose works as expected.