### PR TITLE
Fix untranslated dates in transform / schema

### DIFF
--- a/app/questionnaire/placeholder_transforms.py
+++ b/app/questionnaire/placeholder_transforms.py
@@ -3,9 +3,8 @@ from datetime import datetime
 from dateutil.relativedelta import relativedelta
 from dateutil.tz import tzutc
 
-from babel.numbers import format_currency
+from babel.numbers import format_currency, format_decimal
 from babel.dates import format_datetime
-from babel import numbers
 
 from app.settings import DEFAULT_LOCALE
 
@@ -17,8 +16,8 @@ class PlaceholderTransforms:
 
     def __init__(self, language):
         self.language = language
+        self.locale = DEFAULT_LOCALE if language == 'en' else language
 
-    locale = DEFAULT_LOCALE
     input_date_format = '%Y-%m-%d'
     input_date_format_month_year_only = '%Y-%m'
 
@@ -75,10 +74,9 @@ class PlaceholderTransforms:
 
         return string_to_format
 
-    @staticmethod
-    def format_number(number):
+    def format_number(self, number):
         if number or number == 0:
-            return numbers.format_decimal(number, locale=PlaceholderTransforms.locale)
+            return format_decimal(number, locale=self.locale)
 
         return ''
 


### PR DESCRIPTION
### What is the context of this PR?
Date placeholders- i.e. the census date -are currently showing up with English month names ("June") instead of Welsh ("Mehefin") regardless of chosen UI language.

Changed date_formatter locale from current locale to language based. This is fed in from the URL and not currently validated? Should we be changing the locale instead?

### How to review 
* Get to at least the marriage-type question to see a piped date that includes the month by name, and switch languages using the link in the header.

* Try manually changing URL to a different language, such as "de" and observe the month change to Juli. Try "xx".