### PR TITLE
Change Wales census day from Sept -> June 12

### DIFF
--- a/data/cy/census_individual_gb_wls.json
+++ b/data/cy/census_individual_gb_wls.json
@@ -975,7 +975,7 @@
                                                             "arguments": {
                                                                 "date_format": "d MMMM YYYY",
                                                                 "date_to_format": {
-                                                                    "value": "2019-09-01"
+                                                                    "value": "2019-06-12"
                                                                 }
                                                             },
                                                             "transform": "format_date"
@@ -1052,7 +1052,7 @@
                                                             "arguments": {
                                                                 "date_format": "d MMMM YYYY",
                                                                 "date_to_format": {
-                                                                    "value": "2019-09-01"
+                                                                    "value": "2019-06-12"
                                                                 }
                                                             },
                                                             "transform": "format_date"
@@ -3301,7 +3301,7 @@
                                                     "offset_by": {
                                                         "years": -1
                                                     },
-                                                    "value": "2019-09-01"
+                                                    "value": "2019-06-12"
                                                 },
                                                 "id": "arrive-in-country-answer"
                                             }
@@ -3318,7 +3318,7 @@
                                                     "offset_by": {
                                                         "years": -1
                                                     },
-                                                    "value": "2019-09-01"
+                                                    "value": "2019-06-12"
                                                 },
                                                 "id": "arrive-in-country-answer"
                                             }
@@ -3365,7 +3365,7 @@
                                                             "arguments": {
                                                                 "date_format": "d MMMM YYYY",
                                                                 "date_to_format": {
-                                                                    "value": "2019-09-01"
+                                                                    "value": "2019-06-12"
                                                                 }
                                                             },
                                                             "transform": "format_date"
@@ -3432,7 +3432,7 @@
                                                             "arguments": {
                                                                 "date_format": "d MMMM YYYY",
                                                                 "date_to_format": {
-                                                                    "value": "2019-09-01"
+                                                                    "value": "2019-06-12"
                                                                 }
                                                             },
                                                             "transform": "format_date"


### PR DESCRIPTION
### What is the context of this PR?

Update the census date that is used for the Welsh test to 12 June 2019 based on feedback from the QQD team.

### How to review 

Check that any use of census date has been updated correctly and that the new date is displayed on the Welsh version.
