### PR TITLE
Updating routing rules for individual census.

### DIFF
--- a/data-source/jsonnet/common/lib/rules.libsonnet
+++ b/data-source/jsonnet/common/lib/rules.libsonnet
@@ -19,6 +19,56 @@
       },
     },
   },
+  over15: {
+    id: 'date-of-birth-answer',
+    condition: 'less than',
+    date_comparison: {
+      value: 'now',
+      offset_by: {
+        years: -15,
+      },
+    },
+  },
+  under5: {
+    id: 'date-of-birth-answer',
+    condition: 'greater than',
+    date_comparison: {
+      value: 'now',
+      offset_by: {
+        years: -5,
+      },
+    },
+  },
+  under4: {
+    id: 'date-of-birth-answer',
+    condition: 'greater than',
+    date_comparison: {
+      value: 'now',
+      offset_by: {
+        years: -4,
+      },
+    },
+  },
+  under3: {
+    id: 'date-of-birth-answer',
+    condition: 'greater than',
+    date_comparison: {
+      value: 'now',
+      offset_by: {
+        years: -3,
+      },
+    },
+  },
+  under1: {
+    id: 'date-of-birth-answer',
+    condition: 'greater than',
+    date_comparison: {
+      value: 'now',
+      offset_by: {
+        years: -1,
+      },
+    },
+  },
   mainJob: {
     id: 'employment-status-answer-exclusive',
     condition: 'not set',

--- a/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/arrive_in_country.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/arrive_in_country.jsonnet
@@ -79,6 +79,14 @@ function(region_code, census_date) {
     },
     {
       goto: {
+        block: 'national-identity',
+        when: [
+          rules.under3,
+        ],
+      },
+    },
+    {
+      goto: {
         block: if region_code == 'GB-WLS' then 'understand-welsh' else 'language',
       },
     },

--- a/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/country_of_birth.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/country_of_birth.jsonnet
@@ -135,6 +135,19 @@ function(region_code) {
     },
     {
       goto: {
+        block: 'national-identity',
+        when: [
+          {
+            id: 'country-of-birth-answer',
+            condition: 'equals any',
+            values: ['Wales', 'England', 'Scotland', 'Northern Ireland'],
+          },
+          rules.under3,
+        ],
+      },
+    },
+    {
+      goto: {
         block: if region_code == 'GB-WLS' then 'understand-welsh' else 'language',
       },
     },

--- a/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/disability.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/disability.jsonnet
@@ -82,6 +82,19 @@ local proxyDefinitionContent = [
     },
     {
       goto: {
+        group: 'comments-group',
+        when: [
+          {
+            id: 'disability-answer',
+            condition: 'equals',
+            value: 'No',
+          },
+          rules.under5,
+        ],
+      },
+    },
+    {
+      goto: {
         block: 'carer',
       },
     },

--- a/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/disability_limitation.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/disability_limitation.jsonnet
@@ -84,4 +84,19 @@ local proxyDefinition = {
       when: [rules.proxyYes],
     },
   ],
+  routing_rules: [
+    {
+      goto: {
+        group: 'comments-group',
+        when: [
+          rules.under5,
+        ],
+      },
+    },
+    {
+      goto: {
+        block: 'carer',
+      },
+    },
+  ],
 }

--- a/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/length_of_stay.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/length_of_stay.jsonnet
@@ -49,6 +49,14 @@ function(region_code) {
   routing_rules: [
     {
       goto: {
+        block: 'national-identity',
+        when: [
+          rules.under3,
+        ],
+      },
+    },
+    {
+      goto: {
         block: if region_code == 'GB-WLS' then 'understand-welsh' else 'language',
       },
     },

--- a/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/religion.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/religion.jsonnet
@@ -83,4 +83,19 @@ function(region_code) {
       when: [rules.proxyYes],
     },
   ],
+  routing_rules: [
+    {
+      goto: {
+        block: 'passports',
+        when: [
+          rules.under1,
+        ],
+      },
+    },
+    {
+      goto: {
+        block: 'past-usual-household-address',
+      },
+    },
+  ],
 }

--- a/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/when_arrive_in_uk.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/when_arrive_in_uk.jsonnet
@@ -67,6 +67,19 @@ function(region_code, census_date) {
     },
     {
       goto: {
+        block: 'national-identity',
+        when: [
+          {
+            id: 'when-arrive-in-uk-answer',
+            condition: 'equals',
+            value: 'No',
+          },
+          rules.under3,
+        ],
+      },
+    },
+    {
+      goto: {
         block: if region_code == 'GB-WLS' then 'understand-welsh' else 'language',
       },
     },

--- a/data-source/jsonnet/england-wales/blocks/individual/personal-details/address_type.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/personal-details/address_type.jsonnet
@@ -115,4 +115,19 @@ local proxyNonUkAddressTitle = {
       when: [rules.proxyYes],
     },
   ],
+  routing_rules: [
+    {
+      goto: {
+        group: 'identity-and-health-group',
+        when: [
+          rules.under4,
+        ],
+      },
+    },
+    {
+      goto: {
+        block: 'in-education',
+      },
+    },
+  ],
 }

--- a/data-source/jsonnet/england-wales/blocks/individual/personal-details/another_address.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/personal-details/another_address.jsonnet
@@ -69,6 +69,19 @@ local proxyTitle = {
   routing_rules: [
     {
       goto: {
+        group: 'identity-and-health-group',
+        when: [
+          {
+            id: 'another-address-answer',
+            condition: 'equals',
+            value: 'No',
+          },
+          rules.under4,
+        ],
+      },
+    },
+    {
+      goto: {
         block: 'in-education',
         when: [
           {

--- a/data-source/jsonnet/england-wales/blocks/individual/personal-details/sex.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/personal-details/sex.jsonnet
@@ -47,13 +47,13 @@ local guidance = {
       question: question(nonProxyTitle) + {
         guidance: guidance,
       },
-      when: [rules.proxyNo, rules.over16],
+      when: [rules.proxyNo, rules.over15],
     },
     {
       question: question(proxyTitle) + {
         guidance: guidance,
       },
-      when: [rules.proxyYes, rules.over16],
+      when: [rules.proxyYes, rules.over15],
     },
     {
       question: question(nonProxyTitle),
@@ -69,7 +69,7 @@ local guidance = {
       goto: {
         block: 'marriage-type',
         when: [
-          rules.over16,
+          rules.over15,
         ],
       },
     },


### PR DESCRIPTION
### What is the context of this PR?
Adding new routing rules for the individual census (ENG/WLS). 

Summary of the changes:
1. Routing age 15 years and under past the Marital status questions (currently 16 & under)
2. Routing age 4 years and under past the Education questions
3. Routing age 3 years and under past the Language questions
4. Routing a child under 1 year past the Address one year ago question
5. Routing age 4 and under past the Caring questions

### How to review 
Build the schema and test to ensure that the new routing rules are correct. A more detailed list of the routing changes can be found here: [Trello](https://trello.com/c/TEvX8a4Z/2974-routing-individual-census-eng-wls-m)
