### PR TITLE
Fix descriptions on mutually exclusive checkbox and prepare for "checked" parameter

### DIFF
--- a/data-source/json/test_mutually_exclusive.json
+++ b/data-source/json/test_mutually_exclusive.json
@@ -64,6 +64,7 @@
                             "type": "Checkbox",
                             "options": [{
                                 "label": "I prefer not to say",
+                                "description": "Some description",
                                 "value": "I prefer not to say"
                             }]
                         }]

--- a/scripts/load_templates.sh
+++ b/scripts/load_templates.sh
@@ -4,7 +4,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 cd "${DIR}"/.. || exit
 
-DESIGN_SYSTEM_VERSION="6.1.0"
+DESIGN_SYSTEM_VERSION="8.0.4"
 
 TEMP_DIR=$(mktemp -d)
 

--- a/templates/partials/question.html
+++ b/templates/partials/question.html
@@ -26,13 +26,13 @@
   {% endif %}
 {% endset %}
 
-{%- set mutually_exclusive_quesstion = question.type == 'MutuallyExclusive' -%}
+{%- set mutually_exclusive_question = question.type == 'MutuallyExclusive' -%}
 
 {% set question_answers %}
-  {% if mutually_exclusive_quesstion %}
+  {% if mutually_exclusive_question %}
     {%- set answer = question.answers[0] -%}
     {%- set mutuallyExclusiveAnswer = question.answers[1] -%}
-    {%- set mutuallyExlusiveOptions = mutuallyExclusiveAnswer.options[0] -%}
+    {%- set mutuallyExlusiveOption = mutuallyExclusiveAnswer.options[0] -%}
 
     {%- set deselectionMessage = _("Selecting this will clear your answer") -%}
     {%- set deselectGroupAdjective = _("cleared") -%}
@@ -47,10 +47,12 @@
       "checkbox": {
         "id": mutuallyExclusiveAnswer.id + "-0",
         "label": {
-          "text": mutuallyExlusiveOptions.label
+          "text": mutuallyExlusiveOption.label,
+          "description": mutuallyExlusiveOption.description
         },
-        "value": mutuallyExlusiveOptions.value,
-        "name": mutuallyExclusiveAnswer.id
+        "value": mutuallyExlusiveOption.value,
+        "name": mutuallyExclusiveAnswer.id,
+        "checked": mutuallyExlusiveOption.checked
       },
       "deselectionMessage": deselectionMessage,
       "deselectGroupAdjective": deselectGroupAdjective,
@@ -84,7 +86,7 @@
     "legend": question_title,
     "description": question.description,
     "questionMode": true,
-    "classes": " field--exclusive" if mutually_exclusive_quesstion else "",
+    "classes": " field--exclusive" if mutually_exclusive_question else "",
     "legendClasses": "question__title"
   }) %}
     {{ question_markup }}


### PR DESCRIPTION
Fixes descriptions not showing on the mutually exclusive checkbox, and prepares to accept a "checked" parameter. I can't seem to see if runner stores if a user selects the mutually exclusive option.
