### PR TITLE
Add GTM blacklist

### DIFF
--- a/app/templates/layouts/_base.html
+++ b/app/templates/layouts/_base.html
@@ -49,7 +49,7 @@
     <!-- Google Tag Manager -->
     {% if analytics_gtm_id and analytics_gtm_env_id %}
       <script>
-        dataLayer = [];
+        dataLayer = [{'gtm.blacklist': ['customScripts' , 'html']}];
       </script>
       <script nonce="{{ csp_nonce() }}">(function(w,d,s,l,i,e){w['GoogleTagManagerObject']=l;w[l]=w[l]||[];w[l].push({'gtm.start':
       new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],


### PR DESCRIPTION
### What is the context of this PR?
This adds the blacklist to the DataLayer object which will lockdown the injecting of any JS into the app but will still allow the use of Google Tag Manager

### How to review 
Make sure changes make sense and GTM still works locally by inspecting the page, making sure the tags are rendered and checking preview window displays
