### PR TITLE
Allow managed google tls cert

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,13 +278,13 @@ EQ_KEYS_FILE=dev-keys.yml EQ_SECRETS_FILE=dev-secrets.yml ./k8s/deploy_credentia
 To deploy the app to the cluster, run the following command:
 
 ```
-./k8s/deploy_app.sh <SUBMISSION_BUCKET_NAME> <DOCKER_REGISTRY> <IMAGE_TAG>
+./k8s/deploy_app.sh <SUBMISSION_BUCKET_NAME> [<DOCKER_REGISTRY>] [<IMAGE_TAG>] [<MANAGED_CERTIFICATE_NAME>]
 ```
 
 For example:
 
 ```
-./k8s/deploy_app.sh census-eq-dev-1234567-survey-runner-submission eu.gcr.io/census-eq-dev v3.0.0
+./k8s/deploy_app.sh census-eq-dev-1234567-survey-runner-submission eu.gcr.io/census-eq-dev v3.0.0 runner-mc
 ```
 
 ---

--- a/k8s/deploy_app.sh
+++ b/k8s/deploy_app.sh
@@ -7,10 +7,10 @@ if [[ -z "$1" ]]; then
   exit 1
 fi
 
-#PROJECT_ID=$1
 SUBMISSION_BUCKET_NAME=$1
 DOCKER_REGISTRY="${2:-eu.gcr.io/census-eq-ci}"
 IMAGE_TAG="${3:-latest}"
+MANAGED_CERTIFICATE_NAME="${4:-}"
 
 helm tiller run \
     helm upgrade --install \
@@ -18,4 +18,5 @@ helm tiller run \
     k8s/helm \
     --set submissionBucket=${SUBMISSION_BUCKET_NAME} \
     --set image.repository=${DOCKER_REGISTRY}/eq-survey-runner \
-    --set image.tag=${IMAGE_TAG}
+    --set image.tag=${IMAGE_TAG} \
+    --set ingress.managedCertificateName=${MANAGED_CERTIFICATE_NAME}

--- a/k8s/helm/templates/ingress.yaml
+++ b/k8s/helm/templates/ingress.yaml
@@ -8,18 +8,11 @@ metadata:
     helm.sh/chart: {{ include "chart.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-  {{- with .Values.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+      kubernetes.io/ingress.global-static-ip-name: survey-runner
+      ingress.gcp.kubernetes.io/pre-shared-cert: runner
 spec:
   backend:
     serviceName: {{ .Chart.Name }}
     servicePort: 80
-{{- if .Values.ingress.tls }}
-  tls:
-  {{- range .Values.ingress.tls }}
-    - secretName: {{ .secretName }}
-  {{- end }}
-{{- end }}
 {{- end }}

--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -17,10 +17,6 @@ service:
 
 ingress:
   enabled: true
-  annotations:
-    kubernetes.io/ingress.global-static-ip-name: survey-runner
-  tls:
-    - secretName: tls-cert
 
 resources:
   requests:


### PR DESCRIPTION
### What is the context of this PR?
Allow the use of a managed SSL certificate which has been provisioned in GCP.

This required changing the template to include more of the stuff that was in values.yaml. I don't think that's particularly bad here, but happy to discuss.

### How to review 
- Deploy an environment to google using a managed SSL certificate (as per whitelodge) and ensure that the ingress service yaml does not include the tls secret.
- Deploy a dev environment (with no extra configuration) and ensure that the tls secret is used in the ingress service yaml
