### PR TITLE
Revisit relationships when list changes

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -39,18 +39,18 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:663d5bb17cfdf706a0c157f6eeb01f5c22a29c7528b49f9f4deb73af27301b19",
-                "sha256:b8796d48f06e8701bd26671bee9936cf6403042ab8e79d6561b1e8496a31d19b"
+                "sha256:8d934fcfca83c6ce40d53043cc94b1de6eef1d2dbe2a196343941587717ad1b7",
+                "sha256:e221f6867282266e06aec2213f0ea5fdbd4eb3facbca4fcbf96886073350bc5e"
             ],
             "index": "pypi",
-            "version": "==1.9.209"
+            "version": "==1.9.210"
         },
         "botocore": {
             "hashes": [
-                "sha256:8be475b83c3b654a78c2aa195dc4c82852a31c2e72b32b73f570260ae6451eba",
-                "sha256:bf2dcd604a83b045df0870486c3252785734b1cbe167752b8f777d8174218e64"
+                "sha256:0db52327f8d2891cca4c86dfc5cb3b4821d37b84c34804c26b82e775668490f5",
+                "sha256:7983b7624b3f71648a7101fbcb437e3d599b4f79b754e89220e574482a2f8298"
             ],
-            "version": "==1.12.209"
+            "version": "==1.12.210"
         },
         "cachetools": {
             "hashes": [
@@ -161,8 +161,7 @@
         "eq-translations": {
             "editable": true,
             "git": "https://github.com/ONSDigital/eq-translations.git",
-            "ref": "a1f5fa38f8d54ffbd6d755ea48e3f06a73d34ae0",
-            "version": "==0.2"
+            "ref": "a1f5fa38f8d54ffbd6d755ea48e3f06a73d34ae0"
         },
         "flask": {
             "hashes": [
@@ -211,7 +210,6 @@
         },
         "flask-themes2": {
             "hashes": [
-                "sha256:201aa8153c7fe74058580328386d5153e291af12eae9b8f737ab98b31bffb3a0",
                 "sha256:ccab0153547fd8288489f091ce00c3ba921d4cba1fb218e3bd70f1226923645d"
             ],
             "index": "pypi",
@@ -253,7 +251,6 @@
             ],
             "index": "pypi",
             "markers": "platform_python_implementation == 'CPython'",
-            "platform_python_implementation": "=='CPython'",
             "version": "==1.4.0"
         },
         "google-api-core": {
@@ -513,7 +510,6 @@
                 "sha256:64cf847e843a465b6c1ba90fb6c7f7844d54dbe9eb731e86a60981d03f5b2e6e",
                 "sha256:917c8662b585470e8fd42f052661fc66d59fccaae450a60044307dcbf82a3335",
                 "sha256:afed9003d7f2be2c3df20f64220c30faec441073731511728a2cb4cab4cd46a6",
-                "sha256:b883d7eb129b1b57c5128146bc7c2d1f15de457e96a549827fbee6f26eeedc46",
                 "sha256:bf8e05d638b585d1752c5a84247134a0350d3a8b73d3632489a014a9f6f1e758",
                 "sha256:d831b047bd69becaf64019a47179eb22118a50dd008340655266a906c69c6417",
                 "sha256:de2760583ed28749ff885789c1cbc6c9c06d6de92fc825740ab99deb2f25ea4d",
@@ -524,37 +520,15 @@
         },
         "pyasn1": {
             "hashes": [
-                "sha256:0c444a3482c5f5c7fab93567761324f77045ede002362171e12acdd400ea50e0",
-                "sha256:27e919f274d96829d9c78455eacf6a2253c9fd44979e5f880b672b524161366d",
                 "sha256:3bb81821d47b17146049e7574ab4bf1e315eb7aead30efe5d6a9ca422c9710be",
-                "sha256:3f8b11ba9fde9aeb56882589896cf9c7c8f4d5630f5e83abec1d80d1ef37b28b",
-                "sha256:40f307cb9e351bf54b5cf956a85e02a42d4f881dac79ce7d0b736acb2adab0e5",
-                "sha256:54734028b18e1d625a788d9846479ce088f10015db9ffb1abdd406d82b68b600",
-                "sha256:5616c045d1eb934fecc0162bc2b9bd2c8935d4a3c4642c3ccd96fb1528b1f218",
-                "sha256:5eb6dbc1191dc8a18da9d3ee4c3133909e3cfd0967d434dee958e737c1ca0bb7",
-                "sha256:72f5f934852f4722e769ec9a4dd20d6fa206a78186bab2aadf27753a222892f6",
-                "sha256:86ddc0f9a9062f111e70de780c5eb6d5d726f44809fafaa0af7a534ed66fc7c1",
-                "sha256:b17f6696f920dc712a4dc5c711b1abd623d80531910e1455c70a6cb85ffb6332",
-                "sha256:b773d5c9196ffbc3a1e13bdf909d446cad80a039aa3340bcad72f395b76ebc86",
-                "sha256:f8dda822e63df09237acd8f88940c68c1964076e5d9a906cbf385d71ec1a4006"
+                "sha256:b773d5c9196ffbc3a1e13bdf909d446cad80a039aa3340bcad72f395b76ebc86"
             ],
             "version": "==0.4.6"
         },
         "pyasn1-modules": {
             "hashes": [
-                "sha256:256c234d85baf315f0e99786d812e68b816e4ee4b35bac982689198ff3df5a61",
-                "sha256:3b350a01813f4878f4ebb3e7348d3753556b120145460a810e3121fe78925923",
                 "sha256:43c17a83c155229839cc5c6b868e8d0c6041dba149789b6d6e28801c64821722",
-                "sha256:525edd202cadbb014587e6e8a82a86424d4c92340222000b300cfd4041625f5a",
-                "sha256:5965cb606a914b1b086f6ffdb9e526b5ec21cea81ba0bb75f3b807d5500dda1a",
-                "sha256:75819dd99d1be4effd1322859ec8ac3fa7c7503fec0acbce6985b2aae41aa838",
-                "sha256:a00100a99dcc71a97b2291fcac868a39f32a72cc54d86a4e5504b34b2f5f8584",
-                "sha256:a480489471e67c579f49057a10879cc9a787b64a84af00ed2ed3f68a652b0197",
-                "sha256:b3899b59d6c6b4e91e9c5278ec49c0adb971349ef9c3531ae67149e3bb0b272b",
-                "sha256:b5e0ab3dc16f42ef0c2e5ebf51db9f1e1aa734a68a4d26a2b475a289182b697f",
-                "sha256:bf68431a9043b35aa0a18b865ecbb19ec19f8354488ea0b3b5d9ec33cb4c2be5",
-                "sha256:e30199a9d221f1b26c885ff3d87fd08694dbbe18ed0e8e405a2a7126d30ce4c0",
-                "sha256:ee0eb28ad9e9c0237954b4ca4c8a91cc2e98476c1dc9a1422310332518b0dd82"
+                "sha256:e30199a9d221f1b26c885ff3d87fd08694dbbe18ed0e8e405a2a7126d30ce4c0"
             ],
             "version": "==0.2.6"
         },
@@ -647,26 +621,17 @@
         "simplejson": {
             "hashes": [
                 "sha256:067a7177ddfa32e1483ba5169ebea1bc2ea27f224853211ca669325648ca5642",
-                "sha256:2b8cb601d9ba0381499db719ccc9dfbb2fbd16013f5ff096b1a68a4775576a04",
-                "sha256:2c139daf167b96f21542248f8e0a06596c9b9a7a41c162cc5c9ee9f3833c93cd",
                 "sha256:2fc546e6af49fb45b93bbe878dea4c48edc34083729c0abd09981fe55bdf7f91",
                 "sha256:354fa32b02885e6dae925f1b5bbf842c333c1e11ea5453ddd67309dc31fdb40a",
                 "sha256:37e685986cf6f8144607f90340cff72d36acf654f3653a6c47b84c5c38d00df7",
                 "sha256:3af610ee72efbe644e19d5eaad575c73fb83026192114e5f6719f4901097fce2",
                 "sha256:3b919fc9cf508f13b929a9b274c40786036b31ad28657819b3b9ba44ba651f50",
                 "sha256:3dd289368bbd064974d9a5961101f080e939cbe051e6689a193c99fb6e9ac89b",
-                "sha256:491de7acc423e871a814500eb2dcea8aa66c4a4b1b4825d18f756cdf58e370cb",
-                "sha256:495511fe5f10ccf4e3ed4fc0c48318f533654db6c47ecbc970b4ed215c791968",
-                "sha256:65b41a5cda006cfa7c66eabbcf96aa704a6be2a5856095b9e2fd8c293bad2b46",
                 "sha256:6c3258ffff58712818a233b9737fe4be943d306c40cf63d14ddc82ba563f483a",
                 "sha256:75e3f0b12c28945c08f54350d91e624f8dd580ab74fd4f1bbea54bc6b0165610",
-                "sha256:79b129fe65fdf3765440f7a73edaffc89ae9e7885d4e2adafe6aa37913a00fbb",
                 "sha256:b1f329139ba647a9548aa05fb95d046b4a677643070dc2afc05fa2e975d09ca5",
-                "sha256:c206f47cbf9f32b573c9885f0ec813d2622976cf5effcf7e472344bc2e020ac1",
-                "sha256:d8e238f20bcf70063ee8691d4a72162bcec1f4c38f83c93e6851e72ad545dabb",
                 "sha256:ee9625fc8ee164902dfbb0ff932b26df112da9f871c32f0f9c1bcf20c350fe2a",
-                "sha256:fb2530b53c28f0d4d84990e945c2ebb470edb469d63e389bf02ff409012fe7c5",
-                "sha256:feadb95170e45f439455354904768608e356c5b174ca30b3d11b0e3f24b5c0df"
+                "sha256:fb2530b53c28f0d4d84990e945c2ebb470edb469d63e389bf02ff409012fe7c5"
             ],
             "version": "==3.16.0"
         },
@@ -687,10 +652,10 @@
         },
         "tqdm": {
             "hashes": [
-                "sha256:1dc82f87a8726602fa7177a091b5e8691d6523138a8f7acd08e58088f51e389f",
-                "sha256:47220a4f2aeebbc74b0ab317584264ea44c745e1fd5ff316b675cd0aff8afad8"
+                "sha256:438d6a735167099d75e5fd9a55175c6727c4dbba345ae406b2886c2728fe3e80",
+                "sha256:ebc205051d79b49989140f5f6c73ec23fce5f590cbc4d9cd6e4c47f168fa0f10"
             ],
-            "version": "==4.33.0"
+            "version": "==4.34.0"
         },
         "ua-parser": {
             "hashes": [
@@ -812,18 +777,18 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:663d5bb17cfdf706a0c157f6eeb01f5c22a29c7528b49f9f4deb73af27301b19",
-                "sha256:b8796d48f06e8701bd26671bee9936cf6403042ab8e79d6561b1e8496a31d19b"
+                "sha256:8d934fcfca83c6ce40d53043cc94b1de6eef1d2dbe2a196343941587717ad1b7",
+                "sha256:e221f6867282266e06aec2213f0ea5fdbd4eb3facbca4fcbf96886073350bc5e"
             ],
             "index": "pypi",
-            "version": "==1.9.209"
+            "version": "==1.9.210"
         },
         "botocore": {
             "hashes": [
-                "sha256:8be475b83c3b654a78c2aa195dc4c82852a31c2e72b32b73f570260ae6451eba",
-                "sha256:bf2dcd604a83b045df0870486c3252785734b1cbe167752b8f777d8174218e64"
+                "sha256:0db52327f8d2891cca4c86dfc5cb3b4821d37b84c34804c26b82e775668490f5",
+                "sha256:7983b7624b3f71648a7101fbcb437e3d599b4f79b754e89220e574482a2f8298"
             ],
-            "version": "==1.12.209"
+            "version": "==1.12.210"
         },
         "certifi": {
             "hashes": [
@@ -1005,7 +970,6 @@
         },
         "flake8-blind-except": {
             "hashes": [
-                "sha256:0d7d1adb4cabf2268d6eebb815a7a5014bcb7e8419f7a74339c46d0b8847b858",
                 "sha256:aca3356633825544cec51997260fe31a8f24a1a2795ce8e81696b9916745e599"
             ],
             "index": "pypi",
@@ -1295,19 +1259,8 @@
         },
         "pyasn1": {
             "hashes": [
-                "sha256:0c444a3482c5f5c7fab93567761324f77045ede002362171e12acdd400ea50e0",
-                "sha256:27e919f274d96829d9c78455eacf6a2253c9fd44979e5f880b672b524161366d",
                 "sha256:3bb81821d47b17146049e7574ab4bf1e315eb7aead30efe5d6a9ca422c9710be",
-                "sha256:3f8b11ba9fde9aeb56882589896cf9c7c8f4d5630f5e83abec1d80d1ef37b28b",
-                "sha256:40f307cb9e351bf54b5cf956a85e02a42d4f881dac79ce7d0b736acb2adab0e5",
-                "sha256:54734028b18e1d625a788d9846479ce088f10015db9ffb1abdd406d82b68b600",
-                "sha256:5616c045d1eb934fecc0162bc2b9bd2c8935d4a3c4642c3ccd96fb1528b1f218",
-                "sha256:5eb6dbc1191dc8a18da9d3ee4c3133909e3cfd0967d434dee958e737c1ca0bb7",
-                "sha256:72f5f934852f4722e769ec9a4dd20d6fa206a78186bab2aadf27753a222892f6",
-                "sha256:86ddc0f9a9062f111e70de780c5eb6d5d726f44809fafaa0af7a534ed66fc7c1",
-                "sha256:b17f6696f920dc712a4dc5c711b1abd623d80531910e1455c70a6cb85ffb6332",
-                "sha256:b773d5c9196ffbc3a1e13bdf909d446cad80a039aa3340bcad72f395b76ebc86",
-                "sha256:f8dda822e63df09237acd8f88940c68c1964076e5d9a906cbf385d71ec1a4006"
+                "sha256:b773d5c9196ffbc3a1e13bdf909d446cad80a039aa3340bcad72f395b76ebc86"
             ],
             "version": "==0.4.6"
         },
@@ -1516,10 +1469,10 @@
         },
         "soupsieve": {
             "hashes": [
-                "sha256:72b5f1aea9101cf720a36bb2327ede866fd6f1a07b1e87c92a1cc18113cbc946",
-                "sha256:e4e9c053d59795e440163733a7fec6c5972210e1790c507e4c7b051d6c5259de"
+                "sha256:8662843366b8d8779dec4e2f921bebec9afd856a5ff2e82cd419acc5054a1a92",
+                "sha256:a5a6166b4767725fd52ae55fee8c8b6137d9a51e9f1edea461a062a759160118"
             ],
-            "version": "==1.9.2"
+            "version": "==1.9.3"
         },
         "sshpubkeys": {
             "hashes": [
@@ -1537,8 +1490,7 @@
         "toml": {
             "hashes": [
                 "sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c",
-                "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e",
-                "sha256:f1db651f9657708513243e61e6cc67d101a39bad662eaa9b5546f789338e07a3"
+                "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"
             ],
             "version": "==0.10.0"
         },

--- a/app/data_model/answer_store.py
+++ b/app/data_model/answer_store.py
@@ -117,14 +117,12 @@ class AnswerStore:
             self._is_dirty = True
 
     def remove_all_answers_for_list_item_id(self, list_item_id: str):
-        """Remove all answers associated with a particular list_item_id
+        """Remove all answers associated with a particular list_item_id.
         This method iterates through the entire list of answers.
 
         *Not efficient.*
         """
-
         keys_to_delete = []
-
         for answer in self:
             if answer.list_item_id == list_item_id:
                 keys_to_delete.append((answer.answer_id, answer.list_item_id))

--- a/app/questionnaire/questionnaire_schema.py
+++ b/app/questionnaire/questionnaire_schema.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict, defaultdict
-from typing import Union
+from typing import List, Union
 
 from flask_babel import force_locale
 
@@ -186,6 +186,22 @@ class QuestionnaireSchema:  # pylint: disable=too-many-public-methods
             for block in self.get_blocks()
             if block['type'] in ('Summary', 'Confirmation')
         ]
+
+    def get_relationship_collectors(self) -> List:
+        return [
+            block
+            for block in self.get_blocks()
+            if block['type'] == 'RelationshipCollector'
+        ]
+
+    def get_relationship_collectors_by_list_name(self, list_name: str):
+        relationship_collectors = self.get_relationship_collectors()
+        if relationship_collectors:
+            return [
+                block
+                for block in relationship_collectors
+                if block['for_list'] == list_name
+            ]
 
     @staticmethod
     def get_all_questions_for_block(block):

--- a/app/questionnaire/questionnaire_store_updater.py
+++ b/app/questionnaire/questionnaire_store_updater.py
@@ -1,4 +1,6 @@
-from typing import List, Tuple, Optional
+from itertools import combinations
+
+from typing import List, Optional, Tuple, Union
 
 from app.data_model.answer_store import Answer
 from app.data_model.relationship_store import Relationship, RelationshipStore
@@ -40,27 +42,83 @@ class QuestionnaireStoreUpdater:
         relationship_answer_id = self._schema.get_relationship_answer_id_for_block(
             self._current_location.block_id
         )
-
         answer = self._answer_store.get_answer(relationship_answer_id)
-        if answer:
+        self._create_relationship_store_and_update_answer(
+            relationship_answer_id, answer, form_data, list_item_id, to_list_item_id
+        )
+
+    def _create_relationship_store_and_update_answer(
+        self, relationship_answer_id, answer, form_data, list_item_id, to_list_item_id
+    ):
+        try:
             relationship_store = RelationshipStore(answer.value)
-        else:
+        except AttributeError:
             relationship_store = RelationshipStore()
 
         relationship_answer = form_data.get(relationship_answer_id)
-
         relationship = Relationship(list_item_id, to_list_item_id, relationship_answer)
         relationship_store.add_or_update(relationship)
-
         self._answer_store.add_or_update(
             Answer(relationship_answer_id, relationship_store.serialise())
         )
+
+    def remove_completed_relationship_locations_for_list_name(
+        self, list_name: str
+    ) -> None:
+        target_relationship_collectors = self._get_relationship_collectors_by_list_name(
+            list_name
+        )
+        if target_relationship_collectors:
+            for target in target_relationship_collectors:
+                block_id = target['id']
+                section_id = self._schema.get_section_for_block_id(block_id)['id']
+                self.remove_completed_location(Location(section_id, block_id))
+
+    def update_relationship_question_completeness(self, list_name: str) -> None:
+        relationship_collectors = self._get_relationship_collectors_by_list_name(
+            list_name
+        )
+
+        if not relationship_collectors:
+            return None
+
+        list_items = self._list_store.get(list_name).items
+
+        for collector in relationship_collectors:
+            expected_pairs = {pair for pair in combinations(list_items, 2)}
+            relationship_answer_id = self._schema.get_relationship_answer_id_for_block(
+                collector['id']
+            )
+            relationship_answers = self._get_relationships_in_answer_store(
+                relationship_answer_id
+            )
+
+            if relationship_answers:
+                pairs = {
+                    (answer['list_item_id'], answer['to_list_item_id'])
+                    for answer in relationship_answers
+                }
+
+                if expected_pairs == pairs:
+                    section_id = self._schema.get_section_for_block_id(collector['id'])[
+                        'id'
+                    ]
+                    location = Location(section_id, collector['id'])
+                    self.add_completed_location(location)
+
+    def _get_relationship_collectors_by_list_name(self, list_name: str):
+        return self._schema.get_relationship_collectors_by_list_name(list_name)
+
+    def _get_relationships_in_answer_store(self, relationship_answer_id: str):
+        return self._answer_store.get_answer(relationship_answer_id).value
 
     def remove_answers(self, answer_ids: List):
         for answer_id in answer_ids:
             self._answer_store.remove_answer(answer_id)
 
     def add_primary_person(self, list_name):
+        self.remove_completed_relationship_locations_for_list_name(list_name)
+
         if self._list_store[list_name].primary_person:
             return self._list_store[list_name].primary_person
 
@@ -68,10 +126,9 @@ class QuestionnaireStoreUpdater:
 
     def add_list_item_and_answers(self, form, list_name):
         new_list_item_id = self._list_store.add_list_item(list_name)
-
         self._current_location.list_item_id = new_list_item_id
-
         self.update_answers(form)
+        self.remove_completed_relationship_locations_for_list_name(list_name)
 
     def remove_primary_person(self, list_name: str):
         """ Remove the primary person and all of their answers.
@@ -82,7 +139,8 @@ class QuestionnaireStoreUpdater:
             self.remove_list_item_and_answers(list_name, list_item_id)
 
     def remove_list_item_and_answers(self, list_name: str, list_item_id: str):
-        """ Remove answers from the answer store and update the list store to remove it
+        """ Remove answers from the answer store and update the list store to remove it.
+        Any related relationship answers are re-evaluated for completeness.
         """
         self._list_store.delete_list_item(list_name, list_item_id)
 
@@ -90,7 +148,40 @@ class QuestionnaireStoreUpdater:
             list_item_id=list_item_id
         )
 
+        answers = self.get_relationship_answers_for_list_name(list_name)
+        if answers:
+            self.remove_relationship_answers_for_list_item_id(list_item_id, answers)
+            self.update_relationship_question_completeness(list_name)
+
         self._progress_store.remove_progress_for_list_item_id(list_item_id=list_item_id)
+
+    def get_relationship_answers_for_list_name(
+        self, list_name: str
+    ) -> Union[List[Answer], None]:
+        assosciated_relationship_collectors = self._get_relationship_collectors_by_list_name(
+            list_name
+        )
+        if not assosciated_relationship_collectors:
+            return None
+
+        relationship_answer_ids = [
+            self._schema.get_relationship_answer_id_for_block(block['id'])
+            for block in assosciated_relationship_collectors
+        ]
+
+        return self._answer_store.get_answers_by_answer_id(relationship_answer_ids)
+
+    def remove_relationship_answers_for_list_item_id(
+        self, list_item_id: str, answers: List
+    ) -> None:
+        for answer in answers:
+            answers_to_keep = [
+                value
+                for value in answer.value
+                if list_item_id not in {value['to_list_item_id'], value['list_item_id']}
+            ]
+            answer.value = answers_to_keep
+            self._answer_store.add_or_update(answer)
 
     def add_completed_location(self, location: Optional[Location] = None):
         location = location or self._current_location

--- a/app/views/handlers/list_collector.py
+++ b/app/views/handlers/list_collector.py
@@ -37,6 +37,7 @@ class ListCollector(Question):
         ):
             self._is_adding = True
             self.questionnaire_store_updater.update_answers(form)
+
             self.questionnaire_store_updater.save()
         else:
             return super().handle_post(form)

--- a/data-source/json/test_relationships.json
+++ b/data-source/json/test_relationships.json
@@ -134,6 +134,28 @@
                                         }
                                     ]
                                 }
+                            },
+                            "summary": {
+                                "item_title": {
+                                    "text": "{person_name}",
+                                    "placeholders": [
+                                        {
+                                            "placeholder": "person_name",
+                                            "transforms": [
+                                                {
+                                                    "arguments": {
+                                                        "delimiter": " ",
+                                                        "list_to_concatenate": {
+                                                            "identifier": ["first-name", "last-name"],
+                                                            "source": "answers"
+                                                        }
+                                                    },
+                                                    "transform": "concatenate_list"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
                             }
                         },
                         {

--- a/tests/app/data_model/test_answer_store.py
+++ b/tests/app/data_model/test_answer_store.py
@@ -33,6 +33,36 @@ def basic_answer_store():
     return answer_store
 
 
+@pytest.fixture
+def relationship_answer_store():
+    answer_store = AnswerStore()
+
+    answer_store.add_or_update(
+        Answer(
+            answer_id='relationship-answer',
+            value=[
+                {
+                    'list_item_id': 'abc123',
+                    'to_list_item_id': 'xyz987',
+                    'relationship': 'Husband or Wife',
+                },
+                {
+                    'list_item_id': 'abc123',
+                    'to_list_item_id': '123abc',
+                    'relationship': 'Son or Daughter',
+                },
+                {
+                    'list_item_id': 'xyz987',
+                    'to_list_item_id': '123abc',
+                    'relationship': 'Son or Daughter',
+                },
+            ],
+        )
+    )
+
+    return answer_store
+
+
 @pytest.fixture()
 def store_to_serialise():
     answer_store = AnswerStore()
@@ -133,6 +163,17 @@ def test_remove_answer(basic_answer_store):
     len_before_remove = len(basic_answer_store)
     basic_answer_store.remove_answer('answer1', 'abc123')
     assert len(basic_answer_store) == len_before_remove - 1
+
+
+def test_remove_all_answers_for_list_item_id(relationship_answer_store):
+    relationship_answer_store.remove_all_answers_for_list_item_id('abc123')
+    assert relationship_answer_store.get_answer('answer1') is None
+
+
+def test_remove_all_answers_for_list_item_id_doesnt_exist(relationship_answer_store):
+    len_before = len(relationship_answer_store)
+    relationship_answer_store.remove_all_answers_for_list_item_id('not-an-id')
+    assert len(relationship_answer_store) == len_before
 
 
 def test_list_serialisation(store_to_serialise):

--- a/tests/app/questionnaire/conftest.py
+++ b/tests/app/questionnaire/conftest.py
@@ -454,6 +454,294 @@ def question_schema():
     }
 
 
+# pylint: disable=line-too-long
+@pytest.fixture()
+def relationship_collector_schema():
+    return {
+        'sections': [
+            {
+                'id': 'section',
+                'groups': [
+                    {
+                        'id': 'group',
+                        'title': 'List',
+                        'blocks': [
+                            {
+                                'id': 'block1',
+                                'type': 'ListCollector',
+                                'for_list': 'people',
+                                'add_answer': {'id': 'answer1', 'value': 'Yes'},
+                                'remove_answer': {
+                                    'id': 'remove-confirmation',
+                                    'value': 'Yes',
+                                },
+                                'question_variants': [
+                                    {
+                                        'question': {
+                                            'id': 'confirmation-question',
+                                            'type': 'General',
+                                            'title': 'Collector, Yes',
+                                            'answers': [
+                                                {
+                                                    'id': 'answer1',
+                                                    'label': 'Collector Answer 1 Variant Yes',
+                                                }
+                                            ],
+                                        },
+                                        'when': [
+                                            {
+                                                'id': 'when-answer',
+                                                'condition': 'equals',
+                                                'value': 'yes',
+                                            }
+                                        ],
+                                    },
+                                    {
+                                        'question': {
+                                            'id': 'confirmation-question',
+                                            'type': 'General',
+                                            'title': 'Collector, No',
+                                            'answers': [
+                                                {
+                                                    'id': 'answer1',
+                                                    'label': 'Collector Answer 1 Variant No',
+                                                }
+                                            ],
+                                        },
+                                        'when': [
+                                            {
+                                                'id': 'when-answer',
+                                                'condition': 'equals',
+                                                'value': 'no',
+                                            }
+                                        ],
+                                    },
+                                ],
+                                'add_block': {
+                                    'id': 'add-person',
+                                    'type': 'Question',
+                                    'question_variants': [
+                                        {
+                                            'question': {
+                                                'id': 'add-question',
+                                                'type': 'General',
+                                                'title': 'Add, Yes',
+                                                'answers': [
+                                                    {
+                                                        'id': 'answer1',
+                                                        'label': 'Answer 1 Variant Yes',
+                                                    }
+                                                ],
+                                            },
+                                            'when': [
+                                                {
+                                                    'id': 'when-answer',
+                                                    'condition': 'equals',
+                                                    'value': 'yes',
+                                                }
+                                            ],
+                                        },
+                                        {
+                                            'question': {
+                                                'id': 'add-question',
+                                                'type': 'General',
+                                                'title': 'Add, No',
+                                                'answers': [
+                                                    {
+                                                        'id': 'answer1',
+                                                        'label': 'Answer 1 Variant Yes',
+                                                    }
+                                                ],
+                                            },
+                                            'when': [
+                                                {
+                                                    'id': 'when-answer',
+                                                    'condition': 'equals',
+                                                    'value': 'no',
+                                                }
+                                            ],
+                                        },
+                                    ],
+                                },
+                                'edit_block': {
+                                    'id': 'edit-person',
+                                    'type': 'Question',
+                                    'question_variants': [
+                                        {
+                                            'question': {
+                                                'id': 'edit-question',
+                                                'type': 'General',
+                                                'title': 'Edit, Yes',
+                                                'answers': [
+                                                    {
+                                                        'id': 'answer1',
+                                                        'label': 'Answer 1 Variant Yes',
+                                                    }
+                                                ],
+                                            },
+                                            'when': [
+                                                {
+                                                    'id': 'when-answer',
+                                                    'condition': 'equals',
+                                                    'value': 'yes',
+                                                }
+                                            ],
+                                        },
+                                        {
+                                            'question': {
+                                                'id': 'edit-question',
+                                                'type': 'General',
+                                                'title': 'Edit, No',
+                                                'answers': [
+                                                    {
+                                                        'id': 'answer1',
+                                                        'label': 'Answer 1 Variant No',
+                                                    }
+                                                ],
+                                            },
+                                            'when': [
+                                                {
+                                                    'id': 'when-answer',
+                                                    'condition': 'equals',
+                                                    'value': 'no',
+                                                }
+                                            ],
+                                        },
+                                    ],
+                                },
+                                'remove_block': {
+                                    'id': 'remove-person',
+                                    'type': 'Question',
+                                    'question_variants': [
+                                        {
+                                            'question': {
+                                                'id': 'remove-question',
+                                                'type': 'General',
+                                                'title': 'Remove, Yes',
+                                                'answers': [
+                                                    {
+                                                        'id': 'answer1',
+                                                        'label': 'Answer 1 Variant Yes',
+                                                    }
+                                                ],
+                                            },
+                                            'when': [
+                                                {
+                                                    'id': 'when-answer',
+                                                    'condition': 'equals',
+                                                    'value': 'yes',
+                                                }
+                                            ],
+                                        },
+                                        {
+                                            'question': {
+                                                'id': 'remove-question',
+                                                'type': 'General',
+                                                'title': 'Remove, No',
+                                                'answers': [
+                                                    {
+                                                        'id': 'answer1',
+                                                        'label': 'Answer 1 Variant No',
+                                                    }
+                                                ],
+                                            },
+                                            'when': [
+                                                {
+                                                    'id': 'when-answer',
+                                                    'condition': 'equals',
+                                                    'value': 'no',
+                                                }
+                                            ],
+                                        },
+                                    ],
+                                },
+                            },
+                            {
+                                'type': 'RelationshipCollector',
+                                'id': 'relationships',
+                                'title': 'This will iterate over the people list, capturing the one way relationships.',
+                                'for_list': 'people',
+                                'question': {
+                                    'id': 'relationship-question',
+                                    'type': 'General',
+                                    'title': 'Thinking of {first_person_name}, {second_person_name} is their <em>...</em>',
+                                    'answers': [
+                                        {
+                                            'id': 'relationship-answer',
+                                            'mandatory': True,
+                                            'type': 'Relationship',
+                                            'playback': '{second_person_name} is {first_person_name_possessive} <em>…</em>',
+                                            'options': [
+                                                {
+                                                    'label': 'Husband or Wife',
+                                                    'value': 'Husband or Wife',
+                                                    'title': 'Thinking of {first_person_name}, {second_person_name} is their <em>husband or wife</em>',
+                                                    'playback': '{second_person_name} is {first_person_name_possessive} <em>husband or wife</em>',
+                                                },
+                                                {
+                                                    'label': 'Legally registered civil partner',
+                                                    'value': 'Legally registered civil partner',
+                                                    'title': 'Thinking of {first_person_name}, {second_person_name} is their <em>legally registered civil partner</em>',
+                                                    'playback': '{second_person_name} is {first_person_name_possessive} <em>legally registered civil partner</em>',
+                                                },
+                                                {
+                                                    'label': 'Son or daughter',
+                                                    'value': 'Son or daughter',
+                                                    'title': 'Thinking of {first_person_name}, {second_person_name} is their <em>son or daughter</em>',
+                                                    'playback': '{second_person_name} is {first_person_name_possessive} <em>son or daughter</em>',
+                                                },
+                                            ],
+                                        }
+                                    ],
+                                },
+                            },
+                            {
+                                'type': 'RelationshipCollector',
+                                'id': 'relationships-that-dont-point-to-list-collector',
+                                'title': 'This will iterate over the people list, capturing the one way relationships.',
+                                'for_list': 'not-people',
+                                'question': {
+                                    'id': 'relationship-question',
+                                    'type': 'General',
+                                    'title': 'Thinking of {first_person_name}, {second_person_name} is their <em>...</em>',
+                                    'answers': [
+                                        {
+                                            'id': 'relationship-answer',
+                                            'mandatory': True,
+                                            'type': 'Relationship',
+                                            'playback': '{second_person_name} is {first_person_name_possessive} <em>…</em>',
+                                            'options': [
+                                                {
+                                                    'label': 'Husband or Wife',
+                                                    'value': 'Husband or Wife',
+                                                    'title': 'Thinking of {first_person_name}, {second_person_name} is their <em>husband or wife</em>',
+                                                    'playback': '{second_person_name} is {first_person_name_possessive} <em>husband or wife</em>',
+                                                },
+                                                {
+                                                    'label': 'Legally registered civil partner',
+                                                    'value': 'Legally registered civil partner',
+                                                    'title': 'Thinking of {first_person_name}, {second_person_name} is their <em>legally registered civil partner</em>',
+                                                    'playback': '{second_person_name} is {first_person_name_possessive} <em>legally registered civil partner</em>',
+                                                },
+                                                {
+                                                    'label': 'Son or daughter',
+                                                    'value': 'Son or daughter',
+                                                    'title': 'Thinking of {first_person_name}, {second_person_name} is their <em>son or daughter</em>',
+                                                    'playback': '{second_person_name} is {first_person_name_possessive} <em>son or daughter</em>',
+                                                },
+                                            ],
+                                        }
+                                    ],
+                                },
+                            },
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+
+
 @pytest.fixture
 def section_with_repeating_list():
     return {

--- a/tests/app/questionnaire/test_questionnaire_schema.py
+++ b/tests/app/questionnaire/test_questionnaire_schema.py
@@ -578,6 +578,32 @@ def test_get_default_answer_single_question(single_question_schema):
     assert answer.value == 'test'
 
 
+def test_get_relationship_collectors(relationship_collector_schema):
+    schema = QuestionnaireSchema(relationship_collector_schema)
+    answer = schema.get_relationship_collectors()
+
+    assert len(answer) == 2
+    assert answer[0]['id'] == 'relationships'
+    assert answer[1]['id'] == 'relationships-that-dont-point-to-list-collector'
+
+
+def test_get_relationship_collectors_by_list_name(relationship_collector_schema):
+    schema = QuestionnaireSchema(relationship_collector_schema)
+    answer = schema.get_relationship_collectors_by_list_name('people')
+
+    assert len(answer) == 1
+    assert answer[0]['id'] == 'relationships'
+
+
+def test_get_relationship_collectors_by_list_name_no_collectors(
+    relationship_collector_schema
+):
+    schema = QuestionnaireSchema(relationship_collector_schema)
+    answer = schema.get_relationship_collectors_by_list_name('not-a-list')
+
+    assert not answer
+
+
 def test_get_list_item_id_for_answer_id_without_list_item_id(
     section_with_repeating_list
 ):
@@ -592,8 +618,6 @@ def test_get_list_item_id_for_answer_id_without_list_item_id(
     assert list_item_id == expected_list_item_id
 
 
-#
-#
 def test_get_list_item_id_for_answer_id_without_repeat_or_list_collector(
     question_schema
 ):

--- a/tests/functional/spec/relationships-primary.spec.js
+++ b/tests/functional/spec/relationships-primary.spec.js
@@ -6,10 +6,59 @@ const ListCollectorAddPage = require('../generated_pages/relationships_primary/l
 const RelationshipsPage = require('../generated_pages/relationships_primary/relationships.page.js');
 
 describe('Relationships - Primary Person', function() {
+  const schema = 'test_relationships_primary.json';
 
-  beforeEach(function() {
-    return helpers.openQuestionnaire('test_relationships_primary.json')
-    .then(() => {
+  describe('Given I am completing the test_relationships_primary survey', function() {
+    beforeEach(function() {
+      return helpers.openQuestionnaire(schema);
+    });
+
+    it('When I add household members, Then I will be asked my relationships as a primary person', function() {
+      return addPrimaryAndTwoOthers()
+        .click(ListCollectorPage.no())
+        .click(ListCollectorPage.submit())
+        .getText(RelationshipsPage.questionText()).should.eventually.contain('is your');
+    });
+
+    it('When I add household members, Then non-primary relationships will be asked as a non primary person', function() {
+      return addPrimaryAndTwoOthers()
+        .click(ListCollectorPage.no())
+        .click(ListCollectorPage.submit())
+        .click(RelationshipsPage.relationshipBrotherOrSister())
+        .click(RelationshipsPage.submit())
+        .click(RelationshipsPage.relationshipSonOrDaughter())
+        .click(RelationshipsPage.submit())
+        .getText(RelationshipsPage.questionText()).should.eventually.contain('is their');
+    });
+
+    it('When I add household members And add thir relationships And remove the primary person And add a new primary person then I will be asked for the relationships again', function() {
+      return addPrimaryAndTwoOthersAndCompleteRelationships()
+        .url('/questionnaire/primary-person-list-collector')
+        .click(PrimaryPersonListCollectorPage.no())
+        .click(PrimaryPersonListCollectorPage.submit())
+        .url('/questionnaire/primary-person-list-collector')
+        .click(PrimaryPersonListCollectorPage.yes())
+        .click(PrimaryPersonListCollectorPage.submit())
+        .setValue(PrimaryPersonListCollectorAddPage.firstName(), 'Marcus')
+        .setValue(PrimaryPersonListCollectorAddPage.lastName(), 'Twin')
+        .click(PrimaryPersonListCollectorAddPage.submit())
+        .click(ListCollectorPage.no())
+        .click(ListCollectorPage.submit())
+        .getText(RelationshipsPage.questionText()).should.eventually.contain('Samuel Clemens is your');
+    });
+
+    function addPrimaryAndTwoOthersAndCompleteRelationships() {
+      return addPrimaryAndTwoOthers()
+        .click(ListCollectorPage.no())
+        .click(ListCollectorPage.submit())
+        .click(RelationshipsPage.relationshipBrotherOrSister())
+        .click(RelationshipsPage.submit())
+        .click(RelationshipsPage.relationshipSonOrDaughter())
+        .click(RelationshipsPage.submit())
+        .click(RelationshipsPage.relationshipBrotherOrSister());
+    }
+
+    function addPrimaryAndTwoOthers() {
       return browser
         .click(PrimaryPersonListCollectorPage.yes())
         .click(PrimaryPersonListCollectorPage.submit())
@@ -25,23 +74,7 @@ describe('Relationships - Primary Person', function() {
         .click(ListCollectorPage.submit())
         .setValue(ListCollectorAddPage.firstName(), 'Olivia')
         .setValue(ListCollectorAddPage.lastName(), 'Clemens')
-        .click(ListCollectorAddPage.submit())
-        .click(ListCollectorPage.no())
-        .click(ListCollectorPage.submit());
-    });
-  });
-
-  it('Given I am completing the survey, When I add household members, Then I will be asked my relationships as a primary person', function () {
-    return browser
-      .getText(RelationshipsPage.questionText()).should.eventually.contain('is your');
-  });
-
-  it('Given I am completing the survey, When I add household members, Then non-primary relationships will be asked as a non primary person', function () {
-    return browser
-      .click(RelationshipsPage.relationshipBrotherOrSister())
-      .click(RelationshipsPage.submit())
-      .click(RelationshipsPage.relationshipSonOrDaughter())
-      .click(RelationshipsPage.submit())
-      .getText(RelationshipsPage.questionText()).should.eventually.contain('is their');
+        .click(ListCollectorAddPage.submit());
+    }
   });
 });

--- a/tests/functional/spec/relationships.spec.js
+++ b/tests/functional/spec/relationships.spec.js
@@ -1,96 +1,230 @@
 const helpers = require('../helpers');
 const ListCollectorPage = require('../generated_pages/relationships/list-collector.page.js');
 const ListCollectorAddPage = require('../generated_pages/relationships/list-collector-add.page.js');
+const ListCollectorRemovePage = require('../generated_pages/relationships/list-collector-remove.page.js');
 const RelationshipsPage = require('../generated_pages/relationships/relationships.page.js');
 const ConfirmationPage = require('../generated_pages/relationships/confirmation.page.js');
 
 describe('Relationships', function() {
+  const schema = 'test_relationships.json';
 
-  beforeEach(function() {
-    return helpers.openQuestionnaire('test_relationships.json');
-  });
+  describe('Given I am completing the test_relationships survey,', function() {
+    beforeEach('load the survey', function() {
+      return helpers.openQuestionnaire(schema);
+    });
 
-  it('Given I am completing the survey, When I have one household member, Then I will be not be asked about relationships', function () {
-    return browser
-    .click(ListCollectorPage.yes())
-    .click(ListCollectorPage.submit())
-    .setValue(ListCollectorAddPage.firstName(), 'Marcus')
-    .setValue(ListCollectorAddPage.lastName(), 'Twin')
-    .click(ListCollectorAddPage.submit())
-    .click(ListCollectorPage.no())
-    .click(ListCollectorPage.submit())
-    .getUrl().should.eventually.contain(ConfirmationPage.pageName);
-  });
 
-  it('Given I am completing the survey, When I add two household members, Then I will be asked about one relationship', function () {
-    return browser
-    .click(ListCollectorPage.yes())
-    .click(ListCollectorPage.submit())
-    .setValue(ListCollectorAddPage.firstName(), 'Marcus')
-    .setValue(ListCollectorAddPage.lastName(), 'Twin')
-    .click(ListCollectorAddPage.submit())
-    .click(ListCollectorPage.yes())
-    .click(ListCollectorPage.submit())
-    .setValue(ListCollectorAddPage.firstName(), 'Samuel')
-    .setValue(ListCollectorAddPage.lastName(), 'Clemens')
-    .click(ListCollectorAddPage.submit())
-    .click(ListCollectorPage.no())
-    .click(ListCollectorPage.submit())
-    .getUrl().should.eventually.contain(RelationshipsPage.pageName)
-    .click(RelationshipsPage.husbandOrWife())
-    .click(RelationshipsPage.submit())
-    .getUrl().should.eventually.contain(ConfirmationPage.pageName);
-  });
-
-  it('Given I am completing the survey, When I add three household members, Then I will be asked about all relationships', function () {
-    return helpers.openQuestionnaire('test_relationships.json')
-    .then(addThreePeople)
-    .then(() => {
+    it('When I have one household member, Then I will be not be asked about relationships', function() {
       return browser
+        .click(ListCollectorPage.yes())
+        .click(ListCollectorPage.submit())
+        .setValue(ListCollectorAddPage.firstName(), 'Marcus')
+        .setValue(ListCollectorAddPage.lastName(), 'Twin')
+        .click(ListCollectorAddPage.submit())
         .click(ListCollectorPage.no())
         .click(ListCollectorPage.submit())
-        .click(RelationshipsPage.husbandOrWife())
-        .click(RelationshipsPage.submit())
-        .click(RelationshipsPage.legallyRegisteredCivilPartner())
-        .click(RelationshipsPage.submit())
+        .getUrl().should.eventually.contain(ConfirmationPage.pageName);
+    });
+
+    it('When I add two household members, Then I will be asked about one relationship', function() {
+      return browser
+        .click(ListCollectorPage.yes())
+        .click(ListCollectorPage.submit())
+        .setValue(ListCollectorAddPage.firstName(), 'Marcus')
+        .setValue(ListCollectorAddPage.lastName(), 'Twin')
+        .click(ListCollectorAddPage.submit())
+        .click(ListCollectorPage.yes())
+        .click(ListCollectorPage.submit())
+        .setValue(ListCollectorAddPage.firstName(), 'Samuel')
+        .setValue(ListCollectorAddPage.lastName(), 'Clemens')
+        .click(ListCollectorAddPage.submit())
+        .click(ListCollectorPage.no())
+        .click(ListCollectorPage.submit())
+        .getUrl().should.eventually.contain(RelationshipsPage.pageName)
         .click(RelationshipsPage.husbandOrWife())
         .click(RelationshipsPage.submit())
         .getUrl().should.eventually.contain(ConfirmationPage.pageName);
     });
-  });
 
-  it('Given I am completing the survey, When I add three household members and go to the first relationship, Then the previous link should return to the list collector', function () {
-    return helpers.openQuestionnaire('test_relationships.json')
-    .then(addThreePeople)
-    .then(() => {
-      return browser
-        .click(ListCollectorPage.no())
-        .click(ListCollectorPage.submit())
-        .click(RelationshipsPage.previous())
-        .getUrl().should.eventually.contain(ListCollectorPage.pageName);
+    describe('When I add three household members,', function() {
+      beforeEach('add three people', function() {
+        return addThreePeople();
+      });
+
+      it('Then I will be asked about all relationships', function() {
+        return browser
+          .click(ListCollectorPage.no())
+          .click(ListCollectorPage.submit())
+          .click(RelationshipsPage.husbandOrWife())
+          .click(RelationshipsPage.submit())
+          .click(RelationshipsPage.legallyRegisteredCivilPartner())
+          .click(RelationshipsPage.submit())
+          .click(RelationshipsPage.husbandOrWife())
+          .click(RelationshipsPage.submit())
+          .getUrl().should.eventually.contain(ConfirmationPage.pageName);
+      });
+
+      it('And go to the first relationship, Then the previous link should return to the list collector', function() {
+        return browser
+          .click(ListCollectorPage.no())
+          .click(ListCollectorPage.submit())
+          .click(RelationshipsPage.previous())
+          .getUrl().should.eventually.contain(ListCollectorPage.pageName);
+      });
+
+      it('And go to the second relationship, Then the previous link should return to the first relationship', function() {
+        return browser
+          .click(ListCollectorPage.no())
+          .click(ListCollectorPage.submit())
+          .click(RelationshipsPage.husbandOrWife())
+          .click(RelationshipsPage.submit())
+          .click(RelationshipsPage.previous())
+          .getUrl().should.eventually.contain(RelationshipsPage.pageName)
+          .getText(RelationshipsPage.questionText()).should.eventually.contain('Marcus');
+      });
+
+      it('And go to the confirmation page, Then the previous link should return to the last relationship', function() {
+        return browser
+          .click(ListCollectorPage.no())
+          .click(ListCollectorPage.submit())
+          .click(RelationshipsPage.husbandOrWife())
+          .click(RelationshipsPage.submit())
+          .click(RelationshipsPage.legallyRegisteredCivilPartner())
+          .click(RelationshipsPage.submit())
+          .click(RelationshipsPage.husbandOrWife())
+          .click(RelationshipsPage.submit())
+          .getUrl().should.eventually.contain(ConfirmationPage.pageName)
+          .click(ConfirmationPage.previous())
+          .getUrl().should.eventually.contain(RelationshipsPage.pageName)
+          .getText(RelationshipsPage.questionText()).should.eventually.contain('Olivia');
+      });
+
+      it('When I add all relationships and return to the relationships, Then the relationships should be populated', function() {
+        return browser
+          .click(ListCollectorPage.no())
+          .click(ListCollectorPage.submit())
+          .click(RelationshipsPage.husbandOrWife())
+          .click(RelationshipsPage.submit())
+          .click(RelationshipsPage.legallyRegisteredCivilPartner())
+          .click(RelationshipsPage.submit())
+          .click(RelationshipsPage.husbandOrWife())
+          .click(RelationshipsPage.submit())
+          .getUrl().should.eventually.contain(ConfirmationPage.pageName)
+          .click(ConfirmationPage.previous())
+          .isSelected(RelationshipsPage.husbandOrWife()).should.eventually.be.true
+          .click(ConfirmationPage.previous())
+          .isSelected(RelationshipsPage.legallyRegisteredCivilPartner()).should.eventually.be.true
+          .click(ConfirmationPage.previous())
+          .isSelected(RelationshipsPage.husbandOrWife()).should.eventually.be.true;
+      });
+
+      it('And go to the first relationship, Then the person\'s name should be in the question title and playback text', function() {
+        return browser
+          .click(ListCollectorPage.no())
+          .click(ListCollectorPage.submit())
+          .getText(ListCollectorPage.questionText()).should.eventually.contain('Marcus Twin')
+          .getText(RelationshipsPage.playback()).should.eventually.contain('Marcus Twin');
+      });
+
+      it('And go to the first relationship and submit without selecting an option, Then an error should be displayed', function() {
+        return browser
+          .click(ListCollectorPage.no())
+          .click(ListCollectorPage.submit())
+          .click(RelationshipsPage.submit())
+          .isVisible(RelationshipsPage.error()).should.eventually.be.true;
+      });
+
+      it('And go to a non existent relationship, Then I should be redirected to the first relationship', function() {
+        return browser
+          .click(ListCollectorPage.no())
+          .click(ListCollectorPage.submit())
+          .url('/questionnaire/relationships/fake-id/to/another-fake-id')
+          .getUrl().should.eventually.contain(RelationshipsPage.pageName)
+          .getText(RelationshipsPage.playback()).should.eventually.contain('Marcus Twin');
+      });
+
+      it('And go to the first relationship and click \'Save and sign out\', Then I should be signed out', function() {
+        return browser
+          .click(ListCollectorPage.no())
+          .click(ListCollectorPage.submit())
+          .click(RelationshipsPage.husbandOrWife())
+          .click(RelationshipsPage.saveSignOut())
+          .getUrl().should.eventually.not.contain('questionnaire');
+      });
+
+      it('And go to the first relationship, select a relationship and click \'Save and sign out\', Then I should be signed out', function() {
+        return browser
+          .click(ListCollectorPage.no())
+          .click(ListCollectorPage.submit())
+          .click(RelationshipsPage.saveSignOut())
+          .getUrl().should.eventually.not.contain('questionnaire');
+      });
     });
-  });
 
-  it('Given I am completing the survey, When I add three household members and go to the second relationship, Then the previous link should return to the first relationship', function () {
-    return helpers.openQuestionnaire('test_relationships.json')
-    .then(addThreePeople)
-    .then(() => {
-      return browser
-        .click(ListCollectorPage.no())
-        .click(ListCollectorPage.submit())
-        .click(RelationshipsPage.husbandOrWife())
-        .click(RelationshipsPage.submit())
-        .click(RelationshipsPage.previous())
-        .getUrl().should.eventually.contain(RelationshipsPage.pageName)
-        .getText(RelationshipsPage.questionText()).should.eventually.contain('Marcus');
+    describe('When I have added one or more household members after answering the relationships question,', function() {
+      beforeEach('add three people and complete their relationships', function() {
+        return addThreePeopleAndCompleteRelationships();
+      });
+
+      it('Then I delete one of the original household members I will not be asked for the original members relationships again', function() {
+        return browser
+          .url('/questionnaire/list-collector')
+          .click(ListCollectorPage.listRemoveLink(3))
+          .click(ListCollectorRemovePage.yes())
+          .click(ListCollectorRemovePage.submit())
+          .click(ListCollectorPage.no())
+          .click(ListCollectorPage.submit())
+          .getUrl().should.eventually.contain('/questionnaire/confirmation');
+      });
+
+      it('Then I will be asked for the original household members relationships to all new members', function() {
+        return browser
+          .url('/questionnaire/list-collector')
+          .click(ListCollectorPage.yes())
+          .click(ListCollectorPage.submit())
+          .setValue(ListCollectorAddPage.firstName(), 'Tom')
+          .setValue(ListCollectorAddPage.lastName(), 'Bowden')
+          .click(ListCollectorAddPage.submit())
+          .click(ListCollectorPage.no())
+          .click(ListCollectorPage.submit())
+          .isSelected(RelationshipsPage.husbandOrWife()).should.eventually.be.true
+          .click(RelationshipsPage.submit())
+          .isSelected(RelationshipsPage.legallyRegisteredCivilPartner()).should.eventually.be.true
+          .click(RelationshipsPage.submit())
+          .getText(RelationshipsPage.playback())
+          .should.eventually.contain('Tom Bowden is Marcus Twin’s …')
+          .click(RelationshipsPage.sonOrDaughter())
+          .click(RelationshipsPage.submit())
+          .isSelected(RelationshipsPage.husbandOrWife()).should.eventually.be.true
+          .click(RelationshipsPage.submit())
+          .getText(RelationshipsPage.playback())
+          .should.eventually.contain('Tom Bowden is Samuel Clemens’ …')
+          .click(RelationshipsPage.sonOrDaughter())
+          .click(RelationshipsPage.submit())
+          .pause(20000)
+          .getText(RelationshipsPage.playback())
+          .should.eventually.contain('Tom Bowden is Olivia Clemens’ …');
+      });
+
+      it('When I add a household member after answering the relationships question but remove them again before exiting the list-collector block, Then I will not be asked for the original household members relationships to the new member', function() {
+        return browser
+          .url('/questionnaire/list-collector')
+          .click(ListCollectorPage.yes())
+          .click(ListCollectorPage.submit())
+          .setValue(ListCollectorAddPage.firstName(), 'Tom')
+          .setValue(ListCollectorAddPage.lastName(), 'Bowden')
+          .click(ListCollectorAddPage.submit())
+          .click(ListCollectorPage.listRemoveLink(4))
+          .click(ListCollectorRemovePage.yes())
+          .click(ListCollectorRemovePage.submit())
+          .click(ListCollectorPage.no())
+          .click(ListCollectorPage.submit())
+          .getUrl().should.eventually.contain('/questionnaire/confirmation');
+      });
     });
-  });
 
-  it('Given I am completing the survey, When I add all relationships and go to the confirmation page, Then the previous link should return to the last relationship', function () {
-    return helpers.openQuestionnaire('test_relationships.json')
-    .then(addThreePeople)
-    .then(() => {
-      return browser
+    function addThreePeopleAndCompleteRelationships() {
+      return addThreePeople()
         .click(ListCollectorPage.no())
         .click(ListCollectorPage.submit())
         .click(RelationshipsPage.husbandOrWife())
@@ -98,115 +232,26 @@ describe('Relationships', function() {
         .click(RelationshipsPage.legallyRegisteredCivilPartner())
         .click(RelationshipsPage.submit())
         .click(RelationshipsPage.husbandOrWife())
-        .click(RelationshipsPage.submit())
-        .getUrl().should.eventually.contain(ConfirmationPage.pageName)
-        .click(ConfirmationPage.previous())
-        .getUrl().should.eventually.contain(RelationshipsPage.pageName)
-        .getText(RelationshipsPage.questionText()).should.eventually.contain('Olivia');
-    });
-  });
+        .click(RelationshipsPage.submit());
+    }
 
-  it('Given I am completing the survey, When I add all relationships and return to the relationships, Then the relationships should be populated', function () {
-    return helpers.openQuestionnaire('test_relationships.json')
-    .then(addThreePeople)
-    .then(() => {
+    function addThreePeople() {
       return browser
-        .click(ListCollectorPage.no())
+        .click(ListCollectorPage.yes())
         .click(ListCollectorPage.submit())
-        .click(RelationshipsPage.husbandOrWife())
-        .click(RelationshipsPage.submit())
-        .click(RelationshipsPage.legallyRegisteredCivilPartner())
-        .click(RelationshipsPage.submit())
-        .click(RelationshipsPage.husbandOrWife())
-        .click(RelationshipsPage.submit())
-        .getUrl().should.eventually.contain(ConfirmationPage.pageName)
-        .click(ConfirmationPage.previous())
-        .isSelected(RelationshipsPage.husbandOrWife()).should.eventually.be.true
-        .click(ConfirmationPage.previous())
-        .isSelected(RelationshipsPage.legallyRegisteredCivilPartner()).should.eventually.be.true
-        .click(ConfirmationPage.previous())
-        .isSelected(RelationshipsPage.husbandOrWife()).should.eventually.be.true;
-    });
-  });
-
-  it('Given I am completing the survey, When I add three household members and go to the first relationship, Then the person\'s name should be in the question title and playback text', function () {
-    return helpers.openQuestionnaire('test_relationships.json')
-    .then(addThreePeople)
-    .then(() => {
-      return browser
-        .click(ListCollectorPage.no())
+        .setValue(ListCollectorAddPage.firstName(), 'Marcus')
+        .setValue(ListCollectorAddPage.lastName(), 'Twin')
+        .click(ListCollectorAddPage.submit())
+        .click(ListCollectorPage.yes())
         .click(ListCollectorPage.submit())
-        .getText(ListCollectorPage.questionText()).should.eventually.contain('Marcus Twin')
-        .getText(RelationshipsPage.playback()).should.eventually.contain('Marcus Twin');
-    });
-  });
-
-  it('Given I am completing the survey, When I add three household members and go to the first relationship and submit without selecting an option, Then an error should be displayed', function () {
-    return helpers.openQuestionnaire('test_relationships.json')
-    .then(addThreePeople)
-    .then(() => {
-      return browser
-        .click(ListCollectorPage.no())
+        .setValue(ListCollectorAddPage.firstName(), 'Samuel')
+        .setValue(ListCollectorAddPage.lastName(), 'Clemens')
+        .click(ListCollectorAddPage.submit())
+        .click(ListCollectorPage.yes())
         .click(ListCollectorPage.submit())
-        .click(RelationshipsPage.submit())
-        .isVisible(RelationshipsPage.error()).should.eventually.be.true;
-    });
+        .setValue(ListCollectorAddPage.firstName(), 'Olivia')
+        .setValue(ListCollectorAddPage.lastName(), 'Clemens')
+        .click(ListCollectorAddPage.submit());
+    }
   });
-
-  it('Given I am completing the survey, When I add three household members and go to a non existent relationship, Then I should be redirected to the first relationship', function () {
-    return helpers.openQuestionnaire('test_relationships.json')
-    .then(addThreePeople)
-    .then(() => {
-      return browser
-        .click(ListCollectorPage.no())
-        .click(ListCollectorPage.submit())
-        .url('/questionnaire/relationships/fake-id/to/another-fake-id')
-        .getUrl().should.eventually.contain(RelationshipsPage.pageName)
-        .getText(RelationshipsPage.playback()).should.eventually.contain('Marcus Twin');
-    });
-  });
-
-  it('Given I am completing the survey, When I add three household members and go to the first relationship and click \'Save and sign out\', Then I should be signed out', function () {
-    return helpers.openQuestionnaire('test_relationships.json')
-    .then(addThreePeople)
-    .then(() => {
-      return browser
-        .click(ListCollectorPage.no())
-        .click(ListCollectorPage.submit())
-        .click(RelationshipsPage.husbandOrWife())
-        .click(RelationshipsPage.saveSignOut())
-        .getUrl().should.eventually.not.contain('questionnaire');
-    });
-  });
-
-  it('Given I am completing the survey, When I add three household members and go to the first relationship, select a relationship and click \'Save and sign out\', Then I should be signed out', function () {
-    return helpers.openQuestionnaire('test_relationships.json')
-    .then(addThreePeople)
-    .then(() => {
-      return browser
-        .click(ListCollectorPage.no())
-        .click(ListCollectorPage.submit())
-        .click(RelationshipsPage.saveSignOut())
-        .getUrl().should.eventually.not.contain('questionnaire');
-    });
-  });
-
-  function addThreePeople() {
-    return browser
-      .click(ListCollectorPage.yes())
-      .click(ListCollectorPage.submit())
-      .setValue(ListCollectorAddPage.firstName(), 'Marcus')
-      .setValue(ListCollectorAddPage.lastName(), 'Twin')
-      .click(ListCollectorAddPage.submit())
-      .click(ListCollectorPage.yes())
-      .click(ListCollectorPage.submit())
-      .setValue(ListCollectorAddPage.firstName(), 'Samuel')
-      .setValue(ListCollectorAddPage.lastName(), 'Clemens')
-      .click(ListCollectorAddPage.submit())
-      .click(ListCollectorPage.yes())
-      .click(ListCollectorPage.submit())
-      .setValue(ListCollectorAddPage.firstName(), 'Olivia')
-      .setValue(ListCollectorAddPage.lastName(), 'Clemens')
-      .click(ListCollectorAddPage.submit());
-  }
 });

--- a/tests/integration/integration_test_case.py
+++ b/tests/integration/integration_test_case.py
@@ -139,6 +139,11 @@ class IntegrationTestCase(unittest.TestCase):  # pylint: disable=too-many-public
         dump_submission = json.loads(self.getResponseData())
         return dump_submission
 
+    def dump_debug(self):
+        self.get('/dump/debug')
+        self.assertStatusOK()
+        return json.loads(self.getResponseData())
+
     def get(self, url, **kwargs):
         """
         GETs the specified URL, following any redirects.


### PR DESCRIPTION
### What is the context of this PR?
When a list changes after relationships for the list items have been established, the relationships need to be evaluated again. There are three scenarios covered by this PR:

1) A list item is deleted:
    - All relationships for that list item should be deleted. Users should not be asked the relationship questions again.
2) A list item is added:
    - A user should be taken through all of the relationships questions again. Existing questions will have the previously selected answers already selected. New relationships should not have any answers selected.
3) A list item is added, but removed before submitting the list collector question:
    - No change to the relationship store. User shouldn't be asked relationship questions again.

### How to review 
Look at the code changes. Launch any relationships questionnaire schema. Using the scenarios above check the flow is correct for each. Check the /dump/debug endpoint to monitor updates to the answer store and list store.
