### PR TITLE
Replace slashes in branch name for docker tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ cache:
 script:
     - set -e
     - yarn compile
-    - export TAG=`if [ "$TRAVIS_PULL_REQUEST_BRANCH" == "" ]; then echo "latest"; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi`
+    - export TAG=`if [ "$TRAVIS_PULL_REQUEST_BRANCH" == "" ]; then echo "latest"; else echo branch-$(echo $TRAVIS_PULL_REQUEST_BRANCH | sed s:/:-:g); fi`
     - docker build -t onsdigital/eq-survey-runner:$TAG -f Dockerfile .
     - docker build -t onsdigital/eq-survey-runner-static:$TAG -f Dockerfile.static .
     - pipenv run ./scripts/run.sh


### PR DESCRIPTION
### What is the context of this PR?
Since the dependabot PRs are not being built, this replaces slashes in the branch name with -.

It also prepends `branch` to the tag.
