### PR TITLE
Move schema copy back in to build schemas

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -14,12 +14,4 @@ echo "Building schemas"
 echo "Translating schemas"
 make translate
 
-echo "Creating temporary household schemas based on individual schema in 'data' dir"
-
-# Until household is delivered, temporarily create household schema as copies of the individual schema
-cp data/en/census_individual_gb_wls.json data/en/census_household_gb_wls.json
-cp data/en/census_individual_gb_eng.json data/en/census_household_gb_eng.json
-cp data/en/census_individual_gb_nir.json data/en/census_household_gb_nir.json
-cp data/cy/census_individual_gb_wls.json data/cy/census_household_gb_wls.json
-
 printf $(git rev-parse HEAD) > .application-version

--- a/scripts/build_schemas.sh
+++ b/scripts/build_schemas.sh
@@ -28,3 +28,11 @@ done
 mkdir -p data/en
 mv data-source/jsonnet/*.json data/en
 cp data-source/json/*.json data/en
+
+echo "Creating temporary household schemas based on individual schema in 'data' dir"
+
+# Until household is delivered, temporarily create household schema as copies of the individual schema
+cp data/en/census_individual_gb_wls.json data/en/census_household_gb_wls.json
+cp data/en/census_individual_gb_eng.json data/en/census_household_gb_eng.json
+cp data/en/census_individual_gb_nir.json data/en/census_household_gb_nir.json
+


### PR DESCRIPTION
### What is the context of this PR?

Our Dockerfile currently calls the build_schemas.sh script to generate schemas, but the copy of household schemas has been moved to build.sh since translation has been made part of the build process. Currently, this means that the current household schemas are not currently being created in any environment. 

Translation needs to happen post build of schemas. The Welsh language variation of household is not necessary for our current environments so has been removed for now given it depends on translation. 

### How to review 

Check that the copy command has been correctly moved back into build_schemas.sh and that make build/docker build creates schemas as expected.

A subsequent card to review making docker/travis use the same build script will be necessary at a later date.


