### PR TITLE
Remove repeated bullet point from stocks form types.

### DIFF
--- a/data/en/stocks_0001.json
+++ b/data/en/stocks_0001.json
@@ -42,7 +42,6 @@
                                                 "Consumable stores",
                                                 "Semi-processed goods",
                                                 "Office supplies (including stationery)and packaging materials",
-                                                "All stocks owned and either held by you or currently in transit within the United Kingdom.",
                                                 "Duty for dutiable goods held out of bond",
                                                 "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes"
                                             ]
@@ -64,7 +63,6 @@
                                             "list": [
                                                 "Products that you own in intermediate stages of completion (even if not held by you)",
                                                 "Long term business contract balances in line with UK Generally Accepted Accountancy Practice (GAAP) or International GAAP",
-                                                "All stocks owned and either held by you or currently in transit within the United Kingdom.",
                                                 "Duty for dutiable goods held out of bond",
                                                 "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes"
                                             ]
@@ -91,7 +89,6 @@
                                             "list": [
                                                 "Buildings for sale",
                                                 "Vehicles, plant, machinery, etc. let out on hire only if they were not charged to capital account when acquired or made",
-                                                "All stocks owned and either held by you or currently in transit within the United Kingdom.",
                                                 "Duty for dutiable goods held out of bond",
                                                 "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes"
                                             ]
@@ -223,7 +220,6 @@
                                                 "Consumable stores",
                                                 "Semi-processed goods",
                                                 "Office supplies (including stationery)and packaging materials",
-                                                "All stocks owned and either held by you or currently in transit within the United Kingdom.",
                                                 "Duty for dutiable goods held out of bond",
                                                 "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes"
                                             ]
@@ -274,7 +270,6 @@
                                             "list": [
                                                 "Products that you own in intermediate stages of completion (even if not held by you)",
                                                 "Long term business contract balances in line with UK Generally Accepted Accountancy Practice (GAAP) or International GAAP",
-                                                "All stocks owned and either held by you or currently in transit within the United Kingdom.",
                                                 "Duty for dutiable goods held out of bond",
                                                 "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes"
                                             ]
@@ -336,7 +331,6 @@
                                             "list": [
                                                 "Buildings for sale",
                                                 "Vehicles, plant, machinery, etc. let out on hire only if they were not charged to capital account when acquired or made",
-                                                "All stocks owned and either held by you or currently in transit within the United Kingdom.",
                                                 "Duty for dutiable goods held out of bond",
                                                 "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes"
                                             ]

--- a/data/en/stocks_0002.json
+++ b/data/en/stocks_0002.json
@@ -42,7 +42,6 @@
                                                 "Consumable stores",
                                                 "Semi-processed goods",
                                                 "Office supplies (including stationery)and packaging materials",
-                                                "All stocks owned and either held by you or currently in transit within the United Kingdom.",
                                                 "Duty for dutiable goods held out of bond",
                                                 "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes"
                                             ]
@@ -64,7 +63,6 @@
                                             "list": [
                                                 "Products that you own in intermediate stages of completion (even if not held by you)",
                                                 "Long term business contract balances in line with UK Generally Accepted Accountancy Practice (GAAP) or International GAAP",
-                                                "All stocks owned and either held by you or currently in transit within the United Kingdom.",
                                                 "Duty for dutiable goods held out of bond",
                                                 "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes"
                                             ]
@@ -91,7 +89,6 @@
                                             "list": [
                                                 "Buildings for sale",
                                                 "Vehicles, plant, machinery, etc. let out on hire only if they were not charged to capital account when acquired or made",
-                                                "All stocks owned and either held by you or currently in transit within the United Kingdom.",
                                                 "Duty for dutiable goods held out of bond",
                                                 "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes"
                                             ]
@@ -223,7 +220,6 @@
                                                 "Consumable stores",
                                                 "Semi-processed goods",
                                                 "Office supplies (including stationery)and packaging materials",
-                                                "All stocks owned and either held by you or currently in transit within the United Kingdom.",
                                                 "Duty for dutiable goods held out of bond",
                                                 "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes"
                                             ]
@@ -274,7 +270,6 @@
                                             "list": [
                                                 "Products that you own in intermediate stages of completion (even if not held by you)",
                                                 "Long term business contract balances in line with UK Generally Accepted Accountancy Practice (GAAP) or International GAAP",
-                                                "All stocks owned and either held by you or currently in transit within the United Kingdom.",
                                                 "Duty for dutiable goods held out of bond",
                                                 "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes"
                                             ]
@@ -336,7 +331,6 @@
                                             "list": [
                                                 "Buildings for sale",
                                                 "Vehicles, plant, machinery, etc. let out on hire only if they were not charged to capital account when acquired or made",
-                                                "All stocks owned and either held by you or currently in transit within the United Kingdom.",
                                                 "Duty for dutiable goods held out of bond",
                                                 "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes"
                                             ]

--- a/data/en/stocks_0061.json
+++ b/data/en/stocks_0061.json
@@ -38,7 +38,6 @@
                                     },
                                     {
                                         "list": [
-                                            "All stocks owned and either held by you or currently in transit within the United Kingdom.",
                                             "Duty for dutiable goods held out of bond",
                                             "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes"
                                         ]
@@ -157,7 +156,6 @@
                                     },
                                     {
                                         "list": [
-                                            "All stocks owned, whether held by your business in the UK or abroad",
                                             "Duty for dutiable goods held out of bond",
                                             "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes"
                                         ]

--- a/data/en/stocks_0070.json
+++ b/data/en/stocks_0070.json
@@ -38,7 +38,6 @@
                                     },
                                     {
                                         "list": [
-                                            "All stocks owned and either held by you or currently in transit within the United Kingdom.",
                                             "Duty for dutiable goods held out of bond",
                                             "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes",
                                             "Work in progress"
@@ -158,7 +157,6 @@
                                     },
                                     {
                                         "list": [
-                                            "All stocks owned and either held by you or currently in transit within the United Kingdom.",
                                             "Duty for dutiable goods held out of bond",
                                             "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes",
                                             "Work in progress"


### PR DESCRIPTION
### What is the context of this PR?
There was a bullet point which was repeated several times throughout the survey. This change removes the bullet point in all include and exclude lists.

### How to review 
Ensure that the following bullet point appears only once in the following form types:

- 0001
- 0002	
- 0057
- 0058
- 0061
- 0070

> All stocks owned and either held by you or currently in transit within the United Kingdom.
