### PR TITLE
Updating the default path for unanswered voluntary questions

### DIFF
--- a/data-source/jsonnet/common/blocks/individual/employment/business_name.jsonnet
+++ b/data-source/jsonnet/common/blocks/individual/employment/business_name.jsonnet
@@ -6,7 +6,7 @@ local question(title, description, option) = {
   title: title,
   description: description,
   type: 'MutuallyExclusive',
-  mandatory: true,
+  mandatory: false,
   answers: [
     {
       id: 'business-name-answer',

--- a/data-source/jsonnet/common/blocks/individual/employment/employer_address_depot.jsonnet
+++ b/data-source/jsonnet/common/blocks/individual/employment/employer_address_depot.jsonnet
@@ -9,7 +9,7 @@ local question(title) = {
     {
       id: 'employer-address-depot-answer-building',
       label: 'Building',
-      mandatory: true,
+      mandatory: false,
       type: 'TextField',
     },
     {

--- a/data-source/jsonnet/common/blocks/individual/employment/employer_address_workplace.jsonnet
+++ b/data-source/jsonnet/common/blocks/individual/employment/employer_address_workplace.jsonnet
@@ -9,7 +9,7 @@ local question(title) = {
     {
       id: 'employer-address-workplace-answer-building',
       label: 'Building',
-      mandatory: true,
+      mandatory: false,
       type: 'TextField',
     },
     {

--- a/data-source/jsonnet/common/blocks/individual/employment/employment_type.jsonnet
+++ b/data-source/jsonnet/common/blocks/individual/employment/employment_type.jsonnet
@@ -8,7 +8,7 @@ local question(title) = {
   answers: [
     {
       id: 'employment-type-answer',
-      mandatory: true,
+      mandatory: false,
       options: [
         {
           label: 'Retired',

--- a/data-source/jsonnet/common/blocks/individual/employment/hours_worked.jsonnet
+++ b/data-source/jsonnet/common/blocks/individual/employment/hours_worked.jsonnet
@@ -15,7 +15,7 @@ local question(title) = {
   answers: [
     {
       id: 'hours-worked-answer',
-      mandatory: true,
+      mandatory: false,
       options: [
         {
           label: '0 to 15 hours',

--- a/data-source/jsonnet/common/blocks/individual/employment/job_availability.jsonnet
+++ b/data-source/jsonnet/common/blocks/individual/employment/job_availability.jsonnet
@@ -8,7 +8,7 @@ local question(title) = {
   answers: [
     {
       id: 'job-availability-answer',
-      mandatory: true,
+      mandatory: false,
       options: [
         {
           label: 'Yes',

--- a/data-source/jsonnet/common/blocks/individual/employment/job_description.jsonnet
+++ b/data-source/jsonnet/common/blocks/individual/employment/job_description.jsonnet
@@ -9,7 +9,7 @@ local question(title) = {
     {
       id: 'job-description-answer',
       label: 'Description',
-      mandatory: true,
+      mandatory: false,
       type: 'TextField',
     },
   ],

--- a/data-source/jsonnet/common/blocks/individual/employment/job_pending.jsonnet
+++ b/data-source/jsonnet/common/blocks/individual/employment/job_pending.jsonnet
@@ -8,7 +8,7 @@ local question(title) = {
   answers: [
     {
       id: 'job-pending-answer',
-      mandatory: true,
+      mandatory: false,
       options: [
         {
           label: 'Yes',

--- a/data-source/jsonnet/common/blocks/individual/employment/job_title.jsonnet
+++ b/data-source/jsonnet/common/blocks/individual/employment/job_title.jsonnet
@@ -9,7 +9,7 @@ local question(title) = {
     {
       id: 'job-title-answer',
       label: 'Job title',
-      mandatory: true,
+      mandatory: false,
       type: 'TextField',
     },
   ],

--- a/data-source/jsonnet/common/blocks/individual/employment/jobseeker.jsonnet
+++ b/data-source/jsonnet/common/blocks/individual/employment/jobseeker.jsonnet
@@ -17,7 +17,7 @@ local question(title, guidanceHeader) = {
         ],
       },
       id: 'jobseeker-answer',
-      mandatory: true,
+      mandatory: false,
       options: [
         {
           label: 'Yes',
@@ -59,19 +59,19 @@ local proxyGuidanceHeader = 'Why do I need to answer if they have retired or are
   routing_rules: [
     {
       goto: {
-        block: 'job-availability',
+        block: 'job-pending',
         when: [
           {
             id: 'jobseeker-answer',
             condition: 'equals',
-            value: 'Yes',
+            value: 'No',
           },
         ],
       },
     },
     {
       goto: {
-        block: 'job-pending',
+        block: 'job-availability',
       },
     },
   ],

--- a/data-source/jsonnet/common/blocks/individual/employment/main_job_type.jsonnet
+++ b/data-source/jsonnet/common/blocks/individual/employment/main_job_type.jsonnet
@@ -8,7 +8,7 @@ local question(title) = {
   answers: [
     {
       id: 'main-job-type-answer',
-      mandatory: true,
+      mandatory: false,
       options: [
         {
           label: 'Employee',

--- a/data-source/jsonnet/common/blocks/individual/employment/supervise.jsonnet
+++ b/data-source/jsonnet/common/blocks/individual/employment/supervise.jsonnet
@@ -8,7 +8,7 @@ local question(title) = {
   answers: [
     {
       id: 'supervise-answer',
-      mandatory: true,
+      mandatory: false,
       options: [
         {
           label: 'Yes',

--- a/data-source/jsonnet/common/blocks/individual/employment/work_travel.jsonnet
+++ b/data-source/jsonnet/common/blocks/individual/employment/work_travel.jsonnet
@@ -9,7 +9,7 @@ local question(title, description) = {
   answers: [
     {
       id: 'work-travel-answer',
-      mandatory: true,
+      mandatory: false,
       options: [
         {
           label: 'Work mainly at or from home',

--- a/data-source/jsonnet/common/blocks/individual/identity-and-health/health.jsonnet
+++ b/data-source/jsonnet/common/blocks/individual/identity-and-health/health.jsonnet
@@ -8,7 +8,7 @@ local question(title) = {
   answers: [
     {
       id: 'health-answer',
-      mandatory: true,
+      mandatory: false,
       options: [
         {
           label: 'Very good',

--- a/data-source/jsonnet/common/blocks/individual/identity-and-health/last_year_address.jsonnet
+++ b/data-source/jsonnet/common/blocks/individual/identity-and-health/last_year_address.jsonnet
@@ -9,7 +9,7 @@ local question(title) = {
     {
       id: 'last-year-address-answer-building',
       label: 'House name or number',
-      mandatory: true,
+      mandatory: false,
       type: 'TextField',
     },
     {

--- a/data-source/jsonnet/common/blocks/individual/identity-and-health/passports.jsonnet
+++ b/data-source/jsonnet/common/blocks/individual/identity-and-health/passports.jsonnet
@@ -6,7 +6,7 @@ local question(title, label, definitionContent) = {
   title: title,
   description: '',
   type: 'MutuallyExclusive',
-  mandatory: true,
+  mandatory: false,
   definitions: [
     {
       title: 'What official documents can be included?',

--- a/data-source/jsonnet/common/blocks/individual/identity-and-health/speak_english.jsonnet
+++ b/data-source/jsonnet/common/blocks/individual/identity-and-health/speak_english.jsonnet
@@ -8,7 +8,7 @@ local question(title) = {
   answers: [
     {
       id: 'english-answer',
-      mandatory: true,
+      mandatory: false,
       options: [
         {
           label: 'Very well',

--- a/data-source/jsonnet/common/blocks/individual/personal-details/accommodation_type.jsonnet
+++ b/data-source/jsonnet/common/blocks/individual/personal-details/accommodation_type.jsonnet
@@ -15,7 +15,7 @@ local placeholders = import '../../../lib/placeholders.libsonnet';
     answers: [
       {
         id: 'accommodation-type-answer',
-        mandatory: true,
+        mandatory: false,
         options: [
           {
             label: 'A communal establishment',

--- a/data-source/jsonnet/common/blocks/individual/personal-details/establishment_position.jsonnet
+++ b/data-source/jsonnet/common/blocks/individual/personal-details/establishment_position.jsonnet
@@ -18,7 +18,7 @@ local question(title) = {
   answers: [
     {
       id: 'establishment-position-answer',
-      mandatory: true,
+      mandatory: false,
       options: [
         {
           label: 'Resident',

--- a/data-source/jsonnet/common/blocks/individual/personal-details/name.jsonnet
+++ b/data-source/jsonnet/common/blocks/individual/personal-details/name.jsonnet
@@ -79,6 +79,17 @@ local proxyTitle = 'What is their name?';
     },
     {
       goto: {
+        block: 'date-of-birth',
+        when: [
+          {
+            id: 'accommodation-type-answer',
+            condition: 'not set',
+          },
+        ],
+      },
+    },
+    {
+      goto: {
         block: 'establishment-position',
       },
     },

--- a/data-source/jsonnet/england-wales/blocks/individual/employment/armed_forces.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/employment/armed_forces.jsonnet
@@ -15,7 +15,7 @@ local question(title) = {
   answers: [
     {
       id: 'armed-forces-answer',
-      mandatory: true,
+      mandatory: false,
       guidance: {
         show_guidance: 'Why your answer is important',
         hide_guidance: 'Why your answer is important',

--- a/data-source/jsonnet/england-wales/blocks/individual/employment/employer_type_of_address.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/employment/employer_type_of_address.jsonnet
@@ -8,7 +8,7 @@ local question(title) = {
   answers: [
     {
       id: 'employer-type-of-address-answer',
-      mandatory: true,
+      mandatory: false,
       options: [
         {
           label: 'At a workplace',
@@ -78,6 +78,17 @@ local proxyTitle = {
             id: 'employer-type-of-address-answer',
             condition: 'equals',
             value: 'Report to a depot',
+          },
+        ],
+      },
+    },
+    {
+      goto: {
+        block: 'employer-address-workplace',
+        when: [
+          {
+            id: 'employer-type-of-address-answer',
+            condition: 'not set',
           },
         ],
       },

--- a/data-source/jsonnet/england-wales/blocks/individual/employment/employers_business.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/employment/employers_business.jsonnet
@@ -31,7 +31,7 @@ local question(title, region_code) = (
       {
         id: 'employers-business-answer',
         label: 'Description',
-        mandatory: true,
+        mandatory: false,
         type: 'TextField',
       },
     ],

--- a/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/arrive_in_country.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/arrive_in_country.jsonnet
@@ -9,7 +9,7 @@ local question(title) = {
   answers: [
     {
       id: 'arrive-in-country-answer',
-      mandatory: true,
+      mandatory: false,
       type: 'MonthYearDate',
       minimum: {
         answer_id: 'date-of-birth-answer',
@@ -88,6 +88,23 @@ function(region_code, census_date) {
     {
       goto: {
         block: if region_code == 'GB-WLS' then 'understand-welsh' else 'language',
+        when: [
+          {
+            id: 'arrive-in-country-answer',
+            condition: 'less than',
+            date_comparison: {
+              value: census_date,
+              offset_by: {
+                years: -1,
+              },
+            },
+          },
+        ],
+      },
+    },
+    {
+      goto: {
+        block: 'when-arrive-in-uk',
       },
     },
   ],

--- a/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/carer.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/carer.jsonnet
@@ -15,7 +15,7 @@ local question(title, guidance) = {
   answers: [
     {
       id: 'carer-answer',
-      mandatory: true,
+      mandatory: false,
       options: [
         {
           label: 'No',

--- a/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/disability.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/disability.jsonnet
@@ -14,7 +14,7 @@ local question(title, definitionContent) = {
   answers: [
     {
       id: 'disability-answer',
-      mandatory: true,
+      mandatory: false,
       options: [
         {
           label: 'Yes',

--- a/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/disability_limitation.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/disability_limitation.jsonnet
@@ -9,7 +9,7 @@ local question(title, definition) = {
   answers: [
     {
       id: 'disability-limitation-answer',
-      mandatory: true,
+      mandatory: false,
       options: [
         {
           label: 'Yes, a lot',

--- a/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/ethnic_group.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/ethnic_group.jsonnet
@@ -34,7 +34,7 @@ local question(title, region_code) = (
           ],
         },
         id: 'ethnic-group-answer',
-        mandatory: true,
+        mandatory: false,
         options: [
           {
             label: 'White',

--- a/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/ethnic_group_asian.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/ethnic_group_asian.jsonnet
@@ -21,7 +21,7 @@ local question(title) = {
         ],
       },
       id: 'asian-ethnic-group-answer',
-      mandatory: true,
+      mandatory: false,
       options: [
         {
           label: 'Indian',

--- a/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/ethnic_group_black.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/ethnic_group_black.jsonnet
@@ -21,7 +21,7 @@ local question(title) = {
         ],
       },
       id: 'black-ethnic-group-answer',
-      mandatory: true,
+      mandatory: false,
       options: [
         {
           label: 'Caribbean',

--- a/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/ethnic_group_mixed.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/ethnic_group_mixed.jsonnet
@@ -21,7 +21,7 @@ local question(title) = {
         ],
       },
       id: 'mixed-ethnic-group-answer',
-      mandatory: true,
+      mandatory: false,
       options: [
         {
           label: 'White and Black Caribbean',

--- a/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/ethnic_group_other.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/ethnic_group_other.jsonnet
@@ -21,7 +21,7 @@ local question(title) = {
         ],
       },
       id: 'other-ethnic-group-answer',
-      mandatory: true,
+      mandatory: false,
       options: [
         {
           label: 'Arab',

--- a/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/ethnic_group_white.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/ethnic_group_white.jsonnet
@@ -34,7 +34,7 @@ local question(title, region_code) = (
           ],
         },
         id: 'white-ethnic-group-answer',
-        mandatory: true,
+        mandatory: false,
         options: [
           {
             label: radioOptions,

--- a/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/language.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/language.jsonnet
@@ -39,7 +39,7 @@ local question(title, definitionDescription, region_code) = (
     answers: [
       {
         id: 'language-answer',
-        mandatory: true,
+        mandatory: false,
         type: 'Radio',
         options: [
           regionOption,

--- a/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/length_of_stay.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/length_of_stay.jsonnet
@@ -8,7 +8,7 @@ local question(title) = {
   answers: [
     {
       id: 'length-of-stay-answer',
-      mandatory: true,
+      mandatory: false,
       options: [
         {
           label: 'Less than 12 months',

--- a/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/national_identity.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/national_identity.jsonnet
@@ -67,7 +67,7 @@ local question(title, definitionContent, detailAnswerLabel, region_code) = (
     answers: [
       {
         id: 'national-identity-answer',
-        mandatory: true,
+        mandatory: false,
         type: 'Checkbox',
         options: regionOptions + [
           {

--- a/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/past_usual_household_address.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/past_usual_household_address.jsonnet
@@ -9,7 +9,7 @@ local question(title, description) = {
   answers: [
     {
       id: 'past-usual-address-household-answer',
-      mandatory: true,
+      mandatory: false,
       options: [
         {
           label: {

--- a/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/understand_welsh.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/understand_welsh.jsonnet
@@ -4,7 +4,7 @@ local rules = import '../../../../common/lib/rules.libsonnet';
 local question(title) = {
   id: 'understand-welsh-question',
   title: title,
-  mandatory: true,
+  mandatory: false,
   type: 'MutuallyExclusive',
   answers: [
     {

--- a/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/when_arrive_in_uk.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/identity-and-health/when_arrive_in_uk.jsonnet
@@ -8,7 +8,7 @@ local question(title) = {
   answers: [
     {
       id: 'when-arrive-in-uk-answer',
-      mandatory: true,
+      mandatory: false,
       options: [
         {
           label: 'Yes',
@@ -81,6 +81,18 @@ function(region_code, census_date) {
     {
       goto: {
         block: if region_code == 'GB-WLS' then 'understand-welsh' else 'language',
+        when: [
+          {
+            id: 'when-arrive-in-uk-answer',
+            condition: 'equals',
+            value: 'No',
+          },
+        ],
+      },
+    },
+    {
+      goto: {
+        block: 'length-of-stay',
       },
     },
   ],

--- a/data-source/jsonnet/england-wales/blocks/individual/personal-details/address_type.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/personal-details/address_type.jsonnet
@@ -8,7 +8,7 @@ local question(title) = {
   answers: [
     {
       id: 'address-type-answer',
-      mandatory: true,
+      mandatory: false,
       options: [
         {
           label: 'Armed forces base address',

--- a/data-source/jsonnet/england-wales/blocks/individual/personal-details/another_address.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/personal-details/another_address.jsonnet
@@ -19,7 +19,7 @@ local question(title) = {
   answers: [
     {
       id: 'another-address-answer',
-      mandatory: true,
+      mandatory: false,
       options: [
         {
           label: 'No',
@@ -107,6 +107,18 @@ local proxyTitle = {
     {
       goto: {
         block: 'address-type',
+        when: [
+          {
+            id: 'another-address-answer',
+            condition: 'equals',
+            value: 'Other',
+          },
+        ],
+      },
+    },
+    {
+      goto: {
+        block: 'in-education',
       },
     },
   ],

--- a/data-source/jsonnet/england-wales/blocks/individual/personal-details/current_marriage_status.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/personal-details/current_marriage_status.jsonnet
@@ -8,7 +8,7 @@ local question(title) = {
   answers: [
     {
       id: 'current-marriage-status-answer',
-      mandatory: true,
+      mandatory: false,
       options: [
         {
           label: 'Someone of the opposite sex',

--- a/data-source/jsonnet/england-wales/blocks/individual/personal-details/current_partnership_status.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/personal-details/current_partnership_status.jsonnet
@@ -8,7 +8,7 @@ local question(title) = {
   answers: [
     {
       id: 'current-partnership-status-answer',
-      mandatory: true,
+      mandatory: false,
       options: [
         {
           label: 'Someone of the opposite sex',

--- a/data-source/jsonnet/england-wales/blocks/individual/personal-details/marriage_type.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/personal-details/marriage_type.jsonnet
@@ -8,7 +8,7 @@ local question(title) = {
   answers: [
     {
       id: 'marriage-type-answer',
-      mandatory: true,
+      mandatory: false,
       options: [
         {
           label: 'Never married and never registered a civil partnership',

--- a/data-source/jsonnet/england-wales/blocks/individual/personal-details/previous_marriage_status.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/personal-details/previous_marriage_status.jsonnet
@@ -8,7 +8,7 @@ local question(title) = {
   answers: [
     {
       id: 'previous-marriage-status-answer',
-      mandatory: true,
+      mandatory: false,
       options: [
         {
           label: 'Someone of the opposite sex',

--- a/data-source/jsonnet/england-wales/blocks/individual/personal-details/previous_partnership_status.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/personal-details/previous_partnership_status.jsonnet
@@ -8,7 +8,7 @@ local question(title) = {
   answers: [
     {
       id: 'previous-partnership-status-answer',
-      mandatory: true,
+      mandatory: false,
       options: [
         {
           label: 'Someone of the opposite sex',

--- a/data-source/jsonnet/england-wales/blocks/individual/personal-details/sex.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/personal-details/sex.jsonnet
@@ -8,7 +8,7 @@ local question(title) = {
   answers: [
     {
       id: 'sex-answer',
-      mandatory: true,
+      mandatory: false,
       options: [
         {
           label: 'Female',

--- a/data-source/jsonnet/england-wales/blocks/individual/personal-details/term_time_address_country.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/personal-details/term_time_address_country.jsonnet
@@ -8,7 +8,7 @@
     answers: [
       {
         id: 'term-time-address-country-answer',
-        mandatory: true,
+        mandatory: false,
         options: [
           {
             label: 'Yes',
@@ -45,6 +45,18 @@
     {
       goto: {
         group: 'comments-group',
+        when: [
+          {
+            id: 'term-time-address-country-answer',
+            condition: 'equals',
+            value: 'No',
+          },
+        ],
+      },
+    },
+    {
+      goto: {
+        group: 'identity-and-health-group',
       },
     },
   ],

--- a/data-source/jsonnet/england-wales/blocks/individual/personal-details/term_time_address_details.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/personal-details/term_time_address_details.jsonnet
@@ -9,7 +9,7 @@ local question(title) = {
     {
       id: 'term-time-address-details-answer-building',
       label: 'House name or number',
-      mandatory: true,
+      mandatory: false,
       type: 'TextField',
     },
     {

--- a/data-source/jsonnet/england-wales/blocks/individual/qualifications/a_level.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/qualifications/a_level.jsonnet
@@ -31,7 +31,7 @@ local question(title, region_code) = (
       ],
     },
     type: 'MutuallyExclusive',
-    mandatory: true,
+    mandatory: false,
     answers: [
       {
         id: 'a-level-answer',

--- a/data-source/jsonnet/england-wales/blocks/individual/qualifications/apprenticeship.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/qualifications/apprenticeship.jsonnet
@@ -31,7 +31,7 @@ local question(title, region_code) = (
     answers: [
       {
         id: 'apprenticeship-answer',
-        mandatory: true,
+        mandatory: false,
         options: [
           {
             label: 'Yes',

--- a/data-source/jsonnet/england-wales/blocks/individual/qualifications/degree.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/qualifications/degree.jsonnet
@@ -28,7 +28,7 @@ local question(title, region_code) = (
     answers: [
       {
         id: 'degree-answer',
-        mandatory: true,
+        mandatory: false,
         type: 'Radio',
         options: [
           {

--- a/data-source/jsonnet/england-wales/blocks/individual/qualifications/gcse.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/qualifications/gcse.jsonnet
@@ -30,7 +30,7 @@ local question(title, region_code) = (
     id: 'gcse-question',
     title: title,
     type: 'MutuallyExclusive',
-    mandatory: true,
+    mandatory: false,
     guidance: {
       contents: [
         {
@@ -92,27 +92,12 @@ function(region_code) {
   routing_rules: [
     {
       goto: {
-        block: 'other-qualifications',
+        group: 'employment-group',
         when: [
           {
             id: 'degree-answer',
             condition: 'equals',
-            value: 'No',
-          },
-          {
-            id: 'gcse-answer-exclusive',
-            condition: 'contains',
-            value: 'None of these apply',
-          },
-          {
-            id: 'a-level-answer-exclusive',
-            condition: 'contains',
-            value: 'None of these apply',
-          },
-          {
-            id: 'nvq-level-answer-exclusive',
-            condition: 'contains',
-            value: 'None of these apply',
+            value: 'Yes',
           },
         ],
       },
@@ -120,6 +105,39 @@ function(region_code) {
     {
       goto: {
         group: 'employment-group',
+        when: [
+          {
+            id: 'gcse-answer',
+            condition: 'set',
+          },
+        ],
+      },
+    },
+    {
+      goto: {
+        group: 'employment-group',
+        when: [
+          {
+            id: 'a-level-answer',
+            condition: 'set',
+          },
+        ],
+      },
+    },
+    {
+      goto: {
+        group: 'employment-group',
+        when: [
+          {
+            id: 'nvq-level-answer',
+            condition: 'set',
+          },
+        ],
+      },
+    },
+    {
+      goto: {
+        block: 'other-qualifications',
       },
     },
   ],

--- a/data-source/jsonnet/england-wales/blocks/individual/qualifications/nvq_level.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/qualifications/nvq_level.jsonnet
@@ -25,7 +25,7 @@ local question(title, region_code) = (
         },
       ],
     },
-    mandatory: true,
+    mandatory: false,
     answers: [
       {
         id: 'nvq-level-answer',

--- a/data-source/jsonnet/england-wales/blocks/individual/qualifications/other_qualifications.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/individual/qualifications/other_qualifications.jsonnet
@@ -37,7 +37,7 @@ local question(title, region_code) = (
     id: 'other-qualifications-question',
     title: title,
     type: 'MutuallyExclusive',
-    mandatory: true,
+    mandatory: false,
     answers: [
       {
         id: 'other-qualifications-answer',


### PR DESCRIPTION
### What is the context of this PR?
We need to change the validation and build the default path for unanswered voluntary questions (currently for England and Wales only).

### How to review 
Build and Test the schema changes.

Check that unanswered voluntary questions route correctly through the survey. 
The correct path for unanswered questions is described in column E of the spreadsheet attached to the Trello Card [(here)](https://trello.com/c/qG5xkN0j/3033-voluntary-questions-and-default-path-eng-wls-m).