### PR TITLE
Simplify path finder

### DIFF
--- a/tests/app/questionnaire/test_path_finder.py
+++ b/tests/app/questionnaire/test_path_finder.py
@@ -436,11 +436,7 @@ class TestPathFinder(
 
         routing_path = path_finder.routing_path(current_section)
 
-        expected_path = [
-            Location(block_id='number-of-employees-total-block'),
-            Location(block_id='confirm-zero-employees-block'),
-            Location(block_id='number-of-employees-total-block'),
-        ]
+        expected_path = [Location(block_id='number-of-employees-total-block')]
         self.assertEqual(routing_path, expected_path)
 
         self.assertEqual(


### PR DESCRIPTION
### What is the context of this PR?
Simplifies the path finding code now that we only ever consider a routing path per section rather than per group. This will help when making the changes required for generating routing paths for repeating sections.

### How to review 
- Review the logic
- Could anything be made clearer?
- Has any (untested) functionality been broken?
