### PR TITLE
Fix stocks form types content.

### DIFF
--- a/data/en/stocks_0001.json
+++ b/data/en/stocks_0001.json
@@ -41,7 +41,7 @@
                                                 "Raw materials and components purchased for incorporation into products for sale",
                                                 "Consumable stores",
                                                 "Semi-processed goods",
-                                                "Office supplies (including stationery)and packaging materials",
+                                                "Office supplies (including stationery) and packaging materials",
                                                 "Duty for dutiable goods held out of bond",
                                                 "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes"
                                             ]
@@ -107,7 +107,9 @@
                             "id": "secondary-content",
                             "title": "How we use your data",
                             "content": [{
-                                "list": ["The information supplied is used to estimate changes in stock levels which are used in the compilation of Gross Domestic Product (GDP), the total UK economic activity. GDP is used to measure the UK's financial health and prosperity over time and in comparison to other countries. The results are used by the Bank of England and HM Treasury to monitor interest rates, inflation and in formulating financial policies (e.g. income, expenditure and taxation) for the UK."]
+                                "list": ["The information supplied is used to estimate changes in stock levels which are used in the compilation of Gross Domestic Product (GDP), the total UK economic activity.",
+                                    "GDP is used to measure the UK's financial health and prosperity over time and in comparison to other countries.", "The results are used by the Bank of England and HM Treasury to monitor interest rates, inflation and in formulating financial policies (e.g. income, expenditure and taxation) for the UK."
+                                ]
                             }]
                         }]
                     },
@@ -219,7 +221,7 @@
                                                 "Raw materials and components purchased for incorporation into products for sale",
                                                 "Consumable stores",
                                                 "Semi-processed goods",
-                                                "Office supplies (including stationery)and packaging materials",
+                                                "Office supplies (including stationery) and packaging materials",
                                                 "Duty for dutiable goods held out of bond",
                                                 "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes"
                                             ]
@@ -498,9 +500,9 @@
                                             "value": "Change of business structure, merger or takeover"
                                         },
                                         {
-                                            "label": "One off increase in stocks",
+                                            "label": "One-off increase in stocks",
                                             "q_code": "146f",
-                                            "value": "One off increase in stocks"
+                                            "value": "One-off increase in stocks"
                                         },
                                         {
                                             "label": "Introduction or removal of new legislation or incentive",

--- a/data/en/stocks_0002.json
+++ b/data/en/stocks_0002.json
@@ -41,7 +41,7 @@
                                                 "Raw materials and components purchased for incorporation into products for sale",
                                                 "Consumable stores",
                                                 "Semi-processed goods",
-                                                "Office supplies (including stationery)and packaging materials",
+                                                "Office supplies (including stationery) and packaging materials",
                                                 "Duty for dutiable goods held out of bond",
                                                 "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes"
                                             ]
@@ -107,7 +107,7 @@
                             "id": "secondary-content",
                             "title": "How we use your data",
                             "content": [{
-                                "list": ["The information supplied is used to estimate changes in stock levels which are used in the compilation of Gross Domestic Product (GDP), the total UK economic activity. GDP is used to measure the UK's financial health and prosperity over time and in comparison to other countries. The results are used by the Bank of England and HM Treasury to monitor interest rates, inflation and in formulating financial policies (e.g. income, expenditure and taxation) for the UK."]
+                                "list": ["The information supplied is used to estimate changes in stock levels which are used in the compilation of Gross Domestic Product (GDP), the total UK economic activity.", "GDP is used to measure the UK's financial health and prosperity over time and in comparison to other countries.", "The results are used by the Bank of England and HM Treasury to monitor interest rates, inflation and in formulating financial policies (e.g. income, expenditure and taxation) for the UK."]
                             }]
                         }]
                     },
@@ -219,7 +219,7 @@
                                                 "Raw materials and components purchased for incorporation into products for sale",
                                                 "Consumable stores",
                                                 "Semi-processed goods",
-                                                "Office supplies (including stationery)and packaging materials",
+                                                "Office supplies (including stationery) and packaging materials",
                                                 "Duty for dutiable goods held out of bond",
                                                 "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes"
                                             ]
@@ -498,9 +498,9 @@
                                             "value": "Change of business structure, merger or takeover"
                                         },
                                         {
-                                            "label": "One off increase in stocks",
+                                            "label": "One-off increase in stocks",
                                             "q_code": "146f",
-                                            "value": "One off increase in stocks"
+                                            "value": "One-off increase in stocks"
                                         },
                                         {
                                             "label": "Introduction or removal of new legislation or incentive",

--- a/data/en/stocks_0003.json
+++ b/data/en/stocks_0003.json
@@ -41,7 +41,7 @@
                                                 "Raw materials and components purchased for incorporation into products for sale",
                                                 "Consumable stores",
                                                 "Semi-processed goods",
-                                                "Office supplies (including stationery)and packaging materials",
+                                                "Office supplies (including stationery) and packaging materials",
                                                 "Duty for dutiable goods held out of bond",
                                                 "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes"
                                             ]
@@ -88,7 +88,7 @@
                             "id": "secondary-content",
                             "title": "How we use your data",
                             "content": [{
-                                "list": ["The information supplied is used to estimate changes in stock levels which are used in the compilation of Gross Domestic Product (GDP), the total UK economic activity. GDP is used to measure the UK's financial health and prosperity over time and in comparison to other countries. The results are used by the Bank of England and HM Treasury to monitor interest rates, inflation and in formulating financial policies (e.g. income, expenditure and taxation) for the UK."]
+                                "list": ["The information supplied is used to estimate changes in stock levels which are used in the compilation of Gross Domestic Product (GDP), the total UK economic activity.", "GDP is used to measure the UK's financial health and prosperity over time and in comparison to other countries.", "The results are used by the Bank of England and HM Treasury to monitor interest rates, inflation and in formulating financial policies (e.g. income, expenditure and taxation) for the UK."]
                             }]
                         }]
                     },
@@ -423,9 +423,9 @@
                                         "value": "Change of business structure, merger or takeover"
                                     },
                                     {
-                                        "label": "One off increase in stocks",
+                                        "label": "One-off increase in stocks",
                                         "q_code": "146f",
-                                        "value": "One off increase in stocks"
+                                        "value": "One-off increase in stocks"
                                     },
                                     {
                                         "label": "Introduction or removal of new legislation or incentive",

--- a/data/en/stocks_0004.json
+++ b/data/en/stocks_0004.json
@@ -41,7 +41,7 @@
                                                 "Raw materials and components purchased for incorporation into products for sale",
                                                 "Consumable stores",
                                                 "Semi-processed goods",
-                                                "Office supplies (including stationery)and packaging materials",
+                                                "Office supplies (including stationery) and packaging materials",
                                                 "Duty for dutiable goods held out of bond",
                                                 "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes"
                                             ]
@@ -88,7 +88,7 @@
                             "id": "secondary-content",
                             "title": "How we use your data",
                             "content": [{
-                                "list": ["The information supplied is used to estimate changes in stock levels which are used in the compilation of Gross Domestic Product (GDP), the total UK economic activity. GDP is used to measure the UK's financial health and prosperity over time and in comparison to other countries. The results are used by the Bank of England and HM Treasury to monitor interest rates, inflation and in formulating financial policies (e.g. income, expenditure and taxation) for the UK."]
+                                "list": ["The information supplied is used to estimate changes in stock levels which are used in the compilation of Gross Domestic Product (GDP), the total UK economic activity.", "GDP is used to measure the UK's financial health and prosperity over time and in comparison to other countries.", "The results are used by the Bank of England and HM Treasury to monitor interest rates, inflation and in formulating financial policies (e.g. income, expenditure and taxation) for the UK."]
                             }]
                         }]
                     },
@@ -423,9 +423,9 @@
                                         "value": "Change of business structure, merger or takeover"
                                     },
                                     {
-                                        "label": "One off increase in stocks",
+                                        "label": "One-off increase in stocks",
                                         "q_code": "146f",
-                                        "value": "One off increase in stocks"
+                                        "value": "One-off increase in stocks"
                                     },
                                     {
                                         "label": "Introduction or removal of new legislation or incentive",

--- a/data/en/stocks_0005.json
+++ b/data/en/stocks_0005.json
@@ -152,7 +152,7 @@
                             "id": "secondary-content",
                             "title": "How we use your data",
                             "content": [{
-                                "list": ["The information supplied is used to estimate changes in stock levels which are used in the compilation of Gross Domestic Product (GDP), the total UK economic activity. GDP is used to measure the UK's financial health and prosperity over time and in comparison to other countries. The results are used by the Bank of England and HM Treasury to monitor interest rates, inflation and in formulating financial policies (e.g. income, expenditure and taxation) for the UK."]
+                                "list": ["The information supplied is used to estimate changes in stock levels which are used in the compilation of Gross Domestic Product (GDP), the total UK economic activity.", "GDP is used to measure the UK's financial health and prosperity over time and in comparison to other countries.", "The results are used by the Bank of England and HM Treasury to monitor interest rates, inflation and in formulating financial policies (e.g. income, expenditure and taxation) for the UK."]
                             }]
                         }]
                     },
@@ -632,9 +632,9 @@
                                         "value": "Change of business structure, merger or takeover"
                                     },
                                     {
-                                        "label": "One off increase in stocks",
+                                        "label": "One-off increase in stocks",
                                         "q_code": "146f",
-                                        "value": "One off increase in stocks"
+                                        "value": "One-off increase in stocks"
                                     },
                                     {
                                         "label": "Introduction or removal of new legislation or incentive",

--- a/data/en/stocks_0006.json
+++ b/data/en/stocks_0006.json
@@ -152,7 +152,7 @@
                             "id": "secondary-content",
                             "title": "How we use your data",
                             "content": [{
-                                "list": ["The information supplied is used to estimate changes in stock levels which are used in the compilation of Gross Domestic Product (GDP), the total UK economic activity. GDP is used to measure the UK's financial health and prosperity over time and in comparison to other countries. The results are used by the Bank of England and HM Treasury to monitor interest rates, inflation and in formulating financial policies (e.g. income, expenditure and taxation) for the UK."]
+                                "list": ["The information supplied is used to estimate changes in stock levels which are used in the compilation of Gross Domestic Product (GDP), the total UK economic activity.", "GDP is used to measure the UK's financial health and prosperity over time and in comparison to other countries.", "The results are used by the Bank of England and HM Treasury to monitor interest rates, inflation and in formulating financial policies (e.g. income, expenditure and taxation) for the UK."]
                             }]
                         }]
                     },
@@ -632,9 +632,9 @@
                                         "value": "Change of business structure, merger or takeover"
                                     },
                                     {
-                                        "label": "One off increase in stocks",
+                                        "label": "One-off increase in stocks",
                                         "q_code": "146f",
-                                        "value": "One off increase in stocks"
+                                        "value": "One-off increase in stocks"
                                     },
                                     {
                                         "label": "Introduction or removal of new legislation or incentive",

--- a/data/en/stocks_0007.json
+++ b/data/en/stocks_0007.json
@@ -112,7 +112,7 @@
                             "id": "secondary-content",
                             "title": "How we use your data",
                             "content": [{
-                                "list": ["The information supplied is used to estimate changes in stock levels which are used in the compilation of Gross Domestic Product (GDP), the total UK economic activity. GDP is used to measure the UK's financial health and prosperity over time and in comparison to other countries. The results are used by the Bank of England and HM Treasury to monitor interest rates, inflation and in formulating financial policies (e.g. income, expenditure and taxation) for the UK."]
+                                "list": ["The information supplied is used to estimate changes in stock levels which are used in the compilation of Gross Domestic Product (GDP), the total UK economic activity.", "GDP is used to measure the UK's financial health and prosperity over time and in comparison to other countries.", "The results are used by the Bank of England and HM Treasury to monitor interest rates, inflation and in formulating financial policies (e.g. income, expenditure and taxation) for the UK."]
                             }]
                         }]
                     },
@@ -494,9 +494,9 @@
                                         "value": "Change of business structure, merger or takeover"
                                     },
                                     {
-                                        "label": "One off increase in stocks",
+                                        "label": "One-off increase in stocks",
                                         "q_code": "146f",
-                                        "value": "One off increase in stocks"
+                                        "value": "One-off increase in stocks"
                                     },
                                     {
                                         "label": "Introduction or removal of new legislation or incentive",

--- a/data/en/stocks_0008.json
+++ b/data/en/stocks_0008.json
@@ -112,7 +112,7 @@
                             "id": "secondary-content",
                             "title": "How we use your data",
                             "content": [{
-                                "list": ["The information supplied is used to estimate changes in stock levels which are used in the compilation of Gross Domestic Product (GDP), the total UK economic activity. GDP is used to measure the UK's financial health and prosperity over time and in comparison to other countries. The results are used by the Bank of England and HM Treasury to monitor interest rates, inflation and in formulating financial policies (e.g. income, expenditure and taxation) for the UK."]
+                                "list": ["The information supplied is used to estimate changes in stock levels which are used in the compilation of Gross Domestic Product (GDP), the total UK economic activity.", "GDP is used to measure the UK's financial health and prosperity over time and in comparison to other countries.", "The results are used by the Bank of England and HM Treasury to monitor interest rates, inflation and in formulating financial policies (e.g. income, expenditure and taxation) for the UK."]
                             }]
                         }]
                     },
@@ -494,9 +494,9 @@
                                         "value": "Change of business structure, merger or takeover"
                                     },
                                     {
-                                        "label": "One off increase in stocks",
+                                        "label": "One-off increase in stocks",
                                         "q_code": "146f",
-                                        "value": "One off increase in stocks"
+                                        "value": "One-off increase in stocks"
                                     },
                                     {
                                         "label": "Introduction or removal of new legislation or incentive",

--- a/data/en/stocks_0009.json
+++ b/data/en/stocks_0009.json
@@ -31,13 +31,144 @@
                             "content": [{
                                 "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
                             }],
-                            "questions": []
+                            "questions": [{
+                                    "question": "Value of stocks held for coal",
+                                    "content": [{
+                                            "title": "Include"
+                                        },
+                                        {
+                                            "list": [
+                                                "All stocks owned; whether held by you or in transit in the UK or abroad",
+                                                "Duty for dutiable goods held out of bond",
+                                                "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes"
+                                            ]
+                                        },
+                                        {
+                                            "title": "Exclude"
+                                        },
+                                        {
+                                            "list": ["VAT", "Stocks you hold that do not belong to you", "Duty on stocks held in bond"]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": "Value of stocks held for oil",
+                                    "content": [{
+                                            "title": "Include"
+                                        },
+                                        {
+                                            "list": [
+                                                "All stocks owned; whether held by you or in transit in the UK or abroad",
+                                                "Duty for dutiable goods held out of bond",
+                                                "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes"
+                                            ]
+                                        },
+                                        {
+                                            "title": "Exclude"
+                                        },
+                                        {
+                                            "list": ["VAT", "Stocks you hold that do not belong to you", "Duty on stocks held in bond"]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": "Value of stocks held for other fuels",
+                                    "content": [{
+                                            "title": "Include"
+                                        },
+                                        {
+                                            "list": [
+                                                "All stocks owned; whether held by you or in transit in the UK or abroad",
+                                                "Duty for dutiable goods held out of bond",
+                                                "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes"
+                                            ]
+                                        },
+                                        {
+                                            "title": "Exclude"
+                                        },
+                                        {
+                                            "list": ["VAT", "Stocks you hold that do not belong to you", "Duty on stocks held in bond"]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": "Value of stocks held for stores",
+                                    "content": [{
+                                            "title": "Include"
+                                        },
+                                        {
+                                            "list": [
+                                                "Raw materials and components purchased for incorporation into products for sale",
+                                                "Consumable stores",
+                                                "Semi-processed goods",
+                                                "Office supplies (including stationery) and packaging materials",
+                                                "All stocks owned; whether held by you or in transit in the UK or abroad",
+                                                "Duty for dutiable goods held out of bond",
+                                                "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes"
+                                            ]
+                                        },
+                                        {
+                                            "title": "Exclude"
+                                        },
+                                        {
+                                            "list": ["VAT", "Stocks you hold that do not belong to you", "Duty on stocks held in bond"]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": "Value of stocks held for work in progress",
+                                    "content": [{
+                                            "title": "Include"
+                                        },
+                                        {
+                                            "list": [
+                                                "Products that you own in intermediate stages of completion (even if not held by you)",
+                                                "Long term business contract balances in line with UK Generally Accepted Accountancy Practice or International GAAP",
+                                                "All stocks owned; whether held by you or in transit in the UK or abroad",
+                                                "Duty for dutiable goods held out of bond",
+                                                "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes"
+                                            ]
+                                        },
+                                        {
+                                            "title": "Exclude"
+                                        },
+                                        {
+                                            "list": [
+                                                "VAT",
+                                                "Stocks you hold that do not belong to you",
+                                                "Duty on stocks held in bond",
+                                                "Products in intermediate stages of completion that do not belong to you"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": "Total value of stocks",
+                                    "content": [{
+                                            "title": "Include"
+                                        },
+                                        {
+                                            "list": [
+                                                "All stocks owned; whether held by your business in the UK or abroad",
+                                                "Duty for dutiable goods held out of bond",
+                                                "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes"
+                                            ]
+                                        },
+                                        {
+                                            "title": "Exclude"
+                                        },
+                                        {
+                                            "list": ["VAT", "Stocks you hold that do not belong to you", "Duty on stocks held in bond"]
+                                        }
+                                    ]
+                                }
+                            ]
                         },
                         "secondary_content": [{
                             "id": "secondary-content",
                             "title": "How we use your data",
                             "content": [{
-                                "list": ["The information supplied is used to estimate changes in stock levels which are used in the compilation of Gross Domestic Product (GDP), the total UK economic activity. GDP is used to measure the UK's financial health and prosperity over time and in comparison to other countries. The results are used by the Bank of England and HM Treasury to monitor interest rates, inflation and in formulating financial policies (e.g. income, expenditure and taxation) for the UK."]
+                                "list": ["The information supplied is used to estimate changes in stock levels which are used in the compilation of Gross Domestic Product (GDP), the total UK economic activity.", "GDP is used to measure the UK's financial health and prosperity over time and in comparison to other countries.", "The results are used by the Bank of England and HM Treasury to monitor interest rates, inflation and in formulating financial policies (e.g. income, expenditure and taxation) for the UK."]
                             }]
                         }]
                     },
@@ -526,9 +657,9 @@
                                         "value": "Change of business structure, merger or takeover"
                                     },
                                     {
-                                        "label": "One off increase in stocks",
+                                        "label": "One-off increase in stocks",
                                         "q_code": "146f",
-                                        "value": "One off increase in stocks"
+                                        "value": "One-off increase in stocks"
                                     },
                                     {
                                         "label": "Introduction or removal of new legislation or incentive",

--- a/data/en/stocks_0010.json
+++ b/data/en/stocks_0010.json
@@ -31,13 +31,144 @@
                             "content": [{
                                 "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
                             }],
-                            "questions": []
+                            "questions": [{
+                                    "question": "Value of stocks held for coal",
+                                    "content": [{
+                                            "title": "Include"
+                                        },
+                                        {
+                                            "list": [
+                                                "All stocks owned; whether held by you or in transit in the UK or abroad",
+                                                "Duty for dutiable goods held out of bond",
+                                                "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes"
+                                            ]
+                                        },
+                                        {
+                                            "title": "Exclude"
+                                        },
+                                        {
+                                            "list": ["VAT", "Stocks you hold that do not belong to you", "Duty on stocks held in bond"]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": "Value of stocks held for oil",
+                                    "content": [{
+                                            "title": "Include"
+                                        },
+                                        {
+                                            "list": [
+                                                "All stocks owned; whether held by you or in transit in the UK or abroad",
+                                                "Duty for dutiable goods held out of bond",
+                                                "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes"
+                                            ]
+                                        },
+                                        {
+                                            "title": "Exclude"
+                                        },
+                                        {
+                                            "list": ["VAT", "Stocks you hold that do not belong to you", "Duty on stocks held in bond"]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": "Value of stocks held for other fuels",
+                                    "content": [{
+                                            "title": "Include"
+                                        },
+                                        {
+                                            "list": [
+                                                "All stocks owned; whether held by you or in transit in the UK or abroad",
+                                                "Duty for dutiable goods held out of bond",
+                                                "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes"
+                                            ]
+                                        },
+                                        {
+                                            "title": "Exclude"
+                                        },
+                                        {
+                                            "list": ["VAT", "Stocks you hold that do not belong to you", "Duty on stocks held in bond"]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": "Value of stocks held for stores",
+                                    "content": [{
+                                            "title": "Include"
+                                        },
+                                        {
+                                            "list": [
+                                                "Raw materials and components purchased for incorporation into products for sale",
+                                                "Consumable stores",
+                                                "Semi-processed goods",
+                                                "Office supplies (including stationery) and packaging materials",
+                                                "All stocks owned; whether held by you or in transit in the UK or abroad",
+                                                "Duty for dutiable goods held out of bond",
+                                                "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes"
+                                            ]
+                                        },
+                                        {
+                                            "title": "Exclude"
+                                        },
+                                        {
+                                            "list": ["VAT", "Stocks you hold that do not belong to you", "Duty on stocks held in bond"]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": "Value of stocks held for work in progress",
+                                    "content": [{
+                                            "title": "Include"
+                                        },
+                                        {
+                                            "list": [
+                                                "Products that you own in intermediate stages of completion (even if not held by you)",
+                                                "Long term business contract balances in line with UK Generally Accepted Accountancy Practice or International GAAP",
+                                                "All stocks owned; whether held by you or in transit in the UK or abroad",
+                                                "Duty for dutiable goods held out of bond",
+                                                "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes"
+                                            ]
+                                        },
+                                        {
+                                            "title": "Exclude"
+                                        },
+                                        {
+                                            "list": [
+                                                "VAT",
+                                                "Stocks you hold that do not belong to you",
+                                                "Duty on stocks held in bond",
+                                                "Products in intermediate stages of completion that do not belong to you"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": "Total value of stocks",
+                                    "content": [{
+                                            "title": "Include"
+                                        },
+                                        {
+                                            "list": [
+                                                "All stocks owned; whether held by your business in the UK or abroad",
+                                                "Duty for dutiable goods held out of bond",
+                                                "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes"
+                                            ]
+                                        },
+                                        {
+                                            "title": "Exclude"
+                                        },
+                                        {
+                                            "list": ["VAT", "Stocks you hold that do not belong to you", "Duty on stocks held in bond"]
+                                        }
+                                    ]
+                                }
+                            ]
                         },
                         "secondary_content": [{
                             "id": "secondary-content",
                             "title": "How we use your data",
                             "content": [{
-                                "list": ["The information supplied is used to estimate changes in stock levels which are used in the compilation of Gross Domestic Product (GDP), the total UK economic activity. GDP is used to measure the UK's financial health and prosperity over time and in comparison to other countries. The results are used by the Bank of England and HM Treasury to monitor interest rates, inflation and in formulating financial policies (e.g. income, expenditure and taxation) for the UK."]
+                                "list": ["The information supplied is used to estimate changes in stock levels which are used in the compilation of Gross Domestic Product (GDP), the total UK economic activity.", "GDP is used to measure the UK's financial health and prosperity over time and in comparison to other countries.", "The results are used by the Bank of England and HM Treasury to monitor interest rates, inflation and in formulating financial policies (e.g. income, expenditure and taxation) for the UK."]
                             }]
                         }]
                     },
@@ -526,9 +657,9 @@
                                         "value": "Change of business structure, merger or takeover"
                                     },
                                     {
-                                        "label": "One off increase in stocks",
+                                        "label": "One-off increase in stocks",
                                         "q_code": "146f",
-                                        "value": "One off increase in stocks"
+                                        "value": "One-off increase in stocks"
                                     },
                                     {
                                         "label": "Introduction or removal of new legislation or incentive",

--- a/data/en/stocks_0011.json
+++ b/data/en/stocks_0011.json
@@ -86,7 +86,7 @@
                             "id": "secondary-content",
                             "title": "How we use your data",
                             "content": [{
-                                "list": ["The information supplied is used to estimate changes in stock levels which are used in the compilation of Gross Domestic Product (GDP), the total UK economic activity. GDP is used to measure the UK's financial health and prosperity over time and in comparison to other countries. The results are used by the Bank of England and HM Treasury to monitor interest rates, inflation and in formulating financial policies (e.g. income, expenditure and taxation) for the UK."]
+                                "list": ["The information supplied is used to estimate changes in stock levels which are used in the compilation of Gross Domestic Product (GDP), the total UK economic activity.", "GDP is used to measure the UK's financial health and prosperity over time and in comparison to other countries.", "The results are used by the Bank of England and HM Treasury to monitor interest rates, inflation and in formulating financial policies (e.g. income, expenditure and taxation) for the UK."]
                             }]
                         }]
                     },
@@ -419,9 +419,9 @@
                                         "value": "Change of business structure, merger or takeover"
                                     },
                                     {
-                                        "label": "One off increase in stocks",
+                                        "label": "One-off increase in stocks",
                                         "q_code": "146f",
-                                        "value": "One off increase in stocks"
+                                        "value": "One-off increase in stocks"
                                     },
                                     {
                                         "label": "Introduction or removal of new legislation or incentive",

--- a/data/en/stocks_0012.json
+++ b/data/en/stocks_0012.json
@@ -86,7 +86,7 @@
                             "id": "secondary-content",
                             "title": "How we use your data",
                             "content": [{
-                                "list": ["The information supplied is used to estimate changes in stock levels which are used in the compilation of Gross Domestic Product (GDP), the total UK economic activity. GDP is used to measure the UK's financial health and prosperity over time and in comparison to other countries. The results are used by the Bank of England and HM Treasury to monitor interest rates, inflation and in formulating financial policies (e.g. income, expenditure and taxation) for the UK."]
+                                "list": ["The information supplied is used to estimate changes in stock levels which are used in the compilation of Gross Domestic Product (GDP), the total UK economic activity.", "GDP is used to measure the UK's financial health and prosperity over time and in comparison to other countries.", "The results are used by the Bank of England and HM Treasury to monitor interest rates, inflation and in formulating financial policies (e.g. income, expenditure and taxation) for the UK."]
                             }]
                         }]
                     },
@@ -419,9 +419,9 @@
                                         "value": "Change of business structure, merger or takeover"
                                     },
                                     {
-                                        "label": "One off increase in stocks",
+                                        "label": "One-off increase in stocks",
                                         "q_code": "146f",
-                                        "value": "One off increase in stocks"
+                                        "value": "One-off increase in stocks"
                                     },
                                     {
                                         "label": "Introduction or removal of new legislation or incentive",

--- a/data/en/stocks_0013.json
+++ b/data/en/stocks_0013.json
@@ -41,7 +41,7 @@
                                                 "Raw materials and components purchased for incorporation into products for sale",
                                                 "Consumable stores",
                                                 "Semi-processed goods",
-                                                "Office supplies (including stationery)and packaging materials",
+                                                "Office supplies (including stationery) and packaging materials",
                                                 "Duty for dutiable goods held out of bond",
                                                 "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes"
                                             ]
@@ -110,7 +110,7 @@
                             "id": "secondary-content",
                             "title": "How we use your data",
                             "content": [{
-                                "list": ["The information supplied is used to estimate changes in stock levels which are used in the compilation of Gross Domestic Product (GDP), the total UK economic activity. GDP is used to measure the UK's financial health and prosperity over time and in comparison to other countries. The results are used by the Bank of England and HM Treasury to monitor interest rates, inflation and in formulating financial policies (e.g. income, expenditure and taxation) for the UK."]
+                                "list": ["The information supplied is used to estimate changes in stock levels which are used in the compilation of Gross Domestic Product (GDP), the total UK economic activity.", "GDP is used to measure the UK's financial health and prosperity over time and in comparison to other countries.", "The results are used by the Bank of England and HM Treasury to monitor interest rates, inflation and in formulating financial policies (e.g. income, expenditure and taxation) for the UK."]
                             }]
                         }]
                     },
@@ -214,7 +214,7 @@
                                             "Raw materials and components purchased for incorporation into products for sale",
                                             "Consumable stores",
                                             "Semi-processed goods",
-                                            "Office supplies (including stationery)and packaging materials",
+                                            "Office supplies (including stationery) and packaging materials",
                                             "Duty for dutiable goods held out of bond",
                                             "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes"
                                         ]
@@ -492,9 +492,9 @@
                                         "value": "Change of business structure, merger or takeover"
                                     },
                                     {
-                                        "label": "One off increase in stocks",
+                                        "label": "One-off increase in stocks",
                                         "q_code": "146f",
-                                        "value": "One off increase in stocks"
+                                        "value": "One-off increase in stocks"
                                     },
                                     {
                                         "label": "Introduction or removal of new legislation or incentive",

--- a/data/en/stocks_0014.json
+++ b/data/en/stocks_0014.json
@@ -41,7 +41,7 @@
                                                 "Raw materials and components purchased for incorporation into products for sale",
                                                 "Consumable stores",
                                                 "Semi-processed goods",
-                                                "Office supplies (including stationery)and packaging materials",
+                                                "Office supplies (including stationery) and packaging materials",
                                                 "Duty for dutiable goods held out of bond",
                                                 "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes"
                                             ]
@@ -110,7 +110,7 @@
                             "id": "secondary-content",
                             "title": "How we use your data",
                             "content": [{
-                                "list": ["The information supplied is used to estimate changes in stock levels which are used in the compilation of Gross Domestic Product (GDP), the total UK economic activity. GDP is used to measure the UK's financial health and prosperity over time and in comparison to other countries. The results are used by the Bank of England and HM Treasury to monitor interest rates, inflation and in formulating financial policies (e.g. income, expenditure and taxation) for the UK."]
+                                "list": ["The information supplied is used to estimate changes in stock levels which are used in the compilation of Gross Domestic Product (GDP), the total UK economic activity.", "GDP is used to measure the UK's financial health and prosperity over time and in comparison to other countries.", "The results are used by the Bank of England and HM Treasury to monitor interest rates, inflation and in formulating financial policies (e.g. income, expenditure and taxation) for the UK."]
                             }]
                         }]
                     },
@@ -215,7 +215,7 @@
                                             "Raw materials and components purchased for incorporation into products for sale",
                                             "Consumable stores",
                                             "Semi-processed goods",
-                                            "Office supplies (including stationery)and packaging materials",
+                                            "Office supplies (including stationery) and packaging materials",
                                             "Duty for dutiable goods held out of bond",
                                             "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes"
                                         ]
@@ -493,9 +493,9 @@
                                         "value": "Change of business structure, merger or takeover"
                                     },
                                     {
-                                        "label": "One off increase in stocks",
+                                        "label": "One-off increase in stocks",
                                         "q_code": "146f",
-                                        "value": "One off increase in stocks"
+                                        "value": "One-off increase in stocks"
                                     },
                                     {
                                         "label": "Introduction or removal of new legislation or incentive",

--- a/data/en/stocks_0033.json
+++ b/data/en/stocks_0033.json
@@ -41,7 +41,7 @@
                                                 "Raw materials and components purchased for incorporation into products for sale",
                                                 "Consumable stores",
                                                 "Semi-processed goods",
-                                                "Office supplies (including stationery)and packaging materials",
+                                                "Office supplies (including stationery) and packaging materials",
                                                 "Duty for dutiable goods held out of bond",
                                                 "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes"
                                             ]
@@ -90,7 +90,7 @@
                             "id": "secondary-content",
                             "title": "How we use your data",
                             "content": [{
-                                "list": ["The information supplied is used to estimate changes in stock levels which are used in the compilation of Gross Domestic Product (GDP), the total UK economic activity. GDP is used to measure the UK's financial health and prosperity over time and in comparison to other countries. The results are used by the Bank of England and HM Treasury to monitor interest rates, inflation and in formulating financial policies (e.g. income, expenditure and taxation) for the UK."]
+                                "list": ["The information supplied is used to estimate changes in stock levels which are used in the compilation of Gross Domestic Product (GDP), the total UK economic activity.", "GDP is used to measure the UK's financial health and prosperity over time and in comparison to other countries.", "The results are used by the Bank of England and HM Treasury to monitor interest rates, inflation and in formulating financial policies (e.g. income, expenditure and taxation) for the UK."]
                             }]
                         }]
                     },
@@ -208,7 +208,7 @@
                                             "Raw materials and components purchased for incorporation into products for sale",
                                             "Consumable stores",
                                             "Semi-processed goods",
-                                            "Office supplies (including stationery)and packaging materials",
+                                            "Office supplies (including stationery) and packaging materials",
                                             "Duty for dutiable goods held out of bond",
                                             "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes"
                                         ]
@@ -367,7 +367,7 @@
                                             "Raw materials and components purchased for incorporation into products for sale",
                                             "Consumable stores",
                                             "Semi-processed goods",
-                                            "Office supplies (including stationery)and packaging materials",
+                                            "Office supplies (including stationery) and packaging materials",
                                             "Duty for dutiable goods held out of bond",
                                             "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes"
                                         ]
@@ -608,9 +608,9 @@
                                             "value": "Change of business structure, merger or takeover"
                                         },
                                         {
-                                            "label": "One off increase in stocks",
+                                            "label": "One-off increase in stocks",
                                             "q_code": "146f",
-                                            "value": "One off increase in stocks"
+                                            "value": "One-off increase in stocks"
                                         },
                                         {
                                             "label": "Introduction or removal of new legislation or incentive",

--- a/data/en/stocks_0034.json
+++ b/data/en/stocks_0034.json
@@ -41,7 +41,7 @@
                                                 "Raw materials and components purchased for incorporation into products for sale",
                                                 "Consumable stores",
                                                 "Semi-processed goods",
-                                                "Office supplies (including stationery)and packaging materials",
+                                                "Office supplies (including stationery) and packaging materials",
                                                 "Duty for dutiable goods held out of bond",
                                                 "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes"
                                             ]
@@ -90,7 +90,7 @@
                             "id": "secondary-content",
                             "title": "How we use your data",
                             "content": [{
-                                "list": ["The information supplied is used to estimate changes in stock levels which are used in the compilation of Gross Domestic Product (GDP), the total UK economic activity. GDP is used to measure the UK's financial health and prosperity over time and in comparison to other countries. The results are used by the Bank of England and HM Treasury to monitor interest rates, inflation and in formulating financial policies (e.g. income, expenditure and taxation) for the UK."]
+                                "list": ["The information supplied is used to estimate changes in stock levels which are used in the compilation of Gross Domestic Product (GDP), the total UK economic activity.", "GDP is used to measure the UK's financial health and prosperity over time and in comparison to other countries.", "The results are used by the Bank of England and HM Treasury to monitor interest rates, inflation and in formulating financial policies (e.g. income, expenditure and taxation) for the UK."]
                             }]
                         }]
                     },
@@ -208,7 +208,7 @@
                                             "Raw materials and components purchased for incorporation into products for sale",
                                             "Consumable stores",
                                             "Semi-processed goods",
-                                            "Office supplies (including stationery)and packaging materials",
+                                            "Office supplies (including stationery) and packaging materials",
                                             "Duty for dutiable goods held out of bond",
                                             "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes"
                                         ]
@@ -367,7 +367,7 @@
                                             "Raw materials and components purchased for incorporation into products for sale",
                                             "Consumable stores",
                                             "Semi-processed goods",
-                                            "Office supplies (including stationery)and packaging materials",
+                                            "Office supplies (including stationery) and packaging materials",
                                             "Duty for dutiable goods held out of bond",
                                             "The value of any goods let out on hire, only if they were charged to current account when acquired and do not rank as capital items for taxation purposes"
                                         ]
@@ -608,9 +608,9 @@
                                             "value": "Change of business structure, merger or takeover"
                                         },
                                         {
-                                            "label": "One off increase in stocks",
+                                            "label": "One-off increase in stocks",
                                             "q_code": "146f",
-                                            "value": "One off increase in stocks"
+                                            "value": "One-off increase in stocks"
                                         },
                                         {
                                             "label": "Introduction or removal of new legislation or incentive",

--- a/data/en/stocks_0051.json
+++ b/data/en/stocks_0051.json
@@ -56,7 +56,7 @@
                             "id": "secondary-content",
                             "title": "How we use your data",
                             "content": [{
-                                "list": ["The information supplied is used to estimate changes in stock levels which are used in the compilation of Gross Domestic Product (GDP), the total UK economic activity. GDP is used to measure the UK's financial health and prosperity over time and in comparison to other countries. The results are used by the Bank of England and HM Treasury to monitor interest rates, inflation and in formulating financial policies (e.g. income, expenditure and taxation) for the UK."]
+                                "list": ["The information supplied is used to estimate changes in stock levels which are used in the compilation of Gross Domestic Product (GDP), the total UK economic activity.", "GDP is used to measure the UK's financial health and prosperity over time and in comparison to other countries.", "The results are used by the Bank of England and HM Treasury to monitor interest rates, inflation and in formulating financial policies (e.g. income, expenditure and taxation) for the UK."]
                             }]
                         }]
                     },
@@ -297,9 +297,9 @@
                                         "value": "Change of business structure, merger or takeover"
                                     },
                                     {
-                                        "label": "One off increase in stocks",
+                                        "label": "One-off increase in stocks",
                                         "q_code": "146f",
-                                        "value": "One off increase in stocks"
+                                        "value": "One-off increase in stocks"
                                     },
                                     {
                                         "label": "Introduction or removal of new legislation or incentive",

--- a/data/en/stocks_0052.json
+++ b/data/en/stocks_0052.json
@@ -56,7 +56,7 @@
                             "id": "secondary-content",
                             "title": "How we use your data",
                             "content": [{
-                                "list": ["The information supplied is used to estimate changes in stock levels which are used in the compilation of Gross Domestic Product (GDP), the total UK economic activity. GDP is used to measure the UK's financial health and prosperity over time and in comparison to other countries. The results are used by the Bank of England and HM Treasury to monitor interest rates, inflation and in formulating financial policies (e.g. income, expenditure and taxation) for the UK."]
+                                "list": ["The information supplied is used to estimate changes in stock levels which are used in the compilation of Gross Domestic Product (GDP), the total UK economic activity.", "GDP is used to measure the UK's financial health and prosperity over time and in comparison to other countries.", "The results are used by the Bank of England and HM Treasury to monitor interest rates, inflation and in formulating financial policies (e.g. income, expenditure and taxation) for the UK."]
                             }]
                         }]
                     },
@@ -297,9 +297,9 @@
                                         "value": "Change of business structure, merger or takeover"
                                     },
                                     {
-                                        "label": "One off increase in stocks",
+                                        "label": "One-off increase in stocks",
                                         "q_code": "146f",
-                                        "value": "One off increase in stocks"
+                                        "value": "One-off increase in stocks"
                                     },
                                     {
                                         "label": "Introduction or removal of new legislation or incentive",

--- a/data/en/stocks_0057.json
+++ b/data/en/stocks_0057.json
@@ -106,7 +106,7 @@
                             "id": "secondary-content",
                             "title": "How we use your data",
                             "content": [{
-                                "list": ["The information supplied is used to estimate changes in stock levels which are used in the compilation of Gross Domestic Product (GDP), the total UK economic activity. GDP is used to measure the UK's financial health and prosperity over time and in comparison to other countries. The results are used by the Bank of England and HM Treasury to monitor interest rates, inflation and in formulating financial policies (e.g. income, expenditure and taxation) for the UK."]
+                                "list": ["The information supplied is used to estimate changes in stock levels which are used in the compilation of Gross Domestic Product (GDP), the total UK economic activity.", "GDP is used to measure the UK's financial health and prosperity over time and in comparison to other countries.", "The results are used by the Bank of England and HM Treasury to monitor interest rates, inflation and in formulating financial policies (e.g. income, expenditure and taxation) for the UK."]
                             }]
                         }]
                     },
@@ -500,9 +500,9 @@
                                         "value": "Change of business structure, merger or takeover"
                                     },
                                     {
-                                        "label": "One off increase in stocks",
+                                        "label": "One-off increase in stocks",
                                         "q_code": "146f",
-                                        "value": "One off increase in stocks"
+                                        "value": "One-off increase in stocks"
                                     },
                                     {
                                         "label": "Introduction or removal of new legislation or incentive",

--- a/data/en/stocks_0058.json
+++ b/data/en/stocks_0058.json
@@ -106,7 +106,7 @@
                             "id": "secondary-content",
                             "title": "How we use your data",
                             "content": [{
-                                "list": ["The information supplied is used to estimate changes in stock levels which are used in the compilation of Gross Domestic Product (GDP), the total UK economic activity. GDP is used to measure the UK's financial health and prosperity over time and in comparison to other countries. The results are used by the Bank of England and HM Treasury to monitor interest rates, inflation and in formulating financial policies (e.g. income, expenditure and taxation) for the UK."]
+                                "list": ["The information supplied is used to estimate changes in stock levels which are used in the compilation of Gross Domestic Product (GDP), the total UK economic activity.", "GDP is used to measure the UK's financial health and prosperity over time and in comparison to other countries.", "The results are used by the Bank of England and HM Treasury to monitor interest rates, inflation and in formulating financial policies (e.g. income, expenditure and taxation) for the UK."]
                             }]
                         }]
                     },
@@ -500,9 +500,9 @@
                                         "value": "Change of business structure, merger or takeover"
                                     },
                                     {
-                                        "label": "One off increase in stocks",
+                                        "label": "One-off increase in stocks",
                                         "q_code": "146f",
-                                        "value": "One off increase in stocks"
+                                        "value": "One-off increase in stocks"
                                     },
                                     {
                                         "label": "Introduction or removal of new legislation or incentive",

--- a/data/en/stocks_0061.json
+++ b/data/en/stocks_0061.json
@@ -55,7 +55,7 @@
                             "id": "secondary-content",
                             "title": "How we use your data",
                             "content": [{
-                                "list": ["The information supplied is used to estimate changes in stock levels which are used in the compilation of Gross Domestic Product (GDP), the total UK economic activity. GDP is used to measure the UK's financial health and prosperity over time and in comparison to other countries. The results are used by the Bank of England and HM Treasury to monitor interest rates, inflation and in formulating financial policies (e.g. income, expenditure and taxation) for the UK."]
+                                "list": ["The information supplied is used to estimate changes in stock levels which are used in the compilation of Gross Domestic Product (GDP), the total UK economic activity.", "GDP is used to measure the UK's financial health and prosperity over time and in comparison to other countries.", "The results are used by the Bank of England and HM Treasury to monitor interest rates, inflation and in formulating financial policies (e.g. income, expenditure and taxation) for the UK."]
                             }]
                         }]
                     },
@@ -224,7 +224,7 @@
                         "questions": [{
                             "id": "question4952",
                             "title": "Did any significant changes occur to the total value of stocks for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
-                            "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}{{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
+                            "description": "<p>Please note: what constitutes a &#x2018;significant change&#x2019; is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}&#x2019;s figures from the previous reporting period and the same reporting period last year.</p><p>This information will help us to validate your data and should reduce the need to query any figures with you.</p>",
                             "type": "General",
                             "answers": [{
                                 "id": "answer6287",
@@ -295,9 +295,9 @@
                                         "value": "Change of business structure, merger or takeover"
                                     },
                                     {
-                                        "label": "One off increase in stocks",
+                                        "label": "One-off increase in stocks",
                                         "q_code": "146f",
-                                        "value": "One off increase in stocks"
+                                        "value": "One-off increase in stocks"
                                     },
                                     {
                                         "label": "Introduction or removal of new legislation or incentive",

--- a/data/en/stocks_0070.json
+++ b/data/en/stocks_0070.json
@@ -56,7 +56,7 @@
                             "id": "secondary-content",
                             "title": "How we use your data",
                             "content": [{
-                                "list": ["The information supplied is used to estimate changes in stock levels which are used in the compilation of Gross Domestic Product (GDP), the total UK economic activity. GDP is used to measure the UK's financial health and prosperity over time and in comparison to other countries. The results are used by the Bank of England and HM Treasury to monitor interest rates, inflation and in formulating financial policies (e.g. income, expenditure and taxation) for the UK."]
+                                "list": ["The information supplied is used to estimate changes in stock levels which are used in the compilation of Gross Domestic Product (GDP), the total UK economic activity.", "GDP is used to measure the UK's financial health and prosperity over time and in comparison to other countries.", "The results are used by the Bank of England and HM Treasury to monitor interest rates, inflation and in formulating financial policies (e.g. income, expenditure and taxation) for the UK."]
                             }]
                         }]
                     },
@@ -304,9 +304,9 @@
                                         "value": "Change of business structure, merger or takeover"
                                     },
                                     {
-                                        "label": "One off increase in stocks",
+                                        "label": "One-off increase in stocks",
                                         "q_code": "146f",
-                                        "value": "One off increase in stocks"
+                                        "value": "One-off increase in stocks"
                                     },
                                     {
                                         "label": "Introduction or removal of new legislation or incentive",


### PR DESCRIPTION
### What is the context of this PR?
A number of stocks form types were missing whitespace between a closing parenthesis and the next word. This change fixes this in all known stocks form types.

### How to review 
Ensure content looks correct now.

