### PR TITLE
Content tweaks for NISRA (typo, school address, quals route)

### DIFF
--- a/data-source/jsonnet/common/lib/rules.libsonnet
+++ b/data-source/jsonnet/common/lib/rules.libsonnet
@@ -11,7 +11,7 @@
   },
   over16: {
     id: 'date-of-birth-answer',
-    condition: 'less than',
+    condition: 'less than or equal to',
     date_comparison: {
       value: 'now',
       offset_by: {

--- a/data-source/jsonnet/england-wales/blocks/individual/employment/employers_business.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/employment/employers_business.jsonnet
@@ -1,0 +1,62 @@
+local placeholders = import '../../../../common/lib/placeholders.libsonnet';
+local rules = import '../../../../common/lib/rules.libsonnet';
+
+local nonProxyTitle = 'What is the main activity of your organisation, business or freelance work?';
+local proxyTitle = {
+  text: 'What is the main activity of <em>{person_name_possessive}</em> organisation, business or freelance work?',
+  placeholders: [
+    placeholders.personNamePossessive,
+  ],
+};
+
+local pastNonProxyTitle = 'What was the main activity of your organisation, business or freelance work?';
+local pastProxyTitle = {
+  text: 'What was the main activity of <em>{person_name_possessive}</em> organisation, business or freelance work?',
+  placeholders: [
+    placeholders.personNamePossessive,
+  ],
+};
+
+local englandDescription = 'For example, clothing retail, general hospital, primary education, food wholesale, civil service DWP, local government housing.';
+local walesDescription = 'For example, clothing retail, general hospital, primary education, food wholesale, civil service (Welsh Government), local government (housing).';
+
+local question(title, region_code) = (
+  local description = if region_code == 'GB-WLS' then walesDescription else englandDescription;
+  {
+    id: 'employers-business-question',
+    title: title,
+    description: description,
+    type: 'General',
+    answers: [
+      {
+        id: 'employers-business-answer',
+        label: 'Description',
+        mandatory: true,
+        type: 'TextField',
+      },
+    ],
+  }
+);
+
+function(region_code) {
+  type: 'Question',
+  id: 'employers-business',
+  question_variants: [
+    {
+      question: question(nonProxyTitle, region_code),
+      when: [rules.proxyNo, rules.mainJob],
+    },
+    {
+      question: question(proxyTitle, region_code),
+      when: [rules.proxyYes, rules.mainJob],
+    },
+    {
+      question: question(pastNonProxyTitle, region_code),
+      when: [rules.proxyNo, rules.lastMainJob],
+    },
+    {
+      question: question(pastProxyTitle, region_code),
+      when: [rules.proxyYes, rules.lastMainJob],
+    },
+  ],
+}

--- a/data-source/jsonnet/england-wales/blocks/individual/employment/ever_worked.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/employment/ever_worked.jsonnet
@@ -1,5 +1,5 @@
-local placeholders = import '../../../lib/placeholders.libsonnet';
-local rules = import '../../../lib/rules.libsonnet';
+local placeholders = import '../../../../common/lib/placeholders.libsonnet';
+local rules = import '../../../../common/lib/rules.libsonnet';
 
 local question(title, label) = {
   id: 'ever-worked-question',

--- a/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/carer.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/carer.jsonnet
@@ -1,5 +1,5 @@
-local placeholders = import '../../../lib/placeholders.libsonnet';
-local rules = import '../../../lib/rules.libsonnet';
+local placeholders = import '../../../../common/lib/placeholders.libsonnet';
+local rules = import '../../../../common/lib/rules.libsonnet';
 
 local question(title, guidance) = {
   id: 'carer-question',

--- a/data-source/jsonnet/england-wales/census_individual.jsonnet
+++ b/data-source/jsonnet/england-wales/census_individual.jsonnet
@@ -20,13 +20,13 @@ local term_time_address_details = import 'blocks/individual/personal-details/ter
 local term_time_location = import 'blocks/individual/personal-details/term_time_location.jsonnet';
 
 // identity and health
-local carer = import '../common/blocks/individual/identity-and-health/carer.jsonnet';
 local health = import '../common/blocks/individual/identity-and-health/health.jsonnet';
 local last_year_address = import '../common/blocks/individual/identity-and-health/last_year_address.jsonnet';
 local passports = import '../common/blocks/individual/identity-and-health/passports.jsonnet';
 local speak_english = import '../common/blocks/individual/identity-and-health/speak_english.jsonnet';
 local arrive_in_country = import 'blocks/individual/identity-and-health/arrive_in_country.jsonnet';
 local birth_gender = import 'blocks/individual/identity-and-health/birth_gender.jsonnet';
+local carer = import 'blocks/individual/identity-and-health/carer.jsonnet';
 local country_of_birth = import 'blocks/individual/identity-and-health/country_of_birth.jsonnet';
 local disability = import 'blocks/individual/identity-and-health/disability.jsonnet';
 local disability_limitation = import 'blocks/individual/identity-and-health/disability_limitation.jsonnet';
@@ -58,10 +58,8 @@ local qualifications = import 'blocks/individual/qualifications/qualifications.j
 local business_name = import '../common/blocks/individual/employment/business_name.jsonnet';
 local employer_address_depot = import '../common/blocks/individual/employment/employer_address_depot.jsonnet';
 local employer_address_workplace = import '../common/blocks/individual/employment/employer_address_workplace.jsonnet';
-local employers_business = import '../common/blocks/individual/employment/employers_business.jsonnet';
 local employment_status = import '../common/blocks/individual/employment/employment_status.jsonnet';
 local employment_type = import '../common/blocks/individual/employment/employment_type.jsonnet';
-local ever_worked = import '../common/blocks/individual/employment/ever_worked.jsonnet';
 local hours_worked = import '../common/blocks/individual/employment/hours_worked.jsonnet';
 local job_availability = import '../common/blocks/individual/employment/job_availability.jsonnet';
 local job_description = import '../common/blocks/individual/employment/job_description.jsonnet';
@@ -74,6 +72,8 @@ local supervise = import '../common/blocks/individual/employment/supervise.jsonn
 local work_travel = import '../common/blocks/individual/employment/work_travel.jsonnet';
 local armed_forces = import 'blocks/individual/employment/armed_forces.jsonnet';
 local employer_type_of_address = import 'blocks/individual/employment/employer_type_of_address.jsonnet';
+local employers_business = import 'blocks/individual/employment/employers_business.jsonnet';
+local ever_worked = import 'blocks/individual/employment/ever_worked.jsonnet';
 
 local comments = import '../common/blocks/comments.json';
 

--- a/data-source/jsonnet/northern-ireland/blocks/individual/employment/armed_forces.jsonnet
+++ b/data-source/jsonnet/northern-ireland/blocks/individual/employment/armed_forces.jsonnet
@@ -7,7 +7,7 @@ local question(title) = {
   guidance: {
     contents: [
       {
-        title: 'Current serving members should select “No”',
+        title: 'Current serving members should only select “No”',
       },
     ],
   },
@@ -16,15 +16,6 @@ local question(title) = {
     {
       id: 'armed-forces-answer',
       mandatory: false,
-      guidance: {
-        show_guidance: 'Why your answer is important',
-        hide_guidance: 'Why your answer is important',
-        contents: [
-          {
-            description: 'We are measuring the number of people who have served in the UK Armed Forces and have now left. Government and councils need this information to carry out their commitments made under the Armed Forces Covenant. This is a promise by the nation ensuring that those who serve or who have served in the armed forces, and their families, are not disadvantaged.',
-          },
-        ],
-      },
       options: [
         {
           label: 'No',
@@ -44,9 +35,9 @@ local question(title) = {
   ],
 };
 
-local nonProxyTitle = 'Have you previously served in the UK Armed Forces?';
+local nonProxyTitle = 'Have you <em>previously</em> served in the UK Armed Forces?';
 local proxyTitle = {
-  text: 'Has <em>{person_name}</em> previously served in the UK Armed Forces?',
+  text: 'Has <em>{person_name}</em> <em>previously</em> served in the UK Armed Forces?',
   placeholders: [
     placeholders.personName,
   ],

--- a/data-source/jsonnet/northern-ireland/blocks/individual/employment/employers_business.jsonnet
+++ b/data-source/jsonnet/northern-ireland/blocks/individual/employment/employers_business.jsonnet
@@ -1,5 +1,5 @@
-local placeholders = import '../../../lib/placeholders.libsonnet';
-local rules = import '../../../lib/rules.libsonnet';
+local placeholders = import '../../../../common/lib/placeholders.libsonnet';
+local rules = import '../../../../common/lib/rules.libsonnet';
 
 local nonProxyTitle = 'What is the main activity of your organisation, business or freelance work?';
 local proxyTitle = {
@@ -17,45 +17,47 @@ local pastProxyTitle = {
   ],
 };
 
-local englandDescription = 'For example, clothing retail, general hospital, primary education, food wholesale, civil service DWP, local government housing.';
-local walesDescription = 'For example, clothing retail, general hospital, primary education, food wholesale, civil service (Welsh Government), local government (housing).';
-
-local question(title, region_code) = (
-  local description = if region_code == 'GB-WLS' then walesDescription else englandDescription;
+local question(title) = (
   {
     id: 'employers-business-question',
     title: title,
-    description: description,
+    description: 'For example clothing retail, general hospital, primary education, food wholesale, civil service, local government housing.',
     type: 'General',
     answers: [
       {
         id: 'employers-business-answer',
         label: 'Description',
         mandatory: true,
-        type: 'TextField',
+        type: 'TextArea',
+        max_length: 200,
+        validation: {
+          messages: {
+            MAX_LENGTH_EXCEEDED: 'Your answer has to be less than %(max)d characters long',
+          },
+        },
       },
     ],
   }
 );
 
-function(region_code) {
+{
   type: 'Question',
   id: 'employers-business',
   question_variants: [
     {
-      question: question(nonProxyTitle, region_code),
+      question: question(nonProxyTitle),
       when: [rules.proxyNo, rules.mainJob],
     },
     {
-      question: question(proxyTitle, region_code),
+      question: question(proxyTitle),
       when: [rules.proxyYes, rules.mainJob],
     },
     {
-      question: question(pastNonProxyTitle, region_code),
+      question: question(pastNonProxyTitle),
       when: [rules.proxyNo, rules.lastMainJob],
     },
     {
-      question: question(pastProxyTitle, region_code),
+      question: question(pastProxyTitle),
       when: [rules.proxyYes, rules.lastMainJob],
     },
   ],

--- a/data-source/jsonnet/northern-ireland/blocks/individual/employment/ever_worked.jsonnet
+++ b/data-source/jsonnet/northern-ireland/blocks/individual/employment/ever_worked.jsonnet
@@ -1,0 +1,117 @@
+local placeholders = import '../../../../common/lib/placeholders.libsonnet';
+local rules = import '../../../../common/lib/rules.libsonnet';
+
+local question(title, label) = {
+  id: 'ever-worked-question',
+  title: title,
+  type: 'General',
+  answers: [
+    {
+      id: 'ever-worked-answer',
+      mandatory: true,
+      options: [
+        {
+          label: 'Yes, in the last 12 months',
+          value: 'Yes, in the last 12 months',
+        },
+        {
+          label: 'Yes, but not in the last 12 months',
+          value: 'Yes, but not in the last 12 months',
+        },
+        {
+          label: label,
+          value: label,
+        },
+      ],
+      type: 'Radio',
+    },
+  ],
+};
+
+local studyRouting(label) = [
+  {
+    goto: {
+      group: 'school-group',
+      when: [
+        {
+          id: 'ever-worked-answer',
+          condition: 'equals',
+          value: label,
+        },
+        {
+          id: 'in-education-answer',
+          condition: 'equals',
+          value: 'Yes',
+        },
+      ],
+    },
+  },
+  {
+    goto: {
+      group: 'school-group',
+      when: [
+        {
+          id: 'ever-worked-answer',
+          condition: 'equals',
+          value: label,
+        },
+        {
+          id: 'employment-type-answer',
+          condition: 'contains',
+          value: 'Studying',
+        },
+      ],
+    },
+  },
+];
+
+local commentsRouting(label) = [
+  {
+    goto: {
+      group: 'comments-group',
+      when: [
+        {
+          id: 'ever-worked-answer',
+          condition: 'equals',
+          value: label,
+        },
+      ],
+    },
+  },
+];
+
+local nonProxyTitle = 'Have you ever done any paid work?';
+local nonProxyLabel = 'No, have never worked';
+local proxyTitle = {
+  text: 'Has <em>{person_name}</em> ever done any paid work?',
+  placeholders: [
+    placeholders.personName,
+  ],
+};
+local proxyLabel = 'No, has never worked';
+
+{
+  type: 'Question',
+  id: 'ever-worked',
+  question_variants: [
+    {
+      question: question(nonProxyTitle, nonProxyLabel),
+      when: [rules.proxyNo],
+    },
+    {
+      question: question(proxyTitle, proxyLabel),
+      when: [rules.proxyYes],
+    },
+  ],
+  routing_rules:
+    studyRouting(nonProxyLabel) +
+    studyRouting(proxyLabel) +
+    commentsRouting(nonProxyLabel) +
+    commentsRouting(proxyLabel) + [
+      {
+        goto: {
+          block: 'main-employment-block',
+        },
+      },
+    ],
+}

--- a/data-source/jsonnet/northern-ireland/blocks/individual/identity-and-health/carer.jsonnet
+++ b/data-source/jsonnet/northern-ireland/blocks/individual/identity-and-health/carer.jsonnet
@@ -1,0 +1,84 @@
+local placeholders = import '../../../../common/lib/placeholders.libsonnet';
+local rules = import '../../../../common/lib/rules.libsonnet';
+
+local question(title, guidance) = {
+  id: 'carer-question',
+  title: title,
+  guidance: {
+    content: [
+      {
+        title: guidance,
+      },
+    ],
+  },
+  type: 'General',
+  answers: [
+    {
+      id: 'carer-answer',
+      mandatory: true,
+      options: [
+        {
+          label: 'No',
+          value: 'No',
+        },
+        {
+          label: 'Yes, 19 hours or less a week',
+          value: 'Yes, 19 hours or less a week',
+        },
+        {
+          label: 'Yes, 20 to 34 hours a week',
+          value: 'Yes, 20 to 34 hours a week',
+        },
+        {
+          label: 'Yes, 35 to 49 hours a week',
+          value: 'Yes, 35 to 49 hours a week',
+        },
+        {
+          label: 'Yes, 50 hours or more a week',
+          value: 'Yes, 50 hours or more a week',
+        },
+      ],
+      type: 'Radio',
+    },
+  ],
+};
+
+local nonProxyTitle = 'Do you look after, or give any help or support to, anyone because they have long-term physical or mental health conditions or illnesses, or problems related to old age?';
+local nonProxyGuidance = 'Exclude anything you do in paid employment';
+local proxyTitle = {
+  text: 'Does <em>{person_name}</em> look after, or give any help or support to, anyone because they have long-term physical or mental health conditions or illnesses, or problems related to old age?',
+  placeholders: [
+    placeholders.personName,
+  ],
+};
+local proxyGuidance = 'Exclude anything they do in paid employment';
+
+{
+  type: 'Question',
+  id: 'carer',
+  question_variants: [
+    {
+      question: question(nonProxyTitle, nonProxyGuidance),
+      when: [rules.proxyNo],
+    },
+    {
+      question: question(proxyTitle, proxyGuidance),
+      when: [rules.proxyYes],
+    },
+  ],
+  routing_rules: [
+    {
+      goto: {
+        block: 'sexual-identity',
+        when: [
+          rules.over16,
+        ],
+      },
+    },
+    {
+      goto: {
+        group: 'school-group',
+      },
+    },
+  ],
+}

--- a/data-source/jsonnet/northern-ireland/blocks/individual/identity-and-health/disability.jsonnet
+++ b/data-source/jsonnet/northern-ireland/blocks/individual/identity-and-health/disability.jsonnet
@@ -20,13 +20,13 @@ local question(title) = {
           value: 'Blindness or partial sight loss',
         },
         {
+          label: 'A mobility or dexterity difficulty, which requires the use of a wheelchair in the home',
+          value: 'Full mobility',
+        },
+        {
           label: 'A mobility or dexterity difficulty that limits basic physical activities',
           value: 'Slight mobility',
           description: 'For example walking or dressing',
-        },
-        {
-          label: 'A mobility or dexterity difficulty, which requires the use of a wheelchair in the home',
-          value: 'Full mobility',
         },
         {
           label: 'Shortness of breath or difficulty breathing',
@@ -50,10 +50,10 @@ local question(title) = {
   ],
 };
 
-local nonProxyTitle = 'Do you have any of the following physical health conditions or illnesses lasting or expected to last 12 months or more?';
+local nonProxyTitle = 'Do you have any of the following <em>physical health conditions</em> lasting or expected to last 12 months or more?';
 
 local proxyTitle = {
-  text: 'Does <em>{person_name}</em> have any of the following physical health conditions or illnesses lasting or expected to last 12 months or more?',
+  text: 'Does <em>{person_name}</em> have any of the following <em>physical health conditions</em> lasting or expected to last 12 months or more?',
   placeholders: [
     placeholders.personName,
   ],

--- a/data-source/jsonnet/northern-ireland/blocks/individual/identity-and-health/disability_limitation.jsonnet
+++ b/data-source/jsonnet/northern-ireland/blocks/individual/identity-and-health/disability_limitation.jsonnet
@@ -18,12 +18,16 @@ local question(title) = {
       mandatory: true,
       options: [
         {
-          label: 'Yes',
-          value: 'Yes',
-        },
-        {
           label: 'No',
           value: 'No',
+        },
+        {
+          label: 'Yes, limited a little',
+          value: 'Yes, limited a little',
+        },
+        {
+          label: 'Yes, limited a lot',
+          value: 'Yes, limited a lot',
         },
       ],
       type: 'Radio',

--- a/data-source/jsonnet/northern-ireland/blocks/individual/identity-and-health/disability_other.jsonnet
+++ b/data-source/jsonnet/northern-ireland/blocks/individual/identity-and-health/disability_other.jsonnet
@@ -12,26 +12,37 @@ local question(title) = {
       mandatory: false,
       options: [
         {
-          label: 'Deafness or partial hearing loss',
-          value: 'Deafness or partial hearing loss',
+          label: 'An intellectual or learning disability',
+          value: 'An intellectual or learning disability',
+          description: 'For example Down syndrome',
         },
         {
-          label: 'Blindness or partial sight loss',
-          value: 'Blindness or partial sight loss',
+          label: 'A learning difficulty',
+          value: 'A learning difficulty',
+          description: 'For example dyslexia',
         },
         {
-          label: 'A mobility or dexterity difficulty that limits basic physical activities',
-          value: 'Slight mobility',
-          description: 'For example walking or dressing',
+          label: 'Autism or Asperger syndrome',
+          value: 'Autism or Asperger syndrome',
         },
         {
-          label: 'A mobility or dexterity difficulty, which requires the use of a wheelchair in the home',
-          value: 'Full mobility',
+          label: 'An emotional, psychological or mental health condition',
+          value: 'An emotional, psychological or mental health condition',
+          description: 'For example depression or schizophrenia',
         },
         {
-          label: 'Shortness of breath or difficulty breathing',
+          label: 'Frequent periods of confusion or memory loss',
+          value: 'Frequent periods of confusion or memory loss',
+          description: 'For example dementia',
+        },
+        {
+          label: 'Long-term pain or discomfort',
+          value: 'Long-term pain or discomfort',
+        },
+        {
+          label: 'Other condition',
           value: 'Shortness of breath or difficulty breathing',
-          description: 'For example Asthma',
+          description: 'For example cancer, diabetes or heart disease',
         },
       ],
       type: 'Checkbox',
@@ -50,10 +61,10 @@ local question(title) = {
   ],
 };
 
-local nonProxyTitle = 'Do you have any of the following other health conditions or illnesses lasting or expected to last 12 months or more?';
+local nonProxyTitle = 'Do you have any of the following <em>other health conditions</em> which have lasted, or are expected to last, at least 12 months?';
 
 local proxyTitle = {
-  text: 'Does <em>{person_name}</em> have any of the following other health conditions or illnesses lasting or expected to last 12 months or more?',
+  text: 'Does <em>{person_name}</em> have any of the following <em>other health conditions</em> which have lasted, or are expected to last, at least 12 months?',
   placeholders: [
     placeholders.personName,
   ],

--- a/data-source/jsonnet/northern-ireland/blocks/individual/identity-and-health/ethnic_group.jsonnet
+++ b/data-source/jsonnet/northern-ireland/blocks/individual/identity-and-health/ethnic_group.jsonnet
@@ -54,15 +54,21 @@ local question(title) = {
         {
           label: 'Mixed ethnic group',
           value: 'Mixed ethnic group',
-        },
-        {
-          label: 'Other ethnic group',
-          value: 'Other ethnic group',
           detail_answer: {
-            id: 'ehtnic-group-other',
+            id: 'ethnic-group-mixed',
             type: 'TextField',
             mandatory: false,
-            label: 'Please specify other religion',
+            label: 'Please specify mixed ethnic group',
+          },
+        },
+        {
+          label: 'Any other ethnic group',
+          value: 'Any other ethnic group',
+          detail_answer: {
+            id: 'ethnic-group-other',
+            type: 'TextField',
+            mandatory: false,
+            label: 'Please specify other ethnic group',
           },
         },
       ],

--- a/data-source/jsonnet/northern-ireland/blocks/individual/identity-and-health/language.jsonnet
+++ b/data-source/jsonnet/northern-ireland/blocks/individual/identity-and-health/language.jsonnet
@@ -37,7 +37,7 @@ local question(title, definitionDescription) = {
         {
           label: 'Other',
           value: 'Other',
-          description: 'Including British or Irish Sign Language',
+          description: 'Including British Sign Language or Irish Sign Language',
           detail_answer: {
             id: 'language-answer-other',
             type: 'TextField',
@@ -61,6 +61,25 @@ local question(title, definitionDescription) = {
     {
       question: question(proxyTitle, proxyDefinitionDescription),
       when: [rules.proxyYes],
+    },
+  ],
+  routing_rules: [
+    {
+      goto: {
+        block: 'understand-irish',
+        when: [
+          {
+            id: 'language-answer',
+            condition: 'equals',
+            value: 'English',
+          },
+        ],
+      },
+    },
+    {
+      goto: {
+        block: 'english',
+      },
     },
   ],
 }

--- a/data-source/jsonnet/northern-ireland/blocks/individual/identity-and-health/national_identity.jsonnet
+++ b/data-source/jsonnet/northern-ireland/blocks/individual/identity-and-health/national_identity.jsonnet
@@ -9,37 +9,13 @@ local proxyTitle = {
   ],
 };
 
-local nonProxyDefinitionContent = [
-  {
-    description: 'National identity is not dependent on your ethnic group or citizenship.',
-  },
-  {
-    description: 'It is about the country or countries where you feel you belong or think of as home.',
-  },
-];
-
-local proxyDefinitionContent = [
-  {
-    description: 'National identity is not dependent on their ethnic group or citizenship.',
-  },
-  {
-    description: 'It is about the country or countries where they feel they belong or think of as home.',
-  },
-];
-
 local nonProxyDetailAnswerLabel = 'Please describe your national identity';
 local proxyDetailAnswerLabel = 'Please describe their national identity';
 
-local question(title, definitionContent, detailAnswerLabel) = {
+local question(title, detailAnswerLabel) = {
   id: 'national-identity-question',
   title: title,
   type: 'General',
-  definitions: [
-    {
-      title: 'What do we mean by “national identity”?',
-      contents: definitionContent,
-    },
-  ],
   answers: [
     {
       id: 'national-identity-answer',
@@ -90,11 +66,11 @@ local question(title, definitionContent, detailAnswerLabel) = {
   id: 'national-identity',
   question_variants: [
     {
-      question: question(nonProxyTitle, nonProxyDefinitionContent, nonProxyDetailAnswerLabel),
+      question: question(nonProxyTitle, nonProxyDetailAnswerLabel),
       when: [rules.proxyNo],
     },
     {
-      question: question(proxyTitle, proxyDefinitionContent, proxyDetailAnswerLabel),
+      question: question(proxyTitle, proxyDetailAnswerLabel),
       when: [rules.proxyYes],
     },
   ],

--- a/data-source/jsonnet/northern-ireland/blocks/individual/identity-and-health/no_religion.jsonnet
+++ b/data-source/jsonnet/northern-ireland/blocks/individual/identity-and-health/no_religion.jsonnet
@@ -12,7 +12,8 @@ local proxyTitle = {
 local question(title) = {
   id: 'no-religion-question',
   title: title,
-  type: 'General',
+  type: 'MutuallyExclusive',
+  mandatory: false,
   answers: [
     {
       id: 'no-religion-answer',
@@ -45,12 +46,19 @@ local question(title) = {
             label: 'Please specify religion, religious denomination or body',
           },
         },
+      ],
+      type: 'Checkbox',
+    },
+    {
+      id: 'no-religion-answer-exclusive',
+      type: 'Checkbox',
+      mandatory: false,
+      options: [
         {
           label: 'None',
           value: 'None',
         },
       ],
-      type: 'Radio',
     },
   ],
 };

--- a/data-source/jsonnet/northern-ireland/blocks/individual/identity-and-health/past_usual_household_address.jsonnet
+++ b/data-source/jsonnet/northern-ireland/blocks/individual/identity-and-health/past_usual_household_address.jsonnet
@@ -21,8 +21,8 @@ local question(title, description) = {
           value: 'household-address',
         },
         {
-          label: 'Student term time in the UK',
-          value: 'Student term time in the UK',
+          label: 'Student term time address in the UK',
+          value: 'Student term time address in the UK',
         },
         {
           label: 'Another address in the UK',
@@ -75,8 +75,11 @@ local proxyDescription = 'If they had no usual address one year ago, state the a
         when: [
           {
             id: 'past-usual-address-household-answer',
-            condition: 'equals',
-            value: 'Another address in the UK',
+            condition: 'equals any',
+            values: [
+              'Another address in the UK',
+              'Student term time address in the UK',
+            ],
           },
         ],
       },

--- a/data-source/jsonnet/northern-ireland/blocks/individual/identity-and-health/religion.jsonnet
+++ b/data-source/jsonnet/northern-ireland/blocks/individual/identity-and-health/religion.jsonnet
@@ -12,11 +12,13 @@ local proxyTitle = {
 local question(title) = {
   id: 'religion-question',
   title: title,
-  type: 'General',
+  type: 'MutuallyExclusive',
+  mandatory: false,
   answers: [
     {
       id: 'religion-answer',
       mandatory: false,
+      type: 'Checkbox',
       options: [
         {
           label: 'Roman Catholic',
@@ -44,12 +46,18 @@ local question(title) = {
             label: 'Please specify religion, religious denomination or body',
           },
         },
+      ],
+    },
+    {
+      id: 'religion-answer-exclusive',
+      type: 'Checkbox',
+      mandatory: false,
+      options: [
         {
           label: 'None',
           value: 'None',
         },
       ],
-      type: 'Radio',
     },
   ],
 };
@@ -73,9 +81,8 @@ local question(title) = {
         block: 'no-religion',
         when: [
           {
-            id: 'religion-answer',
-            condition: 'equals',
-            value: 'None',
+            id: 'religion-answer-exclusive',
+            condition: 'set',
           },
         ],
       },

--- a/data-source/jsonnet/northern-ireland/blocks/individual/identity-and-health/sexual_identity.jsonnet
+++ b/data-source/jsonnet/northern-ireland/blocks/individual/identity-and-health/sexual_identity.jsonnet
@@ -1,10 +1,7 @@
 local placeholders = import '../../../../common/lib/placeholders.libsonnet';
 local rules = import '../../../../common/lib/rules.libsonnet';
 
-local nonProxyDetailAnswerLabel = 'Please specify their sexual orientation';
-local proxyDetailAnswerLabel = 'Please specify their sexual orientation';
-
-local question(title, detailAnswerLabel) = {
+local question(title) = {
   id: 'sexual-identity-question',
   title: title,
   type: 'General',
@@ -32,7 +29,7 @@ local question(title, detailAnswerLabel) = {
             id: 'sexual-identity-answer-other',
             type: 'TextField',
             mandatory: false,
-            label: detailAnswerLabel,
+            label: 'Please specify sexual orientation',
           },
         },
         {
@@ -40,7 +37,7 @@ local question(title, detailAnswerLabel) = {
           value: 'Prefer not to say',
         },
       ],
-      type: 'Radio',
+      type: 'Checkbox',
     },
   ],
 };
@@ -59,11 +56,11 @@ local proxyTitle = {
   id: 'sexual-identity',
   question_variants: [
     {
-      question: question(nonProxyTitle, nonProxyDetailAnswerLabel),
+      question: question(nonProxyTitle),
       when: [rules.proxyNo],
     },
     {
-      question: question(proxyTitle, proxyDetailAnswerLabel),
+      question: question(proxyTitle),
       when: [rules.proxyYes],
     },
   ],

--- a/data-source/jsonnet/northern-ireland/blocks/individual/personal-details/term_time_location.jsonnet
+++ b/data-source/jsonnet/northern-ireland/blocks/individual/personal-details/term_time_location.jsonnet
@@ -21,8 +21,8 @@ local question(title) = {
           value: 'household-address',
         },
         {
-          label: 'Another address',
-          value: 'Another address',
+          label: 'At another address',
+          value: 'At another address',
         },
       ],
     },
@@ -58,7 +58,7 @@ local proxyTitle = {
           {
             id: 'term-time-location-answer',
             condition: 'equals',
-            value: 'Another address',
+            value: 'At another address',
           },
         ],
       },

--- a/data-source/jsonnet/northern-ireland/blocks/individual/qualifications/a_level.jsonnet
+++ b/data-source/jsonnet/northern-ireland/blocks/individual/qualifications/a_level.jsonnet
@@ -1,9 +1,9 @@
 local placeholders = import '../../../../common/lib/placeholders.libsonnet';
 local rules = import '../../../../common/lib/rules.libsonnet';
 
-local nonProxyTitle = 'Have you achieved an AS, A level or equivalent qualification?';
+local nonProxyTitle = 'Have you achieved an A level, AS level or equivalent qualifications?';
 local proxyTitle = {
-  text: 'Has <em>{person_name}</em> achieved an AS, A level or equivalent qualification?',
+  text: 'Has <em>{person_name}</em> achieved an A level, AS level or equivalent qualifications?',
   placeholders: [
     placeholders.personName,
   ],
@@ -35,7 +35,7 @@ local question(title) = {
         {
           label: '1 A level',
           value: '1 A level',
-          description: 'Include 2 to 3 AS levels',
+          description: 'Include 2 or 3 AS levels',
         },
         {
           label: '1 AS level',

--- a/data-source/jsonnet/northern-ireland/blocks/individual/qualifications/apprenticeship.jsonnet
+++ b/data-source/jsonnet/northern-ireland/blocks/individual/qualifications/apprenticeship.jsonnet
@@ -28,7 +28,7 @@ local question(title) = {
         {
           label: 'Yes',
           value: 'Yes',
-          description: 'For example trade, advanced, foundation or modern apprenticeships',
+          description: 'For example, trade, advanced, foundation or modern apprenticeships',
         },
         {
           label: 'No',

--- a/data-source/jsonnet/northern-ireland/blocks/individual/qualifications/gcse.jsonnet
+++ b/data-source/jsonnet/northern-ireland/blocks/individual/qualifications/gcse.jsonnet
@@ -37,11 +37,6 @@ local question(title) = {
           value: 'Any other GCSEs',
           description: 'Include any other O levels or CSEs at any grades',
         },
-        {
-          label: 'Basic skills course',
-          value: 'Basic skills course',
-          description: 'Skills for life, literacy, numeracy and language',
-        },
       ],
     },
     {
@@ -101,7 +96,7 @@ local question(title) = {
     },
     {
       goto: {
-        group: 'employment-group',
+        block: 'apprenticeship',
       },
     },
   ],

--- a/data-source/jsonnet/northern-ireland/blocks/individual/qualifications/other_qualifications.jsonnet
+++ b/data-source/jsonnet/northern-ireland/blocks/individual/qualifications/other_qualifications.jsonnet
@@ -12,29 +12,17 @@ local proxyTitle = {
 local question(title) = {
   id: 'other-qualifications-question',
   title: title,
-  type: 'MutuallyExclusive',
-  mandatory: true,
+  type: 'General',
   answers: [
     {
       id: 'other-qualifications-answer',
       mandatory: false,
-      type: 'Checkbox',
+      type: 'Radio',
       options: [
         {
-          label: 'Yes, in England or Wales',
-          value: 'Yes, in England or Wales',
+          label: 'Yes',
+          value: 'Yes',
         },
-        {
-          label: 'Yes, anywhere outside of England and Wales',
-          value: 'Yes, anywhere outside of England and Wales',
-        },
-      ],
-    },
-    {
-      id: 'other-qualifications-answer-exclusive',
-      type: 'Checkbox',
-      mandatory: false,
-      options: [
         {
           label: 'No qualifications',
           value: 'No qualifications',

--- a/data-source/jsonnet/northern-ireland/blocks/individual/qualifications/qualifications.jsonnet
+++ b/data-source/jsonnet/northern-ireland/blocks/individual/qualifications/qualifications.jsonnet
@@ -1,8 +1,8 @@
 local placeholders = import '../../../../common/lib/placeholders.libsonnet';
 local rules = import '../../../../common/lib/rules.libsonnet';
 
-local descriptionNonProxy = 'The next set of questions is about the qualifications you have ever acheived in Northern Ireland or worldwide, even if you are not using them now.';
-local descriptionProxy = 'The next set of questions is about the qualifications <em>{person_name}</em> has ever acheived in Northern Ireland or worldwide, even if they are not using them now.';
+local descriptionNonProxy = 'The next set of questions is about the qualifications you have achieved in Northern Ireland or worldwide, even if you are not using them now.';
+local descriptionProxy = 'The next set of questions is about the qualifications <em>{person_name}</em> has achieved in Northern Ireland or worldwide, even if they are not using them now.';
 
 {
   type: 'Interstitial',

--- a/data-source/jsonnet/northern-ireland/blocks/individual/school/school_location.jsonnet
+++ b/data-source/jsonnet/northern-ireland/blocks/individual/school/school_location.jsonnet
@@ -1,0 +1,63 @@
+local placeholders = import '../../../../common/lib/placeholders.libsonnet';
+local rules = import '../../../../common/lib/rules.libsonnet';
+
+local question(title) = {
+  id: 'school-location-question',
+  type: 'General',
+  title: title,
+  answers: [
+    {
+      id: 'school-address-details-answer-building',
+      label: 'Building name or number',
+      mandatory: true,
+      type: 'TextField',
+    },
+    {
+      id: 'school-address-details-answer-street',
+      label: 'Street',
+      mandatory: false,
+      type: 'TextField',
+    },
+    {
+      id: 'school-address-details-answer-city',
+      label: 'Town or city',
+      mandatory: false,
+      type: 'TextField',
+    },
+    {
+      id: 'school-address-details-answer-county',
+      label: 'County (optional)',
+      mandatory: false,
+      type: 'TextField',
+    },
+    {
+      id: 'school-address-details-answer-postcode',
+      label: 'Postcode',
+      mandatory: false,
+      type: 'TextField',
+    },
+  ],
+};
+
+local nonProxyTitle = 'What address do you travel to for your course of study, including school?';
+local proxyTitle = {
+  text: 'What address does <em>{person_name}</em> travel to for their course of study, including school?',
+  placeholders: [
+    placeholders.personName,
+  ],
+};
+
+{
+  type: 'Question',
+  id: 'school-location',
+  question_variants: [
+    {
+      question: question(nonProxyTitle),
+      when: [rules.proxyNo],
+    },
+    {
+      question: question(proxyTitle),
+      when: [rules.proxyYes],
+    },
+  ],
+}

--- a/data-source/jsonnet/northern-ireland/blocks/individual/school/school_travel_mode.jsonnet
+++ b/data-source/jsonnet/northern-ireland/blocks/individual/school/school_travel_mode.jsonnet
@@ -1,0 +1,89 @@
+local placeholders = import '../../../../common/lib/placeholders.libsonnet';
+local rules = import '../../../../common/lib/rules.libsonnet';
+
+local question(title, guidance) = {
+  id: 'school-travel-mode-question',
+  title: title,
+  guidance: {
+    content: [
+      {
+        title: guidance,
+      },
+    ],
+  },
+  type: 'General',
+  answers: [
+    {
+      id: 'school-travel-mode-answer',
+      mandatory: true,
+      options: [
+        {
+          label: 'Driving a car or van',
+          value: 'Driving a car or van',
+        },
+        {
+          label: 'Passenger in a car or van',
+          value: 'Passenger in a car or van',
+        },
+        {
+          label: 'Car or van pool, sharing driving',
+          value: 'Car or van pool, sharing driving',
+        },
+        {
+          label: 'Bus, minibus or coach (public or private)',
+          value: 'Bus, minibus or coach (public or private)',
+        },
+        {
+          label: 'On foot',
+          value: 'On foot',
+        },
+        {
+          label: 'Taxi',
+          value: 'Taxi',
+        },
+        {
+          label: 'Train',
+          value: 'Train',
+        },
+        {
+          label: 'Bicycle',
+          value: 'Bicycle',
+        },
+        {
+          label: 'Motorcycle, scooter or moped',
+          value: 'Motorcycle, scooter or moped',
+        },
+        {
+          label: 'Other',
+          value: 'Other',
+        },
+      ],
+      type: 'Radio',
+    },
+  ],
+};
+
+local nonProxyTitle = 'How do you usually travel to your place of study, including school?';
+local nonProxyGuidance = 'Select one option only, for the longest part, by distance, of your usual journey to place of study.';
+local proxyTitle = {
+  text: 'How does <em>{person_name}</em> usually travel to their place of study, including school?',
+  placeholders: [
+    placeholders.personName,
+  ],
+};
+local proxyGuidance = 'Select one option only, for the longest part, by distance, of their usual journey to place of study.';
+
+{
+  type: 'Question',
+  id: 'school-travel-mode',
+  question_variants: [
+    {
+      question: question(nonProxyTitle, nonProxyGuidance),
+      when: [rules.proxyNo],
+    },
+    {
+      question: question(proxyTitle, proxyGuidance),
+      when: [rules.proxyYes],
+    },
+  ],
+}

--- a/data-source/jsonnet/northern-ireland/census_individual.jsonnet
+++ b/data-source/jsonnet/northern-ireland/census_individual.jsonnet
@@ -11,12 +11,12 @@ local sex = import 'blocks/individual/personal-details/sex.jsonnet';
 local term_time_location = import 'blocks/individual/personal-details/term_time_location.jsonnet';
 
 // identity and health
-local carer = import '../common/blocks/individual/identity-and-health/carer.jsonnet';
 local health = import '../common/blocks/individual/identity-and-health/health.jsonnet';
 local last_year_address = import '../common/blocks/individual/identity-and-health/last_year_address.jsonnet';
 local passports = import '../common/blocks/individual/identity-and-health/passports.jsonnet';
 local speak_english = import '../common/blocks/individual/identity-and-health/speak_english.jsonnet';
 local arrive_in_country = import 'blocks/individual/identity-and-health/arrive_in_country.jsonnet';
+local carer = import 'blocks/individual/identity-and-health/carer.jsonnet';
 local country_of_birth = import 'blocks/individual/identity-and-health/country_of_birth.jsonnet';
 local disability = import 'blocks/individual/identity-and-health/disability.jsonnet';
 local disability_limitation = import 'blocks/individual/identity-and-health/disability_limitation.jsonnet';
@@ -33,6 +33,10 @@ local sexual_identity = import 'blocks/individual/identity-and-health/sexual_ide
 local understand_irish = import 'blocks/individual/identity-and-health/understand_irish.jsonnet';
 local understand_ulster_scots = import 'blocks/individual/identity-and-health/understand_ulster_scots.jsonnet';
 
+// school
+local school_location = import 'blocks/individual/school/school_location.jsonnet';
+local school_travel_mode = import 'blocks/individual/school/school_travel_mode.jsonnet';
+
 // qualifications
 local a_level = import 'blocks/individual/qualifications/a_level.jsonnet';
 local apprenticeship = import 'blocks/individual/qualifications/apprenticeship.jsonnet';
@@ -46,10 +50,8 @@ local qualifications = import 'blocks/individual/qualifications/qualifications.j
 local business_name = import '../common/blocks/individual/employment/business_name.jsonnet';
 local employer_address_depot = import '../common/blocks/individual/employment/employer_address_depot.jsonnet';
 local employer_address_workplace = import '../common/blocks/individual/employment/employer_address_workplace.jsonnet';
-local employers_business = import '../common/blocks/individual/employment/employers_business.jsonnet';
 local employment_status = import '../common/blocks/individual/employment/employment_status.jsonnet';
 local employment_type = import '../common/blocks/individual/employment/employment_type.jsonnet';
-local ever_worked = import '../common/blocks/individual/employment/ever_worked.jsonnet';
 local hours_worked = import '../common/blocks/individual/employment/hours_worked.jsonnet';
 local job_availability = import '../common/blocks/individual/employment/job_availability.jsonnet';
 local job_description = import '../common/blocks/individual/employment/job_description.jsonnet';
@@ -62,6 +64,8 @@ local supervise = import '../common/blocks/individual/employment/supervise.jsonn
 local work_travel = import '../common/blocks/individual/employment/work_travel.jsonnet';
 local armed_forces = import 'blocks/individual/employment/armed_forces.jsonnet';
 local employer_type_of_address = import 'blocks/individual/employment/employer_type_of_address.jsonnet';
+local employers_business = import 'blocks/individual/employment/employers_business.jsonnet';
+local ever_worked = import 'blocks/individual/employment/ever_worked.jsonnet';
 
 // comments
 local comments = import '../common/blocks/comments.json';
@@ -177,13 +181,21 @@ function(region_code, census_date) {
             business_name,
             job_title,
             job_description,
-            employers_business(region_code),
+            employers_business,
             supervise,
             hours_worked,
             work_travel,
             employer_type_of_address,
             employer_address_workplace,
             employer_address_depot,
+          ],
+        },
+        {
+          id: 'school-group',
+          title: 'School',
+          blocks: [
+            school_location,
+            school_travel_mode,
           ],
         },
       ],


### PR DESCRIPTION
### What is the context of this PR?
* 1 year ago address - current response option "Student term time in the UK" change to Student term time address in the UK
* Routing wrong on quals- if any yes answers to nvq, gcse, a-levels, degree, skip other-quals and onto apprenticeship. Otherwise show other-quals then apprenticeship.
* Missing two questions https://overflow.io/s/30TRR3/?node=739ef6db & https://overflow.io/s/30TRR3/?node=21a93787 which is the place of study and how to travel to school for under 16s

I've also made a change to the Over16 lib test, changing it to "less than or equal", to capture people who have turned 16 that day- this does bring up a corner case of time zones, but this is hopefully a better, not perfect, option.

Had to de-share the carer block, due to it not longer having the same routing rules across all regions.

### How to review 
Build schema, run through and test.
