### PR TITLE
Add Wales Census Individual Schema in Welsh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,7 +91,7 @@ requirements.txt
 .screenshots
 
 # Ignore built schemas
-data/
+data/en/
 
 # Ignore any generated pages for the functional tests
 tests/functional/generated_pages

--- a/data/cy/census_individual_gb_wls.json
+++ b/data/cy/census_individual_gb_wls.json
@@ -1,0 +1,10441 @@
+{
+    "data_version": "0.0.3",
+    "description": "Crynodeb Unigol Cyfrifiad Lloegr",
+    "eq_id": "census",
+    "form_type": "individual_gb_wls",
+    "legal_basis": "Gwirfoddol",
+    "metadata": [
+        {
+            "name": "user_id",
+            "type": "string"
+        },
+        {
+            "name": "period_id",
+            "type": "string"
+        },
+        {
+            "name": "case_type",
+            "optional": true,
+            "type": "string"
+        },
+        {
+            "name": "display_address",
+            "type": "string"
+        }
+    ],
+    "mime_type": "application/json/ons/eq",
+    "navigation": {
+        "visible": false
+    },
+    "schema_version": "0.0.1",
+    "sections": [
+        {
+            "groups": [
+                {
+                    "blocks": [
+                        {
+                            "id": "accommodation-type",
+                            "question": {
+                                "answers": [
+                                    {
+                                        "id": "accommodation-type-answer",
+                                        "mandatory": true,
+                                        "options": [
+                                            {
+                                                "description": "Er enghraifft, neuadd breswyl i fyfyrwyr, ysgol breswyl, un o ganolfannau\u2019r\nlluoedd arfog, ysbyty, cartref gofal, carchar",
+                                                "label": "Sefydliad cymunedol",
+                                                "value": "A communal establishment"
+                                            },
+                                            {
+                                                "label": "Cartref preifat neu gartref teulu",
+                                                "value": "A private or family household"
+                                            }
+                                        ],
+                                        "type": "Radio"
+                                    }
+                                ],
+                                "id": "accommodation-type-question",
+                                "title": {
+                                    "placeholders": [
+                                        {
+                                            "placeholder": "address",
+                                            "value": {
+                                                "identifier": "display_address",
+                                                "source": "metadata"
+                                            }
+                                        }
+                                    ],
+                                    "text": "Pa fath o lety yw <em>{address}</em>?"
+                                },
+                                "type": "General"
+                            },
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "meta": "case_type",
+                                            "value": "HI"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "meta": "case_type",
+                                            "value": "CI"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "proxy",
+                            "question": {
+                                "answers": [
+                                    {
+                                        "id": "proxy-answer",
+                                        "mandatory": true,
+                                        "options": [
+                                            {
+                                                "label": "Na, rwy\u2019n ateb ar ran yr unigolyn hwn",
+                                                "value": "No"
+                                            },
+                                            {
+                                                "label": "Ie",
+                                                "value": "Yes"
+                                            }
+                                        ],
+                                        "type": "Radio"
+                                    }
+                                ],
+                                "id": "proxy-question",
+                                "title": "Ydych chi\u2019n ateb y cwestiynau ar ran rhywun arall?",
+                                "type": "General"
+                            },
+                            "type": "Question"
+                        },
+                        {
+                            "id": "name",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "first-name",
+                                                "label": "Enw cyntaf",
+                                                "mandatory": true,
+                                                "type": "TextField",
+                                                "validation": {
+                                                    "messages": {
+                                                        "MANDATORY_TEXTFIELD": "Nodwch enw neu dil\u00ebwch y person i barhau"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "id": "middle-names",
+                                                "label": "Enw(au) canol",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "id": "last-name",
+                                                "label": "Cyfenw",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            }
+                                        ],
+                                        "id": "name-question",
+                                        "title": "Beth yw eich enw?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "first-name",
+                                                "label": "Enw cyntaf",
+                                                "mandatory": true,
+                                                "type": "TextField",
+                                                "validation": {
+                                                    "messages": {
+                                                        "MANDATORY_TEXTFIELD": "Nodwch enw neu dil\u00ebwch y person i barhau"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "id": "middle-names",
+                                                "label": "Enw(au) canol",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "id": "last-name",
+                                                "label": "Cyfenw",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            }
+                                        ],
+                                        "id": "name-question",
+                                        "title": "Beth yw enw\u2019r unigolyn?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "date-of-birth",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "meta": "case_type",
+                                                "value": "HI"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "date-of-birth",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "id": "accommodation-type-answer",
+                                                "value": "A private or family household"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "establishment-position"
+                                    }
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "establishment-position",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "establishment-position-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "description": "Er enghraifft, myfyriwr, aelod o\u2019r lluoedd arfog, claf, carcharor",
+                                                        "label": "Preswylydd",
+                                                        "value": "Resident"
+                                                    },
+                                                    {
+                                                        "label": "Aelod o staff neu berchennog y sefydliad",
+                                                        "value": "Staff or owner"
+                                                    },
+                                                    {
+                                                        "label": "Perthynas neu bartner i\u2019r perchennog neu i aelod o\u2019r staff",
+                                                        "value": "Family member or partner of staff or owner"
+                                                    },
+                                                    {
+                                                        "description": "Dim cyfeiriad arferol yn y Deyrnas Unedig",
+                                                        "label": "Aros dros dro",
+                                                        "value": "Staying temporarily"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "definitions": [
+                                            {
+                                                "content": [
+                                                    {
+                                                        "description": "Sefydliad sy\u2019n cynnig llety preswyl wedi\u2019i reoli yw sefydliad cymunedol. Ystyr \u201cwedi\u2019i reoli\u201d yn y cyd-destun hwn\nyw bod y llety\u2019n cael ei oruchwylio drwy\u2019r amser neu am ran o\u2019r amser. Mae enghreifftiau o sefydliadau cymunedol yn cynnwys neuadd breswyl i fyfyrwyr, ysgol breswyl, un o ganolfannau\u2019r lluoedd arfog, ysbyty, cartref gofal a charchar."
+                                                    }
+                                                ],
+                                                "title": "What is an establishment?"
+                                            }
+                                        ],
+                                        "id": "establishment-position-question",
+                                        "title": "Pa un o\u2019r rhain sy\u2019n eich disgrifio orau yn y sefydliad hwn?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "establishment-position-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "description": "Er enghraifft, myfyriwr, aelod o\u2019r lluoedd arfog, claf, carcharor",
+                                                        "label": "Preswylydd",
+                                                        "value": "Resident"
+                                                    },
+                                                    {
+                                                        "label": "Aelod o staff neu berchennog y sefydliad",
+                                                        "value": "Staff or owner"
+                                                    },
+                                                    {
+                                                        "label": "Perthynas neu bartner i\u2019r perchennog neu i aelod o\u2019r staff",
+                                                        "value": "Family member or partner of staff or owner"
+                                                    },
+                                                    {
+                                                        "description": "Dim cyfeiriad arferol yn y Deyrnas Unedig",
+                                                        "label": "Aros dros dro",
+                                                        "value": "Staying temporarily"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "definitions": [
+                                            {
+                                                "content": [
+                                                    {
+                                                        "description": "Sefydliad sy\u2019n cynnig llety preswyl wedi\u2019i reoli yw sefydliad cymunedol. Ystyr \u201cwedi\u2019i reoli\u201d yn y cyd-destun hwn\nyw bod y llety\u2019n cael ei oruchwylio drwy\u2019r amser neu am ran o\u2019r amser. Mae enghreifftiau o sefydliadau cymunedol yn cynnwys neuadd breswyl i fyfyrwyr, ysgol breswyl, un o ganolfannau\u2019r lluoedd arfog, ysbyty, cartref gofal a charchar."
+                                                    }
+                                                ],
+                                                "title": "What is an establishment?"
+                                            }
+                                        ],
+                                        "id": "establishment-position-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name_possessive",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        },
+                                                        {
+                                                            "arguments": {
+                                                                "string_to_format": {
+                                                                    "source": "previous_transform"
+                                                                }
+                                                            },
+                                                            "transform": "format_possessive"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Pa un o\u2019r rhain sy\u2019n disgrifio <em>{person_name_possessive}</em> orau yn y sefydliad hwn?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "date-of-birth",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "date-of-birth-answer",
+                                                "mandatory": true,
+                                                "maximum": {
+                                                    "value": "now"
+                                                },
+                                                "minimum": {
+                                                    "value": "1900-01-01"
+                                                },
+                                                "type": "Date"
+                                            }
+                                        ],
+                                        "id": "date-of-birth-question",
+                                        "title": "Beth yw eich dyddiad geni?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "date-of-birth-answer",
+                                                "mandatory": true,
+                                                "maximum": {
+                                                    "value": "now"
+                                                },
+                                                "minimum": {
+                                                    "value": "1900-01-01"
+                                                },
+                                                "type": "Date"
+                                            }
+                                        ],
+                                        "id": "date-of-birth-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name_possessive",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        },
+                                                        {
+                                                            "arguments": {
+                                                                "string_to_format": {
+                                                                    "source": "previous_transform"
+                                                                }
+                                                            },
+                                                            "transform": "format_possessive"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Beth yw dyddiad geni <em>{person_name_possessive}</em>?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "confirm-dob",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "confirm-date-of-birth-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": {
+                                                            "placeholders": [
+                                                                {
+                                                                    "placeholder": "age_in_years",
+                                                                    "transforms": [
+                                                                        {
+                                                                            "arguments": {
+                                                                                "first_date": {
+                                                                                    "identifier": "date-of-birth-answer",
+                                                                                    "source": "answers"
+                                                                                },
+                                                                                "second_date": {
+                                                                                    "value": "now"
+                                                                                }
+                                                                            },
+                                                                            "transform": "calculate_years_difference"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "text": "Ydy, rwy\u2019n {age_in_years} oed"
+                                                        },
+                                                        "value": "Yes"
+                                                    },
+                                                    {
+                                                        "label": "Nac ydy, mae angen i mi newid fy nyddiad geni",
+                                                        "value": "No"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "confirm-date-of-birth",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "age_in_years",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "first_date": {
+                                                                    "identifier": "date-of-birth-answer",
+                                                                    "source": "answers"
+                                                                },
+                                                                "second_date": {
+                                                                    "value": "now"
+                                                                }
+                                                            },
+                                                            "transform": "calculate_years_difference"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Rydych chi\u2019n {age_in_years} oed. Ydy hyn yn gywir?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "confirm-date-of-birth-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": {
+                                                            "placeholders": [
+                                                                {
+                                                                    "placeholder": "person_name",
+                                                                    "transforms": [
+                                                                        {
+                                                                            "arguments": {
+                                                                                "delimiter": " ",
+                                                                                "list_to_concatenate": {
+                                                                                    "identifier": [
+                                                                                        "first-name",
+                                                                                        "last-name"
+                                                                                    ],
+                                                                                    "source": "answers"
+                                                                                }
+                                                                            },
+                                                                            "transform": "concatenate_list"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "placeholder": "age_in_years",
+                                                                    "transforms": [
+                                                                        {
+                                                                            "arguments": {
+                                                                                "first_date": {
+                                                                                    "identifier": "date-of-birth-answer",
+                                                                                    "source": "answers"
+                                                                                },
+                                                                                "second_date": {
+                                                                                    "value": "now"
+                                                                                }
+                                                                            },
+                                                                            "transform": "calculate_years_difference"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "text": "Ydy, mae {person_name} yn {age_in_years} oed"
+                                                        },
+                                                        "value": "Yes"
+                                                    },
+                                                    {
+                                                        "label": "Nac ydy, mae angen i mi newid dyddiad geni\u2019r unigolyn hwn",
+                                                        "value": "No"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "confirm-date-of-birth",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "placeholder": "age_in_years",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "first_date": {
+                                                                    "identifier": "date-of-birth-answer",
+                                                                    "source": "answers"
+                                                                },
+                                                                "second_date": {
+                                                                    "value": "now"
+                                                                }
+                                                            },
+                                                            "transform": "calculate_years_difference"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Mae {person_name} yn {age_in_years} oed. Ydy hyn yn gywir?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "date-of-birth",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "id": "confirm-date-of-birth-answer",
+                                                "value": "No"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "sex"
+                                    }
+                                }
+                            ],
+                            "type": "ConfirmationQuestion"
+                        },
+                        {
+                            "id": "sex",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "sex-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Benyw",
+                                                        "value": "Female"
+                                                    },
+                                                    {
+                                                        "label": "Gwryw",
+                                                        "value": "Male"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "guidance": {
+                                            "content": [
+                                                {
+                                                    "title": "A question about gender will follow"
+                                                }
+                                            ]
+                                        },
+                                        "id": "sex-question",
+                                        "title": "Beth yw eich rhyw?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        },
+                                        {
+                                            "condition": "less than",
+                                            "date_comparison": {
+                                                "offset_by": {
+                                                    "years": -16
+                                                },
+                                                "value": "now"
+                                            },
+                                            "id": "date-of-birth-answer"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "sex-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Benyw",
+                                                        "value": "Female"
+                                                    },
+                                                    {
+                                                        "label": "Gwryw",
+                                                        "value": "Male"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "guidance": {
+                                            "content": [
+                                                {
+                                                    "title": "Bydd cwestiwn am rywedd yn dilyn yn nes ymlaen"
+                                                }
+                                            ]
+                                        },
+                                        "id": "sex-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name_possessive",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        },
+                                                        {
+                                                            "arguments": {
+                                                                "string_to_format": {
+                                                                    "source": "previous_transform"
+                                                                }
+                                                            },
+                                                            "transform": "format_possessive"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Beth yw rhyw <em>{person_name_possessive}</em>?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "condition": "less than",
+                                            "date_comparison": {
+                                                "offset_by": {
+                                                    "years": -16
+                                                },
+                                                "value": "now"
+                                            },
+                                            "id": "date-of-birth-answer"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "sex-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Benyw",
+                                                        "value": "Female"
+                                                    },
+                                                    {
+                                                        "label": "Gwryw",
+                                                        "value": "Male"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "sex-question",
+                                        "title": "Beth yw eich rhyw?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "sex-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Benyw",
+                                                        "value": "Female"
+                                                    },
+                                                    {
+                                                        "label": "Gwryw",
+                                                        "value": "Male"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "sex-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name_possessive",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        },
+                                                        {
+                                                            "arguments": {
+                                                                "string_to_format": {
+                                                                    "source": "previous_transform"
+                                                                }
+                                                            },
+                                                            "transform": "format_possessive"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Beth yw rhyw <em>{person_name_possessive}</em>?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "marriage-type",
+                                        "when": [
+                                            {
+                                                "condition": "less than",
+                                                "date_comparison": {
+                                                    "offset_by": {
+                                                        "years": -16
+                                                    },
+                                                    "value": "now"
+                                                },
+                                                "id": "date-of-birth-answer"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "another-address"
+                                    }
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "marriage-type",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "marriage-type-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Erioed wedi priodi na chofrestru partneriaeth sifil",
+                                                        "value": "Never"
+                                                    },
+                                                    {
+                                                        "label": "Priod",
+                                                        "value": "Married"
+                                                    },
+                                                    {
+                                                        "label": "Mewn partneriaeth sifil gofrestredig",
+                                                        "value": "In a registered civil partnership"
+                                                    },
+                                                    {
+                                                        "label": "Wedi gwahanu, ond yn gyfreithiol yn dal i fod yn briod",
+                                                        "value": "Separated, but still legally married"
+                                                    },
+                                                    {
+                                                        "label": "Wedi gwahanu, ond yn gyfreithiol yn dal i fod mewn partneriaeth sifil",
+                                                        "value": "Separated, but still legally in a civil partnership"
+                                                    },
+                                                    {
+                                                        "label": "Wedi ysgaru",
+                                                        "value": "Divorced"
+                                                    },
+                                                    {
+                                                        "label": "Wedi bod mewn partneriaeth sifil sydd bellach wedi\u2019i diddymu\u2019n gyfreithiol",
+                                                        "value": "Formerly in a civil partnership which is now legally dissolved"
+                                                    },
+                                                    {
+                                                        "label": "Person gweddw",
+                                                        "value": "Widowed"
+                                                    },
+                                                    {
+                                                        "label": "Wedi colli partner sifil cofrestredig drwy farwolaeth",
+                                                        "value": "Surviving partner from a registered civil partnership"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "marriage-type-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "census_date",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "date_format": "d MMMM YYYY",
+                                                                "date_to_format": {
+                                                                    "value": "2019-09-01"
+                                                                }
+                                                            },
+                                                            "transform": "format_date"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Yn gyfreithiol, beth yw eich statws priodasol neu statws eich partneriaeth sifil gofrestredig ar {census_date}?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "marriage-type-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Erioed wedi priodi na chofrestru partneriaeth sifil",
+                                                        "value": "Never"
+                                                    },
+                                                    {
+                                                        "label": "Priod",
+                                                        "value": "Married"
+                                                    },
+                                                    {
+                                                        "label": "Mewn partneriaeth sifil gofrestredig",
+                                                        "value": "In a registered civil partnership"
+                                                    },
+                                                    {
+                                                        "label": "Wedi gwahanu, ond yn gyfreithiol yn dal i fod yn briod",
+                                                        "value": "Separated, but still legally married"
+                                                    },
+                                                    {
+                                                        "label": "Wedi gwahanu, ond yn gyfreithiol yn dal i fod mewn partneriaeth sifil",
+                                                        "value": "Separated, but still legally in a civil partnership"
+                                                    },
+                                                    {
+                                                        "label": "Wedi ysgaru",
+                                                        "value": "Divorced"
+                                                    },
+                                                    {
+                                                        "label": "Wedi bod mewn partneriaeth sifil sydd bellach wedi\u2019i diddymu\u2019n gyfreithiol",
+                                                        "value": "Formerly in a civil partnership which is now legally dissolved"
+                                                    },
+                                                    {
+                                                        "label": "Person gweddw",
+                                                        "value": "Widowed"
+                                                    },
+                                                    {
+                                                        "label": "Wedi colli partner sifil cofrestredig drwy farwolaeth",
+                                                        "value": "Surviving partner from a registered civil partnership"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "marriage-type-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "census_date",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "date_format": "d MMMM YYYY",
+                                                                "date_to_format": {
+                                                                    "value": "2019-09-01"
+                                                                }
+                                                            },
+                                                            "transform": "format_date"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "placeholder": "person_name_possessive",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        },
+                                                        {
+                                                            "arguments": {
+                                                                "string_to_format": {
+                                                                    "source": "previous_transform"
+                                                                }
+                                                            },
+                                                            "transform": "format_possessive"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Yn gyfreithiol, beth yw statws priodasol neu statws partneriaeth sifil gofrestredig <em>{person_name_possessive}</em> ar {census_date}?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "another-address",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "id": "marriage-type-answer",
+                                                "value": "Never"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "current-marriage-status",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "id": "marriage-type-answer",
+                                                "value": "Married"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "current-partnership-status",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "id": "marriage-type-answer",
+                                                "value": "In a registered civil partnership"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "current-marriage-status",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "id": "marriage-type-answer",
+                                                "value": "Separated, but still legally married"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "current-partnership-status",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "id": "marriage-type-answer",
+                                                "value": "Separated, but still legally in a civil partnership"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "previous-marriage-status",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "id": "marriage-type-answer",
+                                                "value": "Divorced"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "previous-partnership-status",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "id": "marriage-type-answer",
+                                                "value": "Formerly in a civil partnership which is now legally dissolved"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "previous-marriage-status",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "id": "marriage-type-answer",
+                                                "value": "Widowed"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "previous-partnership-status",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "id": "marriage-type-answer",
+                                                "value": "Surviving partner from a registered civil partnership"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "another-address"
+                                    }
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "current-marriage-status",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "current-marriage-status-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Person o\u2019r rhyw arall",
+                                                        "value": "Someone of the opposite sex"
+                                                    },
+                                                    {
+                                                        "label": "Person o\u2019r un rhyw",
+                                                        "value": "Someone of the same sex"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "current-marriage-status-question",
+                                        "title": "Pwy yw eich priod cyfreithiol?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "current-marriage-status-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Person o\u2019r rhyw arall",
+                                                        "value": "Someone of the opposite sex"
+                                                    },
+                                                    {
+                                                        "label": "Person o\u2019r un rhyw",
+                                                        "value": "Someone of the same sex"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "current-marriage-status-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name_possessive",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        },
+                                                        {
+                                                            "arguments": {
+                                                                "string_to_format": {
+                                                                    "source": "previous_transform"
+                                                                }
+                                                            },
+                                                            "transform": "format_possessive"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Pwy yw priod cyfreithiol <em>{person_name_possessive}</em>?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "another-address"
+                                    }
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "previous-marriage-status",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "previous-marriage-status-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Person o\u2019r rhyw arall",
+                                                        "value": "Someone of the opposite sex"
+                                                    },
+                                                    {
+                                                        "label": "Person o\u2019r un rhyw",
+                                                        "value": "Someone of the same sex"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "previous-marriage-status-question",
+                                        "title": "Pwy oedd eich priod cyfreithiol?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "previous-marriage-status-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Person o\u2019r rhyw arall",
+                                                        "value": "Someone of the opposite sex"
+                                                    },
+                                                    {
+                                                        "label": "Person o\u2019r un rhyw",
+                                                        "value": "Someone of the same sex"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "previous-marriage-status-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name_possessive",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        },
+                                                        {
+                                                            "arguments": {
+                                                                "string_to_format": {
+                                                                    "source": "previous_transform"
+                                                                }
+                                                            },
+                                                            "transform": "format_possessive"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Pwy oedd priod cyfreithiol <em>{person_name_possessive}</em>?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "another-address"
+                                    }
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "current-partnership-status",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "current-partnership-status-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Person o\u2019r rhyw arall",
+                                                        "value": "Someone of the opposite sex"
+                                                    },
+                                                    {
+                                                        "label": "Person o\u2019r un rhyw",
+                                                        "value": "Someone of the same sex"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "currrent-partnership-status-question",
+                                        "title": "Pwy yw eich partner sifil cofrestredig?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "current-partnership-status-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Person o\u2019r rhyw arall",
+                                                        "value": "Someone of the opposite sex"
+                                                    },
+                                                    {
+                                                        "label": "Person o\u2019r un rhyw",
+                                                        "value": "Someone of the same sex"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "currrent-partnership-status-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name_possessive",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        },
+                                                        {
+                                                            "arguments": {
+                                                                "string_to_format": {
+                                                                    "source": "previous_transform"
+                                                                }
+                                                            },
+                                                            "transform": "format_possessive"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Pwy yw partner sifil cofrestredig <em>{person_name_possessive}</em>?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "another-address"
+                                    }
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "previous-partnership-status",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "previous-partnership-status-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Person o\u2019r rhyw arall",
+                                                        "value": "Someone of the opposite sex"
+                                                    },
+                                                    {
+                                                        "label": "Person o\u2019r un rhyw",
+                                                        "value": "Someone of the same sex"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "previous-partnership-status-question",
+                                        "title": "Pwy oedd eich partner sifil cofrestredig?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "previous-partnership-status-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Person o\u2019r rhyw arall",
+                                                        "value": "Someone of the opposite sex"
+                                                    },
+                                                    {
+                                                        "label": "Person o\u2019r un rhyw",
+                                                        "value": "Someone of the same sex"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "previous-partnership-status-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name_possessive",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        },
+                                                        {
+                                                            "arguments": {
+                                                                "string_to_format": {
+                                                                    "source": "previous_transform"
+                                                                }
+                                                            },
+                                                            "transform": "format_possessive"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Pwy oedd partner sifil cofrestredig <em>{person_name_possessive}</em>?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "another-address"
+                                    }
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "another-address",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "another-address-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Nac ydw",
+                                                        "value": "No"
+                                                    },
+                                                    {
+                                                        "label": "Ydw, mewn cyfeiriad yn y Deyrnas Unedig",
+                                                        "value": "Yes, an address within the UK"
+                                                    },
+                                                    {
+                                                        "detail_answer": {
+                                                            "id": "another-address-answer-other-country",
+                                                            "label": "Nodwch y wlad",
+                                                            "mandatory": true,
+                                                            "type": "TextField"
+                                                        },
+                                                        "label": "Ydw, mewn cyfeiriad y tu allan i\u2019r Deyrnas Unedig",
+                                                        "value": "Other"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "definitions": [
+                                            {
+                                                "content": [
+                                                    {
+                                                        "description": "We mean a different address to the one at the start of this survey. This might be another parent or guardian\u2019s address, a term-time address, a partner's address or a holiday home."
+                                                    }
+                                                ],
+                                                "title": "What do we mean by \u201canother address\u201d?"
+                                            }
+                                        ],
+                                        "description": "Gallai hyn fod yn fwy na 30 diwrnod un ar \u00f4l y llall neu wedi\u2019u rhannu ar hyd y flwyddyn",
+                                        "id": "another-address-question",
+                                        "title": "Ydych chi\u2019n aros mewn cyfeiriad arall am fwy na 30 diwrnod y flwyddyn?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "another-address-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Nac ydw",
+                                                        "value": "No"
+                                                    },
+                                                    {
+                                                        "label": "Ydw, mewn cyfeiriad yn y Deyrnas Unedig",
+                                                        "value": "Yes, an address within the UK"
+                                                    },
+                                                    {
+                                                        "detail_answer": {
+                                                            "id": "another-address-answer-other-country",
+                                                            "label": "Nodwch y wlad",
+                                                            "mandatory": true,
+                                                            "type": "TextField"
+                                                        },
+                                                        "label": "Ydw, mewn cyfeiriad y tu allan i\u2019r Deyrnas Unedig",
+                                                        "value": "Other"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "definitions": [
+                                            {
+                                                "content": [
+                                                    {
+                                                        "description": "We mean a different address to the one at the start of this survey. This might be another parent or guardian\u2019s address, a term-time address, a partner's address or a holiday home."
+                                                    }
+                                                ],
+                                                "title": "Beth mae \u201ccyfeiriad arall\u201d yn ei olygu?"
+                                            }
+                                        ],
+                                        "description": "Gallai hyn fod yn fwy na 30 diwrnod un ar \u00f4l y llall neu wedi\u2019u rhannu ar hyd y flwyddyn",
+                                        "id": "another-address-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name_possessive",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        },
+                                                        {
+                                                            "arguments": {
+                                                                "string_to_format": {
+                                                                    "source": "previous_transform"
+                                                                }
+                                                            },
+                                                            "transform": "format_possessive"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Ydy <em>{person_name_possessive}</em> yn aros mewn cyfeiriad arall am fwy na 30 diwrnod y flwyddyn?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "in-education",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "id": "another-address-answer",
+                                                "value": "No"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "other-address",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "id": "another-address-answer",
+                                                "value": "Yes, an address within the UK"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "address-type"
+                                    }
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "other-address",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "other-address-answer-building",
+                                                "label": "Enw neu rif y t\u0177",
+                                                "mandatory": true,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "id": "other-address-answer-street",
+                                                "label": "Stryd",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "id": "other-address-answer-city",
+                                                "label": "Tref neu ddinas",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "id": "other-address-answer-county",
+                                                "label": "Sir (dewisol)",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "id": "other-address-answer-postcode",
+                                                "label": "Cod post",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            }
+                                        ],
+                                        "id": "other-address-question",
+                                        "title": "Rhowch fanylion y cyfeiriad arall yn y Deyrnas Unedig lle rydych chi\u2019n aros am fwy na 30 diwrnod y flwyddyn",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "other-address-answer-building",
+                                                "label": "Enw neu rif y t\u0177",
+                                                "mandatory": true,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "id": "other-address-answer-street",
+                                                "label": "Stryd",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "id": "other-address-answer-city",
+                                                "label": "Tref neu ddinas",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "id": "other-address-answer-county",
+                                                "label": "Sir (dewisol)",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "id": "other-address-answer-postcode",
+                                                "label": "Cod post",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            }
+                                        ],
+                                        "id": "other-address-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name_possessive",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        },
+                                                        {
+                                                            "arguments": {
+                                                                "string_to_format": {
+                                                                    "source": "previous_transform"
+                                                                }
+                                                            },
+                                                            "transform": "format_possessive"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Rhowch fanylion y cyfeiriad arall yn y Deyrnas Unedig lle mae <em>{person_name_possessive}</em> yn aros am fwy na 30 diwrnod y flwyddyn?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "address-type",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "address-type-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Cyfeiriad un o ganolfannau\u2019r lluoedd arfog",
+                                                        "value": "Armed forces base address"
+                                                    },
+                                                    {
+                                                        "label": "Cyfeiriad arall wrth weithio i ffwrdd o\u2019r cartref",
+                                                        "value": "Another address when working away from home"
+                                                    },
+                                                    {
+                                                        "label": "Cyfeiriad cartref myfyriwr",
+                                                        "value": "Student\u2019s home address"
+                                                    },
+                                                    {
+                                                        "label": "Cyfeiriad myfyriwr yn ystod y tymor",
+                                                        "value": "Student\u2019s term-time address"
+                                                    },
+                                                    {
+                                                        "label": "Cyfeiriad rhiant neu warcheidwad arall",
+                                                        "value": "Another parent or guardian\u2019s address"
+                                                    },
+                                                    {
+                                                        "label": "Cyfeiriad partner",
+                                                        "value": "Partner's address"
+                                                    },
+                                                    {
+                                                        "label": "Cyfeiriad t\u0177 gwyliau",
+                                                        "value": "Holiday home"
+                                                    },
+                                                    {
+                                                        "label": "Arall",
+                                                        "value": "Other"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            }
+                                        ],
+                                        "id": "address-type-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "address",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": ", ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "other-address-answer-building",
+                                                                        "other-address-answer-street"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Pa fath o gyfeiriad yw <em>{address}</em>?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "another-address-answer",
+                                            "value": "Yes, an address within the UK"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "address-type-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Cyfeiriad un o ganolfannau\u2019r lluoedd arfog",
+                                                        "value": "Armed forces base address"
+                                                    },
+                                                    {
+                                                        "label": "Cyfeiriad arall wrth weithio i ffwrdd o\u2019r cartref",
+                                                        "value": "Another address when working away from home"
+                                                    },
+                                                    {
+                                                        "label": "Cyfeiriad cartref myfyriwr",
+                                                        "value": "Student\u2019s home address"
+                                                    },
+                                                    {
+                                                        "label": "Cyfeiriad myfyriwr yn ystod y tymor",
+                                                        "value": "Student\u2019s term-time address"
+                                                    },
+                                                    {
+                                                        "label": "Cyfeiriad rhiant neu warcheidwad arall",
+                                                        "value": "Another parent or guardian\u2019s address"
+                                                    },
+                                                    {
+                                                        "label": "Cyfeiriad partner",
+                                                        "value": "Partner's address"
+                                                    },
+                                                    {
+                                                        "label": "Cyfeiriad t\u0177 gwyliau",
+                                                        "value": "Holiday home"
+                                                    },
+                                                    {
+                                                        "label": "Arall",
+                                                        "value": "Other"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            }
+                                        ],
+                                        "id": "address-type-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "country",
+                                                    "value": {
+                                                        "identifier": "another-address-answer-other-country",
+                                                        "source": "answers"
+                                                    }
+                                                }
+                                            ],
+                                            "text": "Pa fath o gyfeiriad yw eich cyfeiriad yn: <em>{country}</em>?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "address-type-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Cyfeiriad un o ganolfannau\u2019r lluoedd arfog",
+                                                        "value": "Armed forces base address"
+                                                    },
+                                                    {
+                                                        "label": "Cyfeiriad arall wrth weithio i ffwrdd o\u2019r cartref",
+                                                        "value": "Another address when working away from home"
+                                                    },
+                                                    {
+                                                        "label": "Cyfeiriad cartref myfyriwr",
+                                                        "value": "Student\u2019s home address"
+                                                    },
+                                                    {
+                                                        "label": "Cyfeiriad myfyriwr yn ystod y tymor",
+                                                        "value": "Student\u2019s term-time address"
+                                                    },
+                                                    {
+                                                        "label": "Cyfeiriad rhiant neu warcheidwad arall",
+                                                        "value": "Another parent or guardian\u2019s address"
+                                                    },
+                                                    {
+                                                        "label": "Cyfeiriad partner",
+                                                        "value": "Partner's address"
+                                                    },
+                                                    {
+                                                        "label": "Cyfeiriad t\u0177 gwyliau",
+                                                        "value": "Holiday home"
+                                                    },
+                                                    {
+                                                        "label": "Arall",
+                                                        "value": "Other"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            }
+                                        ],
+                                        "id": "address-type-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name_possessive",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        },
+                                                        {
+                                                            "arguments": {
+                                                                "string_to_format": {
+                                                                    "source": "previous_transform"
+                                                                }
+                                                            },
+                                                            "transform": "format_possessive"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "placeholder": "country",
+                                                    "value": {
+                                                        "identifier": "another-address-answer-other-country",
+                                                        "source": "answers"
+                                                    }
+                                                }
+                                            ],
+                                            "text": "Pa fath o gyfeiriad yw cyfeiriad <em>{person_name_possessive}</em> yn: {country}?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "in-education",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "in-education-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Ydy",
+                                                        "value": "Yes"
+                                                    },
+                                                    {
+                                                        "label": "Nac ydy",
+                                                        "value": "No"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "in-education-question",
+                                        "title": "Ydych chi\u2019n blentyn ysgol neu\u2019n fyfyriwr mewn addysg amser llawn?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        },
+                                        {
+                                            "condition": "less than",
+                                            "date_comparison": {
+                                                "offset_by": {
+                                                    "years": -16
+                                                },
+                                                "value": "now"
+                                            },
+                                            "id": "date-of-birth-answer"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "in-education-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Ydy",
+                                                        "value": "Yes"
+                                                    },
+                                                    {
+                                                        "label": "Nac ydy",
+                                                        "value": "No"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "in-education-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Ydy <em>{person_name}</em> yn blentyn ysgol neu\u2019n fyfyriwr mewn addysg amser llawn?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "condition": "less than",
+                                            "date_comparison": {
+                                                "offset_by": {
+                                                    "years": -16
+                                                },
+                                                "value": "now"
+                                            },
+                                            "id": "date-of-birth-answer"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "in-education-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Ydy",
+                                                        "value": "Yes"
+                                                    },
+                                                    {
+                                                        "label": "Nac ydy",
+                                                        "value": "No"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "in-education-question",
+                                        "title": "Ydych chi\u2019n blentyn ysgol neu\u2019n fyfyriwr mewn addysg amser llawn?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "in-education-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Ydy",
+                                                        "value": "Yes"
+                                                    },
+                                                    {
+                                                        "label": "Nac ydy",
+                                                        "value": "No"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "in-education-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Ydy <em>{person_name}</em> yn blentyn ysgol neu\u2019n fyfyriwr mewn addysg amser llawn?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "term-time-location",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "id": "in-education-answer",
+                                                "value": "Yes"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "group": "identity-and-health-group"
+                                    }
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "term-time-location",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "term-time-location-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": {
+                                                            "placeholders": [
+                                                                {
+                                                                    "placeholder": "address",
+                                                                    "value": {
+                                                                        "identifier": "display_address",
+                                                                        "source": "metadata"
+                                                                    }
+                                                                }
+                                                            ],
+                                                            "text": "{address}"
+                                                        },
+                                                        "value": "household-address"
+                                                    },
+                                                    {
+                                                        "label": {
+                                                            "placeholders": [
+                                                                {
+                                                                    "placeholder": "country",
+                                                                    "value": {
+                                                                        "identifier": "another-address-answer-other-country",
+                                                                        "source": "answers"
+                                                                    }
+                                                                }
+                                                            ],
+                                                            "text": "Y cyfeiriad yn: {country}"
+                                                        },
+                                                        "value": "30-day-address"
+                                                    },
+                                                    {
+                                                        "label": "Cyfeiriad arall",
+                                                        "value": "Another address"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "term-time-location-question",
+                                        "title": "Yn ystod y tymor, ble rydych chi\u2019n byw fel arfer?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        },
+                                        {
+                                            "condition": "equals",
+                                            "id": "another-address-answer",
+                                            "value": "Other"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "term-time-location-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": {
+                                                            "placeholders": [
+                                                                {
+                                                                    "placeholder": "address",
+                                                                    "value": {
+                                                                        "identifier": "display_address",
+                                                                        "source": "metadata"
+                                                                    }
+                                                                }
+                                                            ],
+                                                            "text": "{address}"
+                                                        },
+                                                        "value": "household-address"
+                                                    },
+                                                    {
+                                                        "label": {
+                                                            "placeholders": [
+                                                                {
+                                                                    "placeholder": "country",
+                                                                    "value": {
+                                                                        "identifier": "another-address-answer-other-country",
+                                                                        "source": "answers"
+                                                                    }
+                                                                }
+                                                            ],
+                                                            "text": "Y cyfeiriad yn: {country}"
+                                                        },
+                                                        "value": "30-day-address"
+                                                    },
+                                                    {
+                                                        "label": "Cyfeiriad arall",
+                                                        "value": "Another address"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "term-time-location-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Yn ystod y tymor, ble mae <em>{person_name}</em> yn byw fel arfer?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "condition": "equals",
+                                            "id": "another-address-answer",
+                                            "value": "Other"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "term-time-location-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": {
+                                                            "placeholders": [
+                                                                {
+                                                                    "placeholder": "address",
+                                                                    "value": {
+                                                                        "identifier": "display_address",
+                                                                        "source": "metadata"
+                                                                    }
+                                                                }
+                                                            ],
+                                                            "text": "{address}"
+                                                        },
+                                                        "value": "household-address"
+                                                    },
+                                                    {
+                                                        "label": {
+                                                            "placeholders": [
+                                                                {
+                                                                    "placeholder": "address",
+                                                                    "transforms": [
+                                                                        {
+                                                                            "arguments": {
+                                                                                "delimiter": ", ",
+                                                                                "list_to_concatenate": {
+                                                                                    "identifier": [
+                                                                                        "other-address-answer-building",
+                                                                                        "other-address-answer-street"
+                                                                                    ],
+                                                                                    "source": "answers"
+                                                                                }
+                                                                            },
+                                                                            "transform": "concatenate_list"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "text": "{address}"
+                                                        },
+                                                        "value": "30-day-address"
+                                                    },
+                                                    {
+                                                        "label": "Cyfeiriad arall",
+                                                        "value": "Another address"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "term-time-location-question",
+                                        "title": "Yn ystod y tymor, ble rydych chi\u2019n byw fel arfer?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        },
+                                        {
+                                            "condition": "equals",
+                                            "id": "another-address-answer",
+                                            "value": "Yes, an address within the UK"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "term-time-location-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": {
+                                                            "placeholders": [
+                                                                {
+                                                                    "placeholder": "address",
+                                                                    "value": {
+                                                                        "identifier": "display_address",
+                                                                        "source": "metadata"
+                                                                    }
+                                                                }
+                                                            ],
+                                                            "text": "{address}"
+                                                        },
+                                                        "value": "household-address"
+                                                    },
+                                                    {
+                                                        "label": {
+                                                            "placeholders": [
+                                                                {
+                                                                    "placeholder": "address",
+                                                                    "transforms": [
+                                                                        {
+                                                                            "arguments": {
+                                                                                "delimiter": ", ",
+                                                                                "list_to_concatenate": {
+                                                                                    "identifier": [
+                                                                                        "other-address-answer-building",
+                                                                                        "other-address-answer-street"
+                                                                                    ],
+                                                                                    "source": "answers"
+                                                                                }
+                                                                            },
+                                                                            "transform": "concatenate_list"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "text": "{address}"
+                                                        },
+                                                        "value": "30-day-address"
+                                                    },
+                                                    {
+                                                        "label": "Cyfeiriad arall",
+                                                        "value": "Another address"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "term-time-location-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Yn ystod y tymor, ble mae <em>{person_name}</em> yn byw fel arfer?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "condition": "equals",
+                                            "id": "another-address-answer",
+                                            "value": "Yes, an address within the UK"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "term-time-location-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": {
+                                                            "placeholders": [
+                                                                {
+                                                                    "placeholder": "address",
+                                                                    "value": {
+                                                                        "identifier": "display_address",
+                                                                        "source": "metadata"
+                                                                    }
+                                                                }
+                                                            ],
+                                                            "text": "{address}"
+                                                        },
+                                                        "value": "household-address"
+                                                    },
+                                                    {
+                                                        "label": "Cyfeiriad arall",
+                                                        "value": "Another address"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "term-time-location-question",
+                                        "title": "Yn ystod y tymor, ble rydych chi\u2019n byw fel arfer?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "term-time-location-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": {
+                                                            "placeholders": [
+                                                                {
+                                                                    "placeholder": "address",
+                                                                    "value": {
+                                                                        "identifier": "display_address",
+                                                                        "source": "metadata"
+                                                                    }
+                                                                }
+                                                            ],
+                                                            "text": "{address}"
+                                                        },
+                                                        "value": "household-address"
+                                                    },
+                                                    {
+                                                        "label": "Cyfeiriad arall",
+                                                        "value": "Another address"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "term-time-location-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Yn ystod y tymor, ble mae <em>{person_name}</em> yn byw fel arfer?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "term-time-address-country",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "id": "another-address-answer",
+                                                "value": "No"
+                                            },
+                                            {
+                                                "condition": "equals",
+                                                "id": "term-time-location-answer",
+                                                "value": "Another address"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "group": "comments-group",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "id": "term-time-location-answer",
+                                                "value": "Another address"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "group": "comments-group",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "id": "term-time-location-answer",
+                                                "value": "30-day-address"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "group": "identity-and-health-group"
+                                    }
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "term-time-address-country",
+                            "question": {
+                                "answers": [
+                                    {
+                                        "id": "term-time-address-country-answer",
+                                        "mandatory": true,
+                                        "options": [
+                                            {
+                                                "label": "Ydy",
+                                                "value": "Yes"
+                                            },
+                                            {
+                                                "detail_answer": {
+                                                    "id": "term-time-address-country-answer-other",
+                                                    "label": "Nodwch y wlad",
+                                                    "mandatory": false,
+                                                    "type": "TextField"
+                                                },
+                                                "label": "Nac ydy",
+                                                "value": "No"
+                                            }
+                                        ],
+                                        "type": "Radio"
+                                    }
+                                ],
+                                "id": "term-time-address-country-question",
+                                "title": "Ydy\u2019r cyfeiriad hwn yn y Deyrnas Unedig?",
+                                "type": "General"
+                            },
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "term-time-address-details",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "id": "term-time-address-country-answer",
+                                                "value": "Yes"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "group": "comments-group"
+                                    }
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "term-time-address-details",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "term-time-address-details-answer-building",
+                                                "label": "Enw neu rif y t\u0177",
+                                                "mandatory": true,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "id": "term-time-address-details-answer-street",
+                                                "label": "Stryd",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "id": "term-time-address-details-answer-city",
+                                                "label": "Tref neu ddinas",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "id": "term-time-address-details-answer-county",
+                                                "label": "Sir (dewisol)",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "id": "term-time-address-details-answer-postcode",
+                                                "label": "Cod post",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            }
+                                        ],
+                                        "id": "term-time-address-details-question",
+                                        "title": "Rhowch fanylion y cyfeiriad yn y Deyrnas Unedig lle rydych chi\u2019n aros fel arfer yn ystod y tymor",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "term-time-address-details-answer-building",
+                                                "label": "Enw neu rif y t\u0177",
+                                                "mandatory": true,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "id": "term-time-address-details-answer-street",
+                                                "label": "Stryd",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "id": "term-time-address-details-answer-city",
+                                                "label": "Tref neu ddinas",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "id": "term-time-address-details-answer-county",
+                                                "label": "Sir (dewisol)",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "id": "term-time-address-details-answer-postcode",
+                                                "label": "Cod post",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            }
+                                        ],
+                                        "id": "term-time-address-details-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Rhowch fanylion y cyfeiriad yn y Deyrnas Unedig lle mae <em>{person_name}</em> yn aros fel arfer yn ystod y tymor"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "group": "comments-group"
+                                    }
+                                }
+                            ],
+                            "type": "Question"
+                        }
+                    ],
+                    "id": "personal-details-group",
+                    "title": "Manylion Personol"
+                },
+                {
+                    "blocks": [
+                        {
+                            "id": "country-of-birth",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "country-of-birth-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Cymru",
+                                                        "value": "Wales"
+                                                    },
+                                                    {
+                                                        "label": "Lloegr",
+                                                        "value": "England"
+                                                    },
+                                                    {
+                                                        "label": "Yr Alban",
+                                                        "value": "Scotland"
+                                                    },
+                                                    {
+                                                        "label": "Gogledd Iwerddon",
+                                                        "value": "Northern Ireland"
+                                                    },
+                                                    {
+                                                        "label": "Gweriniaeth Iwerddon",
+                                                        "value": "Republic of Ireland"
+                                                    },
+                                                    {
+                                                        "detail_answer": {
+                                                            "id": "country-of-birth-answer-other",
+                                                            "label": "Nodwch enw presennol y wlad",
+                                                            "mandatory": false,
+                                                            "type": "TextField"
+                                                        },
+                                                        "label": "Rhywle arall",
+                                                        "value": "Other"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "country-of-birth-question",
+                                        "title": "Ym mha wlad cawsoch chi eich geni?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "country-of-birth-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Cymru",
+                                                        "value": "Wales"
+                                                    },
+                                                    {
+                                                        "label": "Lloegr",
+                                                        "value": "England"
+                                                    },
+                                                    {
+                                                        "label": "Yr Alban",
+                                                        "value": "Scotland"
+                                                    },
+                                                    {
+                                                        "label": "Gogledd Iwerddon",
+                                                        "value": "Northern Ireland"
+                                                    },
+                                                    {
+                                                        "label": "Gweriniaeth Iwerddon",
+                                                        "value": "Republic of Ireland"
+                                                    },
+                                                    {
+                                                        "detail_answer": {
+                                                            "id": "country-of-birth-answer-other",
+                                                            "label": "Nodwch enw presennol y wlad",
+                                                            "mandatory": false,
+                                                            "type": "TextField"
+                                                        },
+                                                        "label": "Rhywle arall",
+                                                        "value": "Other"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "country-of-birth-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name_possessive",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        },
+                                                        {
+                                                            "arguments": {
+                                                                "string_to_format": {
+                                                                    "source": "previous_transform"
+                                                                }
+                                                            },
+                                                            "transform": "format_possessive"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Ym mha wlad y ganwyd <em>{person_name_possessive}</em>?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "arrive-in-country",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "id": "country-of-birth-answer",
+                                                "value": "Other"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "arrive-in-country",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "id": "country-of-birth-answer",
+                                                "value": "Republic of Ireland"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "understand-welsh"
+                                    }
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "arrive-in-country",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "arrive-in-country-answer",
+                                                "mandatory": true,
+                                                "type": "MonthYearDate"
+                                            }
+                                        ],
+                                        "description": "Peidiwch \u00e2 chyfrif ymweliadau byr i ffwrdd o\u2019r Deyrnas Unedig",
+                                        "id": "arrive-in-country-question",
+                                        "title": "Pryd ddaethoch chi i fyw yn y Deyrnas Unedig ddiwethaf?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "arrive-in-country-answer",
+                                                "mandatory": true,
+                                                "type": "MonthYearDate"
+                                            }
+                                        ],
+                                        "description": "Peidiwch \u00e2 chyfrif ymweliadau byr i ffwrdd o\u2019r Deyrnas Unedig",
+                                        "id": "arrive-in-country-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Pryd ddaeth <em>{person_name}</em> i fyw yn y Deyrnas Unedig ddiwethaf?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "length-of-stay",
+                                        "when": [
+                                            {
+                                                "condition": "greater than",
+                                                "date_comparison": {
+                                                    "offset_by": {
+                                                        "years": -1
+                                                    },
+                                                    "value": "2019-09-01"
+                                                },
+                                                "id": "arrive-in-country-answer"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "when-arrive-in-uk",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "date_comparison": {
+                                                    "offset_by": {
+                                                        "years": -1
+                                                    },
+                                                    "value": "2019-09-01"
+                                                },
+                                                "id": "arrive-in-country-answer"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "understand-welsh"
+                                    }
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "when-arrive-in-uk",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "when-arrive-in-uk-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Do",
+                                                        "value": "Yes"
+                                                    },
+                                                    {
+                                                        "label": "Naddo",
+                                                        "value": "No"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "when-arrive-in-uk-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "census_date",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "date_format": "d MMMM YYYY",
+                                                                "date_to_format": {
+                                                                    "value": "2019-09-01"
+                                                                }
+                                                            },
+                                                            "transform": "format_date"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Wnaethoch chi ddod i\u2019r Deyrnas Unedig ar {census_date} neu ar \u00f4l hynny?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "when-arrive-in-uk-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Do",
+                                                        "value": "Yes"
+                                                    },
+                                                    {
+                                                        "label": "Naddo",
+                                                        "value": "No"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "when-arrive-in-uk-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "placeholder": "census_date",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "date_format": "d MMMM YYYY",
+                                                                "date_to_format": {
+                                                                    "value": "2019-09-01"
+                                                                }
+                                                            },
+                                                            "transform": "format_date"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Wnaeth <em>{person_name}</em> ddod i\u2019r Deyrnas Unedig ar {census_date} neu ar \u00f4l hynny?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "length-of-stay",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "id": "when-arrive-in-uk-answer",
+                                                "value": "Yes"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "understand-welsh"
+                                    }
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "length-of-stay",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "length-of-stay-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Llai na 12 mis",
+                                                        "value": "Less than 12 months"
+                                                    },
+                                                    {
+                                                        "label": "12 mis neu fwy",
+                                                        "value": "12 months or more"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "length-of-stay-question",
+                                        "title": "Gan gynnwys yr amser rydych chi wedi\u2019i dreulio yma\u2019n barod, am faint rydych chi\u2019n bwriadu aros yn y Deyrnas Unedig?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "length-of-stay-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Llai na 12 mis",
+                                                        "value": "Less than 12 months"
+                                                    },
+                                                    {
+                                                        "label": "12 mis neu fwy",
+                                                        "value": "12 months or more"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "length-of-stay-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Gan gynnwys yr amser y mae wedi\u2019i dreulio yma\u2019n barod, am faint mae <em>{person_name}</em> yn bwriadu aros yn y Deyrnas Unedig?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "understand-welsh"
+                                    }
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "understand-welsh",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "understand-welsh-answer",
+                                                "mandatory": false,
+                                                "options": [
+                                                    {
+                                                        "label": "Deall Cymraeg llafar",
+                                                        "value": "Understand spoken Welsh"
+                                                    },
+                                                    {
+                                                        "label": "Siarad Cymraeg",
+                                                        "value": "Speak Welsh"
+                                                    },
+                                                    {
+                                                        "label": "Darllen Cymraeg",
+                                                        "value": "Read Welsh"
+                                                    },
+                                                    {
+                                                        "label": "Ysgrifennu Cymraeg",
+                                                        "value": "Write Welsh"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            },
+                                            {
+                                                "id": "understand-welsh-answer-exclusive",
+                                                "mandatory": false,
+                                                "options": [
+                                                    {
+                                                        "label": "Dim un o\u2019r uchod",
+                                                        "value": "None of the these"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            }
+                                        ],
+                                        "guidance": {
+                                            "content": [
+                                                {
+                                                    "title": "A question about national identity, including Welsh, will follow"
+                                                }
+                                            ]
+                                        },
+                                        "id": "understand-welsh-question",
+                                        "mandatory": true,
+                                        "title": "Ydych chi\u2019n gallu deall, siarad, darllen neu ysgrifennu Cymraeg?",
+                                        "type": "MutuallyExclusive"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "understand-welsh-answer",
+                                                "mandatory": false,
+                                                "options": [
+                                                    {
+                                                        "label": "Deall Cymraeg llafar",
+                                                        "value": "Understand spoken Welsh"
+                                                    },
+                                                    {
+                                                        "label": "Siarad Cymraeg",
+                                                        "value": "Speak Welsh"
+                                                    },
+                                                    {
+                                                        "label": "Darllen Cymraeg",
+                                                        "value": "Read Welsh"
+                                                    },
+                                                    {
+                                                        "label": "Ysgrifennu Cymraeg",
+                                                        "value": "Write Welsh"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            },
+                                            {
+                                                "id": "understand-welsh-answer-exclusive",
+                                                "mandatory": false,
+                                                "options": [
+                                                    {
+                                                        "label": "Dim un o\u2019r uchod",
+                                                        "value": "None of the these"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            }
+                                        ],
+                                        "guidance": {
+                                            "content": [
+                                                {
+                                                    "title": "A question about national identity, including Welsh, will follow"
+                                                }
+                                            ]
+                                        },
+                                        "id": "understand-welsh-question",
+                                        "mandatory": true,
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Ydy <em>{person_name}</em> yn gallu deall, siarad, darllen neu ysgrifennu Cymraeg?"
+                                        },
+                                        "type": "MutuallyExclusive"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "language",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "language-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Cymraeg neu Saesneg",
+                                                        "value": "English or Welsh"
+                                                    },
+                                                    {
+                                                        "description": "Gan gynnwys laith Arwyddion Prydain",
+                                                        "detail_answer": {
+                                                            "id": "language-answer-other",
+                                                            "label": "Nodwch eich prif iaith",
+                                                            "mandatory": false,
+                                                            "type": "TextField"
+                                                        },
+                                                        "label": "Arall",
+                                                        "value": "Other"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "definitions": [
+                                            {
+                                                "content": [
+                                                    {
+                                                        "description": "Eich prif iaith yw\u2019r iaith rydych chi\u2019n ei defnyddio\u2019n fwyaf naturiol, er enghraifft, yr iaith rydych chi\u2019n ei defnyddio gartref."
+                                                    }
+                                                ],
+                                                "title": "What do we mean by \u201cmain language\u201d?"
+                                            }
+                                        ],
+                                        "id": "language-question",
+                                        "title": "Beth yw eich prif iaith?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "language-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Cymraeg neu Saesneg",
+                                                        "value": "English or Welsh"
+                                                    },
+                                                    {
+                                                        "description": "Gan gynnwys laith Arwyddion Prydain",
+                                                        "detail_answer": {
+                                                            "id": "language-answer-other",
+                                                            "label": "Nodwch eich prif iaith",
+                                                            "mandatory": false,
+                                                            "type": "TextField"
+                                                        },
+                                                        "label": "Arall",
+                                                        "value": "Other"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "definitions": [
+                                            {
+                                                "content": [
+                                                    {
+                                                        "description": "Prif iaith yr unigolyn yw\u2019r iaith mae\u2019n ei defnyddio\u2019n fwyaf naturiol, er enghraifft, yr iaith mae\u2019n ei defnyddio gartref."
+                                                    }
+                                                ],
+                                                "title": "Beth mae \u201cprif iaith\u201d yn ei olygu?"
+                                            }
+                                        ],
+                                        "id": "language-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name_possessive",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        },
+                                                        {
+                                                            "arguments": {
+                                                                "string_to_format": {
+                                                                    "source": "previous_transform"
+                                                                }
+                                                            },
+                                                            "transform": "format_possessive"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Beth yw prif iaith <em>{person_name_possessive}</em>?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "national-identity",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "id": "language-answer",
+                                                "value": "English"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "national-identity",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "id": "language-answer",
+                                                "value": "English or Welsh"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "english"
+                                    }
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "english",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "english-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Da iawn",
+                                                        "value": "Very well"
+                                                    },
+                                                    {
+                                                        "label": "Da",
+                                                        "value": "Well"
+                                                    },
+                                                    {
+                                                        "label": "Ddim yn dda",
+                                                        "value": "Not well"
+                                                    },
+                                                    {
+                                                        "label": "Ddim o gwbl",
+                                                        "value": "Not at all"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "english-question",
+                                        "title": "Pa mor dda ydych chi\u2019n gallu siarad Saesneg?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "english-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Da iawn",
+                                                        "value": "Very well"
+                                                    },
+                                                    {
+                                                        "label": "Da",
+                                                        "value": "Well"
+                                                    },
+                                                    {
+                                                        "label": "Ddim yn dda",
+                                                        "value": "Not well"
+                                                    },
+                                                    {
+                                                        "label": "Ddim o gwbl",
+                                                        "value": "Not at all"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "english-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Pa mor dda mae <em>{person_name}</em> yn gallu siarad Saesneg?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "national-identity",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "national-identity-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Cymro/Cymraes",
+                                                        "value": "Welsh"
+                                                    },
+                                                    {
+                                                        "label": "Sais/Saesnes",
+                                                        "value": "English"
+                                                    },
+                                                    {
+                                                        "label": "Albanwr/Albanes",
+                                                        "value": "Scottish"
+                                                    },
+                                                    {
+                                                        "label": "Gwyddel/Gwyddeles o Ogledd Iwerddon",
+                                                        "value": "Northern Irish"
+                                                    },
+                                                    {
+                                                        "label": "Prydeiniwr/Prydeinwraig",
+                                                        "value": "British"
+                                                    },
+                                                    {
+                                                        "detail_answer": {
+                                                            "id": "national-identity-answer-other",
+                                                            "label": "Disgrifiwch eich hunaniaeth genedlaethol",
+                                                            "mandatory": false,
+                                                            "type": "TextField"
+                                                        },
+                                                        "label": "Arall",
+                                                        "value": "Other"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            }
+                                        ],
+                                        "definitions": [
+                                            {
+                                                "content": [
+                                                    {
+                                                        "description": "Nid yw hunaniaeth genedlaethol yn dibynnu ar eich gr\u0175p ethnig na\u2019ch dinasyddiaeth."
+                                                    },
+                                                    {
+                                                        "description": "Gallai olygu\u2019r wlad neu\u2019r gwledydd lle rydych chi\u2019n teimlo eich bod yn perthyn, neu sy\u2019n teimlo fel cartref i chi."
+                                                    }
+                                                ],
+                                                "title": "What do we mean by \u201cnational identity\u201d?"
+                                            }
+                                        ],
+                                        "id": "national-identity-question",
+                                        "title": "Sut fyddech chi\u2019n disgrifio eich hunaniaeth genedlaethol?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "national-identity-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Cymro/Cymraes",
+                                                        "value": "Welsh"
+                                                    },
+                                                    {
+                                                        "label": "Sais/Saesnes",
+                                                        "value": "English"
+                                                    },
+                                                    {
+                                                        "label": "Albanwr/Albanes",
+                                                        "value": "Scottish"
+                                                    },
+                                                    {
+                                                        "label": "Gwyddel/Gwyddeles o Ogledd Iwerddon",
+                                                        "value": "Northern Irish"
+                                                    },
+                                                    {
+                                                        "label": "Prydeiniwr/Prydeinwraig",
+                                                        "value": "British"
+                                                    },
+                                                    {
+                                                        "detail_answer": {
+                                                            "id": "national-identity-answer-other",
+                                                            "label": "Please describe their national identity",
+                                                            "mandatory": false,
+                                                            "type": "TextField"
+                                                        },
+                                                        "label": "Arall",
+                                                        "value": "Other"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            }
+                                        ],
+                                        "definitions": [
+                                            {
+                                                "content": [
+                                                    {
+                                                        "description": "Nid yw hunaniaeth genedlaethol yn dibynnu ar gr\u0175p ethnig na dinasyddiaeth."
+                                                    },
+                                                    {
+                                                        "description": "Gallai olygu\u2019r wlad neu\u2019r gwledydd lle mae person yn teimlo ei fod yn perthyn, neu sy\u2019n teimlo fel cartref."
+                                                    }
+                                                ],
+                                                "title": "Beth mae \u201chunaniaeth genedlaethol\u201d yn ei olygu?"
+                                            }
+                                        ],
+                                        "id": "national-identity-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Sut fyddai <em>{person_name}</em> yn disgrifio ei hunaniaeth genedlaethol?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "ethnic-group",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "guidance": {
+                                                    "content": [
+                                                        {
+                                                            "description": "Bydd eich ateb yn helpu i gefnogi cydraddoldeb a thegwch yn eich cymuned. Mae cynghorau a\u2019r llywodraeth yn defnyddio gwybodaeth am gr\u0175p ethnig i wneud yn si\u0175r eu bod yn:",
+                                                            "list": [
+                                                                "darparu gwasanaethau a rhannu cyllid yn deg",
+                                                                "deall a chynrychioli buddiannau pawb"
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "hide_guidance": "Pam mae eich ateb yn bwysig?",
+                                                    "show_guidance": "Pam mae eich ateb yn bwysig?"
+                                                },
+                                                "id": "ethnic-group-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "description": "Yn cynnwys Cymreig, Prydeinig, Gwyddelig Gogledd Iwerddon, Gwyddelig, Sipsi, Teithiwr Gwyddelig, Roma neu unrhyw gefndir Gwyn arall",
+                                                        "label": "Gwyn",
+                                                        "value": "White"
+                                                    },
+                                                    {
+                                                        "description": "Yn cynnwys Gwyn a Du Carib\u00efaidd, Gwyn a Du Affricanaidd, Gwyn ac Asiaidd neu unrhyw gefndir Cymysg neu Aml-ethnig arall",
+                                                        "label": "Grwpiau Cymysg neu Aml-ethnig",
+                                                        "value": "Mixed or Multiple ethnic groups"
+                                                    },
+                                                    {
+                                                        "description": "Yn cynnwys Indiaidd, Pacistanaidd, Bangladeshaidd, Tsieineaidd neu unrhyw gefndir Asiaidd arall",
+                                                        "label": "Asiaidd neu Asiaidd Prydeinig",
+                                                        "value": "Asian or Asian British"
+                                                    },
+                                                    {
+                                                        "description": "Yn cynnwys Du Prydeinig, Carib\u00efaidd, Affricanaidd neu unrhyw gefndir Du arall",
+                                                        "label": "Du, Du Prydeinig, Carib\u00efaidd neu Affricanaidd",
+                                                        "value": "Black, Black British, Caribbean or African"
+                                                    },
+                                                    {
+                                                        "description": "Yn cynnwys Arabaidd neu unrhyw gr\u0175p ethnig arall",
+                                                        "label": "Gr\u0175p ethnig arall",
+                                                        "value": "Other ethnic group"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "ethnic-group-question",
+                                        "title": "Beth yw eich gr\u0175p ethnig?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "guidance": {
+                                                    "content": [
+                                                        {
+                                                            "description": "Bydd eich ateb yn helpu i gefnogi cydraddoldeb a thegwch yn eich cymuned. Mae cynghorau a\u2019r llywodraeth yn defnyddio gwybodaeth am gr\u0175p ethnig i wneud yn si\u0175r eu bod yn:",
+                                                            "list": [
+                                                                "darparu gwasanaethau a rhannu cyllid yn deg",
+                                                                "deall a chynrychioli buddiannau pawb"
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "hide_guidance": "Pam mae eich ateb yn bwysig?",
+                                                    "show_guidance": "Pam mae eich ateb yn bwysig?"
+                                                },
+                                                "id": "ethnic-group-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "description": "Yn cynnwys Cymreig, Prydeinig, Gwyddelig Gogledd Iwerddon, Gwyddelig, Sipsi, Teithiwr Gwyddelig, Roma neu unrhyw gefndir Gwyn arall",
+                                                        "label": "Gwyn",
+                                                        "value": "White"
+                                                    },
+                                                    {
+                                                        "description": "Yn cynnwys Gwyn a Du Carib\u00efaidd, Gwyn a Du Affricanaidd, Gwyn ac Asiaidd neu unrhyw gefndir Cymysg neu Aml-ethnig arall",
+                                                        "label": "Grwpiau Cymysg neu Aml-ethnig",
+                                                        "value": "Mixed or Multiple ethnic groups"
+                                                    },
+                                                    {
+                                                        "description": "Yn cynnwys Indiaidd, Pacistanaidd, Bangladeshaidd, Tsieineaidd neu unrhyw gefndir Asiaidd arall",
+                                                        "label": "Asiaidd neu Asiaidd Prydeinig",
+                                                        "value": "Asian or Asian British"
+                                                    },
+                                                    {
+                                                        "description": "Yn cynnwys Du Prydeinig, Carib\u00efaidd, Affricanaidd neu unrhyw gefndir Du arall",
+                                                        "label": "Du, Du Prydeinig, Carib\u00efaidd neu Affricanaidd",
+                                                        "value": "Black, Black British, Caribbean or African"
+                                                    },
+                                                    {
+                                                        "description": "Yn cynnwys Arabaidd neu unrhyw gr\u0175p ethnig arall",
+                                                        "label": "Gr\u0175p ethnig arall",
+                                                        "value": "Other ethnic group"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "ethnic-group-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name_possessive",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        },
+                                                        {
+                                                            "arguments": {
+                                                                "string_to_format": {
+                                                                    "source": "previous_transform"
+                                                                }
+                                                            },
+                                                            "transform": "format_possessive"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Beth yw gr\u0175p ethnig <em>{person_name_possessive}</em>?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "white-ethnic-group",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "id": "ethnic-group-answer",
+                                                "value": "White"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "mixed-ethnic-group",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "id": "ethnic-group-answer",
+                                                "value": "Mixed or Multiple ethnic groups"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "asian-ethnic-group",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "id": "ethnic-group-answer",
+                                                "value": "Asian or Asian British"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "black-ethnic-group",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "id": "ethnic-group-answer",
+                                                "value": "Black, Black British, Caribbean or African"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "other-ethnic-group",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "id": "ethnic-group-answer",
+                                                "value": "Other ethnic group"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "religion"
+                                    }
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "white-ethnic-group",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "guidance": {
+                                                    "content": [
+                                                        {
+                                                            "description": "Wrth rannu\u2019r wybodaeth hon byddwch yn galluogi\u2019r llywodraeth a sefydliadau eraill i ddarparu adnoddau a pholis\u00efau priodol fel tai, addysg, iechyd a chyfiawnder troseddol."
+                                                        }
+                                                    ],
+                                                    "hide_guidance": "Pam mae eich ateb yn bwysig?",
+                                                    "show_guidance": "Pam mae eich ateb yn bwysig?"
+                                                },
+                                                "id": "white-ethnic-group-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Cymreig, Seisnig, Albanaidd, Gwyddelig Gogledd Iwerddon neu Brydeinig",
+                                                        "value": "Welsh, English, Scottish, Northern Irish or British"
+                                                    },
+                                                    {
+                                                        "label": "Gwyddelig",
+                                                        "value": "Irish"
+                                                    },
+                                                    {
+                                                        "label": "Sipsi neu Deithiwr Gwyddelig",
+                                                        "value": "Gypsy or Irish Traveller"
+                                                    },
+                                                    {
+                                                        "label": "Roma",
+                                                        "value": "Roma"
+                                                    },
+                                                    {
+                                                        "detail_answer": {
+                                                            "id": "white-ethnic-group-answer-other",
+                                                            "label": "Nodwch y cefndir Gwyn",
+                                                            "mandatory": false,
+                                                            "type": "TextField"
+                                                        },
+                                                        "label": "Unrhyw gefndir Gwyn arall",
+                                                        "value": "Other"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "white-ethnic-group-question",
+                                        "title": "Pa un sy\u2019n disgrifio orau eich gr\u0175p ethnig neu eich cefndir Gwyn?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "guidance": {
+                                                    "content": [
+                                                        {
+                                                            "description": "Wrth rannu\u2019r wybodaeth hon byddwch yn galluogi\u2019r llywodraeth a sefydliadau eraill i ddarparu adnoddau a pholis\u00efau priodol fel tai, addysg, iechyd a chyfiawnder troseddol."
+                                                        }
+                                                    ],
+                                                    "hide_guidance": "Pam mae eich ateb yn bwysig?",
+                                                    "show_guidance": "Pam mae eich ateb yn bwysig?"
+                                                },
+                                                "id": "white-ethnic-group-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Cymreig, Seisnig, Albanaidd, Gwyddelig Gogledd Iwerddon neu Brydeinig",
+                                                        "value": "Welsh, English, Scottish, Northern Irish or British"
+                                                    },
+                                                    {
+                                                        "label": "Gwyddelig",
+                                                        "value": "Irish"
+                                                    },
+                                                    {
+                                                        "label": "Sipsi neu Deithiwr Gwyddelig",
+                                                        "value": "Gypsy or Irish Traveller"
+                                                    },
+                                                    {
+                                                        "label": "Roma",
+                                                        "value": "Roma"
+                                                    },
+                                                    {
+                                                        "detail_answer": {
+                                                            "id": "white-ethnic-group-answer-other",
+                                                            "label": "Nodwch y cefndir Gwyn",
+                                                            "mandatory": false,
+                                                            "type": "TextField"
+                                                        },
+                                                        "label": "Unrhyw gefndir Gwyn arall",
+                                                        "value": "Other"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "white-ethnic-group-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name_possessive",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        },
+                                                        {
+                                                            "arguments": {
+                                                                "string_to_format": {
+                                                                    "source": "previous_transform"
+                                                                }
+                                                            },
+                                                            "transform": "format_possessive"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Pa un sy\u2019n disgrifio orau gr\u0175p ethnig neu gefndir Gwyn <em>{person_name_possessive}</em>?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "religion"
+                                    }
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "mixed-ethnic-group",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "guidance": {
+                                                    "content": [
+                                                        {
+                                                            "description": "Wrth rannu\u2019r wybodaeth hon byddwch yn galluogi\u2019r llywodraeth a sefydliadau eraill i ddarparu adnoddau a pholis\u00efau priodol fel tai, addysg, iechyd a chyfiawnder troseddol."
+                                                        }
+                                                    ],
+                                                    "hide_guidance": "Pam mae eich ateb yn bwysig?",
+                                                    "show_guidance": "Pam mae eich ateb yn bwysig?"
+                                                },
+                                                "id": "mixed-ethnic-group-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Gwyn a Du Carib\u00efaidd",
+                                                        "value": "White and Black Caribbean"
+                                                    },
+                                                    {
+                                                        "label": "Gwyn a Du Affricanaidd",
+                                                        "value": "White and Black African"
+                                                    },
+                                                    {
+                                                        "label": "Gwyn ac Asiaidd",
+                                                        "value": "White and Asian"
+                                                    },
+                                                    {
+                                                        "detail_answer": {
+                                                            "id": "mixed-ethnic-group-answer-other",
+                                                            "label": "Nodwch y cefndir Cymysg neu Aml-ethnig",
+                                                            "mandatory": false,
+                                                            "type": "TextField"
+                                                        },
+                                                        "label": "Unrhyw gefndir Cymysg neu Aml-ethnig arall",
+                                                        "value": "Other"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "mixed-ethnic-group-question",
+                                        "title": "Pa un sy\u2019n disgrifio orau eich gr\u0175p ethnig neu eich cefndir Cymysg neu Aml-ethnig?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "guidance": {
+                                                    "content": [
+                                                        {
+                                                            "description": "Wrth rannu\u2019r wybodaeth hon byddwch yn galluogi\u2019r llywodraeth a sefydliadau eraill i ddarparu adnoddau a pholis\u00efau priodol fel tai, addysg, iechyd a chyfiawnder troseddol."
+                                                        }
+                                                    ],
+                                                    "hide_guidance": "Pam mae eich ateb yn bwysig?",
+                                                    "show_guidance": "Pam mae eich ateb yn bwysig?"
+                                                },
+                                                "id": "mixed-ethnic-group-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Gwyn a Du Carib\u00efaidd",
+                                                        "value": "White and Black Caribbean"
+                                                    },
+                                                    {
+                                                        "label": "Gwyn a Du Affricanaidd",
+                                                        "value": "White and Black African"
+                                                    },
+                                                    {
+                                                        "label": "Gwyn ac Asiaidd",
+                                                        "value": "White and Asian"
+                                                    },
+                                                    {
+                                                        "detail_answer": {
+                                                            "id": "mixed-ethnic-group-answer-other",
+                                                            "label": "Nodwch y cefndir Cymysg neu Aml-ethnig",
+                                                            "mandatory": false,
+                                                            "type": "TextField"
+                                                        },
+                                                        "label": "Unrhyw gefndir Cymysg neu Aml-ethnig arall",
+                                                        "value": "Other"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "mixed-ethnic-group-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name_possessive",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        },
+                                                        {
+                                                            "arguments": {
+                                                                "string_to_format": {
+                                                                    "source": "previous_transform"
+                                                                }
+                                                            },
+                                                            "transform": "format_possessive"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Pa un sy\u2019n disgrifio orau gr\u0175p ethnig neu gefndir Cymysg neu Aml-ethnig <em>{person_name_possessive}</em>?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "religion"
+                                    }
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "asian-ethnic-group",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "guidance": {
+                                                    "content": [
+                                                        {
+                                                            "description": "Wrth rannu\u2019r wybodaeth hon byddwch yn galluogi\u2019r llywodraeth a sefydliadau eraill i ddarparu adnoddau a pholis\u00efau priodol fel tai, addysg, iechyd a chyfiawnder troseddol."
+                                                        }
+                                                    ],
+                                                    "hide_guidance": "Pam mae eich ateb yn bwysig?",
+                                                    "show_guidance": "Pam mae eich ateb yn bwysig?"
+                                                },
+                                                "id": "asian-ethnic-group-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Indiaidd",
+                                                        "value": "Indian"
+                                                    },
+                                                    {
+                                                        "label": "Pacistanaidd",
+                                                        "value": "Pakistani"
+                                                    },
+                                                    {
+                                                        "label": "Bangladeshaidd",
+                                                        "value": "Bangladeshi"
+                                                    },
+                                                    {
+                                                        "label": "Tsieineaidd",
+                                                        "value": "Chinese"
+                                                    },
+                                                    {
+                                                        "detail_answer": {
+                                                            "id": "asian-ethnic-group-answer-other",
+                                                            "label": "Nodwch y cefndir Asiaidd",
+                                                            "mandatory": false,
+                                                            "type": "TextField"
+                                                        },
+                                                        "label": "Unrhyw gefndir Asiaidd arall",
+                                                        "value": "Other"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "asian-ethnic-group-question",
+                                        "title": "Pa un sy\u2019n disgrifio orau eich gr\u0175p ethnig neu eich cefndir Asiaidd neu Asiaidd Prydeinig?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "guidance": {
+                                                    "content": [
+                                                        {
+                                                            "description": "Wrth rannu\u2019r wybodaeth hon byddwch yn galluogi\u2019r llywodraeth a sefydliadau eraill i ddarparu adnoddau a pholis\u00efau priodol fel tai, addysg, iechyd a chyfiawnder troseddol."
+                                                        }
+                                                    ],
+                                                    "hide_guidance": "Pam mae eich ateb yn bwysig?",
+                                                    "show_guidance": "Pam mae eich ateb yn bwysig?"
+                                                },
+                                                "id": "asian-ethnic-group-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Indiaidd",
+                                                        "value": "Indian"
+                                                    },
+                                                    {
+                                                        "label": "Pacistanaidd",
+                                                        "value": "Pakistani"
+                                                    },
+                                                    {
+                                                        "label": "Bangladeshaidd",
+                                                        "value": "Bangladeshi"
+                                                    },
+                                                    {
+                                                        "label": "Tsieineaidd",
+                                                        "value": "Chinese"
+                                                    },
+                                                    {
+                                                        "detail_answer": {
+                                                            "id": "asian-ethnic-group-answer-other",
+                                                            "label": "Nodwch y cefndir Asiaidd",
+                                                            "mandatory": false,
+                                                            "type": "TextField"
+                                                        },
+                                                        "label": "Unrhyw gefndir Asiaidd arall",
+                                                        "value": "Other"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "asian-ethnic-group-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name_possessive",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        },
+                                                        {
+                                                            "arguments": {
+                                                                "string_to_format": {
+                                                                    "source": "previous_transform"
+                                                                }
+                                                            },
+                                                            "transform": "format_possessive"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Pa un sy\u2019n disgrifio orau gr\u0175p ethnig neu gefndir Asiaidd neu Asiaidd Prydeinig <em>{person_name_possessive}</em>?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "religion"
+                                    }
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "black-ethnic-group",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "guidance": {
+                                                    "content": [
+                                                        {
+                                                            "description": "Wrth rannu\u2019r wybodaeth hon byddwch yn galluogi\u2019r llywodraeth a sefydliadau eraill i ddarparu adnoddau a pholis\u00efau priodol fel tai, addysg, iechyd a chyfiawnder troseddol."
+                                                        }
+                                                    ],
+                                                    "hide_guidance": "Pam mae eich ateb yn bwysig?",
+                                                    "show_guidance": "Pam mae eich ateb yn bwysig?"
+                                                },
+                                                "id": "black-ethnic-group-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Carib\u00efaidd",
+                                                        "value": "Caribbean"
+                                                    },
+                                                    {
+                                                        "detail_answer": {
+                                                            "id": "african-ethnic-group-answer-other",
+                                                            "label": "Nodwch y cefndir Affricanaidd",
+                                                            "mandatory": false,
+                                                            "type": "TextField"
+                                                        },
+                                                        "label": "Affricanaidd",
+                                                        "value": "African"
+                                                    },
+                                                    {
+                                                        "detail_answer": {
+                                                            "id": "black-ethnic-group-answer-other",
+                                                            "label": "Nodwch y cefndir Du, Du Prydeinig neu Garib\u00efaidd",
+                                                            "mandatory": false,
+                                                            "type": "TextField"
+                                                        },
+                                                        "label": "Unrhyw gefndir Du, Du Prydeinig neu Garib\u00efaidd arall",
+                                                        "value": "Other"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "black-ethnic-group-question",
+                                        "title": "Pa un sy\u2019n disgrifio orau eich gr\u0175p ethnig neu eich cefndir Du, Du Prydeinig, Carib\u00efaidd, Affricanaidd neu unrhyw gefndir Du arall?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "guidance": {
+                                                    "content": [
+                                                        {
+                                                            "description": "Wrth rannu\u2019r wybodaeth hon byddwch yn galluogi\u2019r llywodraeth a sefydliadau eraill i ddarparu adnoddau a pholis\u00efau priodol fel tai, addysg, iechyd a chyfiawnder troseddol."
+                                                        }
+                                                    ],
+                                                    "hide_guidance": "Pam mae eich ateb yn bwysig?",
+                                                    "show_guidance": "Pam mae eich ateb yn bwysig?"
+                                                },
+                                                "id": "black-ethnic-group-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Carib\u00efaidd",
+                                                        "value": "Caribbean"
+                                                    },
+                                                    {
+                                                        "detail_answer": {
+                                                            "id": "african-ethnic-group-answer-other",
+                                                            "label": "Nodwch y cefndir Affricanaidd",
+                                                            "mandatory": false,
+                                                            "type": "TextField"
+                                                        },
+                                                        "label": "Affricanaidd",
+                                                        "value": "African"
+                                                    },
+                                                    {
+                                                        "detail_answer": {
+                                                            "id": "black-ethnic-group-answer-other",
+                                                            "label": "Nodwch y cefndir Du, Du Prydeinig neu Garib\u00efaidd",
+                                                            "mandatory": false,
+                                                            "type": "TextField"
+                                                        },
+                                                        "label": "Unrhyw gefndir Du, Du Prydeinig neu Garib\u00efaidd arall",
+                                                        "value": "Other"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "black-ethnic-group-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name_possessive",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        },
+                                                        {
+                                                            "arguments": {
+                                                                "string_to_format": {
+                                                                    "source": "previous_transform"
+                                                                }
+                                                            },
+                                                            "transform": "format_possessive"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Pa un sy\u2019n disgrifio orau gr\u0175p ethnig neu gefndir Du, Du Prydeinig, Carib\u00efaidd, Affricanaidd neu unrhyw gefndir Du arall <em>{person_name_possessive}</em>?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "religion"
+                                    }
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "other-ethnic-group",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "guidance": {
+                                                    "content": [
+                                                        {
+                                                            "description": "Wrth rannu\u2019r wybodaeth hon byddwch yn galluogi\u2019r llywodraeth a sefydliadau eraill i ddarparu adnoddau a pholis\u00efau priodol fel tai, addysg, iechyd a chyfiawnder troseddol."
+                                                        }
+                                                    ],
+                                                    "hide_guidance": "Pam mae eich ateb yn bwysig?",
+                                                    "show_guidance": "Pam mae eich ateb yn bwysig?"
+                                                },
+                                                "id": "other-ethnic-group-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Arabaidd",
+                                                        "value": "Arab"
+                                                    },
+                                                    {
+                                                        "detail_answer": {
+                                                            "id": "other-ethnic-group-answer-other",
+                                                            "label": "Nodwch y gr\u0175p ethnig arall",
+                                                            "mandatory": false,
+                                                            "type": "TextField"
+                                                        },
+                                                        "label": "Unrhyw gr\u0175p ethnig arall",
+                                                        "value": "Other"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "other-ethnic-group-question",
+                                        "title": "Pa un sy\u2019n disgrifio orau eich gr\u0175p ethnig neu eich cefndir arall?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "guidance": {
+                                                    "content": [
+                                                        {
+                                                            "description": "Wrth rannu\u2019r wybodaeth hon byddwch yn galluogi\u2019r llywodraeth a sefydliadau eraill i ddarparu adnoddau a pholis\u00efau priodol fel tai, addysg, iechyd a chyfiawnder troseddol."
+                                                        }
+                                                    ],
+                                                    "hide_guidance": "Pam mae eich ateb yn bwysig?",
+                                                    "show_guidance": "Pam mae eich ateb yn bwysig?"
+                                                },
+                                                "id": "other-ethnic-group-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Arabaidd",
+                                                        "value": "Arab"
+                                                    },
+                                                    {
+                                                        "detail_answer": {
+                                                            "id": "other-ethnic-group-answer-other",
+                                                            "label": "Nodwch y gr\u0175p ethnig arall",
+                                                            "mandatory": false,
+                                                            "type": "TextField"
+                                                        },
+                                                        "label": "Unrhyw gr\u0175p ethnig arall",
+                                                        "value": "Other"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "other-ethnic-group-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name_possessive",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        },
+                                                        {
+                                                            "arguments": {
+                                                                "string_to_format": {
+                                                                    "source": "previous_transform"
+                                                                }
+                                                            },
+                                                            "transform": "format_possessive"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Pa un sy\u2019n disgrifio orau gr\u0175p ethnig neu gefndir arall <em>{person_name_possessive}</em>?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "religion"
+                                    }
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "religion",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "religion-answer",
+                                                "label": "Dewiswch un opsiwn yn unig",
+                                                "mandatory": false,
+                                                "options": [
+                                                    {
+                                                        "label": "Dim crefydd",
+                                                        "value": "No religion"
+                                                    },
+                                                    {
+                                                        "description": "All denominations",
+                                                        "label": "Cristnogaeth",
+                                                        "value": "Christian"
+                                                    },
+                                                    {
+                                                        "label": "Bwdhaeth",
+                                                        "value": "Buddhist"
+                                                    },
+                                                    {
+                                                        "label": "Hind\u0175aeth",
+                                                        "value": "Hindu"
+                                                    },
+                                                    {
+                                                        "label": "Iddewiaeth",
+                                                        "value": "Jewish"
+                                                    },
+                                                    {
+                                                        "label": "Islam",
+                                                        "value": "Muslim"
+                                                    },
+                                                    {
+                                                        "label": "Siciaeth",
+                                                        "value": "Sikh"
+                                                    },
+                                                    {
+                                                        "detail_answer": {
+                                                            "id": "religion-answer-other",
+                                                            "label": "Nodwch y crefydd",
+                                                            "mandatory": false,
+                                                            "type": "TextField"
+                                                        },
+                                                        "label": "Unrhyw grefydd arall",
+                                                        "value": "Other"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            }
+                                        ],
+                                        "description": "Mae\u2019r cwestiwn hwn yn wirfoddol",
+                                        "id": "religion-question",
+                                        "title": "Beth yw eich crefydd?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "religion-answer",
+                                                "label": "Dewiswch un opsiwn yn unig",
+                                                "mandatory": false,
+                                                "options": [
+                                                    {
+                                                        "label": "Dim crefydd",
+                                                        "value": "No religion"
+                                                    },
+                                                    {
+                                                        "description": "All denominations",
+                                                        "label": "Cristnogaeth",
+                                                        "value": "Christian"
+                                                    },
+                                                    {
+                                                        "label": "Bwdhaeth",
+                                                        "value": "Buddhist"
+                                                    },
+                                                    {
+                                                        "label": "Hind\u0175aeth",
+                                                        "value": "Hindu"
+                                                    },
+                                                    {
+                                                        "label": "Iddewiaeth",
+                                                        "value": "Jewish"
+                                                    },
+                                                    {
+                                                        "label": "Islam",
+                                                        "value": "Muslim"
+                                                    },
+                                                    {
+                                                        "label": "Siciaeth",
+                                                        "value": "Sikh"
+                                                    },
+                                                    {
+                                                        "detail_answer": {
+                                                            "id": "religion-answer-other",
+                                                            "label": "Nodwch y crefydd",
+                                                            "mandatory": false,
+                                                            "type": "TextField"
+                                                        },
+                                                        "label": "Unrhyw grefydd arall",
+                                                        "value": "Other"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            }
+                                        ],
+                                        "description": "Mae\u2019r cwestiwn hwn yn wirfoddol",
+                                        "id": "religion-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name_possessive",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        },
+                                                        {
+                                                            "arguments": {
+                                                                "string_to_format": {
+                                                                    "source": "previous_transform"
+                                                                }
+                                                            },
+                                                            "transform": "format_possessive"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Beth yw crefydd <em>{person_name_possessive}</em>?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "past-usual-household-address",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "past-usual-address-household-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": {
+                                                            "placeholders": [
+                                                                {
+                                                                    "placeholder": "address",
+                                                                    "value": {
+                                                                        "identifier": "display_address",
+                                                                        "source": "metadata"
+                                                                    }
+                                                                }
+                                                            ],
+                                                            "text": "{address}"
+                                                        },
+                                                        "value": "household-address"
+                                                    },
+                                                    {
+                                                        "label": "Cyfeiriad myfyriwr yn ystod y tymor neu gyfeiriad ysgol breswyl yn y Deyrnas Unedig",
+                                                        "value": "Student term-time or boarding school address in the UK"
+                                                    },
+                                                    {
+                                                        "label": "Cyfeiriad arall yn y Deyrnas Unedig",
+                                                        "value": "Another address in the UK"
+                                                    },
+                                                    {
+                                                        "detail_answer": {
+                                                            "id": "past-usual-address-household-answer-other",
+                                                            "label": "Nodwch y wlad",
+                                                            "mandatory": false,
+                                                            "type": "TextField"
+                                                        },
+                                                        "label": "Cyfeiriad y tu allan i\u2019r Deyrnas Unedig",
+                                                        "value": "Other"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "description": "Os nad oedd gennych gyfeiriad arferol flwyddyn yn \u00f4l, nodwch y cyfeiriad lle roeddech chi\u2019n aros",
+                                        "id": "past-usual-address-household-question",
+                                        "title": "Flwyddyn yn \u00f4l, beth oedd eich cyfeiriad arferol?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "past-usual-address-household-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": {
+                                                            "placeholders": [
+                                                                {
+                                                                    "placeholder": "address",
+                                                                    "value": {
+                                                                        "identifier": "display_address",
+                                                                        "source": "metadata"
+                                                                    }
+                                                                }
+                                                            ],
+                                                            "text": "{address}"
+                                                        },
+                                                        "value": "household-address"
+                                                    },
+                                                    {
+                                                        "label": "Cyfeiriad myfyriwr yn ystod y tymor neu gyfeiriad ysgol breswyl yn y Deyrnas Unedig",
+                                                        "value": "Student term-time or boarding school address in the UK"
+                                                    },
+                                                    {
+                                                        "label": "Cyfeiriad arall yn y Deyrnas Unedig",
+                                                        "value": "Another address in the UK"
+                                                    },
+                                                    {
+                                                        "detail_answer": {
+                                                            "id": "past-usual-address-household-answer-other",
+                                                            "label": "Nodwch y wlad",
+                                                            "mandatory": false,
+                                                            "type": "TextField"
+                                                        },
+                                                        "label": "Cyfeiriad y tu allan i\u2019r Deyrnas Unedig",
+                                                        "value": "Other"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "description": "Os nad oedd gan yr unigolyn hwn gyfeiriad arferol flwyddyn yn \u00f4l, nodwch y cyfeiriad lle\u2019r oedd yn aros",
+                                        "id": "past-usual-address-household-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name_possessive",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        },
+                                                        {
+                                                            "arguments": {
+                                                                "string_to_format": {
+                                                                    "source": "previous_transform"
+                                                                }
+                                                            },
+                                                            "transform": "format_possessive"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Flwyddyn yn \u00f4l, beth oedd cyfeiriad arferol <em>{person_name_possessive}</em>?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "last-year-address",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "id": "past-usual-address-household-answer",
+                                                "value": "Student term-time or boarding school address in the UK"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "last-year-address",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "id": "past-usual-address-household-answer",
+                                                "value": "Another address in the UK"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "passports"
+                                    }
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "last-year-address",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "last-year-address-answer-building",
+                                                "label": "Enw neu rif y t\u0177",
+                                                "mandatory": true,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "id": "last-year-address-answer-street",
+                                                "label": "Stryd",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "id": "last-year-address-answer-city",
+                                                "label": "Tref neu Ddinas",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "id": "last-year-address-answer-county",
+                                                "label": "Sir (dewisol)",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "id": "last-year-address-answer-postcode",
+                                                "label": "Cod post",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            }
+                                        ],
+                                        "id": "last-year-address-question",
+                                        "title": "Rhowch fanylion eich cyfeiriad flwyddyn yn \u00f4l",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "last-year-address-answer-building",
+                                                "label": "Enw neu rif y t\u0177",
+                                                "mandatory": true,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "id": "last-year-address-answer-street",
+                                                "label": "Stryd",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "id": "last-year-address-answer-city",
+                                                "label": "Tref neu Ddinas",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "id": "last-year-address-answer-county",
+                                                "label": "Sir (dewisol)",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "id": "last-year-address-answer-postcode",
+                                                "label": "Cod post",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            }
+                                        ],
+                                        "id": "last-year-address-question",
+                                        "title": "Rhowch fanylion cyfeiriad yr unigolyn flwyddyn yn \u00f4l",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "passports",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "passports-answer",
+                                                "mandatory": false,
+                                                "options": [
+                                                    {
+                                                        "label": "Y Deyrnas Unedig",
+                                                        "value": "United Kingdom"
+                                                    },
+                                                    {
+                                                        "label": "Iwerddon",
+                                                        "value": "Ireland"
+                                                    },
+                                                    {
+                                                        "detail_answer": {
+                                                            "id": "passport-answer-other",
+                                                            "label": "Nodwch y pasbortau sydd gennych chi",
+                                                            "mandatory": false,
+                                                            "type": "TextField"
+                                                        },
+                                                        "label": "Arall",
+                                                        "value": "Other"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            },
+                                            {
+                                                "id": "passports-answer-exclusive",
+                                                "mandatory": false,
+                                                "options": [
+                                                    {
+                                                        "label": "Dim un",
+                                                        "value": "None"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            }
+                                        ],
+                                        "description": "",
+                                        "id": "passports-question",
+                                        "mandatory": true,
+                                        "title": "Pa basbortau sydd gennych chi?",
+                                        "type": "MutuallyExclusive"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "passports-answer",
+                                                "mandatory": false,
+                                                "options": [
+                                                    {
+                                                        "label": "Y Deyrnas Unedig",
+                                                        "value": "United Kingdom"
+                                                    },
+                                                    {
+                                                        "label": "Iwerddon",
+                                                        "value": "Ireland"
+                                                    },
+                                                    {
+                                                        "detail_answer": {
+                                                            "id": "passport-answer-other",
+                                                            "label": "Nodwch y pasbortau sydd gan yr unigolyn",
+                                                            "mandatory": false,
+                                                            "type": "TextField"
+                                                        },
+                                                        "label": "Arall",
+                                                        "value": "Other"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            },
+                                            {
+                                                "id": "passports-answer-exclusive",
+                                                "mandatory": false,
+                                                "options": [
+                                                    {
+                                                        "label": "Dim un",
+                                                        "value": "None"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            }
+                                        ],
+                                        "description": "",
+                                        "id": "passports-question",
+                                        "mandatory": true,
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Pa basbortau sydd gan <em>{person_name}</em>?"
+                                        },
+                                        "type": "MutuallyExclusive"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "health",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "health-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Da iawn",
+                                                        "value": "Very good"
+                                                    },
+                                                    {
+                                                        "label": "Da",
+                                                        "value": "Good"
+                                                    },
+                                                    {
+                                                        "label": "Gweddol",
+                                                        "value": "Fair"
+                                                    },
+                                                    {
+                                                        "label": "Gwael",
+                                                        "value": "Bad"
+                                                    },
+                                                    {
+                                                        "label": "Gwael iawn",
+                                                        "value": "Very bad"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "health-question",
+                                        "title": "Sut mae eich iechyd yn gyffredinol?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "health-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Da iawn",
+                                                        "value": "Very good"
+                                                    },
+                                                    {
+                                                        "label": "Da",
+                                                        "value": "Good"
+                                                    },
+                                                    {
+                                                        "label": "Gweddol",
+                                                        "value": "Fair"
+                                                    },
+                                                    {
+                                                        "label": "Gwael",
+                                                        "value": "Bad"
+                                                    },
+                                                    {
+                                                        "label": "Gwael iawn",
+                                                        "value": "Very bad"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "health-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name_possessive",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        },
+                                                        {
+                                                            "arguments": {
+                                                                "string_to_format": {
+                                                                    "source": "previous_transform"
+                                                                }
+                                                            },
+                                                            "transform": "format_possessive"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Sut mae iechyd <em>{person_name_possessive}</em> yn gyffredinol?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "disability",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "disability-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Oes",
+                                                        "value": "Yes"
+                                                    },
+                                                    {
+                                                        "label": "Nac oes",
+                                                        "value": "No"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "definitions": [
+                                            {
+                                                "content": [
+                                                    {
+                                                        "description": "Mae hyn yn golygu cyflwr iechyd, salwch neu nam a all fod gennych."
+                                                    },
+                                                    {
+                                                        "description": "Dylech ystyried cyflyrau sydd bob amser yn effeithio arnoch a\u2019r rhai sy\u2019n ailgychwyn o bryd i\u2019w gilydd. \nGall hyn gynnwys, er enghraifft, gyflwr synhwyraidd, cyflwr datblygiadol neu anhawster dysgu."
+                                                    }
+                                                ],
+                                                "title": "What do we mean by \u201cphysical and mental health conditions or illness\u201d?"
+                                            }
+                                        ],
+                                        "id": "disability-question",
+                                        "title": "Oes gennych chi gyflwr neu salwch corfforol neu feddyliol sydd wedi para neu sy\u2019n debygol o bara 12 mis neu fwy?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "disability-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Oes",
+                                                        "value": "Yes"
+                                                    },
+                                                    {
+                                                        "label": "Nac oes",
+                                                        "value": "No"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "definitions": [
+                                            {
+                                                "content": [
+                                                    {
+                                                        "description": "Mae hyn yn golygu cyflwr iechyd, salwch neu nam a all fod gan yr unigolyn."
+                                                    },
+                                                    {
+                                                        "description": "Dylech ystyried cyflyrau sydd bob amser yn effeithio ar yr unigolyn a\u2019r rhai sy\u2019n ailgychwyn o bryd i\u2019w gilydd. \nGall hyn gynnwys, er enghraifft, cyflwr synhwyraidd, cyflwr datblygiadol neu anhawster dysgu."
+                                                    }
+                                                ],
+                                                "title": "Beth mae \u201ccyflwr neu salwch corfforol neu feddyliol\u201d yn ei olygu?"
+                                            }
+                                        ],
+                                        "id": "disability-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Oes gan <em>{person_name}</em> gyflwr neu salwch corfforol neu feddyliol sydd wedi para neu sy\u2019n debygol o bara 12 mis neu fwy?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "disability-limitation",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "id": "disability-answer",
+                                                "value": "Yes"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "carer"
+                                    }
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "disability-limitation",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "disability-limitation-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Ydy, yn fawr",
+                                                        "value": "Yes, a lot"
+                                                    },
+                                                    {
+                                                        "label": "Ydy, ychydig",
+                                                        "value": "Yes, a little"
+                                                    },
+                                                    {
+                                                        "label": "Ddim o gwbl",
+                                                        "value": "Not at all"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "definitions": [
+                                            {
+                                                "content": [
+                                                    {
+                                                        "description": "Rydym ni\u2019n golygu faint o effaith mae eich cyflwr iechyd neu\u2019ch salwch yn ei chael ar eich gallu i wneud gweithgareddau pob dydd, arferol ar hyn o bryd."
+                                                    },
+                                                    {
+                                                        "description": "Dylech ystyried a yw eich cyflwr neu\u2019ch salwch yn dal i effeithio arnoch wrth i chi gael unrhyw driniaeth neu feddyginiaeth, neu wrth i chi ddefnyddio unrhyw ddyfeisiau ar ei gyfer."
+                                                    },
+                                                    {
+                                                        "description": "Er enghraifft, os oes angen i chi ddefnyddio cymorth clyw, ac nad yw eich gallu i wneud gweithgareddau pob dydd yn cael ei gyfyngu o gwbl wrth i chi ei ddefnyddio, dylech ddewis \u2018Ddim o gwbl\u2019."
+                                                    },
+                                                    {
+                                                        "description": "Dylech ddewis \u201cYdy, yn fawr\u201d os oes angen rhywfaint o gymorth, fel arfer, gan aelodau o\u2019r teulu, ffrindiau neu wasanaethau cymdeithasol personol ar gyfer y rhan fwyaf o weithgareddau pob dydd, arferol."
+                                                    }
+                                                ],
+                                                "title": "What do we mean by \u201creduce your ability\u201d?"
+                                            }
+                                        ],
+                                        "id": "disability-limitation-question",
+                                        "title": "Ydy unrhyw gyflwr neu salwch sydd gennych chi\u2019n lleihau eich gallu i wneud gweithgareddau pob dydd?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "disability-limitation-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Ydy, yn fawr",
+                                                        "value": "Yes, a lot"
+                                                    },
+                                                    {
+                                                        "label": "Ydy, ychydig",
+                                                        "value": "Yes, a little"
+                                                    },
+                                                    {
+                                                        "label": "Ddim o gwbl",
+                                                        "value": "Not at all"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "definitions": [
+                                            {
+                                                "content": [
+                                                    {
+                                                        "description": "Rydym ni\u2019n golygu faint o effaith mae cyflwr iechyd neu salwch yr unigolyn yn ei chael ar y gallu i wneud gweithgareddau pob dydd, arferol ar hyn o bryd."
+                                                    },
+                                                    {
+                                                        "description": "Dylech ystyried a yw\u2019r cyflwr neu\u2019r salwch yn dal i gael effaith ar yr unigolyn wrth gael unrhyw driniaeth neu feddyginiaeth, neu wrth ddefnyddio unrhyw ddyfeisiau ar ei gyfer."
+                                                    },
+                                                    {
+                                                        "description": "Er enghraifft, os oes angen i\u2019r unigolyn ddefnyddio cymorth clyw, ac nad yw\u2019r gallu i wneud gweithgareddau pob dydd, arferol yn cael ei gyfyngu o gwbl wrth ei ddefnyddio, dylech ddewis \"Ddim o gwbl\"."
+                                                    },
+                                                    {
+                                                        "description": "Dylech ddewis \u201cYdy, yn fawr\u201d os oes angen rhywfaint o gymorth, fel arfer, gan aelodau o\u2019r teulu, ffrindiau neu wasanaethau cymdeithasol personol ar gyfer y rhan fwyaf o weithgareddau pob dydd, arferol."
+                                                    }
+                                                ],
+                                                "title": "Beth mae \u201clleihau gallu\u201d yn ei olygu\u2019?"
+                                            }
+                                        ],
+                                        "id": "disability-limitation-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name_possessive",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        },
+                                                        {
+                                                            "arguments": {
+                                                                "string_to_format": {
+                                                                    "source": "previous_transform"
+                                                                }
+                                                            },
+                                                            "transform": "format_possessive"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Ydy unrhyw gyflwr neu salwch sydd gan <em>{person_name_possessive}</em> yn lleihau\u2019r gallu i wneud gweithgareddau pob dydd?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "carer",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "carer-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Nac ydw",
+                                                        "value": "No"
+                                                    },
+                                                    {
+                                                        "label": "Ydw, 9 awr neu lai yr wythnos",
+                                                        "value": "Yes, 9 hours a week or less"
+                                                    },
+                                                    {
+                                                        "label": "Ydw, 10 i 19 awr yr wythnos",
+                                                        "value": "Yes, 10 to 19 hours a week"
+                                                    },
+                                                    {
+                                                        "label": "Ydw, 20 i 34 awr yr wythnos",
+                                                        "value": "Yes, 20 to 34 hours a week"
+                                                    },
+                                                    {
+                                                        "label": "Ydw, 35 i 49 awr yr wythnos",
+                                                        "value": "Yes, 35 to 49 hours a week"
+                                                    },
+                                                    {
+                                                        "label": "Ydw, 50 awr neu fwy yr wythnos",
+                                                        "value": "Yes, 50 or more hours a week"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "guidance": {
+                                            "content": [
+                                                {
+                                                    "title": "Exclude anything you do as part of your paid employment"
+                                                }
+                                            ]
+                                        },
+                                        "id": "carer-question",
+                                        "title": "Ydych chi\u2019n gofalu am unrhyw un, neu\u2019n cynnig unrhyw help neu gefnogaeth i unrhyw un, oherwydd cyflwr neu salwch corfforol neu feddyliol hir dymor, neu broblemau sy\u2019n gysylltiedig \u00e2 henaint?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "carer-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Nac ydw",
+                                                        "value": "No"
+                                                    },
+                                                    {
+                                                        "label": "Ydw, 9 awr neu lai yr wythnos",
+                                                        "value": "Yes, 9 hours a week or less"
+                                                    },
+                                                    {
+                                                        "label": "Ydw, 10 i 19 awr yr wythnos",
+                                                        "value": "Yes, 10 to 19 hours a week"
+                                                    },
+                                                    {
+                                                        "label": "Ydw, 20 i 34 awr yr wythnos",
+                                                        "value": "Yes, 20 to 34 hours a week"
+                                                    },
+                                                    {
+                                                        "label": "Ydw, 35 i 49 awr yr wythnos",
+                                                        "value": "Yes, 35 to 49 hours a week"
+                                                    },
+                                                    {
+                                                        "label": "Ydw, 50 awr neu fwy yr wythnos",
+                                                        "value": "Yes, 50 or more hours a week"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "guidance": {
+                                            "content": [
+                                                {
+                                                    "title": "Peidiwch \u00e2 chyfrif unrhyw beth y bydd yn derbyn cyflog am ei wneud"
+                                                }
+                                            ]
+                                        },
+                                        "id": "carer-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Ydy <em>{person_name}</em> yn gofalu am unrhyw un, neu\u2019n cynnig unrhyw help neu gefnogaeth i unrhyw un, oherwydd cyflwr neu salwch corfforol neu feddyliol hir dymor, neu broblemau sy\u2019n gysylltiedig \u00e2 henaint?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "sexual-identity",
+                                        "when": [
+                                            {
+                                                "condition": "less than",
+                                                "date_comparison": {
+                                                    "offset_by": {
+                                                        "years": -16
+                                                    },
+                                                    "value": "now"
+                                                },
+                                                "id": "date-of-birth-answer"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "group": "comments-group"
+                                    }
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "sexual-identity",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "sexual-identity-answer",
+                                                "label": "Dewiswch un opsiwn yn unig",
+                                                "mandatory": false,
+                                                "options": [
+                                                    {
+                                                        "label": "Heterorywiol/Str\u00eat",
+                                                        "value": "Straight or Heterosexual"
+                                                    },
+                                                    {
+                                                        "label": "Hoyw neu Lesbiaidd",
+                                                        "value": "Gay or Lesbian"
+                                                    },
+                                                    {
+                                                        "label": "Deurywiol/Bi",
+                                                        "value": "Bisexual"
+                                                    },
+                                                    {
+                                                        "detail_answer": {
+                                                            "id": "sexual-identity-answer-other",
+                                                            "label": "Nodwch eich cyfeiriadedd rhywiol",
+                                                            "mandatory": false,
+                                                            "type": "TextField"
+                                                        },
+                                                        "label": "Cyfeiriadedd rhywiol arall",
+                                                        "value": "Other sexual orientation"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            }
+                                        ],
+                                        "description": "Mae\u2019r cwestiwn hwn yn wirfoddol",
+                                        "id": "sexual-identity-question",
+                                        "title": "Pa un o\u2019r canlynol sy\u2019n disgrifio orau eich cyfeiriadedd rhywiol?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "sexual-identity-answer",
+                                                "label": "Dewiswch un opsiwn yn unig",
+                                                "mandatory": false,
+                                                "options": [
+                                                    {
+                                                        "label": "Heterorywiol/Str\u00eat",
+                                                        "value": "Straight or Heterosexual"
+                                                    },
+                                                    {
+                                                        "label": "Hoyw neu Lesbiaidd",
+                                                        "value": "Gay or Lesbian"
+                                                    },
+                                                    {
+                                                        "label": "Deurywiol/Bi",
+                                                        "value": "Bisexual"
+                                                    },
+                                                    {
+                                                        "detail_answer": {
+                                                            "id": "sexual-identity-answer-other",
+                                                            "label": "Nodwch gyfeiriadedd rhywiol yr unigolyn",
+                                                            "mandatory": false,
+                                                            "type": "TextField"
+                                                        },
+                                                        "label": "Cyfeiriadedd rhywiol arall",
+                                                        "value": "Other sexual orientation"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            }
+                                        ],
+                                        "description": "Mae\u2019r cwestiwn hwn yn wirfoddol",
+                                        "id": "sexual-identity-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name_possessive",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        },
+                                                        {
+                                                            "arguments": {
+                                                                "string_to_format": {
+                                                                    "source": "previous_transform"
+                                                                }
+                                                            },
+                                                            "transform": "format_possessive"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Pa un o\u2019r canlynol sy\u2019n disgrifio orau gyfeiriadedd rhywiol <em>{person_name_possessive}</em>?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "birth-gender",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "birth-gender-answer",
+                                                "label": "Dewiswch un opsiwn yn unig",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Ydy",
+                                                        "value": "Yes"
+                                                    },
+                                                    {
+                                                        "detail_answer": {
+                                                            "id": "birth-gender-answer-other",
+                                                            "label": "Nodwch eich rhywedd",
+                                                            "mandatory": false,
+                                                            "type": "TextField"
+                                                        },
+                                                        "label": "Nac ydy",
+                                                        "value": "No"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            }
+                                        ],
+                                        "description": "Mae\u2019r cwestiwn hwn yn wirfoddol",
+                                        "id": "birth-gender-question",
+                                        "title": "Ydy eich rhywedd yr un peth \u00e2\u2019r rhyw a gofrestrwyd pan gawsoch chi eich geni?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "birth-gender-answer",
+                                                "label": "Dewiswch un opsiwn yn unig",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Ydy",
+                                                        "value": "Yes"
+                                                    },
+                                                    {
+                                                        "detail_answer": {
+                                                            "id": "birth-gender-answer-other",
+                                                            "label": "Nodwch eich rhywedd",
+                                                            "mandatory": false,
+                                                            "type": "TextField"
+                                                        },
+                                                        "label": "Nac ydy",
+                                                        "value": "No"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            }
+                                        ],
+                                        "description": "Mae\u2019r cwestiwn hwn yn wirfoddol",
+                                        "id": "birth-gender-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name_possessive",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        },
+                                                        {
+                                                            "arguments": {
+                                                                "string_to_format": {
+                                                                    "source": "previous_transform"
+                                                                }
+                                                            },
+                                                            "transform": "format_possessive"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Ydy rhywedd <em>{person_name_possessive}</em> yr un peth \u00e2\u2019r rhyw a gofrestrwyd pan y\u2019i ganwyd?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "type": "Question"
+                        }
+                    ],
+                    "id": "identity-and-health-group",
+                    "title": "Hunaniaeth ac Iechyd"
+                },
+                {
+                    "blocks": [
+                        {
+                            "content_variants": [
+                                {
+                                    "content": [
+                                        {
+                                            "description": "Mae\u2019r gyfres nesaf o gwestiynau yn ymwneud ag unrhyw gymwysterau rydych chi wedi\u2019u hennill erioed yng Nghymru, Lloegr neu unrhyw le arall yn y byd, gan gynnwys cymwysterau cyfatebol, hyd yn oed os nad ydych yn eu defnyddio erbyn hyn."
+                                        }
+                                    ],
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "content": [
+                                        {
+                                            "description": {
+                                                "placeholders": [
+                                                    {
+                                                        "placeholder": "person_name",
+                                                        "transforms": [
+                                                            {
+                                                                "arguments": {
+                                                                    "delimiter": " ",
+                                                                    "list_to_concatenate": {
+                                                                        "identifier": [
+                                                                            "first-name",
+                                                                            "last-name"
+                                                                        ],
+                                                                        "source": "answers"
+                                                                    }
+                                                                },
+                                                                "transform": "concatenate_list"
+                                                            }
+                                                        ]
+                                                    }
+                                                ],
+                                                "text": "Mae\u2019r gyfres nesaf o gwestiynau yn ymwneud ag unrhyw gymwysterau y mae <em>{person_name}</em> wedi\u2019u hennill erioed yng Nghymru, Lloegr neu unrhyw le arall yn y byd, gan gynnwys cymwysterau cyfatebol, hyd yn oed os nad yw\u2019n eu defnyddio erbyn hyn."
+                                            }
+                                        }
+                                    ],
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "id": "qualifications",
+                            "title": "Cymwysterau",
+                            "type": "Interstitial"
+                        },
+                        {
+                            "id": "apprenticeship",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "apprenticeship-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "description": "Er enghraifft, masnach, uwch, sylfaen neu fodern",
+                                                        "label": "Ydw",
+                                                        "value": "Yes"
+                                                    },
+                                                    {
+                                                        "label": "Nac ydw",
+                                                        "value": "No"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "guidance": {
+                                            "content": [
+                                                {
+                                                    "title": "Include equivalent apprenticeships completed anywhere outside Wales and England"
+                                                }
+                                            ]
+                                        },
+                                        "id": "apprenticeship-question",
+                                        "title": "Ydych chi wedi cwblhau prentisiaeth?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "apprenticeship-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "description": "Er enghraifft, masnach, uwch, sylfaen neu fodern",
+                                                        "label": "Ydw",
+                                                        "value": "Yes"
+                                                    },
+                                                    {
+                                                        "label": "Nac ydw",
+                                                        "value": "No"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "guidance": {
+                                            "content": [
+                                                {
+                                                    "title": "Dylech gynnwys prentisiaethau cyfatebol sydd wedi eu cwblhau unrhyw le y tu allan i Gymru a Lloegr"
+                                                }
+                                            ]
+                                        },
+                                        "id": "apprenticeship-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Ydy <em>{person_name}</em> wedi cwblhau prentisiaeth?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "degree",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "degree-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "description": "Er enghraifft, gradd, gradd sylfaen, HND neu HNC, NVQ lefel 4 ac uwch, addysgu neu nyrsio",
+                                                        "label": "Oes",
+                                                        "value": "Yes"
+                                                    },
+                                                    {
+                                                        "description": "Bydd cwestiynau am gymwysterau NVQ eraill, Lefel A (Safon Uwch), TGAU a chymwysterau cyfatebol yn dilyn",
+                                                        "label": "Nac oes",
+                                                        "value": "No"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "guidance": {
+                                            "content": [
+                                                {
+                                                    "title": "Include equivalent qualifications achieved anywhere outside Wales and England"
+                                                }
+                                            ]
+                                        },
+                                        "id": "degree-question",
+                                        "title": "Oes gennych chi gymhwyster ar lefel gradd neu uwch?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "degree-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "description": "Er enghraifft, gradd, gradd sylfaen, HND neu HNC, NVQ lefel 4 ac uwch, addysgu neu nyrsio",
+                                                        "label": "Oes",
+                                                        "value": "Yes"
+                                                    },
+                                                    {
+                                                        "description": "Bydd cwestiynau am gymwysterau NVQ eraill, Lefel A (Safon Uwch), TGAU a chymwysterau cyfatebol yn dilyn",
+                                                        "label": "Nac oes",
+                                                        "value": "No"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "guidance": {
+                                            "content": [
+                                                {
+                                                    "title": "Dylech chi hefyd gynnwys cymwysterau cyfatebol o unrhyw le y tu allan i Gymru a Lloegr"
+                                                }
+                                            ]
+                                        },
+                                        "id": "degree-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Oes gan <em>{person_name}</em> gymhwyster ar lefel gradd neu uwch?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "nvq-level",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "nvq-level-answer",
+                                                "mandatory": false,
+                                                "options": [
+                                                    {
+                                                        "description": "Er enghraifft, BTEC Cenedlaethol, OND neu ONC, Crefft Uwch City and Guilds",
+                                                        "label": "NVQ lefel 3 neu gymhwyster cyfatebol",
+                                                        "value": "NVQ level 3 or equivalent"
+                                                    },
+                                                    {
+                                                        "description": "Er enghraifft, BTEC Cyffredinol, Crefft City and Guilds",
+                                                        "label": "NVQ lefel 2 neu gymhwyster cyfatebol",
+                                                        "value": "NVQ level 2 or equivalent"
+                                                    },
+                                                    {
+                                                        "label": "NVQ lefel 1 neu gymhwyster cyfatebol",
+                                                        "value": "NVQ level 1 or equivalent"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            },
+                                            {
+                                                "id": "nvq-level-answer-exclusive",
+                                                "mandatory": false,
+                                                "options": [
+                                                    {
+                                                        "description": "Bydd cwestiynau am gymwysterau Lefel A (Safon Uwch) a TGAU a chymwysterau cyfatebol yn dilyn",
+                                                        "label": "Dim un o\u2019r rhain yn berthnasol",
+                                                        "value": "None of these apply"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            }
+                                        ],
+                                        "guidance": {
+                                            "content": [
+                                                {
+                                                    "title": "Include equivalent qualifications achieved anywhere outside Wales and England"
+                                                }
+                                            ]
+                                        },
+                                        "id": "nvq-level-question",
+                                        "mandatory": true,
+                                        "title": "Oes gennych chi NVQ neu gymhwyster cyfatebol?",
+                                        "type": "MutuallyExclusive"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "nvq-level-answer",
+                                                "mandatory": false,
+                                                "options": [
+                                                    {
+                                                        "description": "Er enghraifft, BTEC Cenedlaethol, OND neu ONC, Crefft Uwch City and Guilds",
+                                                        "label": "NVQ lefel 3 neu gymhwyster cyfatebol",
+                                                        "value": "NVQ level 3 or equivalent"
+                                                    },
+                                                    {
+                                                        "description": "Er enghraifft, BTEC Cyffredinol, Crefft City and Guilds",
+                                                        "label": "NVQ lefel 2 neu gymhwyster cyfatebol",
+                                                        "value": "NVQ level 2 or equivalent"
+                                                    },
+                                                    {
+                                                        "label": "NVQ lefel 1 neu gymhwyster cyfatebol",
+                                                        "value": "NVQ level 1 or equivalent"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            },
+                                            {
+                                                "id": "nvq-level-answer-exclusive",
+                                                "mandatory": false,
+                                                "options": [
+                                                    {
+                                                        "description": "Bydd cwestiynau am gymwysterau Lefel A (Safon Uwch) a TGAU a chymwysterau cyfatebol yn dilyn",
+                                                        "label": "Dim un o\u2019r rhain yn berthnasol",
+                                                        "value": "None of these apply"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            }
+                                        ],
+                                        "guidance": {
+                                            "content": [
+                                                {
+                                                    "title": "Dylech chi hefyd gynnwys cymwysterau cyfatebol o unrhyw le y tu allan i Gymru a Lloegr"
+                                                }
+                                            ]
+                                        },
+                                        "id": "nvq-level-question",
+                                        "mandatory": true,
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Oes gan <em>{person_name}</em> NVQ neu gymhwyster cyfatebol?"
+                                        },
+                                        "type": "MutuallyExclusive"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "a-level",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "a-level-answer",
+                                                "mandatory": false,
+                                                "options": [
+                                                    {
+                                                        "description": "Dylech gynnwys 4 neu fwy o gymwysterau Lefel AS (Safon UG)",
+                                                        "label": "2 neu fwy o gymwysterau Lefel A (Safon Uwch)",
+                                                        "value": "2 or more A levels"
+                                                    },
+                                                    {
+                                                        "description": "Dylech gynnwys 2-3 Lefel AS (Safon UG)",
+                                                        "label": "1 Lefel A (Safon Uwch)",
+                                                        "value": "1 A level"
+                                                    },
+                                                    {
+                                                        "label": "1 Lefel AS (Safon UG)",
+                                                        "value": "1 AS level"
+                                                    },
+                                                    {
+                                                        "label": "Bagloriaeth Cymru \u2013 Uwch",
+                                                        "value": "Advanced Welsh Baccalaureate"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            },
+                                            {
+                                                "id": "a-level-answer-exclusive",
+                                                "mandatory": false,
+                                                "options": [
+                                                    {
+                                                        "description": "Bydd cwestiynau am gymwysterau TGAU a chymwysterau cyfatebol yn dilyn",
+                                                        "label": "Dim un o\u2019r rhain yn berthnasol",
+                                                        "value": "None of these apply"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            }
+                                        ],
+                                        "guidance": {
+                                            "content": [
+                                                {
+                                                    "title": "Include equivalent qualifications achieved anywhere outside Wales and England"
+                                                }
+                                            ]
+                                        },
+                                        "id": "a-level-question",
+                                        "mandatory": true,
+                                        "title": "Oes gennych chi Lefel AS (Safon UG), Lefel A (Safon Uwch) neu gymhwyster cyfatebol?",
+                                        "type": "MutuallyExclusive"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "a-level-answer",
+                                                "mandatory": false,
+                                                "options": [
+                                                    {
+                                                        "description": "Dylech gynnwys 4 neu fwy o gymwysterau Lefel AS (Safon UG)",
+                                                        "label": "2 neu fwy o gymwysterau Lefel A (Safon Uwch)",
+                                                        "value": "2 or more A levels"
+                                                    },
+                                                    {
+                                                        "description": "Dylech gynnwys 2-3 Lefel AS (Safon UG)",
+                                                        "label": "1 Lefel A (Safon Uwch)",
+                                                        "value": "1 A level"
+                                                    },
+                                                    {
+                                                        "label": "1 Lefel AS (Safon UG)",
+                                                        "value": "1 AS level"
+                                                    },
+                                                    {
+                                                        "label": "Bagloriaeth Cymru \u2013 Uwch",
+                                                        "value": "Advanced Welsh Baccalaureate"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            },
+                                            {
+                                                "id": "a-level-answer-exclusive",
+                                                "mandatory": false,
+                                                "options": [
+                                                    {
+                                                        "description": "Bydd cwestiynau am gymwysterau TGAU a chymwysterau cyfatebol yn dilyn",
+                                                        "label": "Dim un o\u2019r rhain yn berthnasol",
+                                                        "value": "None of these apply"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            }
+                                        ],
+                                        "guidance": {
+                                            "content": [
+                                                {
+                                                    "title": "Dylech chi hefyd gynnwys cymwysterau cyfatebol o unrhyw le y tu allan i Gymru a Lloegr"
+                                                }
+                                            ]
+                                        },
+                                        "id": "a-level-question",
+                                        "mandatory": true,
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Oes gan <em>{person_name}</em> gymhwyster Lefel AS (Safon UG), Lefel A (Safon Uwch) neu gymhwyster cyfatebol?"
+                                        },
+                                        "type": "MutuallyExclusive"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "gcse",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "gcse-answer",
+                                                "mandatory": false,
+                                                "options": [
+                                                    {
+                                                        "description": "Dylech gynnwys 5 neu fwy o gymwysterau lefel O (llwyddo) neu gymwysterau TAU (gradd 1)",
+                                                        "label": "5 neu fwy o gymwysterau TGAU (A*-C neu 9-4)",
+                                                        "value": "5 or more GCSEs"
+                                                    },
+                                                    {
+                                                        "description": "Dylech gynnwys unrhyw gymwysterau lefel O neu TAU eraill (unrhyw radd)",
+                                                        "label": "Unrhyw gymwysterau TGAU eraill",
+                                                        "value": "Any other GCSEs"
+                                                    },
+                                                    {
+                                                        "description": "Sgiliau bywyd, llythrennedd, rhifedd ac iaith",
+                                                        "label": "Cwrs sgiliau sylfaenol",
+                                                        "value": "Basic skills course"
+                                                    },
+                                                    {
+                                                        "label": "Bagloriaeth Cymru \u2013 Canolradd neu Genedlaethol",
+                                                        "value": "Intermediate or National Welsh Baccalaureate"
+                                                    },
+                                                    {
+                                                        "label": "Bagloriaeth Cymru \u2013 Sylfaen",
+                                                        "value": "Foundation Welsh Baccalaureate"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            },
+                                            {
+                                                "id": "gcse-answer-exclusive",
+                                                "mandatory": false,
+                                                "options": [
+                                                    {
+                                                        "label": "Dim un o\u2019r rhain yn berthnasol",
+                                                        "value": "None of these apply"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            }
+                                        ],
+                                        "guidance": {
+                                            "content": [
+                                                {
+                                                    "title": "Include equivalent qualifications achieved anywhere outside Wales and England"
+                                                }
+                                            ]
+                                        },
+                                        "id": "gcse-question",
+                                        "mandatory": true,
+                                        "title": "Oes gennych chi gymhwyster TGAU neu gymhwyster cyfatebol?",
+                                        "type": "MutuallyExclusive"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "gcse-answer",
+                                                "mandatory": false,
+                                                "options": [
+                                                    {
+                                                        "description": "Dylech gynnwys 5 neu fwy o gymwysterau lefel O (llwyddo) neu gymwysterau TAU (gradd 1)",
+                                                        "label": "5 neu fwy o gymwysterau TGAU (A*-C neu 9-4)",
+                                                        "value": "5 or more GCSEs"
+                                                    },
+                                                    {
+                                                        "description": "Dylech gynnwys unrhyw gymwysterau lefel O neu TAU eraill (unrhyw radd)",
+                                                        "label": "Unrhyw gymwysterau TGAU eraill",
+                                                        "value": "Any other GCSEs"
+                                                    },
+                                                    {
+                                                        "description": "Sgiliau bywyd, llythrennedd, rhifedd ac iaith",
+                                                        "label": "Cwrs sgiliau sylfaenol",
+                                                        "value": "Basic skills course"
+                                                    },
+                                                    {
+                                                        "label": "Bagloriaeth Cymru \u2013 Canolradd neu Genedlaethol",
+                                                        "value": "Intermediate or National Welsh Baccalaureate"
+                                                    },
+                                                    {
+                                                        "label": "Bagloriaeth Cymru \u2013 Sylfaen",
+                                                        "value": "Foundation Welsh Baccalaureate"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            },
+                                            {
+                                                "id": "gcse-answer-exclusive",
+                                                "mandatory": false,
+                                                "options": [
+                                                    {
+                                                        "label": "Dim un o\u2019r rhain yn berthnasol",
+                                                        "value": "None of these apply"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            }
+                                        ],
+                                        "guidance": {
+                                            "content": [
+                                                {
+                                                    "title": "Dylech chi hefyd gynnwys cymwysterau cyfatebol o unrhyw le y tu allan i Gymru a Lloegr"
+                                                }
+                                            ]
+                                        },
+                                        "id": "gcse-question",
+                                        "mandatory": true,
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Oes gan <em>{person_name}</em> gymhwyster TGAU neu gymhwyster cyfatebol?"
+                                        },
+                                        "type": "MutuallyExclusive"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "other-qualifications",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "id": "degree-answer",
+                                                "value": "No"
+                                            },
+                                            {
+                                                "condition": "contains",
+                                                "id": "gcse-answer-exclusive",
+                                                "value": "None of these apply"
+                                            },
+                                            {
+                                                "condition": "contains",
+                                                "id": "a-level-answer-exclusive",
+                                                "value": "None of these apply"
+                                            },
+                                            {
+                                                "condition": "contains",
+                                                "id": "nvq-level-answer-exclusive",
+                                                "value": "None of these apply"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "group": "employment-group"
+                                    }
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "other-qualifications",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "other-qualifications-answer",
+                                                "mandatory": false,
+                                                "options": [
+                                                    {
+                                                        "label": "Oes, yng Nghymru neu yn Lloegr",
+                                                        "value": "Yes, in Wales or England"
+                                                    },
+                                                    {
+                                                        "label": "Oes, unrhyw le y tu allan i Gymru a Lloegr",
+                                                        "value": "Yes, anywhere outside of Wales and England"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            },
+                                            {
+                                                "id": "other-qualifications-answer-exclusive",
+                                                "mandatory": false,
+                                                "options": [
+                                                    {
+                                                        "label": "Dim cymwysterau",
+                                                        "value": "No qualifications"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            }
+                                        ],
+                                        "id": "other-qualifications-question",
+                                        "mandatory": true,
+                                        "title": "Oes gennych chi unrhyw gymwysterau eraill?",
+                                        "type": "MutuallyExclusive"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "other-qualifications-answer",
+                                                "mandatory": false,
+                                                "options": [
+                                                    {
+                                                        "label": "Oes, yng Nghymru neu yn Lloegr",
+                                                        "value": "Yes, in Wales or England"
+                                                    },
+                                                    {
+                                                        "label": "Oes, unrhyw le y tu allan i Gymru a Lloegr",
+                                                        "value": "Yes, anywhere outside of Wales and England"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            },
+                                            {
+                                                "id": "other-qualifications-answer-exclusive",
+                                                "mandatory": false,
+                                                "options": [
+                                                    {
+                                                        "label": "Dim cymwysterau",
+                                                        "value": "No qualifications"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            }
+                                        ],
+                                        "id": "other-qualifications-question",
+                                        "mandatory": true,
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Oes gan <em>{person_name}</em> unrhyw gymwysterau eraill?"
+                                        },
+                                        "type": "MutuallyExclusive"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "group": "employment-group"
+                                    }
+                                }
+                            ],
+                            "type": "Question"
+                        }
+                    ],
+                    "id": "qualifications-group",
+                    "title": "Cymwysterau"
+                },
+                {
+                    "blocks": [
+                        {
+                            "id": "armed-forces",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "guidance": {
+                                                    "content": [
+                                                        {
+                                                            "description": "Rydym ni\u2019n mesur faint o bobl sydd wedi gwasanaethu yn Lluoedd Arfog y Deyrnas Unedig ac sydd bellach wedi gadael. Mae angen i\u2019r llywodraeth a chynghorau gael y wybodaeth hon er mwyn cyflawni eu hymrwymiadau o dan Gyfamod y Lluoedd Arfog. Addewid gan y genedl yw hwn, sy\u2019n sicrhau nad yw\u2019r rhai sy\u2019n gwasanaethu neu sydd wedi gwasanaethu yn y lluoedd arfog, na\u2019u teuluoedd, o dan anfantais."
+                                                        }
+                                                    ],
+                                                    "hide_guidance": "Pam mae eich ateb yn bwysig?",
+                                                    "show_guidance": "Pam mae eich ateb yn bwysig?"
+                                                },
+                                                "id": "armed-forces-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Nac ydw",
+                                                        "value": "No"
+                                                    },
+                                                    {
+                                                        "label": "Ydw, wedi gwasanaethu yn y Lluoedd Arfog Rheolaidd yn y gorffennol",
+                                                        "value": "Yes, previously served in Regular Armed Forces"
+                                                    },
+                                                    {
+                                                        "label": "Ydw, wedi gwasanaethu yn y Lluoedd Arfog Wrth Gefn yn y gorffennol",
+                                                        "value": "Yes, previously served in Reserve Armed Forces"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            }
+                                        ],
+                                        "guidance": {
+                                            "content": [
+                                                {
+                                                    "title": "Current serving members should select \u201cNo\u201d"
+                                                }
+                                            ]
+                                        },
+                                        "id": "armed-forces-question",
+                                        "title": "Ydych chi wedi gwasanaethu yn Lluoedd Arfog y Deyrnas Unedig yn y gorffennol (er enghraifft, y fyddin)?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "guidance": {
+                                                    "content": [
+                                                        {
+                                                            "description": "Rydym ni\u2019n mesur faint o bobl sydd wedi gwasanaethu yn Lluoedd Arfog y Deyrnas Unedig ac sydd bellach wedi gadael. Mae angen i\u2019r llywodraeth a chynghorau gael y wybodaeth hon er mwyn cyflawni eu hymrwymiadau o dan Gyfamod y Lluoedd Arfog. Addewid gan y genedl yw hwn, sy\u2019n sicrhau nad yw\u2019r rhai sy\u2019n gwasanaethu neu sydd wedi gwasanaethu yn y lluoedd arfog, na\u2019u teuluoedd, o dan anfantais."
+                                                        }
+                                                    ],
+                                                    "hide_guidance": "Pam mae eich ateb yn bwysig?",
+                                                    "show_guidance": "Pam mae eich ateb yn bwysig?"
+                                                },
+                                                "id": "armed-forces-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Nac ydw",
+                                                        "value": "No"
+                                                    },
+                                                    {
+                                                        "label": "Ydw, wedi gwasanaethu yn y Lluoedd Arfog Rheolaidd yn y gorffennol",
+                                                        "value": "Yes, previously served in Regular Armed Forces"
+                                                    },
+                                                    {
+                                                        "label": "Ydw, wedi gwasanaethu yn y Lluoedd Arfog Wrth Gefn yn y gorffennol",
+                                                        "value": "Yes, previously served in Reserve Armed Forces"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            }
+                                        ],
+                                        "guidance": {
+                                            "content": [
+                                                {
+                                                    "title": "Aelodau sy\u2019n gwasanaethu ar hyn o bryd, dewiswch \u2018Nac ydy\u2019 yn unig"
+                                                }
+                                            ]
+                                        },
+                                        "id": "armed-forces-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Ydy <em>{person_name}</em> wedi gwasanaethu yn Lluoedd Arfog y Deyrnas Unedig yn y gorffennol (er enghraifft, y fyddin)?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "employment-status",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "employment-status-answer",
+                                                "mandatory": false,
+                                                "options": [
+                                                    {
+                                                        "label": "Gwaith cyflogedig",
+                                                        "value": "Working as an employee"
+                                                    },
+                                                    {
+                                                        "label": "Gwaith hunangyflogedig neu ar eich liwt eich hun",
+                                                        "value": "Self-employed or freelance"
+                                                    },
+                                                    {
+                                                        "label": "I ffwrdd o\u2019ch gwaith dros dro yn s\u00e2l, ar wyliau, neu wedi\u2019ch cadw o\u2019ch gwaith dros dro am na all eich cyflogwr gynnig gwaith ar hyn o bryd",
+                                                        "value": "Temporarily away from work ill, on holiday or temporarily laid off"
+                                                    },
+                                                    {
+                                                        "label": "Ar gyfnod mamolaeth neu dadolaeth",
+                                                        "value": "On maternity or paternity leave"
+                                                    },
+                                                    {
+                                                        "label": "Unrhyw fath arall o waith am d\u00e2l",
+                                                        "value": "Doing any other kind of paid work"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            },
+                                            {
+                                                "id": "employment-status-answer-exclusive",
+                                                "mandatory": false,
+                                                "options": [
+                                                    {
+                                                        "label": "Dim un o\u2019r rhain yn berthnasol",
+                                                        "value": "None of these apply"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            }
+                                        ],
+                                        "guidance": {
+                                            "content": [
+                                                {
+                                                    "title": "Include casual or temporary work, even if only for one hour"
+                                                }
+                                            ]
+                                        },
+                                        "id": "employment-status-question",
+                                        "mandatory": true,
+                                        "title": "Yn ystod y 7 diwrnod diwethaf, oeddech chi\u2019n gwneud unrhyw un o\u2019r canlynol?",
+                                        "type": "MutuallyExclusive"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "employment-status-answer",
+                                                "mandatory": false,
+                                                "options": [
+                                                    {
+                                                        "label": "Gwaith cyflogedig",
+                                                        "value": "Working as an employee"
+                                                    },
+                                                    {
+                                                        "label": "Gwaith hunangyflogedig neu ar eich liwt eich hun",
+                                                        "value": "Self-employed or freelance"
+                                                    },
+                                                    {
+                                                        "label": "I ffwrdd o\u2019ch gwaith dros dro yn s\u00e2l, ar wyliau, neu wedi\u2019ch cadw o\u2019ch gwaith dros dro am na all eich cyflogwr gynnig gwaith ar hyn o bryd",
+                                                        "value": "Temporarily away from work ill, on holiday or temporarily laid off"
+                                                    },
+                                                    {
+                                                        "label": "Ar gyfnod mamolaeth neu dadolaeth",
+                                                        "value": "On maternity or paternity leave"
+                                                    },
+                                                    {
+                                                        "label": "Unrhyw fath arall o waith am d\u00e2l",
+                                                        "value": "Doing any other kind of paid work"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            },
+                                            {
+                                                "id": "employment-status-answer-exclusive",
+                                                "mandatory": false,
+                                                "options": [
+                                                    {
+                                                        "label": "Dim un o\u2019r rhain yn berthnasol",
+                                                        "value": "None of these apply"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            }
+                                        ],
+                                        "guidance": {
+                                            "content": [
+                                                {
+                                                    "title": "Dylech gynnwys gwaith achlysurol neu dros dro, hyd yn oed os mai dim ond am awr y buoch chi\u2019n gweithio"
+                                                }
+                                            ]
+                                        },
+                                        "id": "employment-status-question",
+                                        "mandatory": true,
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Yn ystod y 7 diwrnod diwethaf, oedd <em>{person_name}</em> yn gwneud unrhyw un o\u2019r canlynol?"
+                                        },
+                                        "type": "MutuallyExclusive"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "employment-type",
+                                        "when": [
+                                            {
+                                                "condition": "contains",
+                                                "id": "employment-status-answer-exclusive",
+                                                "value": "None of these apply"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "main-employment-block"
+                                    }
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "employment-type",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "employment-type-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "description": "Gan dderbyn pensiwn neu beidio",
+                                                        "label": "Wedi ymddeol",
+                                                        "value": "Retired"
+                                                    },
+                                                    {
+                                                        "label": "Astudio",
+                                                        "value": "Studying"
+                                                    },
+                                                    {
+                                                        "label": "Gofalu am y cartref neu am y teulu",
+                                                        "value": "Looking after home or family"
+                                                    },
+                                                    {
+                                                        "label": "Anabl neu yn s\u00e2l am gyfnod hir",
+                                                        "value": "Long-term sick or disabled"
+                                                    },
+                                                    {
+                                                        "label": "Arall",
+                                                        "value": "Other"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            }
+                                        ],
+                                        "id": "employment-type-question",
+                                        "title": "Pa un o\u2019r canlynol sy\u2019n disgrifio\u2019r hyn roeddech chi\u2019n ei wneud yn ystod y 7 diwrnod diwethaf?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "employment-type-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "description": "Gan dderbyn pensiwn neu beidio",
+                                                        "label": "Wedi ymddeol",
+                                                        "value": "Retired"
+                                                    },
+                                                    {
+                                                        "label": "Astudio",
+                                                        "value": "Studying"
+                                                    },
+                                                    {
+                                                        "label": "Gofalu am y cartref neu am y teulu",
+                                                        "value": "Looking after home or family"
+                                                    },
+                                                    {
+                                                        "label": "Anabl neu yn s\u00e2l am gyfnod hir",
+                                                        "value": "Long-term sick or disabled"
+                                                    },
+                                                    {
+                                                        "label": "Arall",
+                                                        "value": "Other"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            }
+                                        ],
+                                        "id": "employment-type-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Pa un o\u2019r canlynol sy\u2019n disgrifio\u2019r hyn roedd <em>{person_name}</em> yn ei wneud yn ystod y 7 diwrnod diwethaf?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "jobseeker",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "guidance": {
+                                                    "content": [
+                                                        {
+                                                            "description": "Pam mae angen i mi ateb os ydw i wedi ymddeol neu wedi bod yn s\u00e2l neu\u2019n anabl am gyfnod hir? \nI gael darlun cywir o\u2019r boblogaeth o oedran gweithio yn y Deyrnas Unedig, rydym ni\u2019n gofyn y cwestiwn hwn i bawb sydd ddim yn gweithio ar hyn o bryd. Rydym ni\u2019n gofyn i bobl sydd wedi ymddeol am fod mwy a mwy o bobl yn parhau i weithio ar \u00f4l oedran ymddeol. Rydym ni\u2019n gofyn i bobl sydd wedi bod yn s\u00e2l neu\u2019n anabl am gyfnod hir am fod rhai ohonyn nhw\u2019n bwriadu mynd yn \u00f4l i\u2019r gwaith."
+                                                        }
+                                                    ],
+                                                    "hide_guidance": "Pam mae angen i mi ateb os ydw i wedi ymddeol neu wedi bod yn s\u00e2l neu\u2019n anabl am gyfnod hir?",
+                                                    "show_guidance": "Pam mae angen i mi ateb os ydw i wedi ymddeol neu wedi bod yn s\u00e2l neu\u2019n anabl am gyfnod hir?"
+                                                },
+                                                "id": "jobseeker-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Oeddwn",
+                                                        "value": "Yes"
+                                                    },
+                                                    {
+                                                        "label": "Nac oeddwn",
+                                                        "value": "No"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "jobseeker-question",
+                                        "title": "Yn ystod y 4 wythnos diwethaf, oeddech chi wrthi\u2019n chwilio am unrhyw fath o waith am d\u00e2l?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "guidance": {
+                                                    "content": [
+                                                        {
+                                                            "description": "Pam mae angen i mi ateb os ydw i wedi ymddeol neu wedi bod yn s\u00e2l neu\u2019n anabl am gyfnod hir? \nI gael darlun cywir o\u2019r boblogaeth o oedran gweithio yn y Deyrnas Unedig, rydym ni\u2019n gofyn y cwestiwn hwn i bawb sydd ddim yn gweithio ar hyn o bryd. Rydym ni\u2019n gofyn i bobl sydd wedi ymddeol am fod mwy a mwy o bobl yn parhau i weithio ar \u00f4l oedran ymddeol. Rydym ni\u2019n gofyn i bobl sydd wedi bod yn s\u00e2l neu\u2019n anabl am gyfnod hir am fod rhai ohonyn nhw\u2019n bwriadu mynd yn \u00f4l i\u2019r gwaith."
+                                                        }
+                                                    ],
+                                                    "hide_guidance": "Pam mae angen i mi ateb os yw wedi ymddeol neu wedi bod yn s\u00e2l neu\u2019n anabl am gyfnod hir?",
+                                                    "show_guidance": "Pam mae angen i mi ateb os yw wedi ymddeol neu wedi bod yn s\u00e2l neu\u2019n anabl am gyfnod hir?"
+                                                },
+                                                "id": "jobseeker-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Oeddwn",
+                                                        "value": "Yes"
+                                                    },
+                                                    {
+                                                        "label": "Nac oeddwn",
+                                                        "value": "No"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "jobseeker-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Yn ystod y 4 wythnos diwethaf, oedd <em>{person_name}</em> wrthi\u2019n chwilio am unrhyw fath o waith am d\u00e2l?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "job-availability",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "id": "jobseeker-answer",
+                                                "value": "Yes"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "job-pending"
+                                    }
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "job-availability",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "job-availability-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Ydw",
+                                                        "value": "Yes"
+                                                    },
+                                                    {
+                                                        "label": "Nac ydw",
+                                                        "value": "No"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "job-availability-question",
+                                        "title": "Ydych chi ar gael i ddechrau gweithio yn y pythefnos nesaf?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "job-availability-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Ydw",
+                                                        "value": "Yes"
+                                                    },
+                                                    {
+                                                        "label": "Nac ydw",
+                                                        "value": "No"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "job-availability-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Ydy <em>{person_name}</em> ar gael i ddechrau gweithio yn y pythefnos nesaf?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "ever-worked",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "id": "job-availability-answer",
+                                                "value": "Yes"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "job-pending"
+                                    }
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "job-pending",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "job-pending-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Oeddwn",
+                                                        "value": "Yes"
+                                                    },
+                                                    {
+                                                        "label": "Nac oeddwn",
+                                                        "value": "No"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "job-pending-question",
+                                        "title": "Yn ystod y 7 diwrnod diwethaf, oeddech chi\u2019n aros i ddechrau swydd roeddech chi eisoes wedi\u2019i derbyn?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "job-pending-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Oeddwn",
+                                                        "value": "Yes"
+                                                    },
+                                                    {
+                                                        "label": "Nac oeddwn",
+                                                        "value": "No"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "job-pending-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Yn ystod y 7 diwrnod diwethaf, oedd <em>{person_name}</em> yn aros i ddechrau swydd roedd eisoes wedi\u2019i derbyn?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "ever-worked",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "ever-worked-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Ydw, yn ystod y 12 mis diwethaf",
+                                                        "value": "Yes, in the last 12 months"
+                                                    },
+                                                    {
+                                                        "label": "Ydw, ond nid yn ystod y 12 mis diwethaf",
+                                                        "value": "Yes, but not in the last 12 months"
+                                                    },
+                                                    {
+                                                        "label": "Nac ydw, erioed wedi gweithio",
+                                                        "value": "No, have never worked"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "ever-worked-question",
+                                        "title": "Ydych chi erioed wedi gwneud unrhyw waith am d\u00e2l?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "ever-worked-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Ydw, yn ystod y 12 mis diwethaf",
+                                                        "value": "Yes, in the last 12 months"
+                                                    },
+                                                    {
+                                                        "label": "Ydw, ond nid yn ystod y 12 mis diwethaf",
+                                                        "value": "Yes, but not in the last 12 months"
+                                                    },
+                                                    {
+                                                        "label": "Nac ydy, erioed wedi gweithio",
+                                                        "value": "No, has never worked"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "ever-worked-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Ydy <em>{person_name}</em> erioed wedi gwneud unrhyw waith am d\u00e2l?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "group": "comments-group",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "id": "ever-worked-answer",
+                                                "value": "No, have never worked"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "group": "comments-group",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "id": "ever-worked-answer",
+                                                "value": "No, has never worked"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "group": "comments-group",
+                                        "when": [
+                                            {
+                                                "condition": "not set",
+                                                "id": "ever-worked-answer"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "main-employment-block"
+                                    }
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "content_variants": [
+                                {
+                                    "content": [
+                                        {
+                                            "description": "Atebwch y gyfres nesaf o gwestiynau ar gyfer eich prif swydd ddiwethaf\nEich prif swydd yw\u2019r swydd roeddech chi fel arfer yn gweithio\u2019r nifer fwyaf o oriau ynddi",
+                                            "title": "Prif swydd"
+                                        }
+                                    ],
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        },
+                                        {
+                                            "condition": "not set",
+                                            "id": "employment-status-answer-exclusive"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "content": [
+                                        {
+                                            "description": {
+                                                "placeholders": [
+                                                    {
+                                                        "placeholder": "person_name_possessive",
+                                                        "transforms": [
+                                                            {
+                                                                "arguments": {
+                                                                    "delimiter": " ",
+                                                                    "list_to_concatenate": {
+                                                                        "identifier": [
+                                                                            "first-name",
+                                                                            "last-name"
+                                                                        ],
+                                                                        "source": "answers"
+                                                                    }
+                                                                },
+                                                                "transform": "concatenate_list"
+                                                            },
+                                                            {
+                                                                "arguments": {
+                                                                    "string_to_format": {
+                                                                        "source": "previous_transform"
+                                                                    }
+                                                                },
+                                                                "transform": "format_possessive"
+                                                            }
+                                                        ]
+                                                    }
+                                                ],
+                                                "text": "Atebwch y gyfres nesaf o gwestiynau ar gyfer prif swydd ddiwethaf <em>{person_name_possessive}</em>. Prif swydd yr unigolyn hwn yw\u2019r swydd yr oedd fel arfer yn gweithio\u2019r nifer fwyaf o oriau ynddi"
+                                            },
+                                            "title": "Prif swydd"
+                                        }
+                                    ],
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "condition": "not set",
+                                            "id": "employment-status-answer-exclusive"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "content": [
+                                        {
+                                            "description": "Atebwch y gyfres nesaf o gwestiynau ar gyfer eich prif swydd\nEich prif swydd yw\u2019r swydd rydych chi fel arfer yn gweithio\u2019r nifer fwyaf o oriau ynddi",
+                                            "title": "Prif swydd ddiwethaf"
+                                        }
+                                    ],
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        },
+                                        {
+                                            "condition": "contains",
+                                            "id": "employment-status-answer-exclusive",
+                                            "value": "None of these apply"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "content": [
+                                        {
+                                            "description": {
+                                                "placeholders": [
+                                                    {
+                                                        "placeholder": "person_name_possessive",
+                                                        "transforms": [
+                                                            {
+                                                                "arguments": {
+                                                                    "delimiter": " ",
+                                                                    "list_to_concatenate": {
+                                                                        "identifier": [
+                                                                            "first-name",
+                                                                            "last-name"
+                                                                        ],
+                                                                        "source": "answers"
+                                                                    }
+                                                                },
+                                                                "transform": "concatenate_list"
+                                                            },
+                                                            {
+                                                                "arguments": {
+                                                                    "string_to_format": {
+                                                                        "source": "previous_transform"
+                                                                    }
+                                                                },
+                                                                "transform": "format_possessive"
+                                                            }
+                                                        ]
+                                                    }
+                                                ],
+                                                "text": "Atebwch y gyfres nesaf o gwestiynau ar gyfer prif swydd <em>{person_name_possessive}</em>. Prif swydd yr unigolyn hwn yw\u2019r swydd y mae fel arfer yn gweithio\u2019r nifer fwyaf o oriau ynddi"
+                                            },
+                                            "title": "Prif swydd ddiwethaf"
+                                        }
+                                    ],
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "condition": "contains",
+                                            "id": "employment-status-answer-exclusive",
+                                            "value": "None of these apply"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "id": "main-employment-block",
+                            "title": "",
+                            "type": "Interstitial"
+                        },
+                        {
+                            "id": "main-job-type",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "main-job-type-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Gweithiwr cyflogedig",
+                                                        "value": "Employee"
+                                                    },
+                                                    {
+                                                        "label": "Hunangyflogedig neu\u2019n gweithio ar eich liwt eich hun heb gyflogi gweithwyr eraill",
+                                                        "value": "Self-employed or freelance without employees"
+                                                    },
+                                                    {
+                                                        "label": "Hunangyflogedig ac yn cyflogi gweithwyr eraill",
+                                                        "value": "Self-employed with employees"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "main-job-type-question",
+                                        "title": "Yn eich prif swydd, beth yw eich statws cyflogaeth?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        },
+                                        {
+                                            "condition": "not set",
+                                            "id": "employment-status-answer-exclusive"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "main-job-type-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Gweithiwr cyflogedig",
+                                                        "value": "Employee"
+                                                    },
+                                                    {
+                                                        "label": "Hunangyflogedig neu\u2019n gweithio ar eich liwt eich hun heb gyflogi gweithwyr eraill",
+                                                        "value": "Self-employed or freelance without employees"
+                                                    },
+                                                    {
+                                                        "label": "Hunangyflogedig ac yn cyflogi gweithwyr eraill",
+                                                        "value": "Self-employed with employees"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "main-job-type-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name_possessive",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        },
+                                                        {
+                                                            "arguments": {
+                                                                "string_to_format": {
+                                                                    "source": "previous_transform"
+                                                                }
+                                                            },
+                                                            "transform": "format_possessive"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Yn y brif swydd, beth yw statws cyflogaeth <em>{person_name_possessive}</em>?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "condition": "not set",
+                                            "id": "employment-status-answer-exclusive"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "main-job-type-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Gweithiwr cyflogedig",
+                                                        "value": "Employee"
+                                                    },
+                                                    {
+                                                        "label": "Hunangyflogedig neu\u2019n gweithio ar eich liwt eich hun heb gyflogi gweithwyr eraill",
+                                                        "value": "Self-employed or freelance without employees"
+                                                    },
+                                                    {
+                                                        "label": "Hunangyflogedig ac yn cyflogi gweithwyr eraill",
+                                                        "value": "Self-employed with employees"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "main-job-type-question",
+                                        "title": "Yn eich prif swydd, beth oedd eich statws cyflogaeth?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        },
+                                        {
+                                            "condition": "contains",
+                                            "id": "employment-status-answer-exclusive",
+                                            "value": "None of these apply"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "main-job-type-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Gweithiwr cyflogedig",
+                                                        "value": "Employee"
+                                                    },
+                                                    {
+                                                        "label": "Hunangyflogedig neu\u2019n gweithio ar eich liwt eich hun heb gyflogi gweithwyr eraill",
+                                                        "value": "Self-employed or freelance without employees"
+                                                    },
+                                                    {
+                                                        "label": "Hunangyflogedig ac yn cyflogi gweithwyr eraill",
+                                                        "value": "Self-employed with employees"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "main-job-type-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name_possessive",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        },
+                                                        {
+                                                            "arguments": {
+                                                                "string_to_format": {
+                                                                    "source": "previous_transform"
+                                                                }
+                                                            },
+                                                            "transform": "format_possessive"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Yn y brif swydd, beth oedd statws cyflogaeth <em>{person_name_possessive}</em>?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "condition": "contains",
+                                            "id": "employment-status-answer-exclusive",
+                                            "value": "None of these apply"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "business-name",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "business-name-answer",
+                                                "label": "Enw\u2019r sefydliad neu\u2019r busnes",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "id": "no-business-name-answer",
+                                                "mandatory": false,
+                                                "options": [
+                                                    {
+                                                        "label": "Dim sefydliad neu\u2019n gweithio i unigolyn preifat",
+                                                        "value": "No organisation or work for a private individual"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            }
+                                        ],
+                                        "description": "Os ydych chi\u2019n hunangyflogedig yn eich busnes eich hun, nodwch enw eich busnes.",
+                                        "id": "business-name-question",
+                                        "mandatory": true,
+                                        "title": "Beth yw enw\u2019r sefydliad neu\u2019r busnes rydych chi\u2019n gweithio iddo?",
+                                        "type": "MutuallyExclusive"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        },
+                                        {
+                                            "condition": "not set",
+                                            "id": "employment-status-answer-exclusive"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "business-name-answer",
+                                                "label": "Enw\u2019r sefydliad neu\u2019r busnes",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "id": "no-business-name-answer",
+                                                "mandatory": false,
+                                                "options": [
+                                                    {
+                                                        "label": "Dim sefydliad neu\u2019n gweithio i unigolyn preifat",
+                                                        "value": "No organisation or work for a private individual"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            }
+                                        ],
+                                        "description": "Os yw\u2019r person yn hunangyflogedig yn ei fusnes ei hun, nodwch enw\u2019r busnes.",
+                                        "id": "business-name-question",
+                                        "mandatory": true,
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Beth yw enw\u2019r sefydliad neu\u2019r busnes mae <em>{person_name}</em> yn gweithio iddo?"
+                                        },
+                                        "type": "MutuallyExclusive"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "condition": "not set",
+                                            "id": "employment-status-answer-exclusive"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "business-name-answer",
+                                                "label": "Enw\u2019r sefydliad neu\u2019r busnes",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "id": "no-business-name-answer",
+                                                "mandatory": false,
+                                                "options": [
+                                                    {
+                                                        "label": "Dim sefydliad neu\u2019n gweithio i unigolyn preifat",
+                                                        "value": "No organisation or worked for a private individual"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            }
+                                        ],
+                                        "description": "Os oeddech chi\u2019n hunangyflogedig yn eich busnes eich hun, nodwch enw eich busnes.",
+                                        "id": "business-name-question",
+                                        "mandatory": true,
+                                        "title": "Beth oedd enw\u2019r sefydliad neu\u2019r busnes roeddech chi\u2019n gweithio iddo?",
+                                        "type": "MutuallyExclusive"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        },
+                                        {
+                                            "condition": "contains",
+                                            "id": "employment-status-answer-exclusive",
+                                            "value": "None of these apply"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "business-name-answer",
+                                                "label": "Enw\u2019r sefydliad neu\u2019r busnes",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "id": "no-business-name-answer",
+                                                "mandatory": false,
+                                                "options": [
+                                                    {
+                                                        "label": "Dim sefydliad neu\u2019n gweithio i unigolyn preifat",
+                                                        "value": "No organisation or worked for a private individual"
+                                                    }
+                                                ],
+                                                "type": "Checkbox"
+                                            }
+                                        ],
+                                        "description": "Os oedd y person yn hunangyflogedig yn ei fusnes ei hun, nodwch enw\u2019r busnes.",
+                                        "id": "business-name-question",
+                                        "mandatory": true,
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Beth oedd enw\u2019r sefydliad neu\u2019r busnes roedd <em>{person_name}</em> yn gweithio iddo?"
+                                        },
+                                        "type": "MutuallyExclusive"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "condition": "contains",
+                                            "id": "employment-status-answer-exclusive",
+                                            "value": "None of these apply"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "job-title",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "job-title-answer",
+                                                "label": "Teitl swydd",
+                                                "mandatory": true,
+                                                "type": "TextField"
+                                            }
+                                        ],
+                                        "id": "job-title-question",
+                                        "title": "Beth yw teitl llawn eich swydd?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        },
+                                        {
+                                            "condition": "not set",
+                                            "id": "employment-status-answer-exclusive"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "job-title-answer",
+                                                "label": "Teitl swydd",
+                                                "mandatory": true,
+                                                "type": "TextField"
+                                            }
+                                        ],
+                                        "id": "job-title-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name_possessive",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        },
+                                                        {
+                                                            "arguments": {
+                                                                "string_to_format": {
+                                                                    "source": "previous_transform"
+                                                                }
+                                                            },
+                                                            "transform": "format_possessive"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Beth yw teitl llawn swydd <em>{person_name_possessive}</em>?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "condition": "not set",
+                                            "id": "employment-status-answer-exclusive"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "job-title-answer",
+                                                "label": "Teitl swydd",
+                                                "mandatory": true,
+                                                "type": "TextField"
+                                            }
+                                        ],
+                                        "id": "job-title-question",
+                                        "title": "Beth oedd teitl llawn eich swydd?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        },
+                                        {
+                                            "condition": "contains",
+                                            "id": "employment-status-answer-exclusive",
+                                            "value": "None of these apply"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "job-title-answer",
+                                                "label": "Teitl swydd",
+                                                "mandatory": true,
+                                                "type": "TextField"
+                                            }
+                                        ],
+                                        "id": "job-title-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name_possessive",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        },
+                                                        {
+                                                            "arguments": {
+                                                                "string_to_format": {
+                                                                    "source": "previous_transform"
+                                                                }
+                                                            },
+                                                            "transform": "format_possessive"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Beth oedd teitl llawn swydd <em>{person_name_possessive}</em>?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "condition": "contains",
+                                            "id": "employment-status-answer-exclusive",
+                                            "value": "None of these apply"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "job-description",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "job-description-answer",
+                                                "label": "Disgrifiad",
+                                                "mandatory": true,
+                                                "max_length": 200,
+                                                "type": "TextArea",
+                                                "validation": {
+                                                    "messages": {
+                                                        "MAX_LENGTH_EXCEEDED": "Mae\u2019n rhaid i\u2019ch ateb fod yn llai na %(max)d o nodau"
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "id": "job-description-question",
+                                        "title": "Beth ydych chi\u2019n ei wneud yn eich prif swydd?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        },
+                                        {
+                                            "condition": "not set",
+                                            "id": "employment-status-answer-exclusive"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "job-description-answer",
+                                                "label": "Disgrifiad",
+                                                "mandatory": true,
+                                                "max_length": 200,
+                                                "type": "TextArea",
+                                                "validation": {
+                                                    "messages": {
+                                                        "MAX_LENGTH_EXCEEDED": "Mae\u2019n rhaid i\u2019ch ateb fod yn llai na %(max)d o nodau"
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "id": "job-description-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Beth mae <em>{person_name}</em> yn ei wneud yn y brif swydd?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "condition": "not set",
+                                            "id": "employment-status-answer-exclusive"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "job-description-answer",
+                                                "label": "Disgrifiad",
+                                                "mandatory": true,
+                                                "max_length": 200,
+                                                "type": "TextArea",
+                                                "validation": {
+                                                    "messages": {
+                                                        "MAX_LENGTH_EXCEEDED": "Mae\u2019n rhaid i\u2019ch ateb fod yn llai na %(max)d o nodau"
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "id": "job-description-question",
+                                        "title": "Beth oeddech chi\u2019n ei wneud yn eich prif swydd?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        },
+                                        {
+                                            "condition": "contains",
+                                            "id": "employment-status-answer-exclusive",
+                                            "value": "None of these apply"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "job-description-answer",
+                                                "label": "Disgrifiad",
+                                                "mandatory": true,
+                                                "max_length": 200,
+                                                "type": "TextArea",
+                                                "validation": {
+                                                    "messages": {
+                                                        "MAX_LENGTH_EXCEEDED": "Mae\u2019n rhaid i\u2019ch ateb fod yn llai na %(max)d o nodau"
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "id": "job-description-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Beth oedd <em>{person_name}</em> yn ei wneud yn y brif swydd?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "condition": "contains",
+                                            "id": "employment-status-answer-exclusive",
+                                            "value": "None of these apply"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "employers-business",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "employers-business-answer",
+                                                "label": "Disgrifiad",
+                                                "mandatory": true,
+                                                "max_length": 200,
+                                                "type": "TextArea",
+                                                "validation": {
+                                                    "messages": {
+                                                        "MAX_LENGTH_EXCEEDED": "Mae\u2019n rhaid i\u2019ch ateb fod yn llai na %(max)d o nodau"
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "description": "Er enghraifft, manwerthu dillad, ysbyty cyffredinol, addysg gynradd, cyfanwerthu bwyd, y gwasanaeth sifil (Llywodraeth Cymru), llywodraeth leol (tai).",
+                                        "id": "employers-business-question",
+                                        "title": "Beth yw prif weithgarwch eich sefydliad, busnes neu\u2019ch gwaith ar eich liwt eich hun?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        },
+                                        {
+                                            "condition": "not set",
+                                            "id": "employment-status-answer-exclusive"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "employers-business-answer",
+                                                "label": "Disgrifiad",
+                                                "mandatory": true,
+                                                "max_length": 200,
+                                                "type": "TextArea",
+                                                "validation": {
+                                                    "messages": {
+                                                        "MAX_LENGTH_EXCEEDED": "Mae\u2019n rhaid i\u2019ch ateb fod yn llai na %(max)d o nodau"
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "description": "Er enghraifft, manwerthu dillad, ysbyty cyffredinol, addysg gynradd, cyfanwerthu bwyd, y gwasanaeth sifil (Llywodraeth Cymru), llywodraeth leol (tai).",
+                                        "id": "employers-business-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name_possessive",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        },
+                                                        {
+                                                            "arguments": {
+                                                                "string_to_format": {
+                                                                    "source": "previous_transform"
+                                                                }
+                                                            },
+                                                            "transform": "format_possessive"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Beth yw prif weithgarwch sefydliad, busnes neu waith ar ei liwt ei hun <em>{person_name_possessive}</em>?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "condition": "not set",
+                                            "id": "employment-status-answer-exclusive"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "employers-business-answer",
+                                                "label": "Disgrifiad",
+                                                "mandatory": true,
+                                                "max_length": 200,
+                                                "type": "TextArea",
+                                                "validation": {
+                                                    "messages": {
+                                                        "MAX_LENGTH_EXCEEDED": "Mae\u2019n rhaid i\u2019ch ateb fod yn llai na %(max)d o nodau"
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "description": "Er enghraifft, manwerthu dillad, ysbyty cyffredinol, addysg gynradd, cyfanwerthu bwyd, y gwasanaeth sifil (Llywodraeth Cymru), llywodraeth leol (tai).",
+                                        "id": "employers-business-question",
+                                        "title": "Beth oedd prif weithgarwch eich sefydliad, busnes neu\u2019ch gwaith ar eich liwt eich hun?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        },
+                                        {
+                                            "condition": "contains",
+                                            "id": "employment-status-answer-exclusive",
+                                            "value": "None of these apply"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "employers-business-answer",
+                                                "label": "Disgrifiad",
+                                                "mandatory": true,
+                                                "max_length": 200,
+                                                "type": "TextArea",
+                                                "validation": {
+                                                    "messages": {
+                                                        "MAX_LENGTH_EXCEEDED": "Mae\u2019n rhaid i\u2019ch ateb fod yn llai na %(max)d o nodau"
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "description": "Er enghraifft, manwerthu dillad, ysbyty cyffredinol, addysg gynradd, cyfanwerthu bwyd, y gwasanaeth sifil (Llywodraeth Cymru), llywodraeth leol (tai).",
+                                        "id": "employers-business-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name_possessive",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        },
+                                                        {
+                                                            "arguments": {
+                                                                "string_to_format": {
+                                                                    "source": "previous_transform"
+                                                                }
+                                                            },
+                                                            "transform": "format_possessive"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Beth oedd prif weithgarwch sefydliad, busnes neu waith ar ei liwt ei hun <em>{person_name_possessive}</em>?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "condition": "contains",
+                                            "id": "employment-status-answer-exclusive",
+                                            "value": "None of these apply"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "supervise",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "supervise-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Ydw",
+                                                        "value": "Yes"
+                                                    },
+                                                    {
+                                                        "label": "Nac ydw",
+                                                        "value": "No"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "supervise-question",
+                                        "title": "Ydych chi\u2019n goruchwylio neu\u2019n cadw golwg ar waith gweithwyr eraill o ddydd i ddydd?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        },
+                                        {
+                                            "condition": "not set",
+                                            "id": "employment-status-answer-exclusive"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "supervise-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Ydw",
+                                                        "value": "Yes"
+                                                    },
+                                                    {
+                                                        "label": "Nac ydw",
+                                                        "value": "No"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "supervise-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Ydy <em>{person_name}</em> yn goruchwylio neu\u2019n cadw golwg ar waith gweithwyr eraill o ddydd i ddydd?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "condition": "not set",
+                                            "id": "employment-status-answer-exclusive"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "supervise-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Ydw",
+                                                        "value": "Yes"
+                                                    },
+                                                    {
+                                                        "label": "Nac ydw",
+                                                        "value": "No"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "supervise-question",
+                                        "title": "Oeddech chi\u2019n goruchwylio neu\u2019n cadw golwg ar waith gweithwyr eraill o ddydd i ddydd?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        },
+                                        {
+                                            "condition": "contains",
+                                            "id": "employment-status-answer-exclusive",
+                                            "value": "None of these apply"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "supervise-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Ydw",
+                                                        "value": "Yes"
+                                                    },
+                                                    {
+                                                        "label": "Nac ydw",
+                                                        "value": "No"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "supervise-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Oedd <em>{person_name}</em> yn goruchwylio neu\u2019n cadw golwg ar waith gweithwyr eraill o ddydd i ddydd?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "condition": "contains",
+                                            "id": "employment-status-answer-exclusive",
+                                            "value": "None of these apply"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "group": "comments-group",
+                                        "when": [
+                                            {
+                                                "condition": "contains",
+                                                "id": "employment-status-answer-exclusive",
+                                                "value": "None of these apply"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "hours-worked"
+                                    }
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "hours-worked",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "hours-worked-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "0 i 15 awr",
+                                                        "value": "0 to 15 hours"
+                                                    },
+                                                    {
+                                                        "label": "16 i 30 awr",
+                                                        "value": "16 to 30 hours"
+                                                    },
+                                                    {
+                                                        "label": "31 i 48 awr",
+                                                        "value": "31 to 48 hours"
+                                                    },
+                                                    {
+                                                        "label": "49 awr neu fwy",
+                                                        "value": "49 hours or more "
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "guidance": {
+                                            "content": [
+                                                {
+                                                    "title": "Include paid and unpaid overtime"
+                                                }
+                                            ]
+                                        },
+                                        "id": "hours-worked-question",
+                                        "title": "Yn eich prif swydd, sawl awr yr wythnos ydych chi\u2019n gweithio fel arfer?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "hours-worked-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "0 i 15 awr",
+                                                        "value": "0 to 15 hours"
+                                                    },
+                                                    {
+                                                        "label": "16 i 30 awr",
+                                                        "value": "16 to 30 hours"
+                                                    },
+                                                    {
+                                                        "label": "31 i 48 awr",
+                                                        "value": "31 to 48 hours"
+                                                    },
+                                                    {
+                                                        "label": "49 awr neu fwy",
+                                                        "value": "49 hours or more "
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "guidance": {
+                                            "content": [
+                                                {
+                                                    "title": "Dylech gynnwys oriau ychwanegol am d\u00e2l neu heb d\u00e2l"
+                                                }
+                                            ]
+                                        },
+                                        "id": "hours-worked-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name_possessive",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        },
+                                                        {
+                                                            "arguments": {
+                                                                "string_to_format": {
+                                                                    "source": "previous_transform"
+                                                                }
+                                                            },
+                                                            "transform": "format_possessive"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Ym mhrif swydd <em>{person_name_possessive}</em>, sawl awr yr wythnos mae\u2019n gweithio fel arfer?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "work-travel",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "work-travel-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Gweithio gartref neu o\u2019r cartref yn bennaf",
+                                                        "value": "Work mainly at or from home"
+                                                    },
+                                                    {
+                                                        "label": "Tr\u00ean tanddaearol, metro, tram, neu reilffordd ysgafn",
+                                                        "value": "Underground, metro, light rail or tram"
+                                                    },
+                                                    {
+                                                        "label": "Tr\u00ean",
+                                                        "value": "Train"
+                                                    },
+                                                    {
+                                                        "label": "Bws neu fws mini",
+                                                        "value": "Bus, minibus or coach "
+                                                    },
+                                                    {
+                                                        "label": "Tacsi",
+                                                        "value": "Taxi "
+                                                    },
+                                                    {
+                                                        "label": "Beic modur, moped neu sgwter",
+                                                        "value": "Motorcycle, scooter or moped"
+                                                    },
+                                                    {
+                                                        "label": "Gyrru car neu fan",
+                                                        "value": "Driving a car or van"
+                                                    },
+                                                    {
+                                                        "label": "Teithiwr mewn car neu fan",
+                                                        "value": "Passenger in a car or van"
+                                                    },
+                                                    {
+                                                        "label": "Beic",
+                                                        "value": "Bicycle"
+                                                    },
+                                                    {
+                                                        "label": "Cerdded",
+                                                        "value": "On foot"
+                                                    },
+                                                    {
+                                                        "label": "Arall",
+                                                        "value": "Other"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "description": "Atebwch ar gyfer y rhan hiraf, o ran pellter, o\u2019r daith arferol i\u2019r gwaith",
+                                        "id": "work-travel-question",
+                                        "title": "Sut ydych chi\u2019n teithio i\u2019r gwaith fel arfer?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "work-travel-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Gweithio gartref neu o\u2019r cartref yn bennaf",
+                                                        "value": "Work mainly at or from home"
+                                                    },
+                                                    {
+                                                        "label": "Tr\u00ean tanddaearol, metro, tram, neu reilffordd ysgafn",
+                                                        "value": "Underground, metro, light rail or tram"
+                                                    },
+                                                    {
+                                                        "label": "Tr\u00ean",
+                                                        "value": "Train"
+                                                    },
+                                                    {
+                                                        "label": "Bws neu fws mini",
+                                                        "value": "Bus, minibus or coach "
+                                                    },
+                                                    {
+                                                        "label": "Tacsi",
+                                                        "value": "Taxi "
+                                                    },
+                                                    {
+                                                        "label": "Beic modur, moped neu sgwter",
+                                                        "value": "Motorcycle, scooter or moped"
+                                                    },
+                                                    {
+                                                        "label": "Gyrru car neu fan",
+                                                        "value": "Driving a car or van"
+                                                    },
+                                                    {
+                                                        "label": "Teithiwr mewn car neu fan",
+                                                        "value": "Passenger in a car or van"
+                                                    },
+                                                    {
+                                                        "label": "Beic",
+                                                        "value": "Bicycle"
+                                                    },
+                                                    {
+                                                        "label": "Cerdded",
+                                                        "value": "On foot"
+                                                    },
+                                                    {
+                                                        "label": "Arall",
+                                                        "value": "Other"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "description": "Atebwch ar gyfer y rhan hiraf, o ran pellter, o\u2019r daith arferol i\u2019r gwaith Atebwch ar gyfer rhan hiraf, yn \u00f4l pellter, o daith arferol yr unigolyn hwn i\u2019r gwaith",
+                                        "id": "work-travel-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Sut mae <em>{person_name}</em> yn teithio i\u2019r gwaith fel arfer?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "employer-type-of-address",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "employer-type-of-address-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Mewn gweithle",
+                                                        "value": "At a workplace"
+                                                    },
+                                                    {
+                                                        "label": "Adrodd i ddepo",
+                                                        "value": "Report to a depot"
+                                                    },
+                                                    {
+                                                        "label": "Gartref neu o\u2019r cartref",
+                                                        "value": "At or from home"
+                                                    },
+                                                    {
+                                                        "label": "Ar safle ar y m\u00f4r",
+                                                        "value": "An offshore installation"
+                                                    },
+                                                    {
+                                                        "label": "Dim man penodol",
+                                                        "value": "No fixed place"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "employer-type-of-address-question",
+                                        "title": "Ble ydych chi\u2019n gweithio\u2019n bennaf?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "employer-type-of-address-answer",
+                                                "mandatory": true,
+                                                "options": [
+                                                    {
+                                                        "label": "Mewn gweithle",
+                                                        "value": "At a workplace"
+                                                    },
+                                                    {
+                                                        "label": "Adrodd i ddepo",
+                                                        "value": "Report to a depot"
+                                                    },
+                                                    {
+                                                        "label": "Gartref neu o\u2019r cartref",
+                                                        "value": "At or from home"
+                                                    },
+                                                    {
+                                                        "label": "Ar safle ar y m\u00f4r",
+                                                        "value": "An offshore installation"
+                                                    },
+                                                    {
+                                                        "label": "Dim man penodol",
+                                                        "value": "No fixed place"
+                                                    }
+                                                ],
+                                                "type": "Radio"
+                                            }
+                                        ],
+                                        "id": "employer-type-of-address-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Ble mae <em>{person_name}</em> yn gweithio\u2019n bennaf?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "employer-address-workplace",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "id": "employer-type-of-address-answer",
+                                                "value": "At a workplace"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "employer-address-depot",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "id": "employer-type-of-address-answer",
+                                                "value": "Report to a depot"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "group": "comments-group"
+                                    }
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "employer-address-workplace",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "employer-address-workplace-answer-building",
+                                                "label": "Adeilad",
+                                                "mandatory": true,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "id": "employer-address-workplace-answer-street",
+                                                "label": "Stryd",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "id": "employer-address-workplace-answer-city",
+                                                "label": "Tref neu Ddinas",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "id": "employer-address-workplace-answer-county",
+                                                "label": "Sir (dewisol)",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "guidance": {
+                                                    "content": [
+                                                        {
+                                                            "description": "Mae\u2019r llywodraeth yn defnyddio gwybodaeth am gyfeiriad y gweithle a\u2019r dull o deithio i\u2019r gwaith er mwyn llunio polis\u00efau trafnidiaeth a chynllunio gwasanaethau. Mae\u2019r wybodaeth yn helpu i asesu pa ddarpariaeth trafnidiaeth sydd ei hangen yn lleol."
+                                                        }
+                                                    ],
+                                                    "hide_guidance": "Pam mae eich ateb yn bwysig?",
+                                                    "show_guidance": "Pam mae eich ateb yn bwysig?"
+                                                },
+                                                "id": "employer-adress-workplace-answer-postcode",
+                                                "label": "Cod post",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            }
+                                        ],
+                                        "id": "employer-address-workplace-question",
+                                        "title": "Beth yw cyfeiriad eich gweithle?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "employer-address-workplace-answer-building",
+                                                "label": "Adeilad",
+                                                "mandatory": true,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "id": "employer-address-workplace-answer-street",
+                                                "label": "Stryd",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "id": "employer-address-workplace-answer-city",
+                                                "label": "Tref neu Ddinas",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "id": "employer-address-workplace-answer-county",
+                                                "label": "Sir (dewisol)",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "guidance": {
+                                                    "content": [
+                                                        {
+                                                            "description": "Mae\u2019r llywodraeth yn defnyddio gwybodaeth am gyfeiriad y gweithle a\u2019r dull o deithio i\u2019r gwaith er mwyn llunio polis\u00efau trafnidiaeth a chynllunio gwasanaethau. Mae\u2019r wybodaeth yn helpu i asesu pa ddarpariaeth trafnidiaeth sydd ei hangen yn lleol."
+                                                        }
+                                                    ],
+                                                    "hide_guidance": "Pam mae eich ateb yn bwysig?",
+                                                    "show_guidance": "Pam mae eich ateb yn bwysig?"
+                                                },
+                                                "id": "employer-adress-workplace-answer-postcode",
+                                                "label": "Cod post",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            }
+                                        ],
+                                        "id": "employer-address-workplace-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name_possessive",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        },
+                                                        {
+                                                            "arguments": {
+                                                                "string_to_format": {
+                                                                    "source": "previous_transform"
+                                                                }
+                                                            },
+                                                            "transform": "format_possessive"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Beth yw cyfeiriad depo <em>{person_name_possessive}</em>?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "group": "comments-group"
+                                    }
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "employer-address-depot",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "employer-address-depot-answer-building",
+                                                "label": "Enw neu rif yr adeilad",
+                                                "mandatory": true,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "id": "employer-address-depot-answer-street",
+                                                "label": "Stryd",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "id": "employer-address-depot-answer-city",
+                                                "label": "Tref neu Ddinas",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "id": "employer-address-depot-answer-county",
+                                                "label": "Sir (dewisol)",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "guidance": {
+                                                    "content": [
+                                                        {
+                                                            "description": "Mae\u2019r llywodraeth yn defnyddio gwybodaeth am gyfeiriad y gweithle a\u2019r dull o deithio i\u2019r gwaith er mwyn llunio polis\u00efau trafnidiaeth a chynllunio gwasanaethau. Mae\u2019r wybodaeth yn helpu i asesu pa ddarpariaeth trafnidiaeth sydd ei hangen yn lleol."
+                                                        }
+                                                    ],
+                                                    "hide_guidance": "Pam mae eich ateb yn bwysig?",
+                                                    "show_guidance": "Pam mae eich ateb yn bwysig?"
+                                                },
+                                                "id": "employer-adress-depot-answer-postcode",
+                                                "label": "Cod post",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            }
+                                        ],
+                                        "id": "employer-address-depot-question",
+                                        "title": "Beth yw cyfeiriad eich depo?",
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "No"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "answers": [
+                                            {
+                                                "id": "employer-address-depot-answer-building",
+                                                "label": "Enw neu rif yr adeilad",
+                                                "mandatory": true,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "id": "employer-address-depot-answer-street",
+                                                "label": "Stryd",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "id": "employer-address-depot-answer-city",
+                                                "label": "Tref neu Ddinas",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "id": "employer-address-depot-answer-county",
+                                                "label": "Sir (dewisol)",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            },
+                                            {
+                                                "guidance": {
+                                                    "content": [
+                                                        {
+                                                            "description": "Mae\u2019r llywodraeth yn defnyddio gwybodaeth am gyfeiriad y gweithle a\u2019r dull o deithio i\u2019r gwaith er mwyn llunio polis\u00efau trafnidiaeth a chynllunio gwasanaethau. Mae\u2019r wybodaeth yn helpu i asesu pa ddarpariaeth trafnidiaeth sydd ei hangen yn lleol."
+                                                        }
+                                                    ],
+                                                    "hide_guidance": "Pam mae eich ateb yn bwysig?",
+                                                    "show_guidance": "Pam mae eich ateb yn bwysig?"
+                                                },
+                                                "id": "employer-adress-depot-answer-postcode",
+                                                "label": "Cod post",
+                                                "mandatory": false,
+                                                "type": "TextField"
+                                            }
+                                        ],
+                                        "id": "employer-address-depot-question",
+                                        "title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name_possessive",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": [
+                                                                        "first-name",
+                                                                        "last-name"
+                                                                    ],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        },
+                                                        {
+                                                            "arguments": {
+                                                                "string_to_format": {
+                                                                    "source": "previous_transform"
+                                                                }
+                                                            },
+                                                            "transform": "format_possessive"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "Beth yw cyfeiriad gweithle <em>{person_name_possessive}</em>?"
+                                        },
+                                        "type": "General"
+                                    },
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "proxy-answer",
+                                            "value": "Yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "group": "comments-group"
+                                    }
+                                }
+                            ],
+                            "type": "Question"
+                        }
+                    ],
+                    "id": "employment-group",
+                    "title": "Cyflogaeth"
+                }
+            ],
+            "id": "individual-section",
+            "title": "Adran Unigol"
+        },
+        {
+            "groups": [
+                {
+                    "blocks": [
+                        {
+                            "id": "comments-block",
+                            "question": {
+                                "answers": [
+                                    {
+                                        "id": "comments-answer",
+                                        "label": "Sylwadau",
+                                        "mandatory": false,
+                                        "type": "TextArea"
+                                    }
+                                ],
+                                "description": "",
+                                "id": "comments-question",
+                                "title": "Diolch, rydych wedi gorffen!",
+                                "type": "General"
+                            },
+                            "type": "Question"
+                        }
+                    ],
+                    "id": "comments-group",
+                    "title": "Sylwadau"
+                }
+            ],
+            "id": "comments",
+            "title": "Sylwadau"
+        },
+        {
+            "groups": [
+                {
+                    "blocks": [
+                        {
+                            "content": [
+                                {
+                                    "description": "Diolch am gymryd rhan ym Mhrawf Cyfrifiad 2017"
+                                },
+                                {
+                                    "list": [
+                                        "drwy gyflwyno\u2019ch ymatebion, rydych yn datgan eich bod wedi cwblhau\u2019r prawf hyd eithaf eich gwybodaeth a\u2019ch cred.",
+                                        "os na fyddwch yn cyflwyno\u2019ch ymatebion, byddant yn cael eu cyflwyno\u2019n awtomatig pan fydd Prawf Cyfrifiad 2017 yn cau.",
+                                        "ar \u00f4l eu cyflwyno cewch gyfle i roi adborth ar eich profiad."
+                                    ],
+                                    "title": "Nodwch:"
+                                }
+                            ],
+                            "id": "confirmation",
+                            "title": "Rydych yn barod i gyflwyno Prawf Cyfrifiad 2017",
+                            "type": "Confirmation"
+                        }
+                    ],
+                    "id": "submit-group",
+                    "title": "Cyflwyno atebion"
+                }
+            ],
+            "id": "submit-answers-section",
+            "title": "Cyflwyno atebion"
+        }
+    ],
+    "survey_id": "census",
+    "theme": "census",
+    "title": "Prawf Cyfrifiad 2017"
+}


### PR DESCRIPTION
### What is the context of this PR?
This adds a translated version of the current wales census individual schema in welsh. This has been manually created for now until we determine a better build process for schemas generated from translations.

### How to review 

Check the schema appears to be correct. Check you're able to run the new schema when using the cy region code. Ensure that build process continues as normal with the new cy directory.
