### PR TITLE
Updating EQ_ENABLE_SECURE_SESSION_COOKIE to True in Helm deployment

### DIFF
--- a/k8s/helm/templates/deployment.yaml
+++ b/k8s/helm/templates/deployment.yaml
@@ -54,7 +54,7 @@ spec:
             - name: EQ_STORAGE_BACKEND
               value: "datastore"
             - name: EQ_ENABLE_SECURE_SESSION_COOKIE
-              value: "False"
+              value: "True"
             - name: EQ_SECRETS_FILE
               value: /secrets/secrets.yml
             - name: EQ_KEYS_FILE


### PR DESCRIPTION
Pen testing has identified that the session cookie does not have the secure flag set and this need to be resolved.

Update the Helm deployment.yaml EQ_ENABLE_SECURE_SESSION_COOKIE to True

### How to review 
Check the cookie in the browser has the secure attribute assigned.
