### PR TITLE
Use jinja for creating mutually exclusive checkbox

### DIFF
--- a/data-source/json/test_mutually_exclusive.json
+++ b/data-source/json/test_mutually_exclusive.json
@@ -16,9 +16,6 @@
         "name": "ru_name",
         "type": "string"
     }],
-    "navigation": {
-        "visible": true
-    },
     "sections": [{
         "id": "mutually-exclusive-checkbox-section",
         "title": "Checkbox",

--- a/templates/partials/question.html
+++ b/templates/partials/question.html
@@ -33,8 +33,6 @@
 {% set question_answers %}
   {% if mutually_exclusive_question %}
     {%- set answer = question.answers[0] -%}
-    {%- set mutuallyExclusiveAnswer = question.answers[1] -%}
-    {%- set mutuallyExlusiveOption = mutuallyExclusiveAnswer.options[0] -%}
 
     {%- set deselectionMessage = _("Selecting this will clear your answer") -%}
     {%- set deselectGroupAdjective = _("cleared") -%}
@@ -46,16 +44,7 @@
 
     {%- set mutuallyExclusive = {
       "or": _("Or"),
-      "checkbox": {
-        "id": mutuallyExclusiveAnswer.id + "-0",
-        "label": {
-          "text": mutuallyExlusiveOption.label,
-          "description": mutuallyExlusiveOption.description
-        },
-        "value": mutuallyExlusiveOption.value,
-        "name": mutuallyExclusiveAnswer.id,
-        "checked": mutuallyExlusiveOption.checked
-      },
+      "checkbox": map_checkbox_config(form, question.answers[-1])[0],
       "deselectionMessage": deselectionMessage,
       "deselectGroupAdjective": deselectGroupAdjective,
       "deselectCheckboxAdjective": _("deselected"),

--- a/tests/functional/spec/components/checkbox/mutually_exclusive/mutually_exclusive_checkbox.spec.js
+++ b/tests/functional/spec/components/checkbox/mutually_exclusive/mutually_exclusive_checkbox.spec.js
@@ -54,7 +54,7 @@ describe('Component: Mutually Exclusive Checkbox With Single Checkbox Override',
         .click(SummaryPage.previous())
 
         // Then
-        .isSelected(MandatoryCheckboxPage.checkboxExclusiveIPreferNotToSay()).should.eventually.be.true
+        .isSelected(MandatoryCheckboxPage.checkboxExclusiveIPreferNotToSay()).should.eventually.be.true;
     });
   });
 

--- a/tests/functional/spec/components/checkbox/mutually_exclusive/mutually_exclusive_checkbox.spec.js
+++ b/tests/functional/spec/components/checkbox/mutually_exclusive/mutually_exclusive_checkbox.spec.js
@@ -42,6 +42,22 @@ describe('Component: Mutually Exclusive Checkbox With Single Checkbox Override',
     });
   });
 
+  describe('Given the user has clicked the mutually exclusive "other" option', function() {
+    it('When the user returns to the question, Then the mutually exclusive other option should remain checked.', function() {
+
+      return browser
+        // Given
+        .click(MandatoryCheckboxPage.checkboxExclusiveIPreferNotToSay())
+        .click(MandatoryCheckboxPage.submit())
+
+        // When
+        .click(SummaryPage.previous())
+
+        // Then
+        .isSelected(MandatoryCheckboxPage.checkboxExclusiveIPreferNotToSay()).should.eventually.be.true
+    });
+  });
+
   describe('Given the user has clicked the mutually exclusive option', function() {
     it('When the user clicks the non-exclusive options, Then only the non-exclusive options should be checked.', function() {
 


### PR DESCRIPTION
### What is the context of this PR?

The "other" answer for mutually exclusive questions is not being shown as checked when it has been selected and returned to in a questionnaire. It is being correctly stored as its value shows on summary pages.

Textbox "other" values are not populated for text "other" options due to a pattern library bug tracked separately here: https://trello.com/c/dRlbxVr9/3126-defect-other-write-in-answers-not-displayed.

### How to review 

Use the test_mutually_exclusive schema to select the other option, submit and return to the question and ensure it remains checked.

