### PR TITLE
Use 12 June 2019 as Census Individual Date

### DIFF
--- a/data-source/jsonnet/common/blocks/confirmation.json
+++ b/data-source/jsonnet/common/blocks/confirmation.json
@@ -1,16 +1,16 @@
 {
     "type": "Confirmation",
     "id": "confirmation",
-    "title": "You’re ready to submit your 2017 Census Test",
+    "title": "You’re ready to submit your 2019 Census Test",
     "content": [
         {
-            "description": "Thank you for taking part in the 2017 Census Test"
+            "description": "Thank you for taking part in the 2019 Census Test"
         },
         {
             "title": "Please note:",
             "list": [
                 "by submitting your responses, you are declaring that you have completed to the best of your knowledge and belief.",
-                "if you do not submit, your responses will be automatically submitted when the Census 2017 Test closes.",
+                "if you do not submit, your responses will be automatically submitted when the Census 2019 Test closes.",
                 "after submission you will have an opportunity to provide feedback on your experience."
             ]
         }

--- a/data-source/jsonnet/england-wales/census_individual.jsonnet
+++ b/data-source/jsonnet/england-wales/census_individual.jsonnet
@@ -86,7 +86,7 @@ function(region_code, census_date) {
   schema_version: '0.0.1',
   data_version: '0.0.3',
   survey_id: 'census',
-  title: '2017 Census Test',
+  title: '2019 Census Test',
   description: 'Census England Individual Schema',
   theme: 'census',
   legal_basis: 'Voluntary',

--- a/data-source/jsonnet/northern-ireland/census_individual.jsonnet
+++ b/data-source/jsonnet/northern-ireland/census_individual.jsonnet
@@ -74,7 +74,7 @@ function(region_code) {
   schema_version: '0.0.1',
   data_version: '0.0.3',
   survey_id: 'census',
-  title: '2017 Census Test',
+  title: '2019 Census Test',
   description: 'Census England Individual Schema',
   theme: 'census',
   legal_basis: 'Voluntary',

--- a/scripts/build_schemas.sh
+++ b/scripts/build_schemas.sh
@@ -13,7 +13,7 @@ for region_code in GB-WLS GB-ENG GB-NIR; do
         jsonnet --tla-str region_code=${region_code} "${SOURCE_FILE}" > "${DESTINATION_FILE}"
     else
         SOURCE_FILE="data-source/jsonnet/england-wales/census_individual.jsonnet"
-        jsonnet --tla-str region_code=${region_code} --tla-str census_date="2019-09-01" "${SOURCE_FILE}" > "${DESTINATION_FILE}"
+        jsonnet --tla-str region_code=${region_code} --tla-str census_date="2019-06-12" "${SOURCE_FILE}" > "${DESTINATION_FILE}"
     fi
 
     echo "Built ${DESTINATION_FILE}"


### PR DESCRIPTION
### What is the context of this PR?

12th June 2019 is now to be used as the census date for the individual survey. Additionally update titles to be in line.

### How to review 

Check census dates are modified to 2019 throughout. Check that Wales/England schemas have had census date modified to 12/06/2019

