### PR TITLE
Ability to remove 'Select all that apply' from checkbox answers

### DIFF
--- a/data-source/json/test_checkbox.json
+++ b/data-source/json/test_checkbox.json
@@ -85,7 +85,6 @@
                 "question": {
                     "answers": [{
                         "id": "non-mandatory-checkbox-answer",
-                        "label": "",
                         "mandatory": false,
                         "options": [{
                             "label": "None",

--- a/templates/partials/answers/checkbox.html
+++ b/templates/partials/answers/checkbox.html
@@ -2,7 +2,7 @@
 
 {{ onsCheckboxes({
   "id": answer["id"],
-  "checkboxesLabel": _("Select all that apply"),
+  "checkboxesLabel": '' if answer.label == '' else answer.label or _("Select all that apply"),
   "checkboxes": map_checkbox_config(form, answer),
   "mutuallyExclusive": mutuallyExclusive
 }) }}

--- a/tests/functional/spec/checkbox.spec.js
+++ b/tests/functional/spec/checkbox.spec.js
@@ -8,6 +8,22 @@ describe('Checkbox with "other" option', function() {
 
   const checkbox_schema = 'test_checkbox.json';
 
+  it('Given a label has not been provided in the schema for a checkbox answer, When the checkbox answer is displayed, Then the label should be not visible', function() {
+    return helpers.openQuestionnaire(checkbox_schema).then(() => {
+      return browser
+        .getText('body').should.not.eventually.have.string('Select all that apply');
+    });
+  });
+
+  it('Given a label has been set in the schema for a checkbox answer, When the checkbox answer is displayed, Then the label "Select all that apply" should be visible', function() {
+    return helpers.openQuestionnaire(checkbox_schema).then(() => {
+      return browser
+        .click(MandatoryCheckboxPage.none())
+        .click(MandatoryCheckboxPage.submit())
+        .getText('body').should.eventually.have.string('Select all that apply');
+    });
+  });
+
   it('Given an "other" option is available, when the user clicks the "other" option the other input should be visible.', function() {
     return helpers.openQuestionnaire(checkbox_schema).then(() => {
       return browser


### PR DESCRIPTION
### What is the context of this PR?
Census requires the ability to remove the `Select all that apply` from Checkbox answers, this PR allows that behavior by providing an empty string: Feel free to suggest if you have any better ideas of achieving this, the goal was to not introduce any new schema changes etc.

Previously the label defined in the schemas were ignored since it was hard coded to `Select all that apply`.

### How to review 
1. Ensure `Select all that apply` is not displayed when the answer label is `""`.
2. Ensure `Select all that apply` is displayed when the answer label doesn't exist or is not `""`