### PR TITLE
Fixes for guidance and question definitions.

### DIFF
--- a/data-source/jsonnet/common/blocks/individual/employment/employment_status.jsonnet
+++ b/data-source/jsonnet/common/blocks/individual/employment/employment_status.jsonnet
@@ -9,7 +9,7 @@ local question(title) = {
   guidance: {
     contents: [
       {
-        title: 'Include casual or temporary work, even if only for one hour',
+        description: 'Include casual or temporary work, even if only for one hour',
       },
     ],
   },

--- a/data-source/jsonnet/common/blocks/individual/employment/hours_worked.jsonnet
+++ b/data-source/jsonnet/common/blocks/individual/employment/hours_worked.jsonnet
@@ -7,7 +7,7 @@ local question(title) = {
   guidance: {
     contents: [
       {
-        title: 'Include paid and unpaid overtime',
+        description: 'Include paid and unpaid overtime',
       },
     ],
   },

--- a/data-source/jsonnet/common/blocks/individual/personal-details/date_of_birth.jsonnet
+++ b/data-source/jsonnet/common/blocks/individual/personal-details/date_of_birth.jsonnet
@@ -5,9 +5,9 @@ local question(title, census_date) = {
   id: 'date-of-birth-question',
   title: title,
   guidance: {
-    content: [
+    contents: [
       {
-        title: 'For example 31 12 1970',
+        description: 'For example 31 12 1970',
       },
     ],
   },

--- a/data-source/jsonnet/england-wales/blocks/individual/employment/armed_forces.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/employment/armed_forces.jsonnet
@@ -7,7 +7,7 @@ local question(title) = {
   guidance: {
     contents: [
       {
-        title: 'Current serving members should select “No”',
+        description: 'Current serving members should select “No”',
       },
     ],
   },

--- a/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/carer.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/carer.jsonnet
@@ -7,7 +7,7 @@ local question(title, guidance) = {
   guidance: {
     contents: [
       {
-        title: guidance,
+        description: guidance,
       },
     ],
   },

--- a/data-source/jsonnet/england-wales/blocks/individual/personal-details/sex.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/personal-details/sex.jsonnet
@@ -34,7 +34,7 @@ local proxyTitle = {
 local guidance = {
   contents: [
     {
-      title: 'A question about gender will follow',
+      description: 'A question about gender will follow',
     },
   ],
 };

--- a/data-source/jsonnet/england-wales/blocks/individual/qualifications/a_level.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/qualifications/a_level.jsonnet
@@ -26,7 +26,7 @@ local question(title, region_code) = (
     guidance: {
       contents: [
         {
-          title: regionGuidanceTitle,
+          description: regionGuidanceTitle,
         },
       ],
     },

--- a/data-source/jsonnet/england-wales/blocks/individual/qualifications/apprenticeship.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/qualifications/apprenticeship.jsonnet
@@ -24,7 +24,7 @@ local question(title, region_code) = (
     guidance: {
       contents: [
         {
-          title: regionGuidanceTitle,
+          description: regionGuidanceTitle,
         },
       ],
     },

--- a/data-source/jsonnet/england-wales/blocks/individual/qualifications/degree.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/qualifications/degree.jsonnet
@@ -21,7 +21,7 @@ local question(title, region_code) = (
     guidance: {
       contents: [
         {
-          title: regionGuidanceTitle,
+          description: regionGuidanceTitle,
         },
       ],
     },

--- a/data-source/jsonnet/england-wales/blocks/individual/qualifications/gcse.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/qualifications/gcse.jsonnet
@@ -34,7 +34,7 @@ local question(title, region_code) = (
     guidance: {
       contents: [
         {
-          title: regionGuidanceTitle,
+          description: regionGuidanceTitle,
         },
       ],
     },

--- a/data-source/jsonnet/england-wales/blocks/individual/qualifications/nvq_level.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/qualifications/nvq_level.jsonnet
@@ -21,7 +21,7 @@ local question(title, region_code) = (
     guidance: {
       contents: [
         {
-          title: regionGuidanceTitle,
+          description: regionGuidanceTitle,
         },
       ],
     },

--- a/data-source/jsonnet/northern-ireland/blocks/individual/employment/armed_forces.jsonnet
+++ b/data-source/jsonnet/northern-ireland/blocks/individual/employment/armed_forces.jsonnet
@@ -7,7 +7,7 @@ local question(title) = {
   guidance: {
     contents: [
       {
-        title: 'Current serving members should only select “No”',
+        description: 'Current serving members should only select “No”',
       },
     ],
   },

--- a/data-source/jsonnet/northern-ireland/blocks/individual/identity-and-health/carer.jsonnet
+++ b/data-source/jsonnet/northern-ireland/blocks/individual/identity-and-health/carer.jsonnet
@@ -5,9 +5,9 @@ local question(title, guidance) = {
   id: 'carer-question',
   title: title,
   guidance: {
-    content: [
+    contents: [
       {
-        title: guidance,
+        description: guidance,
       },
     ],
   },

--- a/data-source/jsonnet/northern-ireland/blocks/individual/identity-and-health/disability_limitation.jsonnet
+++ b/data-source/jsonnet/northern-ireland/blocks/individual/identity-and-health/disability_limitation.jsonnet
@@ -7,7 +7,7 @@ local question(title) = {
   guidance: {
     contents: [
       {
-        title: 'Include problems relating to old age',
+        description: 'Include problems relating to old age',
       },
     ],
   },

--- a/data-source/jsonnet/northern-ireland/blocks/individual/qualifications/a_level.jsonnet
+++ b/data-source/jsonnet/northern-ireland/blocks/individual/qualifications/a_level.jsonnet
@@ -15,7 +15,7 @@ local question(title) = {
   guidance: {
     contents: [
       {
-        title: 'Include equivalent qualifications achieved anywhere outside Northern Ireland',
+        description: 'Include equivalent qualifications achieved anywhere outside Northern Ireland',
       },
     ],
   },

--- a/data-source/jsonnet/northern-ireland/blocks/individual/qualifications/apprenticeship.jsonnet
+++ b/data-source/jsonnet/northern-ireland/blocks/individual/qualifications/apprenticeship.jsonnet
@@ -16,7 +16,7 @@ local question(title) = {
   guidance: {
     contents: [
       {
-        title: 'Include equivalent apprenticeships completed anywhere outside Northern Ireland',
+        description: 'Include equivalent apprenticeships completed anywhere outside Northern Ireland',
       },
     ],
   },

--- a/data-source/jsonnet/northern-ireland/blocks/individual/qualifications/degree.jsonnet
+++ b/data-source/jsonnet/northern-ireland/blocks/individual/qualifications/degree.jsonnet
@@ -16,7 +16,7 @@ local question(title) = {
   guidance: {
     contents: [
       {
-        title: 'Include equivalent qualifications achieved anywhere outside Northern Ireland',
+        description: 'Include equivalent qualifications achieved anywhere outside Northern Ireland',
       },
     ],
   },

--- a/data-source/jsonnet/northern-ireland/blocks/individual/qualifications/gcse.jsonnet
+++ b/data-source/jsonnet/northern-ireland/blocks/individual/qualifications/gcse.jsonnet
@@ -17,7 +17,7 @@ local question(title) = {
   guidance: {
     contents: [
       {
-        title: 'Include equivalent qualifications achieved anywhere outside Northern Ireland',
+        description: 'Include equivalent qualifications achieved anywhere outside Northern Ireland',
       },
     ],
   },

--- a/data-source/jsonnet/northern-ireland/blocks/individual/qualifications/nvq_level.jsonnet
+++ b/data-source/jsonnet/northern-ireland/blocks/individual/qualifications/nvq_level.jsonnet
@@ -16,7 +16,7 @@ local question(title) = {
   guidance: {
     contents: [
       {
-        title: 'Include equivalent qualifications achieved anywhere outside Northern Ireland',
+        description: 'Include equivalent qualifications achieved anywhere outside Northern Ireland',
       },
     ],
   },

--- a/data-source/jsonnet/northern-ireland/blocks/individual/school/school_travel_mode.jsonnet
+++ b/data-source/jsonnet/northern-ireland/blocks/individual/school/school_travel_mode.jsonnet
@@ -5,9 +5,9 @@ local question(title, guidance) = {
   id: 'school-travel-mode-question',
   title: title,
   guidance: {
-    content: [
+    contents: [
       {
-        title: guidance,
+        description: guidance,
       },
     ],
   },

--- a/templates/multiple_survey.html
+++ b/templates/multiple_survey.html
@@ -7,7 +7,7 @@
   <h1>{{ _("Information") }}</h1>
 
   {% call onsPanel({
-    "type": "error"
+    "type": "error",
     "spacious": true,
     "attributes": {
       "data-qa": "multiple-survey-error"

--- a/templates/partials/question-definition.html
+++ b/templates/partials/question-definition.html
@@ -1,7 +1,6 @@
 {% from "components/details/_macro.njk" import onsDetails %}
 
 {% for definition in question.definitions %}
-  {% set content_block = definition %}
   {% call onsDetails({
       "title": definition.title,
       "classes": "u-mt-s u-mb-s",
@@ -21,6 +20,7 @@
         }
       }
   }) %}
-    {% include 'partials/content-block.html' %}
+    {% set contents = definition.contents %}
+    {% include 'partials/contents.html' %}
   {% endcall %}
 {% endfor %}


### PR DESCRIPTION
### What is the context of this PR?
Will noticed a few issues around guidance and interstitials yesterday, these included strong text in question guidance and h2s instead of h1s on interstitial pages.

I have changed all usages of title inside guidance to `description`. I think this makes sense and matches up with how we've used description elsewhere.

Additionally, question guidance wasn't working correctly after https://github.com/ONSdigital/eq-survey-runner/pull/2091. Question definitions were showing a double title. This should fix that issue. 

### How to review 
Double check that the census schema works correctly, paying particular attention to any content types like guidance or interstitials.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
