### PR TITLE
NISRA: Remove 'Select all that apply label'

### DIFF
--- a/data-source/jsonnet/northern-ireland/blocks/individual/employment/armed_forces.jsonnet
+++ b/data-source/jsonnet/northern-ireland/blocks/individual/employment/armed_forces.jsonnet
@@ -16,6 +16,7 @@ local question(title) = {
     {
       id: 'armed-forces-answer',
       mandatory: false,
+      label: '',
       options: [
         {
           label: 'No',

--- a/data-source/jsonnet/northern-ireland/blocks/individual/identity-and-health/sexual_identity.jsonnet
+++ b/data-source/jsonnet/northern-ireland/blocks/individual/identity-and-health/sexual_identity.jsonnet
@@ -9,6 +9,7 @@ local question(title) = {
     {
       id: 'sexual-identity-answer',
       mandatory: false,
+      label: '',
       options: [
         {
           label: 'Straight or Heterosexual',


### PR DESCRIPTION
### What is the context of this PR?
Removed 'Select all that apply' from armed forces + sexual identity question.

### How to review 
Ensure:
- Changes are as per instructions on Trello.

[Quick launch for NIR schema](https://v3-launcher.gcp.dev.eq.ons.digital/quick-launch?language_code=en&survey=CENSUS&case_type=HI&region_code=GB-NIR&url=https://raw.githubusercontent.com/ONSdigital/eq-survey-runner/eq-3176-nisra-content-changes/data/en/census_individual_gb_nir.json)