### PR TITLE
Remove managed certificate override in deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ EQ_KEYS_FILE=dev-keys.yml EQ_SECRETS_FILE=dev-secrets.yml ./k8s/deploy_credentia
 To deploy the app to the cluster, run the following command:
 
 ```
-./k8s/deploy_app.sh <SUBMISSION_BUCKET_NAME> [<DOCKER_REGISTRY>] [<IMAGE_TAG>] [<MANAGED_CERTIFICATE_NAME>]
+./k8s/deploy_app.sh <SUBMISSION_BUCKET_NAME> [<DOCKER_REGISTRY>] [<IMAGE_TAG>]
 ```
 
 For example:

--- a/k8s/deploy_app.sh
+++ b/k8s/deploy_app.sh
@@ -10,7 +10,6 @@ fi
 SUBMISSION_BUCKET_NAME=$1
 DOCKER_REGISTRY="${2:-eu.gcr.io/census-eq-ci}"
 IMAGE_TAG="${3:-latest}"
-MANAGED_CERTIFICATE_NAME="${4:-}"
 
 helm tiller run \
     helm upgrade --install \
@@ -19,4 +18,3 @@ helm tiller run \
     --set submissionBucket=${SUBMISSION_BUCKET_NAME} \
     --set image.repository=${DOCKER_REGISTRY}/eq-survey-runner \
     --set image.tag=${IMAGE_TAG} \
-    --set ingress.managedCertificateName=${MANAGED_CERTIFICATE_NAME}


### PR DESCRIPTION
### What is the context of this PR?
The managed certificate name was still being overridden in the k8s deploy script. It has been hardcoded, and shouldn't be set in that script.
