### PR TITLE
copy individual schema to household during build_schemas

### DIFF
--- a/scripts/build_schemas.sh
+++ b/scripts/build_schemas.sh
@@ -23,4 +23,13 @@ done
 mkdir -p data/en
 mv data-source/jsonnet/*.json data/en
 cp data-source/json/*.json data/en
+
 echo "Moved newly built schemas to 'data/en' dir"
+
+# Until household is delivered, temporarily create household schema as copies of the individual schema
+cp data/en/census_individual_gb_wls.json data/en/census_household_gb_wls.json
+cp data/en/census_individual_gb_eng.json data/en/census_household_gb_eng.json
+cp data/en/census_individual_gb_nir.json data/en/census_household_gb_nir.json
+cp data/cy/census_individual_gb_wls.json data/cy/census_household_gb_wls.json
+
+echo "Created temporary household schema based on individual schema in 'data' dir"


### PR DESCRIPTION
As RM/RH doesn't yet support the launching of HI cases, it has been agreed that HH case launches will launch the same question set as is defined in the HI schema (until eQ deliver the household schema). Although this is what has been happening to date in WL/BL, the recent change to remove eq_id and form_type means that RH will now (correctly) try and launch census_household_gb_eng (etc).

While RH could include the schema_name claim to override the schema being launched, this is a code change that they shouldn't need to accommodate.

This PR simply makes a copy of the "individual" schema naming them as "household" so that HH launches continue to resolve to an existent schema.

To test: ensure census_household_gb_[ eng | wls | nir ] are presented as schema options in launcher. Additionally, test a launch and submission of a "household" schema (successfully tested). 