### PR TITLE
Upgrade to a newer version of sqlalchemy.

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -510,9 +510,10 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:c30925d60af95443458ebd7525daf791f55762b106049ae71e18f8dd58084c2f"
+                "sha256:11ead7047ff3f394ed0d4b62aded6c5d970a9b718e1dc6add9f5e79442cc5b14",
+                "sha256:8394d9a06247974190680c7ebe5023e4d7cc5e76ac5bcee25fcd8133fe34dfd2"
             ],
-            "version": "==1.3.5"
+            "version": "==1.3.0"
         },
         "structlog": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -510,9 +510,9 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:6af3ca2f7f00844465ab4fa78337d487b39e53f516c51328aed4ed3a719d4264"
+                "sha256:c30925d60af95443458ebd7525daf791f55762b106049ae71e18f8dd58084c2f"
             ],
-            "version": "==1.2.16"
+            "version": "==1.3.5"
         },
         "structlog": {
             "hashes": [


### PR DESCRIPTION
### What is the context of this PR?
Github highlighted a moderately severe security vulnerability in the version of sqlalchemy  dependency. This change updates sqlalchemy to the lates patched version.
See https://nvd.nist.gov/vuln/detail/CVE-2019-7164 and https://nvd.nist.gov/vuln/detail/CVE-2019-7548.

### How to review 
Changes look sensible. All checks and tests should pass.
Worth testing survey runner survey runner without dynamo to ensure communication with postgres is working as expected.
