### PR TITLE
Add Primary Person Variant to Relationships

### DIFF
--- a/app/questionnaire/schema_utils.py
+++ b/app/questionnaire/schema_utils.py
@@ -2,18 +2,34 @@ from app.questionnaire.rules import evaluate_when_rules
 
 
 def _choose_variant(
-    block, schema, metadata, answer_store, list_store, variants_key, single_key
+    block,
+    schema,
+    metadata,
+    answer_store,
+    list_store,
+    variants_key,
+    single_key,
+    current_location=None,
 ):
     if block.get(single_key):
         return block[single_key]
 
     for variant in block.get(variants_key, []):
         when_rules = variant.get('when', [])
-        if evaluate_when_rules(when_rules, schema, metadata, answer_store, list_store):
+        if evaluate_when_rules(
+            when_rules,
+            schema,
+            metadata,
+            answer_store,
+            list_store,
+            current_location=current_location,
+        ):
             return variant[single_key]
 
 
-def choose_question_to_display(block, schema, metadata, answer_store, list_store):
+def choose_question_to_display(
+    block, schema, metadata, answer_store, list_store, current_location=None
+):
     return _choose_variant(
         block,
         schema,
@@ -22,10 +38,13 @@ def choose_question_to_display(block, schema, metadata, answer_store, list_store
         list_store,
         variants_key='question_variants',
         single_key='question',
+        current_location=current_location,
     )
 
 
-def choose_content_to_display(block, schema, metadata, answer_store, list_store):
+def choose_content_to_display(
+    block, schema, metadata, answer_store, list_store, current_location=None
+):
     return _choose_variant(
         block,
         schema,
@@ -34,15 +53,18 @@ def choose_content_to_display(block, schema, metadata, answer_store, list_store)
         list_store,
         variants_key='content_variants',
         single_key='content',
+        current_location=current_location,
     )
 
 
-def transform_variants(block, schema, metadata, answer_store, list_store):
+def transform_variants(
+    block, schema, metadata, answer_store, list_store, current_location=None
+):
     output_block = block.copy()
 
     if 'question_variants' in block:
         question = choose_question_to_display(
-            block, schema, metadata, answer_store, list_store
+            block, schema, metadata, answer_store, list_store, current_location
         )
         output_block.pop('question_variants', None)
         output_block.pop('question', None)
@@ -51,7 +73,7 @@ def transform_variants(block, schema, metadata, answer_store, list_store):
 
     if 'content_variants' in block:
         content = choose_content_to_display(
-            block, schema, metadata, answer_store, list_store
+            block, schema, metadata, answer_store, list_store, current_location
         )
         output_block.pop('content_variants', None)
         output_block.pop('content', None)
@@ -63,7 +85,12 @@ def transform_variants(block, schema, metadata, answer_store, list_store):
         for list_operation in list_operations:
             if block.get(list_operation):
                 output_block[list_operation] = transform_variants(
-                    block[list_operation], schema, metadata, answer_store, list_store
+                    block[list_operation],
+                    schema,
+                    metadata,
+                    answer_store,
+                    list_store,
+                    current_location,
                 )
 
     return output_block

--- a/app/views/handlers/block.py
+++ b/app/views/handlers/block.py
@@ -113,6 +113,7 @@ class BlockHandler:
             self._questionnaire_store.metadata,
             self._questionnaire_store.answer_store,
             self._questionnaire_store.list_store,
+            self._current_location,
         )
 
         placeholder_renderer = PlaceholderRenderer(

--- a/data-source/json/test_relationships_primary.json
+++ b/data-source/json/test_relationships_primary.json
@@ -1,0 +1,345 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.3",
+    "survey_id": "0",
+    "title": "Test PrimaryPersonListCollector",
+    "theme": "default",
+    "description": "A questionnaire to test Primary Person ListCollector",
+    "metadata": [
+        {
+            "name": "user_id",
+            "type": "string"
+        },
+        {
+            "name": "period_id",
+            "type": "string"
+        },
+        {
+            "name": "ru_name",
+            "type": "string"
+        }
+    ],
+    "sections": [
+        {
+            "id": "section",
+            "groups": [
+                {
+                    "id": "group",
+                    "title": "Primary Person",
+                    "blocks": [
+                        {
+                            "id": "primary-person-list-collector",
+                            "type": "PrimaryPersonListCollector",
+                            "for_list": "people",
+                            "add_or_edit_answer": {
+                                "id": "you-live-here",
+                                "value": "Yes"
+                            },
+                            "add_or_edit_block": {
+                                "id": "add-or-edit-primary-person",
+                                "type": "PrimaryPersonListAddOrEditQuestion",
+                                "question": {
+                                    "id": "primary-person-add-or-edit-question",
+                                    "type": "General",
+                                    "title": "What is your name",
+                                    "answers": [
+                                        {
+                                            "id": "first-name",
+                                            "label": "First name",
+                                            "mandatory": true,
+                                            "type": "TextField"
+                                        },
+                                        {
+                                            "id": "last-name",
+                                            "label": "Last name",
+                                            "mandatory": true,
+                                            "type": "TextField"
+                                        }
+                                    ]
+                                }
+                            },
+                            "question": {
+                                "id": "primary-confirmation-question",
+                                "type": "General",
+                                "title": "Do you live here?",
+                                "answers": [
+                                    {
+                                        "id": "you-live-here",
+                                        "mandatory": true,
+                                        "type": "Radio",
+                                        "options": [
+                                            {
+                                                "label": "Yes",
+                                                "value": "Yes"
+                                            },
+                                            {
+                                                "label": "No",
+                                                "value": "No"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "id": "list-collector",
+                            "type": "ListCollector",
+                            "for_list": "people",
+                            "add_answer": {
+                                "id": "anyone-else",
+                                "value": "Yes"
+                            },
+                            "remove_answer": {
+                                "id": "remove-confirmation",
+                                "value": "Yes"
+                            },
+                            "question": {
+                                "id": "confirmation-question",
+                                "type": "General",
+                                "title": "Does anyone else live here?",
+                                "answers": [
+                                    {
+                                        "id": "anyone-else",
+                                        "mandatory": true,
+                                        "type": "Radio",
+                                        "options": [
+                                            {
+                                                "label": "Yes",
+                                                "value": "Yes"
+                                            },
+                                            {
+                                                "label": "No",
+                                                "value": "No"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "add_block": {
+                                "id": "add-person",
+                                "type": "ListAddQuestion",
+                                "question": {
+                                    "id": "add-question",
+                                    "type": "General",
+                                    "title": "What is the name of the person?",
+                                    "answers": [
+                                        {
+                                            "id": "first-name",
+                                            "label": "First name",
+                                            "mandatory": true,
+                                            "type": "TextField"
+                                        },
+                                        {
+                                            "id": "last-name",
+                                            "label": "Last name",
+                                            "mandatory": true,
+                                            "type": "TextField"
+                                        }
+                                    ]
+                                }
+                            },
+                            "edit_block": {
+                                "id": "edit-person",
+                                "type": "ListEditQuestion",
+                                "question": {
+                                    "id": "edit-question",
+                                    "type": "General",
+                                    "title": {
+                                        "text": "Change details for {first_name} {last_name}",
+                                        "placeholders": [
+                                            {
+                                                "placeholder": "first_name",
+                                                "value": {
+                                                    "source": "answers",
+                                                    "identifier": "first-name"
+                                                }
+                                            },
+                                            {
+                                                "placeholder": "last_name",
+                                                "value": {
+                                                    "source": "answers",
+                                                    "identifier": "last-name"
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "answers": [
+                                        {
+                                            "id": "first-name",
+                                            "label": "First name",
+                                            "mandatory": true,
+                                            "type": "TextField"
+                                        },
+                                        {
+                                            "id": "last-name",
+                                            "label": "Last name",
+                                            "mandatory": true,
+                                            "type": "TextField"
+                                        }
+                                    ]
+                                }
+                            },
+                            "remove_block": {
+                                "id": "remove-person",
+                                "type": "ListRemoveQuestion",
+                                "question": {
+                                    "id": "remove-question",
+                                    "type": "General",
+                                    "title": "Are you sure you want to remove this person?",
+                                    "answers": [
+                                        {
+                                            "id": "remove-confirmation",
+                                            "mandatory": true,
+                                            "type": "Radio",
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "type": "RelationshipCollector",
+                            "id": "relationships",
+                            "title": "This will iterate over the people list, capturing the one way relationships.",
+                            "for_list": "people",
+                            "question_variants": [
+                                {
+                                    "question": {
+                                        "id": "relationship-question",
+                                        "type": "General",
+                                        "title": "{second_person_name} is your <em>...</em>",
+                                        "answers": [
+                                            {
+                                                "id": "relationship-answer",
+                                                "mandatory": true,
+                                                "type": "Relationship",
+                                                "playback": "{second_person_name} is your <em>...</em>",
+                                                "options": [
+                                                    {
+                                                        "label": "Husband or Wife",
+                                                        "value": "Husband or Wife",
+                                                        "title": "{second_person_name} is your <em>husband or wife</em>",
+                                                        "playback": "{second_person_name} is your <em>husband or wife</em>"
+                                                    },
+                                                    {
+                                                        "label": "Legally registered civil partner",
+                                                        "value": "Legally registered civil partner",
+                                                        "title": "{second_person_name} is your <em>legally registered civil partner</em>",
+                                                        "playback": "{second_person_name} is your <em>legally registered civil partner</em>"
+                                                    },
+                                                    {
+                                                        "label": "Son or daughter",
+                                                        "value": "Son or daughter",
+                                                        "title": "{second_person_name} is your <em>son or daughter</em>",
+                                                        "playback": "{second_person_name} is your <em>son or daughter</em>"
+                                                    },
+                                                    {
+                                                        "label": "Brother or sister",
+                                                        "value": "Brother or sister",
+                                                        "title": "{second_person_name} is your <em>brother or sister</em>",
+                                                        "playback": "{second_person_name} is your <em>brother or sister</em>"
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "when": [
+                                        {
+                                            "list": "people",
+                                            "id_selector": "primary_person",
+                                            "condition": "equals",
+                                            "comparison": {
+                                                "source": "location",
+                                                "id": "from_list_item_id"
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": {
+                                        "id": "relationship-question",
+                                        "type": "General",
+                                        "title": "Thinking of {first_person_name}, {second_person_name} is their <em>...</em>",
+                                        "answers": [
+                                            {
+                                                "id": "relationship-answer",
+                                                "mandatory": true,
+                                                "type": "Relationship",
+                                                "playback": "{second_person_name} is {first_person_name_possessive} <em>…</em>",
+                                                "options": [
+                                                    {
+                                                        "label": "Husband or Wife",
+                                                        "value": "Husband or Wife",
+                                                        "title": "Thinking of {first_person_name}, {second_person_name} is their <em>husband or wife</em>",
+                                                        "playback": "{second_person_name} is {first_person_name_possessive} <em>husband or wife</em>"
+                                                    },
+                                                    {
+                                                        "label": "Legally registered civil partner",
+                                                        "value": "Legally registered civil partner",
+                                                        "title": "Thinking of {first_person_name}, {second_person_name} is their <em>legally registered civil partner</em>",
+                                                        "playback": "{second_person_name} is {first_person_name_possessive} <em>legally registered civil partner</em>"
+                                                    },
+                                                    {
+                                                        "label": "Son or daughter",
+                                                        "value": "Son or daughter",
+                                                        "title": "Thinking of {first_person_name}, {second_person_name} is their <em>son or daughter</em>",
+                                                        "playback": "{second_person_name} is {first_person_name_possessive} <em>son or daughter</em>"
+                                                    },
+                                                    {
+                                                        "label": "Brother or sister",
+                                                        "value": "Brother or sister",
+                                                        "title": "Thinking of {first_person_name}, {second_person_name} is their <em>brother or sister</em>",
+                                                        "playback": "{second_person_name} is {first_person_name_possessive} <em>brother or sister</em>"
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "when": [
+                                        {
+                                            "list": "people",
+                                            "id_selector": "primary_person",
+                                            "condition": "not equals",
+                                            "comparison": {
+                                                "source": "location",
+                                                "id": "from_list_item_id"
+                                            }
+                                        }
+                                    ]
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "list": "people",
+                                            "condition": "less than",
+                                            "value": 2
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "type": "Confirmation",
+                            "id": "confirmation",
+                            "content": {
+                                "title": "Thank you for your answers, do you wish to submit"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/data-source/json/test_routing_answer_comparison.json
+++ b/data-source/json/test_routing_answer_comparison.json
@@ -72,7 +72,10 @@
                                             {
                                                 "id": "route-comparison-2-answer",
                                                 "condition": "greater than",
-                                                "comparison_id": "route-comparison-1-answer"
+                                                "comparison": {
+                                                    "source": "answers",
+                                                    "id": "route-comparison-1-answer"
+                                                }
                                             }
                                         ]
                                     }

--- a/data-source/json/test_skip_condition_answer_comparison.json
+++ b/data-source/json/test_skip_condition_answer_comparison.json
@@ -80,7 +80,10 @@
                                         {
                                             "id": "comparison-1-answer",
                                             "condition": "not equals",
-                                            "comparison_id": "comparison-2-answer"
+                                            "comparison": {
+                                                "source": "answers",
+                                                "id": "comparison-2-answer"
+                                            }
                                         }
                                     ]
                                 }
@@ -103,7 +106,10 @@
                                         {
                                             "id": "comparison-1-answer",
                                             "condition": "greater than",
-                                            "comparison_id": "comparison-2-answer"
+                                            "comparison": {
+                                                "source": "answers",
+                                                "id": "comparison-2-answer"
+                                            }
                                         }
                                     ]
                                 },
@@ -112,7 +118,10 @@
                                         {
                                             "id": "comparison-1-answer",
                                             "condition": "equals",
-                                            "comparison_id": "comparison-2-answer"
+                                            "comparison": {
+                                                "source": "answers",
+                                                "id": "comparison-2-answer"
+                                            }
                                         }
                                     ]
                                 }
@@ -135,7 +144,10 @@
                                         {
                                             "id": "comparison-1-answer",
                                             "condition": "less than",
-                                            "comparison_id": "comparison-2-answer"
+                                            "comparison": {
+                                                "source": "answers",
+                                                "id": "comparison-2-answer"
+                                            }
                                         }
                                     ]
                                 },
@@ -144,7 +156,10 @@
                                         {
                                             "id": "comparison-1-answer",
                                             "condition": "equals",
-                                            "comparison_id": "comparison-2-answer"
+                                            "comparison": {
+                                                "source": "answers",
+                                                "id": "comparison-2-answer"
+                                            }
                                         }
                                     ]
                                 }

--- a/tests/functional/spec/relationships-primary.spec.js
+++ b/tests/functional/spec/relationships-primary.spec.js
@@ -1,0 +1,47 @@
+const helpers = require('../helpers');
+const PrimaryPersonListCollectorPage = require('../generated_pages/relationships_primary/primary-person-list-collector.page.js');
+const PrimaryPersonListCollectorAddPage = require('../generated_pages/relationships_primary/primary-person-list-collector-add.page.js');
+const ListCollectorPage = require('../generated_pages/relationships_primary/list-collector.page.js');
+const ListCollectorAddPage = require('../generated_pages/relationships_primary/list-collector-add.page.js');
+const RelationshipsPage = require('../generated_pages/relationships_primary/relationships.page.js');
+
+describe('Relationships - Primary Person', function() {
+
+  beforeEach(function() {
+    return helpers.openQuestionnaire('test_relationships_primary.json')
+    .then(() => {
+      return browser
+        .click(PrimaryPersonListCollectorPage.yes())
+        .click(PrimaryPersonListCollectorPage.submit())
+        .setValue(PrimaryPersonListCollectorAddPage.firstName(), 'Marcus')
+        .setValue(PrimaryPersonListCollectorAddPage.lastName(), 'Twin')
+        .click(PrimaryPersonListCollectorAddPage.submit())
+        .click(ListCollectorPage.yes())
+        .click(ListCollectorPage.submit())
+        .setValue(ListCollectorAddPage.firstName(), 'Samuel')
+        .setValue(ListCollectorAddPage.lastName(), 'Clemens')
+        .click(ListCollectorAddPage.submit())
+        .click(ListCollectorPage.yes())
+        .click(ListCollectorPage.submit())
+        .setValue(ListCollectorAddPage.firstName(), 'Olivia')
+        .setValue(ListCollectorAddPage.lastName(), 'Clemens')
+        .click(ListCollectorAddPage.submit())
+        .click(ListCollectorPage.no())
+        .click(ListCollectorPage.submit());
+    });
+  });
+
+  it('Given I am completing the survey, When I add household members, Then I will be asked my relationships as a primary person', function () {
+    return browser
+      .getText(RelationshipsPage.questionText()).should.eventually.contain('is your');
+  });
+
+  it('Given I am completing the survey, When I add household members, Then non-primary relationships will be asked as a non primary person', function () {
+    return browser
+      .click(RelationshipsPage.relationshipBrotherOrSister())
+      .click(RelationshipsPage.submit())
+      .click(RelationshipsPage.relationshipSonOrDaughter())
+      .click(RelationshipsPage.submit())
+      .getText(RelationshipsPage.questionText()).should.eventually.contain('is their');
+  });
+});


### PR DESCRIPTION
### What is the context of this PR?

Currently during relationship definition, we have no way of displaying question variants for a primary person. 

### How to review 
This adds a new test_relationship_primary schema which includes a question variant for the primary person. To support display of the variant a new "when" comparison needs to be added to allow comparisons against location.

This needs to be run with: https://github.com/ONSdigital/eq-schema-validator/pull/143

