### PR TITLE
Remove direction from voluntary questions

### DIFF
--- a/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/birth_gender.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/birth_gender.jsonnet
@@ -10,7 +10,6 @@ local question(title) = {
     {
       id: 'birth-gender-answer',
       mandatory: true,
-      label: 'Select one option only',
       options: [
         {
           label: 'Yes',

--- a/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/religion.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/religion.jsonnet
@@ -23,7 +23,6 @@ local question(title, region_code) = (
       {
         id: 'religion-answer',
         mandatory: false,
-        label: 'Select one option only',
         options: [
           {
             label: 'No religion',

--- a/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/sexual_identity.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/sexual_identity.jsonnet
@@ -10,7 +10,6 @@ local question(title, label) = {
     {
       id: 'sexual-identity-answer',
       mandatory: false,
-      label: 'Select one option only',
       options: [
         {
           label: 'Straight or Heterosexual',


### PR DESCRIPTION
### What is the context of this PR?
Removing 'Select one option only' from voluntary questions due to accessibility problems. 


### How to review 
Check that the 'Select one option only' labels have been removed from the schema for the questions listed on the Trello card:
[Trello](https://trello.com/c/yvhpHMgC/2995-remove-direction-from-voluntary-questions)

