### PR TITLE
Rename 'populates_list' to 'for_list'

### DIFF
--- a/app/submitter/convert_payload_0_0_3.py
+++ b/app/submitter/convert_payload_0_0_3.py
@@ -64,7 +64,7 @@ def add_list_collector_answers(
         answers_ids_in_add_block = schema.get_answer_ids_for_list_items(
             list_collector_block['id']
         )
-        list_name = list_collector_block['populates_list']
+        list_name = list_collector_block['for_list']
         list_item_ids = list_store[list_name].items
 
         for list_item_id in list_item_ids:

--- a/app/templating/view_context.py
+++ b/app/templating/view_context.py
@@ -94,7 +94,7 @@ def build_view_context_for_list_collector(
 ):
     question_context = build_view_context_for_question(rendered_block, form)
 
-    list_name = rendered_block['populates_list']
+    list_name = rendered_block['for_list']
     list_item_ids = list_store[list_name].items
 
     list_title_answer_ids = [
@@ -141,7 +141,7 @@ def build_view_context_for_list_collector(
         'list_items': list_items,
         'add_link': url_for(
             'questionnaire.get_block',
-            list_name=rendered_block['populates_list'],
+            list_name=rendered_block['for_list'],
             block_id=rendered_block['id'],
         ),
     }

--- a/app/views/questionnaire.py
+++ b/app/views/questionnaire.py
@@ -361,7 +361,7 @@ def _validate_list_collector_child_location(
     block = schema.get_block(current_location.block_id)
     parent_block = schema.get_list_collector_for_block_id(current_location.block_id)
 
-    if list_name != parent_block['populates_list']:
+    if list_name != parent_block['for_list']:
         logger.info(
             f'Mismatched list_name: {list_name} and block_id: {current_location.block_id}'
         )
@@ -557,7 +557,7 @@ def perform_list_action(
             questionnaire_store_updater.save()
             add_url = url_for(
                 'questionnaire.get_block',
-                list_name=rendered_block['populates_list'],
+                list_name=rendered_block['for_list'],
                 block_id=rendered_block['add_block']['id'],
             )
             return add_url
@@ -568,7 +568,7 @@ def perform_list_action(
             form.data[parent_block['remove_answer']['id']]
             == parent_block['remove_answer']['value']
         ):
-            list_name = parent_block['populates_list']
+            list_name = parent_block['for_list']
             questionnaire_store_updater.remove_list_item_and_answers(
                 list_name, list_item_id
             )
@@ -577,7 +577,7 @@ def perform_list_action(
 
     if block['type'] == 'ListAddQuestion':
         questionnaire_store_updater.add_list_item_and_answers(
-            form, parent_block['populates_list']
+            form, parent_block['for_list']
         )
     if block['type'] == 'ListEditQuestion':
         questionnaire_store_updater.update_answers(form)
@@ -596,7 +596,7 @@ def handle_primary_person_action(
     schema, router, routing_path, form, block, questionnaire_store_updater
 ):
     if block['type'] == 'PrimaryPersonListCollector':
-        list_name = block['populates_list']
+        list_name = block['for_list']
 
         if (
             form.data[block['add_or_edit_answer']['id']]
@@ -612,7 +612,7 @@ def handle_primary_person_action(
 
             add_or_edit_url = url_for(
                 'questionnaire.get_block',
-                list_name=block['populates_list'],
+                list_name=block['for_list'],
                 block_id=block['add_or_edit_block']['id'],
                 list_item_id=primary_person_id,
             )

--- a/data-source/json/test_list_collector.json
+++ b/data-source/json/test_list_collector.json
@@ -31,7 +31,7 @@
                         {
                             "id": "list-collector",
                             "type": "ListCollector",
-                            "populates_list": "people",
+                            "for_list": "people",
                             "add_answer": {
                                 "id": "anyone-else",
                                 "value": "Yes"
@@ -156,7 +156,7 @@
                         {
                             "id": "another-list-collector-block",
                             "type": "ListCollector",
-                            "populates_list": "people",
+                            "for_list": "people",
                             "add_answer": {
                                 "id": "another-anyone-else",
                                 "value": "Yes"

--- a/data-source/json/test_list_collector_primary_person.json
+++ b/data-source/json/test_list_collector_primary_person.json
@@ -24,7 +24,7 @@
             "blocks": [{
                     "id": "primary-person-list-collector",
                     "type": "PrimaryPersonListCollector",
-                    "populates_list": "people",
+                    "for_list": "people",
                     "add_or_edit_answer": {
                         "id": "you-live-here",
                         "value": "Yes"
@@ -73,7 +73,7 @@
                 }, {
                     "id": "list-collector",
                     "type": "ListCollector",
-                    "populates_list": "people",
+                    "for_list": "people",
                     "add_answer": {
                         "id": "anyone-else",
                         "value": "Yes"

--- a/data-source/json/test_list_collector_variants.json
+++ b/data-source/json/test_list_collector_variants.json
@@ -57,7 +57,7 @@
                         {
                             "id": "list-collector",
                             "type": "ListCollector",
-                            "populates_list": "people",
+                            "for_list": "people",
                             "add_answer": {
                                 "id": "anyone-else",
                                 "value": "Yes"

--- a/data-source/json/test_list_collector_variants_primary_person.json
+++ b/data-source/json/test_list_collector_variants_primary_person.json
@@ -50,7 +50,7 @@
                 {
                     "id": "primary-person-list-collector",
                     "type": "PrimaryPersonListCollector",
-                    "populates_list": "people",
+                    "for_list": "people",
                     "add_or_edit_answer": {
                         "id": "you-live-here",
                         "value": "Yes"
@@ -167,7 +167,7 @@
                 {
                     "id": "list-collector",
                     "type": "ListCollector",
-                    "populates_list": "people",
+                    "for_list": "people",
                     "add_answer": {
                         "id": "anyone-else",
                         "value": "Yes"

--- a/data-source/json/test_relationships.json
+++ b/data-source/json/test_relationships.json
@@ -28,7 +28,7 @@
             "blocks": [{
                     "id": "list-collector",
                     "type": "ListCollector",
-                    "populates_list": "people",
+                    "for_list": "people",
                     "add_answer": {
                         "id": "anyone-else",
                         "value": "Yes"

--- a/data-source/json/test_skip_condition_list.json
+++ b/data-source/json/test_skip_condition_list.json
@@ -31,7 +31,7 @@
                         {
                             "id": "list-collector",
                             "type": "ListCollector",
-                            "populates_list": "people",
+                            "for_list": "people",
                             "add_answer": {
                                 "id": "anyone-else",
                                 "value": "Yes"

--- a/doc/architecture/decisions/0006-make-named-lists-a-first-class-construct.md
+++ b/doc/architecture/decisions/0006-make-named-lists-a-first-class-construct.md
@@ -20,7 +20,7 @@ A new block type will co-ordinate the collection of a list of things:
 {
     "id": "block-id",
     "type": "ListCollector",
-    "populates_list": "people",
+    "for_list": "people",
     "question": {},
     "add_block": {},
     "edit_block": {},

--- a/tests/app/questionnaire/conftest.py
+++ b/tests/app/questionnaire/conftest.py
@@ -79,7 +79,7 @@ def list_collector_variant_schema():
                             {
                                 'id': 'block1',
                                 'type': 'ListCollector',
-                                'populates_list': 'people',
+                                'for_list': 'people',
                                 'add_answer': {'id': 'answer1', 'value': 'Yes'},
                                 'remove_answer': {
                                     'id': 'remove-confirmation',

--- a/tests/app/questionnaire/test_questionnaire_schema.py
+++ b/tests/app/questionnaire/test_questionnaire_schema.py
@@ -467,7 +467,7 @@ class TestQuestionnaireSchema(AppContextTestCase):
                                 {
                                     'id': 'list-collector',
                                     'type': 'ListCollector',
-                                    'populates_list': 'list',
+                                    'for_list': 'list',
                                     'question': {},
                                     'add_block': {
                                         'id': 'add-block',


### PR DESCRIPTION
### What is the context of this PR?
To align with `RelationshipCollector` schema, ListCollector and PrimaryPersonListCollector now uses `for_list` instead of `populates_list`.

### How to review

Ensure:
- No change in behaviour, everything works as expected.