### PR TITLE
Add main method back for PyCharm CE

### DIFF
--- a/application.py
+++ b/application.py
@@ -73,3 +73,7 @@ configure_logging()
 from app.setup import create_app  # NOQA
 
 application = create_app()
+
+if __name__ == '__main__':
+    port = int(os.environ.get('PORT', 5000))
+    application.run(port=port, threaded=True)


### PR DESCRIPTION
### What is the context of this PR?

Currently we can't debug runner within PyCharm CE due to the main method having been removed. (PyCharm CE does not include the flask integration).

### How to review 

Confirm whether flask can now be started from within PyCharm CE.
