### PR TITLE
Change channel validation to not check for explicit values

### DIFF
--- a/app/storage/metadata_parser.py
+++ b/app/storage/metadata_parser.py
@@ -82,9 +82,7 @@ class RunnerMetadataSchema(Schema, StripWhitespaceMixin):
     roles = fields.List(fields.String(), required=False)
     survey_url = VALIDATORS['url'](required=False)
     language_code = VALIDATORS['string'](required=False)
-    channel = VALIDATORS['string'](
-        required=False, validate=validate.OneOf(('RH', 'FIELD', 'CC', 'AD'))
-    )
+    channel = VALIDATORS['string'](required=False, validate=validate.Length(min=1))
 
     # Either schema_name OR the three census parameters are required. Should be required after census.
     schema_name = VALIDATORS['string'](required=False)


### PR DESCRIPTION
### What is the context of this PR?
Due to RH not at this time sending one of the required values for the channel claim, we will skip checking for any specific value, instead just checking it is a string of minimum length one.

### How to review 
Load up a census schema using questionnaire-launcher, and test with values for channel, such as "", "X", or "RH" (only the last one would have worked prior to this PR). All non-empty values should work, empty should give you a 500 error.