### PR TITLE
Add channel claim to downstream submission

### DIFF
--- a/app/storage/metadata_parser.py
+++ b/app/storage/metadata_parser.py
@@ -82,6 +82,9 @@ class RunnerMetadataSchema(Schema, StripWhitespaceMixin):
     roles = fields.List(fields.String(), required=False)
     survey_url = VALIDATORS['url'](required=False)
     language_code = VALIDATORS['string'](required=False)
+    channel = VALIDATORS['string'](
+        required=False, validate=validate.OneOf(('RH', 'FIELD', 'CC', 'AD'))
+    )
 
     # Either schema_name OR the three census parameters are required. Should be required after census.
     schema_name = VALIDATORS['string'](required=False)
@@ -120,10 +123,8 @@ class RunnerMetadataSchema(Schema, StripWhitespaceMixin):
         """
         if data.get('schema_name'):
             logger.info(
-                f'Ignoring claims: survey: {data.get("survey")}, case_type: {data.get("case_type")} because schema_name was specified'
+                'Using schema_name claim to specify schema, overriding survey, case_type and region_code'
             )
-            data.pop('survey', None)
-            data.pop('case_type', None)
         else:
             data['schema_name'] = get_schema_name_from_census_params(
                 data.get('survey'), data.get('case_type'), data.get('region_code')

--- a/app/submitter/converter.py
+++ b/app/submitter/converter.py
@@ -35,19 +35,21 @@ def convert_answers(schema, questionnaire_store, routing_path, flushed=False):
         'submitted_at': '2016-03-07T15:28:05Z',
         'response_id': '1234567890123456',
         'questionnaire_id': '1234567890000000',
+        'channel': 'RH',
         'metadata': {
           'user_id': '789473423',
           'ru_ref': '432423423423'
         },
-        'data': {
+        'data': [
             ...
-        },
+        ],
       }
     ```
 
     Args:
         schema: QuestionnaireSchema instance with populated schema json
-        full_routing_path: The full routing path followed by the user when answering the questionnaire
+        questionnaire_store: EncryptedQuestionnaireStorage instance for accessing current questionnaire data
+        routing_path: The full routing path followed by the user when answering the questionnaire
         flushed: True when system submits the users answers, False when submitted by user.
     Returns:
         Data payload
@@ -74,6 +76,12 @@ def convert_answers(schema, questionnaire_store, routing_path, flushed=False):
         'questionnaire_id': metadata['questionnaire_id'],
     }
 
+    if metadata.get('channel'):
+        payload['channel'] = metadata['channel']
+    if metadata.get('case_type'):
+        payload['case_type'] = metadata['case_type']
+    if metadata.get('region_code'):
+        payload['region_code'] = metadata['region_code']
     if collection_metadata.get('started_at'):
         payload['started_at'] = collection_metadata['started_at']
     if metadata.get('case_id'):

--- a/tests/integration/create_token.py
+++ b/tests/integration/create_token.py
@@ -20,6 +20,8 @@ PAYLOAD = {
     'trad_as': 'Integration Tests',
     'employment_date': '1983-06-02',
     'region_code': 'GB-ENG',
+    'channel': 'RH',
+    'case_type': 'HI',
     'language_code': 'en',
     'roles': [],
     'account_service_url': 'http://upstream.url',

--- a/tests/integration/views/test_dump.py
+++ b/tests/integration/views/test_dump.py
@@ -88,6 +88,9 @@ class TestDumpSubmission(IntegrationTestCase):
                 'case_id': actual['submission']['case_id'],
                 'response_id': '1234567890123456',
                 'questionnaire_id': actual['submission']['questionnaire_id'],
+                'region_code': 'GB-ENG',
+                'channel': 'RH',
+                'case_type': 'HI',
                 'collection': {
                     'period': '201604',
                     'exercise_sid': '789',
@@ -131,6 +134,9 @@ class TestDumpSubmission(IntegrationTestCase):
                 'case_id': actual['submission']['case_id'],
                 'response_id': '1234567890123456',
                 'questionnaire_id': actual['submission']['questionnaire_id'],
+                'region_code': 'GB-ENG',
+                'channel': 'RH',
+                'case_type': 'HI',
                 'collection': {
                     'period': '201604',
                     'exercise_sid': '789',


### PR DESCRIPTION
### What is the context of this PR?
We are required to pass some new claims downstream- channel, case_type and region_code. The latter two had been ingested from RH, but were not being passed on the the submission JSON. The channel claim wasn't being handled at all.
This adds validation for channel, enforcing an enumerated list of FIELD, RH, AD and CC, if channel is present (it should be for all census surveys, but making it mandatory would break all the other schemas).

### How to review 
Using the eq-2754-add-channel-to-submission branch of eq-questionnaire-launcher, you can inject values for the new claim types, and test they would be sent downstream using the /dump/submission API endpoint during a survey.
