### PR TITLE
Schema changes for HH accomodation type Eng & Wal

### DIFF
--- a/data-source/json/test_repeating_sections_with_hub_and_spoke.json
+++ b/data-source/json/test_repeating_sections_with_hub_and_spoke.json
@@ -203,10 +203,7 @@
                                                     "arguments": {
                                                         "delimiter": " ",
                                                         "list_to_concatenate": {
-                                                            "identifier": [
-                                                                "first-name",
-                                                                "last-name"
-                                                            ],
+                                                            "identifier": ["first-name", "last-name"],
                                                             "source": "answers"
                                                         }
                                                     },
@@ -353,10 +350,7 @@
                                                     "arguments": {
                                                         "delimiter": " ",
                                                         "list_to_concatenate": {
-                                                            "identifier": [
-                                                                "first-name",
-                                                                "last-name"
-                                                            ],
+                                                            "identifier": ["first-name", "last-name"],
                                                             "source": "answers"
                                                         }
                                                     },
@@ -491,10 +485,7 @@
                                                     "arguments": {
                                                         "delimiter": " ",
                                                         "list_to_concatenate": {
-                                                            "identifier": [
-                                                                "first-name",
-                                                                "last-name"
-                                                            ],
+                                                            "identifier": ["first-name", "last-name"],
                                                             "source": "answers"
                                                         }
                                                     },
@@ -623,10 +614,7 @@
                                                             "arguments": {
                                                                 "delimiter": " ",
                                                                 "list_to_concatenate": {
-                                                                    "identifier": [
-                                                                        "first-name",
-                                                                        "last-name"
-                                                                    ],
+                                                                    "identifier": ["first-name", "last-name"],
                                                                     "source": "answers"
                                                                 }
                                                             },
@@ -751,10 +739,7 @@
                                                                             "arguments": {
                                                                                 "delimiter": " ",
                                                                                 "list_to_concatenate": {
-                                                                                    "identifier": [
-                                                                                        "first-name",
-                                                                                        "last-name"
-                                                                                    ],
+                                                                                    "identifier": ["first-name", "last-name"],
                                                                                     "source": "answers"
                                                                                 }
                                                                             },
@@ -802,10 +787,7 @@
                                                             "arguments": {
                                                                 "delimiter": " ",
                                                                 "list_to_concatenate": {
-                                                                    "identifier": [
-                                                                        "first-name",
-                                                                        "last-name"
-                                                                    ],
+                                                                    "identifier": ["first-name", "last-name"],
                                                                     "source": "answers"
                                                                 }
                                                             },
@@ -952,10 +934,7 @@
                                                             "arguments": {
                                                                 "delimiter": " ",
                                                                 "list_to_concatenate": {
-                                                                    "identifier": [
-                                                                        "first-name",
-                                                                        "last-name"
-                                                                    ],
+                                                                    "identifier": ["first-name", "last-name"],
                                                                     "source": "answers"
                                                                 }
                                                             },
@@ -1054,10 +1033,7 @@
                                                             "arguments": {
                                                                 "delimiter": " ",
                                                                 "list_to_concatenate": {
-                                                                    "identifier": [
-                                                                        "first-name",
-                                                                        "last-name"
-                                                                    ],
+                                                                    "identifier": ["first-name", "last-name"],
                                                                     "source": "answers"
                                                                 }
                                                             },
@@ -1141,10 +1117,7 @@
                                                     "arguments": {
                                                         "delimiter": " ",
                                                         "list_to_concatenate": {
-                                                            "identifier": [
-                                                                "first-name",
-                                                                "last-name"
-                                                            ],
+                                                            "identifier": ["first-name", "last-name"],
                                                             "source": "answers"
                                                         }
                                                     },

--- a/data-source/jsonnet/england-wales/blocks/household/accommodation/accommodation_type.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/household/accommodation/accommodation_type.jsonnet
@@ -14,7 +14,7 @@ local rules = import '../../../lib/rules.libsonnet';
     answers: [
       {
         id: 'accommodation-type-answer',
-        mandatory: true,
+        mandatory: false,
         type: 'Radio',
         options: [
           {

--- a/data-source/jsonnet/england-wales/blocks/household/accommodation/central_heating.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/household/accommodation/central_heating.jsonnet
@@ -20,7 +20,7 @@ local placeholders = import '../../../lib/placeholders.libsonnet';
     answers: [
       {
         id: 'central-heating-answer',
-        mandatory: true,
+        mandatory: false,
         type: 'Checkbox',
         options: [
           {

--- a/data-source/jsonnet/england-wales/blocks/household/accommodation/number_bedrooms.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/household/accommodation/number_bedrooms.jsonnet
@@ -13,7 +13,7 @@
     answers: [{
       id: 'number-of-bedrooms-answer',
       label: 'Number of bedrooms',
-      mandatory: true,
+      mandatory: false,
       type: 'Number',
       max_value: {
         value: 99,

--- a/data-source/jsonnet/england-wales/blocks/household/accommodation/number_of_vehicles.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/household/accommodation/number_of_vehicles.jsonnet
@@ -12,7 +12,7 @@
     },
     answers: [{
       id: 'number-of-vehicles-answer',
-      mandatory: true,
+      mandatory: false,
       options: [
         {
           label: 'None',

--- a/data-source/jsonnet/england-wales/blocks/household/accommodation/self_contained.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/household/accommodation/self_contained.jsonnet
@@ -13,7 +13,7 @@
     }],
     answers: [{
       id: 'self-contained-answer',
-      mandatory: true,
+      mandatory: false,
       options: [
         {
           label: 'Yes',

--- a/data-source/jsonnet/england-wales/blocks/household/accommodation/type_of_flat.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/household/accommodation/type_of_flat.jsonnet
@@ -7,7 +7,7 @@
     type: 'General',
     answers: [{
       id: 'type-of-flat-answer',
-      mandatory: true,
+      mandatory: false,
       options: [
         {
           label: 'In a purpose-built block of flats or tenement',

--- a/data-source/jsonnet/england-wales/blocks/household/accommodation/type_of_house.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/household/accommodation/type_of_house.jsonnet
@@ -7,7 +7,7 @@
     type: 'General',
     answers: [{
       id: 'type-of-house-answer',
-      mandatory: true,
+      mandatory: false,
       options: [
         {
           label: 'Detached',

--- a/data-source/jsonnet/england-wales/blocks/household/accommodation/who_rent_from.jsonnet
+++ b/data-source/jsonnet/england-wales/blocks/household/accommodation/who_rent_from.jsonnet
@@ -7,7 +7,7 @@
     type: 'General',
     answers: [{
       id: 'who-rent-from-answer',
-      mandatory: true,
+      mandatory: false,
       options: [
         {
           label: 'Housing association, housing co-operative, charitable trust, registered social landlord',


### PR DESCRIPTION
### What is the context of this PR?
Schema changes for Household England and Wales Survey accommodation section.

### How to review 
Build the new schema changes. Test that the house hold accommodation flow is as specified in  https://trello.com/c/s3FsJSyh/3209-household-accommodation-eng-wls 