### PR TITLE
Fixing question variants for the sex question

### DIFF
--- a/data-source/jsonnet/common/lib/rules.libsonnet
+++ b/data-source/jsonnet/common/lib/rules.libsonnet
@@ -21,7 +21,7 @@
   },
   over15: {
     id: 'date-of-birth-answer',
-    condition: 'less than',
+    condition: 'less than or equal to',
     date_comparison: {
       value: 'now',
       offset_by: {

--- a/data-source/jsonnet/england-wales/blocks/individual/personal-details/sex.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/personal-details/sex.jsonnet
@@ -47,13 +47,13 @@ local guidance = {
       question: question(nonProxyTitle) + {
         guidance: guidance,
       },
-      when: [rules.proxyNo, rules.over15],
+      when: [rules.proxyNo, rules.over16],
     },
     {
       question: question(proxyTitle) + {
         guidance: guidance,
       },
-      when: [rules.proxyYes, rules.over15],
+      when: [rules.proxyYes, rules.over16],
     },
     {
       question: question(nonProxyTitle),


### PR DESCRIPTION
### What is the context of this PR?
Need to revert a recent change [PR](https://github.com/ONSdigital/eq-survey-runner/pull/2117) to question variant rules for the sex question. 

### How to review 
Test the schema to ensure that the question guidance for the sex question is only being displayed when the individual is aged 16 years or older.

