### PR TITLE
Update design system version

### DIFF
--- a/scripts/load_templates.sh
+++ b/scripts/load_templates.sh
@@ -4,7 +4,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 cd "${DIR}"/.. || exit
 
-DESIGN_SYSTEM_VERSION="13.2.1"
+DESIGN_SYSTEM_VERSION="13.4.2"
 
 TEMP_DIR=$(mktemp -d)
 


### PR DESCRIPTION
### What is the context of this PR?
Quick PR to update to the latest design system version. 
Currently using keyboard 'Enter' will sign you out. This fixes that. Also part of recently merged: #2277 

### How to review 
1. Ensure `Save and sign out` button is a link.
2. Ensure `Enter` key doesn't submit the form.