### PR TITLE
Fix default answers populating answer store

### DIFF
--- a/app/questionnaire/questionnaire_schema.py
+++ b/app/questionnaire/questionnaire_schema.py
@@ -3,6 +3,7 @@ from typing import Union
 
 from flask_babel import force_locale
 
+from app.data_model.answer import Answer
 from app.validation.error_messages import error_messages
 
 DEFAULT_LANGUAGE_CODE = 'en'
@@ -82,6 +83,15 @@ class QuestionnaireSchema:  # pylint: disable=too-many-public-methods
         variants
         """
         return self._answers_by_id.get(answer_id)
+
+    def get_default_answer(self, answer_id):
+        try:
+            answer_schema = self.get_answers_by_answer_id(answer_id)[0]
+            answer = Answer(answer_schema['id'], answer_schema['default'])
+        except (KeyError, TypeError):
+            return None
+
+        return answer
 
     def get_add_block_for_list_collector(self, list_collector_id):
         add_block_map = {

--- a/app/questionnaire/questionnaire_store_updater.py
+++ b/app/questionnaire/questionnaire_store_updater.py
@@ -118,18 +118,6 @@ class QuestionnaireStoreUpdater:
 
         for answer_id, answer_value in form_data.items():
 
-            # If answer is not answered then check for a schema specified default
-            if answer_value in self.EMPTY_ANSWER_VALUES:
-                answer = next(
-                    (
-                        answer
-                        for answer in self._current_question.get('answers', [])
-                        if answer['id'] == answer_id
-                    ),
-                    {},
-                )
-                answer_value = answer.get('default')
-
             if answer_id in answer_ids_for_question:
                 if answer_value not in self.EMPTY_ANSWER_VALUES:
                     answer = Answer(

--- a/app/questionnaire/rules.py
+++ b/app/questionnaire/rules.py
@@ -260,7 +260,8 @@ def get_answer_store_value(answer_id, answer_store, schema, routing_path=None):
     If answer is not on the routing path, return None
     If routing_path empty, return answer value
     """
-    answer = answer_store.get_answer(answer_id)
+    answer = answer_store.get_answer(answer_id) or schema.get_default_answer(answer_id)
+
     if not answer:
         return None
 

--- a/data-source/json/test_default_with_skip.json
+++ b/data-source/json/test_default_with_skip.json
@@ -40,7 +40,7 @@
                                     }
                                 ],
                                 "id": "question",
-                                "title": "Don't enter an answer. A default value will be used",
+                                "title": "Question One",
                                 "type": "General"
                             }
                         },
@@ -53,13 +53,53 @@
                                         "id": "answer-two",
                                         "mandatory": false,
                                         "type": "Number",
-                                        "label": "Enter a Value"
+                                        "label": "Enter a Value",
+                                        "default": 1
                                     }
                                 ],
                                 "id": "question2",
-                                "title": "Enter an answer. It will be shown on the summary page",
+                                "title": "Question Two",
                                 "type": "General"
-                            }
+                            },
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "condition": "not equals",
+                                            "id": "answer-one",
+                                            "value": 1
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "type": "Question",
+                            "id": "number-question-three",
+                            "question": {
+                                "answers": [
+                                    {
+                                        "id": "answer-three",
+                                        "mandatory": false,
+                                        "type": "Number",
+                                        "label": "Leave blank"
+                                    }
+                                ],
+                                "id": "question3",
+                                "title": "Question Three",
+                                "type": "General"
+                            },
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "condition": "equals",
+                                            "id": "answer-two",
+                                            "value": 1
+                                        }
+                                    ]
+                                }
+                            ]
                         },
                         {
                             "type": "Summary",

--- a/data-source/json/test_view_submitted_response.json
+++ b/data-source/json/test_view_submitted_response.json
@@ -76,7 +76,8 @@
                                             }
                                         ],
                                         "q_code": "20",
-                                        "type": "Radio"
+                                        "type": "Radio",
+                                        "default": "Bacon"
                                     }
                                 ],
                                 "description": "",

--- a/tests/app/questionnaire/conftest.py
+++ b/tests/app/questionnaire/conftest.py
@@ -2,6 +2,70 @@ import pytest
 
 
 @pytest.fixture()
+def question_variant_schema_evaluates_to_false():
+    return {
+        'sections': [
+            {
+                'id': 'section1',
+                'groups': [
+                    {
+                        'id': 'group1',
+                        'title': 'Group 1',
+                        'blocks': [
+                            {
+                                'id': 'block1',
+                                'type': 'Question',
+                                'title': 'Block 1',
+                                'question_variants': [
+                                    {
+                                        'when': [
+                                            {
+                                                'id': 'when-answer',
+                                                'condition': 'equals',
+                                                'value': 'yes',
+                                            }
+                                        ],
+                                        'question': {
+                                            'id': 'question1',
+                                            'title': 'Question 1, Yes',
+                                            'answers': [
+                                                {
+                                                    'id': 'answer1',
+                                                    'label': 'Answer 1 Variant 1',
+                                                }
+                                            ],
+                                        },
+                                    },
+                                    {
+                                        'when': [
+                                            {
+                                                'id': 'when-answer',
+                                                'condition': 'equals',
+                                                'value': 'no',
+                                            }
+                                        ],
+                                        'question': {
+                                            'id': 'question1',
+                                            'title': 'Question 1, No',
+                                            'answers': [
+                                                {
+                                                    'id': 'answer1',
+                                                    'label': 'Answer 1 Variant 2',
+                                                }
+                                            ],
+                                        },
+                                    },
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+
+
+@pytest.fixture()
 def question_variant_schema():
     return {
         'sections': [
@@ -56,6 +120,41 @@ def question_variant_schema():
                                         },
                                     },
                                 ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+
+
+@pytest.fixture()
+def single_question_schema():
+    return {
+        'sections': [
+            {
+                'id': 'section1',
+                'groups': [
+                    {
+                        'id': 'group1',
+                        'title': 'Group 1',
+                        'blocks': [
+                            {
+                                'id': 'block1',
+                                'type': 'Question',
+                                'title': 'Block 1',
+                                'question': {
+                                    'id': 'question1',
+                                    'title': 'Question 1, Yes',
+                                    'answers': [
+                                        {
+                                            'id': 'answer1',
+                                            'label': 'Answer 1 Variant 1',
+                                            'default': 'test',
+                                        }
+                                    ],
+                                },
                             }
                         ],
                     }

--- a/tests/app/questionnaire/test_placeholder_renderer.py
+++ b/tests/app/questionnaire/test_placeholder_renderer.py
@@ -9,6 +9,7 @@ from tests.app.app_context_test_case import AppContextTestCase
 class TestPlaceholderRenderer(AppContextTestCase):
     def setUp(self):
         super().setUp()
+
         self.question_json = {
             'id': 'confirm-date-of-birth-proxy',
             'title': 'Confirm date of birth',

--- a/tests/app/questionnaire/test_questionnaire_schema.py
+++ b/tests/app/questionnaire/test_questionnaire_schema.py
@@ -558,3 +558,21 @@ def test_get_all_questions_for_block_empty():
     all_questions = QuestionnaireSchema.get_all_questions_for_block(block)
 
     assert not all_questions
+
+
+def test_get_default_answer_no_answer_in_answer_store(question_variant_schema):
+    schema = QuestionnaireSchema(question_variant_schema)
+    assert schema.get_default_answer('test') is None
+
+
+def test_get_default_answer_no_default_in_schema(question_variant_schema):
+    schema = QuestionnaireSchema(question_variant_schema)
+    assert schema.get_default_answer('answer1') is None
+
+
+def test_get_default_answer_single_question(single_question_schema):
+    schema = QuestionnaireSchema(single_question_schema)
+    answer = schema.get_default_answer('answer1')
+
+    assert answer.answer_id == 'answer1'
+    assert answer.value == 'test'

--- a/tests/app/questionnaire/test_questionnaire_store_updater.py
+++ b/tests/app/questionnaire/test_questionnaire_store_updater.py
@@ -67,7 +67,7 @@ class TestQuestionnaireStoreUpdater(unittest.TestCase):
             'value': answer_value,
         }
 
-    def test_save_answers_data_with_default_value(self):
+    def test_default_answers_are_not_saved(self):
         answer_id = 'answer'
         default_value = 0
 
@@ -87,14 +87,7 @@ class TestQuestionnaireStoreUpdater(unittest.TestCase):
         )
         self.questionnaire_store_updater.update_answers(form)
 
-        assert self.answer_store.add_or_update.call_count == 1
-
-        created_answer = self.answer_store.add_or_update.call_args[0][0]
-        assert created_answer.__dict__ == {
-            'answer_id': answer_id,
-            'list_item_id': None,
-            'value': default_value,
-        }
+        assert self.answer_store.add_or_update.call_count == 0
 
     def test_empty_answers(self):
         string_answer_id = 'string-answer'

--- a/tests/app/questionnaire/test_rules.py
+++ b/tests/app/questionnaire/test_rules.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+
 from app.data_model.answer_store import AnswerStore, Answer
 from app.data_model.list_store import ListStore
 from app.questionnaire.location import Location
@@ -13,7 +14,7 @@ from app.questionnaire.rules import (
 from tests.app.app_context_test_case import AppContextTestCase
 
 
-def get_schema_mock():
+def get_schema():
     schema = QuestionnaireSchema({})
     return schema
 
@@ -141,7 +142,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         answer_store.add_or_update(Answer(answer_id='my_answer', value='Yes'))
 
         self.assertTrue(
-            evaluate_goto(goto, get_schema_mock(), {}, answer_store, ListStore())
+            evaluate_goto(goto, get_schema(), {}, answer_store, ListStore({}))
         )
 
     def test_do_not_go_to_next_question_for_answer(self):
@@ -155,7 +156,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         answer_store.add_or_update(Answer(answer_id='my_answer', value='No'))
 
         self.assertFalse(
-            evaluate_goto(goto_rule, get_schema_mock(), {}, answer_store, ListStore())
+            evaluate_goto(goto_rule, get_schema(), {}, answer_store, ListStore({}))
         )
 
     def test_evaluate_goto_returns_false_when_checkbox_question_not_answered(self):
@@ -174,13 +175,11 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         answer_store = AnswerStore({})
 
         self.assertFalse(
-            evaluate_goto(
-                goto_contains, get_schema_mock(), {}, answer_store, ListStore()
-            )
+            evaluate_goto(goto_contains, get_schema(), {}, answer_store, ListStore({}))
         )
         self.assertFalse(
             evaluate_goto(
-                goto_not_contains, get_schema_mock(), {}, answer_store, ListStore()
+                goto_not_contains, get_schema(), {}, answer_store, ListStore({})
             )
         )
 
@@ -198,7 +197,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         )
 
         self.assertTrue(
-            evaluate_goto(goto, get_schema_mock(), {}, answer_store, ListStore())
+            evaluate_goto(goto, get_schema(), {}, answer_store, ListStore({}))
         )
 
     def test_evaluate_goto_returns_true_when_answer_value_list_not_contains_match_value(
@@ -216,7 +215,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
             Answer(answer_id='my_answers', value=['answer2', 'answer3'])
         )
 
-        self.assertTrue(evaluate_goto(goto, get_schema_mock(), {}, answer_store, 0))
+        self.assertTrue(evaluate_goto(goto, get_schema(), {}, answer_store, 0))
 
     def test_evaluate_goto_returns_true_when_answer_values_contains_any_match_values(
         self
@@ -238,7 +237,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         )
 
         self.assertTrue(
-            evaluate_goto(goto, get_schema_mock(), {}, answer_store, ListStore())
+            evaluate_goto(goto, get_schema(), {}, answer_store, ListStore({}))
         )
 
     def test_evaluate_goto_returns_true_when_answer_values_contains_all_match_values(
@@ -261,7 +260,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         )
 
         self.assertTrue(
-            evaluate_goto(goto, get_schema_mock(), {}, answer_store, ListStore())
+            evaluate_goto(goto, get_schema(), {}, answer_store, ListStore({}))
         )
 
     def test_evaluate_goto_returns_true_when_answer_value_equals_any_match_values(self):
@@ -280,7 +279,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         answer_store.add_or_update(Answer(answer_id='my_answers', value='answer2'))
 
         self.assertTrue(
-            evaluate_goto(goto, get_schema_mock(), {}, answer_store, ListStore())
+            evaluate_goto(goto, get_schema(), {}, answer_store, ListStore({}))
         )
 
     def test_evaluate_goto_returns_true_when_answer_value_not_equals_any_match_values(
@@ -301,7 +300,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         answer_store.add_or_update(Answer(answer_id='my_answers', value='answer3'))
 
         self.assertTrue(
-            evaluate_goto(goto, get_schema_mock(), {}, answer_store, ListStore())
+            evaluate_goto(goto, get_schema(), {}, answer_store, ListStore({}))
         )
 
     def test_evaluate_skip_condition_returns_true_when_this_rule_true(self):
@@ -315,7 +314,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
 
         # When
         condition = evaluate_skip_conditions(
-            skip_conditions, get_schema_mock(), {}, answer_store, ListStore()
+            skip_conditions, get_schema(), {}, answer_store, ListStore({})
         )
 
         # Given
@@ -333,7 +332,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
 
         self.assertTrue(
             evaluate_skip_conditions(
-                skip_conditions, get_schema_mock(), {}, answer_store, ListStore()
+                skip_conditions, get_schema(), {}, answer_store, ListStore({})
             )
         )
 
@@ -349,7 +348,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
 
         # When
         condition = evaluate_skip_conditions(
-            skip_conditions, get_schema_mock(), {}, answer_store, ListStore()
+            skip_conditions, get_schema(), {}, answer_store, ListStore({})
         )
 
         # Then
@@ -367,7 +366,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
 
         # When
         condition = evaluate_skip_conditions(
-            skip_conditions, get_schema_mock(), {}, answer_store, ListStore()
+            skip_conditions, get_schema(), {}, answer_store, ListStore({})
         )
 
         # Then
@@ -379,7 +378,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
 
         # When
         condition = evaluate_skip_conditions(
-            skip_conditions, get_schema_mock(), {}, AnswerStore({}), ListStore()
+            skip_conditions, get_schema(), {}, AnswerStore({}), ListStore({})
         )
 
         # Then
@@ -391,7 +390,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
 
         self.assertTrue(
             evaluate_when_rules(
-                when['when'], get_schema_mock(), {}, answer_store, ListStore(), None
+                when['when'], get_schema(), {}, answer_store, ListStore({}), None
             )
         )
 
@@ -409,7 +408,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         answer_store.add_or_update(Answer(answer_id='my_other_answer', value='2'))
 
         self.assertTrue(
-            evaluate_goto(goto, get_schema_mock(), {}, answer_store, ListStore())
+            evaluate_goto(goto, get_schema(), {}, answer_store, ListStore({}))
         )
 
     def test_do_not_go_to_next_question_for_multiple_answers(self):
@@ -425,7 +424,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         answer_store.add_or_update(Answer(answer_id='my_answer', value='No'))
 
         self.assertFalse(
-            evaluate_goto(goto_rule, get_schema_mock(), {}, answer_store, ListStore())
+            evaluate_goto(goto_rule, get_schema(), {}, answer_store, ListStore({}))
         )
 
     def test_should_go_to_next_question_when_condition_is_meta_and_answer_type(self):
@@ -443,7 +442,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
 
         # When
         goto = evaluate_goto(
-            goto_rule, get_schema_mock(), metadata, answer_store, ListStore()
+            goto_rule, get_schema(), metadata, answer_store, ListStore({})
         )
 
         # Then
@@ -467,7 +466,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
 
         # When
         goto = evaluate_goto(
-            goto_rule, get_schema_mock(), metadata, answer_store, ListStore()
+            goto_rule, get_schema(), metadata, answer_store, ListStore({})
         )
 
         # Then
@@ -488,7 +487,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
 
         # When
         goto = evaluate_goto(
-            goto_rule, get_schema_mock(), metadata, answer_store, ListStore()
+            goto_rule, get_schema(), metadata, answer_store, ListStore({})
         )
 
         # Then
@@ -583,9 +582,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
                 ]
 
                 self.assertEqual(
-                    evaluate_when_rules(
-                        when, get_schema_mock(), {}, answer_store, None
-                    ),
+                    evaluate_when_rules(when, get_schema(), {}, answer_store, None),
                     expected_result,
                 )
 
@@ -594,7 +591,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         answer_store = AnswerStore({})
         with self.assertRaises(Exception):
             evaluate_when_rules(
-                when['when'], get_schema_mock(), {}, answer_store, ListStore(), None
+                when['when'], get_schema(), {}, answer_store, ListStore({}), None
             )
 
     def test_list_rules_less_than(self):
@@ -604,7 +601,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         when_rules = [{'list': 'people', 'condition': 'less than', 'value': 2}]
         self.assertTrue(
             evaluate_when_rules(
-                when_rules, get_schema_mock(), {}, answer_store, list_store, None
+                when_rules, get_schema(), {}, answer_store, list_store, None
             )
         )
 
@@ -615,7 +612,7 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         when_rules = [{'list': 'people', 'condition': 'equals', 'value': 1}]
         self.assertTrue(
             evaluate_when_rules(
-                when_rules, get_schema_mock(), {}, answer_store, list_store, None
+                when_rules, get_schema(), {}, answer_store, list_store, None
             )
         )
 
@@ -630,14 +627,14 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
 
         routing_path = [Location('test_block_id')]
         self.assertTrue(
-            evaluate_when_rules(when['when'], get_schema_mock(), {}, answer_store, None)
+            evaluate_when_rules(when['when'], get_schema(), {}, answer_store, None)
         )
 
         with patch('app.questionnaire.rules._is_answer_on_path', return_value=False):
             self.assertFalse(
                 evaluate_when_rules(
                     when['when'],
-                    get_schema_mock(),
+                    get_schema(),
                     {},
                     answer_store,
                     ListStore(),

--- a/tests/functional/spec/features/default_value/default_value.spec.js
+++ b/tests/functional/spec/features/default_value/default_value.spec.js
@@ -1,19 +1,48 @@
 const helpers = require('../../../helpers');
 
-const QuestionPage = require('../../../generated_pages/default/number-question.page.js');
+const QuestionPageOne = require('../../../generated_pages/default/number-question-one.page.js');
+const QuestionPageTwo = require('../../../generated_pages/default/number-question-two.page.js');
 const Summary = require('../../../generated_pages/default/summary.page.js');
+const QuestionPageOneSkip = require('../../../generated_pages/default_with_skip/number-question-one.page.js');
+const QuestionPageThreeSkip = require('../../../generated_pages/default_with_skip/number-question-three.page.js');
+
 
 describe('Feature: Default Value', function() {
 
-  it('Given I start default schema, When I do not give a value, Then the default value will be stored', function() {
+  it('Given I start default schema, When I do not answer a question, Then "no answer provided" is displayed on the Summary page', function() {
     return helpers.openQuestionnaire('test_default.json').then(() => {
       return browser
-        .click(QuestionPage.submit())
+        .click(QuestionPageOne.submit())
+          .getUrl().should.eventually.contain(QuestionPageTwo.pageName)
+          .setValue(QuestionPageTwo.two(), 123)
+          .click(QuestionPageTwo.submit())
           .getUrl().should.eventually.contain(Summary.pageName)
-          .getText(Summary.answer()).should.eventually.contain('0')
-          .click(Summary.previous())
-          .getUrl().should.eventually.contain(QuestionPage.pageName)
-          .getValue(QuestionPage.answer()).should.eventually.contain('0');
+          .getText(Summary.answerOne()).should.eventually.contain('No answer provided');
     });
   });
+
+  it('Given I have not answered a question containing a default value, When I return to the question, Then no value should be displayed', function() {
+  return helpers.openQuestionnaire('test_default.json').then(() => {
+    return browser
+      .click(QuestionPageOne.submit())
+        .getUrl().should.eventually.contain(QuestionPageTwo.pageName)
+        .setValue(QuestionPageTwo.two(), 123)
+        .click(QuestionPageTwo.submit())
+        .getUrl().should.eventually.contain(Summary.pageName)
+        .click(Summary.previous())
+        .getUrl().should.eventually.contain(QuestionPageTwo.pageName)
+        .click(QuestionPageTwo.previous())
+        .getUrl().should.eventually.contain(QuestionPageOne.pageName)
+        .getValue(QuestionPageOne.one()).should.eventually.equal('');
+    });
+  });
+
+  it('Given I have not answered a question containing a default value, When a skip condition checks for the default value, Then I should skip the next question', function() {
+  return helpers.openQuestionnaire('test_default_with_skip.json').then(() => {
+    return browser
+      .click(QuestionPageOneSkip.submit())
+       .getUrl().should.eventually.contain(QuestionPageThreeSkip.pageName)
+       .getText(QuestionPageThreeSkip.questionText()).should.eventually.contain('Question Three');
+    });
+   });
 });

--- a/tests/integration/views/test_view_submission.py
+++ b/tests/integration/views/test_view_submission.py
@@ -268,6 +268,48 @@ class TestViewSubmissionTradingAs(IntegrationTestCase):
             self.assertInUrl('view-submission')
             self.assertNotInBody('(Integration Tests)')
 
+    def test_view_submission_default_shows_no_answer_provided(self):
+        no_trading_as_payload = {
+            'user_id': 'integration-test',
+            'period_str': 'April 2016',
+            'period_id': '201604',
+            'collection_exercise_sid': '789',
+            'questionnaire_id': '0123456789000000',
+            'ru_ref': '123456789012A',
+            'response_id': '1234567890123456',
+            'ru_name': 'Integration Testing',
+            'ref_p_start_date': '2016-04-01',
+            'ref_p_end_date': '2016-04-30',
+            'return_by': '2016-05-06',
+            'employment_date': '1983-06-02',
+            'region_code': 'GB-ENG',
+            'language_code': 'en',
+            'roles': [],
+            'trad_as': '',
+            'account_service_url': 'http://upstream.url',
+        }
+        with patch('tests.integration.create_token.PAYLOAD', no_trading_as_payload):
+            self.launchSurvey('test_view_submitted_response')
+            self.assertInBody('What is your favourite breakfast food')
+
+            form_data = {}
+
+            self.post(form_data)
+            self.assertInBody('Please enter test values (none mandatory)')
+
+            form_data = {
+                'test-currency': '12',
+                'square-kilometres': '345',
+                'test-decimal': '67.89',
+            }
+
+            self.post(form_data)
+            self.post(action=None)
+            self.get('submitted/view-submission')
+
+            self.assertInUrl('view-submission')
+            self.assertInBody('No answer provided')
+
 
 class TestViewSubmissionCompression(IntegrationTestCase):
     def test_compressed_submitted_response_data(self):


### PR DESCRIPTION
### What is the context of this PR?
Default answers were previously stored in the AnswerStore, even when an answer wasn't submitted by the user. This PR alters the behaviour so that default answers are never stored on the answer store. To continue routing correctly and displaying the right placeholders, a new check has been added to the get_answer_store_value function in rules.py, that populates an answer object based on it's default value. This only happens when a user supplied answer is not present on the answer store.

### How to review 
Complete surveys with default answers in their schema.
- Notice that for answers with default values, the default values aren't displayed in the summary and aren't passed downstream when an answer isn't provided.
- Check that placeholders are evaluated using the default answer when an answer isn't provided.
- Check that routing is evaluated using the default value when an answer isn't provided
