### PR TITLE
Remove error block from summary page template

### DIFF
--- a/templates/summary.html
+++ b/templates/summary.html
@@ -11,13 +11,6 @@
     <h1>{{ _("Check your answers and submit") }}</h1>
 
     {% call onsPanel({
-      "type": "error",
-      "classes": "print__message u-mb-l"
-    }) %}
-      <h2>{{ _("Please remember to submit these answers") }}.</h2>
-    {% endcall %}
-
-    {% call onsPanel({
       "classes": "print__hidden u-mb-l"
     }) %}
       <strong>{{ _("Please submit this survey to complete it") }}</strong>


### PR DESCRIPTION
### What is the context of this PR?
Removed redundant/misleading error block from the summary page template.

### How to review 
Run through any census individual schema (or anyone that uses the summary template as a block), and check the error block is now gone, leaving just a blue info block.
