### PR TITLE
Pass tx_id to GA via GTM.

### DIFF
--- a/app/templates/layouts/_base.html
+++ b/app/templates/layouts/_base.html
@@ -50,6 +50,11 @@
     {% if analytics_gtm_id and analytics_gtm_env_id %}
       <script>
         dataLayer = [{'gtm.blacklist': ['customScripts' , 'html']}];
+        {%  if metadata and metadata.tx_id %}
+          dataLayer.push({
+            'txId': {{  metadata.tx_id }}
+          });
+        {%- endif %}
       </script>
       <script nonce="{{ csp_nonce() }}">(function(w,d,s,l,i,e){w['GoogleTagManagerObject']=l;w[l]=w[l]||[];w[l].push({'gtm.start':
       new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],


### PR DESCRIPTION
### What is the context of this PR?
This change is being made to help troubleshoot session timeout issues that happen periodically within EQ. This will help to tie up analytics information with logs on the backend when session timeout issues are reported.

It was agreed at today's IA meeting that the `tx_id` is acceptable to use in this case since there is no direct link between the `tx_id` and a respondent.

### How to review 
All tests and checks should pass.
Changes being made look sensible.
When deployed to an environment where GTM is enabled we should observe that the `txId` tag should be populated with the `tx_id`.
When the session is ended e.g. by logging out, then we should observe that the `txId` tag is no longer present.