### PR TITLE
Update urllib3 dependency.

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -532,11 +532,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
-                "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
+                "sha256:4c291ca23bbb55c76518905869ef34bdd5f0e46af7afe6861e8375643ffee1a0",
+                "sha256:9a247273df709c4fedb38c711e44292304f73f39ab01beda9f6b9fc375669ac3"
             ],
             "markers": "python_version >= '3.4'",
-            "version": "==1.24.1"
+            "version": "==1.24.2"
         },
         "werkzeug": {
             "hashes": [


### PR DESCRIPTION
### What is the context of this PR?
This change upgrades the dependency to a later version patched for a security vulnerability.
See https://nvd.nist.gov/vuln/detail/CVE-2019-11324

### How to review 
Change looks sensible.
All tests and checks should pass.
