### PR TITLE
Removed the check for an answer array on (not)contains any

### DIFF
--- a/app/questionnaire/rules.py
+++ b/app/questionnaire/rules.py
@@ -75,11 +75,11 @@ def evaluate_condition(condition, answer_value, match_value):
             and isinstance(match_value, list)
             and set(answer_value) >= set(match_value),
         'contains any':
-            lambda answer_value, match_value: isinstance(answer_value, list)
+            lambda answer_value, match_value: answer_and_match
             and isinstance(match_value, list)
             and bool(set(answer_value) & set(match_value)),
         'not contains any':
-            lambda answer_value, match_value: isinstance(answer_value, list)
+            lambda answer_value, match_value: answer_and_match
             and isinstance(match_value, list)
             and set(answer_value).isdisjoint(set(match_value)),
         'not contains all':
@@ -106,7 +106,6 @@ def evaluate_condition(condition, answer_value, match_value):
     }
 
     match_function = comparison_operators[condition]
-
     return match_function(answer_value, match_value)
 
 

--- a/tests/app/questionnaire/test_rules.py
+++ b/tests/app/questionnaire/test_rules.py
@@ -210,6 +210,22 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         self.assertFalse(evaluate_rule(when, ['a', 'b']))
         self.assertFalse(evaluate_rule(when, ['a', 'b', 'c']))
 
+    def test_evaluate_rule_radio_contains_any(self):
+        when = {'values': ['a', 'b'], 'condition': 'contains any'}
+
+        self.assertTrue(evaluate_rule(when, 'a'))
+        self.assertTrue(evaluate_rule(when, 'b'))
+        self.assertFalse(evaluate_rule(when, ''))
+        self.assertFalse(evaluate_rule(when, 'c'))
+
+    def test_evaluate_rule_radio_not_contains_any(self):
+        when = {'values': ['a', 'b'], 'condition': 'not contains any'}
+
+        self.assertTrue(evaluate_rule(when, 'c'))
+        self.assertTrue(evaluate_rule(when, ''))
+        self.assertFalse(evaluate_rule(when, 'b'))
+        self.assertFalse(evaluate_rule(when, 'a'))
+
     def test_go_to_next_question_for_answer(self):
         # Given
         goto = {


### PR DESCRIPTION
### What is the context of this PR?
After seeing how complex the current implementation of the transformation between Author radio answer routing and Runners version was it made sense to enable match_values arrays on Radio answers for contains_any conditions and not contains any conditions.
 
### How to review 
Existing functionality is unchanged and new tests pass proving the new stuff works.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
