### PR TITLE
Default survey claim to census

### DIFF
--- a/app/storage/metadata_parser.py
+++ b/app/storage/metadata_parser.py
@@ -88,7 +88,7 @@ class RunnerMetadataSchema(Schema, StripWhitespaceMixin):
 
     # The following three parameters can be removed after Census
     survey = VALIDATORS['string'](
-        required=False, validate=validate.OneOf(('CENSUS', 'CCS'))
+        required=False, validate=validate.OneOf(('CENSUS', 'CCS')), missing='CENSUS'
     )
     case_type = VALIDATORS['string'](
         required=False, validate=validate.OneOf(('HH', 'HI', 'CE', 'CI'))

--- a/tests/app/parser/test_metadata_parser.py
+++ b/tests/app/parser/test_metadata_parser.py
@@ -173,10 +173,17 @@ def test_region_code_is_lower_cased_and_underscored(test_input, expected):
 
 
 def test_survey_parameter_defaults_to_census(fake_census_metadata_runner):
+    del fake_census_metadata_runner['survey']
     claims = validate_runner_claims(fake_census_metadata_runner)
-    del claims['survey']
 
     assert claims['schema_name'] == 'census_individual_gb_eng'
+
+
+def test_survey_parameter_allows_ccs(fake_census_metadata_runner):
+    fake_census_metadata_runner['survey'] = 'CCS'
+    claims = validate_runner_claims(fake_census_metadata_runner)
+
+    assert claims['schema_name'] == 'ccs_individual_gb_eng'
 
 
 def test_bad_survey_parameter(fake_census_metadata_runner):


### PR DESCRIPTION
### What is the context of this PR?
The survey claim is meant to default to 'CENSUS' if not provided. The test I added for this in https://github.com/ONSdigital/eq-survey-runner/pull/2139 was broken, and survey wasn't actually being defaulted.

This change ensures it is actually defaulted and fixes the test.
