### PR TITLE
Amending Census Downstream Submission Data

### DIFF
--- a/app/submitter/converter.py
+++ b/app/submitter/converter.py
@@ -90,9 +90,12 @@ def convert_answers(schema, questionnaire_store, routing_path, flushed=False):
         payload['case_ref'] = metadata['case_ref']
 
     if schema.json['data_version'] == '0.0.3':
-        payload['data'] = convert_answers_to_payload_0_0_3(
-            answer_store, list_store, schema, routing_path
-        )
+        payload['data'] = {
+            'answers': convert_answers_to_payload_0_0_3(
+                answer_store, list_store, schema, routing_path
+            ),
+            'lists': list_store.serialise(),
+        }
     elif schema.json['data_version'] == '0.0.1':
         payload['data'] = convert_answers_to_payload_0_0_1(
             metadata, answer_store, list_store, schema, routing_path

--- a/tests/app/submitter/test_convert_payload_0_0_3.py
+++ b/tests/app/submitter/test_convert_payload_0_0_3.py
@@ -66,9 +66,9 @@ def test_convert_answers_to_payload_0_0_3(fake_questionnaire_store):
     )
 
     # Then
-    assert len(answer_object['data']) == 2
-    assert answer_object['data'][0].value == 'Joe Bloggs'
-    assert answer_object['data'][1].value, '62 Somewhere'
+    assert len(answer_object['data']['answers']) == 2
+    assert answer_object['data']['answers'][0].value == 'Joe Bloggs'
+    assert answer_object['data']['answers'][1].value, '62 Somewhere'
 
 
 def test_convert_payload_0_0_3_multiple_answers(fake_questionnaire_store):
@@ -104,8 +104,8 @@ def test_convert_payload_0_0_3_multiple_answers(fake_questionnaire_store):
         QuestionnaireSchema(questionnaire), fake_questionnaire_store, routing_path
     )
     # Then
-    assert len(answer_object['data']) == 1
-    assert answer_object['data'][0].value == ['Ready salted', 'Sweet chilli']
+    assert len(answer_object['data']['answers']) == 1
+    assert answer_object['data']['answers'][0].value == ['Ready salted', 'Sweet chilli']
 
 
 def test_radio_answer(fake_questionnaire_store):
@@ -137,8 +137,8 @@ def test_radio_answer(fake_questionnaire_store):
         QuestionnaireSchema(questionnaire), fake_questionnaire_store, routing_path
     )
 
-    assert len(answer_object['data']) == 1
-    assert answer_object['data'][0].value == 'Coffee'
+    assert len(answer_object['data']['answers']) == 1
+    assert answer_object['data']['answers'][0].value == 'Coffee'
 
 
 def test_number_answer(fake_questionnaire_store):
@@ -161,8 +161,8 @@ def test_number_answer(fake_questionnaire_store):
         QuestionnaireSchema(questionnaire), fake_questionnaire_store, routing_path
     )
 
-    assert len(answer_object['data']) == 1
-    assert answer_object['data'][0].value == 1.755
+    assert len(answer_object['data']['answers']) == 1
+    assert answer_object['data']['answers'][0].value == 1.755
 
 
 def test_percentage_answer(fake_questionnaire_store):
@@ -185,8 +185,8 @@ def test_percentage_answer(fake_questionnaire_store):
         QuestionnaireSchema(questionnaire), fake_questionnaire_store, routing_path
     )
 
-    assert len(answer_object['data']) == 1
-    assert answer_object['data'][0].value == 99
+    assert len(answer_object['data']['answers']) == 1
+    assert answer_object['data']['answers'][0].value == 99
 
 
 def test_textarea_answer(fake_questionnaire_store):
@@ -211,8 +211,8 @@ def test_textarea_answer(fake_questionnaire_store):
         QuestionnaireSchema(questionnaire), fake_questionnaire_store, routing_path
     )
 
-    assert len(answer_object['data']) == 1
-    assert answer_object['data'][0].value == 'This is an example text!'
+    assert len(answer_object['data']['answers']) == 1
+    assert answer_object['data']['answers'][0].value == 'This is an example text!'
 
 
 def test_currency_answer(fake_questionnaire_store):
@@ -235,8 +235,8 @@ def test_currency_answer(fake_questionnaire_store):
         QuestionnaireSchema(questionnaire), fake_questionnaire_store, routing_path
     )
 
-    assert len(answer_object['data']) == 1
-    assert answer_object['data'][0].value == 100
+    assert len(answer_object['data']['answers']) == 1
+    assert answer_object['data']['answers'][0].value == 100
 
 
 def test_dropdown_answer(fake_questionnaire_store):
@@ -270,8 +270,8 @@ def test_dropdown_answer(fake_questionnaire_store):
     )
 
     # Then
-    assert len(answer_object['data']) == 1
-    assert answer_object['data'][0].value == 'Rugby is better!'
+    assert len(answer_object['data']['answers']) == 1
+    assert answer_object['data']['answers'][0].value == 'Rugby is better!'
 
 
 def test_date_answer(fake_questionnaire_store):
@@ -299,9 +299,9 @@ def test_date_answer(fake_questionnaire_store):
         QuestionnaireSchema(questionnaire), fake_questionnaire_store, routing_path
     )
 
-    assert len(answer_object['data']) == 1
+    assert len(answer_object['data']['answers']) == 1
 
-    assert answer_object['data'][0].value == '01-01-1990'
+    assert answer_object['data']['answers'][0].value == '01-01-1990'
 
 
 def test_month_year_date_answer(fake_questionnaire_store):
@@ -329,9 +329,9 @@ def test_month_year_date_answer(fake_questionnaire_store):
         QuestionnaireSchema(questionnaire), fake_questionnaire_store, routing_path
     )
 
-    assert len(answer_object['data']) == 1
+    assert len(answer_object['data']['answers']) == 1
 
-    assert answer_object['data'][0].value == '01-1990'
+    assert answer_object['data']['answers'][0].value == '01-1990'
 
 
 def test_unit_answer(fake_questionnaire_store):
@@ -351,8 +351,8 @@ def test_unit_answer(fake_questionnaire_store):
         QuestionnaireSchema(questionnaire), fake_questionnaire_store, routing_path
     )
 
-    assert len(answer_object['data']) == 1
-    assert answer_object['data'][0].value == 10
+    assert len(answer_object['data']['answers']) == 1
+    assert answer_object['data']['answers'][0].value == 10
 
 
 def test_primary_person_list_item_conversion(fake_questionnaire_store):
@@ -390,7 +390,7 @@ def test_primary_person_list_item_conversion(fake_questionnaire_store):
 
     output = convert_answers(schema, fake_questionnaire_store, routing_path)
 
-    data_dict = json.loads(json.dumps(output['data'], for_json=True))
+    data_dict = json.loads(json.dumps(output['data']['answers'], for_json=True))
 
     assert sorted(answer_objects, key=lambda x: x['answer_id']) == sorted(
         data_dict, key=lambda x: x['answer_id']
@@ -430,7 +430,7 @@ def test_list_item_conversion(fake_questionnaire_store):
 
     del answer_objects[-1]
 
-    data_dict = json.loads(json.dumps(output['data'], for_json=True))
+    data_dict = json.loads(json.dumps(output['data']['answers'], for_json=True))
 
     assert sorted(answer_objects, key=lambda x: x['answer_id']) == sorted(
         data_dict, key=lambda x: x['answer_id']
@@ -465,7 +465,7 @@ def test_list_item_conversion_empty_list(fake_questionnaire_store):
     del answer_objects[0]
     del answer_objects[-1]
 
-    data_dict = json.loads(json.dumps(output['data'], for_json=True))
+    data_dict = json.loads(json.dumps(output['data']['answers'], for_json=True))
 
     assert sorted(answer_objects, key=lambda x: x['answer_id']) == sorted(
         data_dict, key=lambda x: x['answer_id']
@@ -492,7 +492,85 @@ def test_default_answers_not_present_when_not_answered(fake_questionnaire_store)
     ]
 
     output = convert_answers(schema, fake_questionnaire_store, routing_path)
-    data = json.loads(json.dumps(output['data'], for_json=True))
+    data = json.loads(json.dumps(output['data']['answers'], for_json=True))
 
     answer_ids = {answer['answer_id'] for answer in data}
     assert 'radio-answer' not in answer_ids
+
+
+def test_list_structure_in_payload_is_as_expected(fake_questionnaire_store):
+    routing_path = [
+        Location(section_id='section-1', block_id='primary-person-list-collector'),
+        Location(section_id='section-1', block_id='list-collector'),
+        Location(section_id='section-2', block_id='summary'),
+    ]
+
+    answer_objects = [
+        {'answer_id': 'you-live-here', 'value': 'Yes'},
+        {'answer_id': 'first-name', 'value': '1', 'list_item_id': 'xJlKBy'},
+        {'answer_id': 'last-name', 'value': '1', 'list_item_id': 'xJlKBy'},
+        {'answer_id': 'first-name', 'value': '2', 'list_item_id': 'RfAGDc'},
+        {'answer_id': 'last-name', 'value': '2', 'list_item_id': 'RfAGDc'},
+        {'answer_id': 'anyone-else', 'value': 'No'},
+    ]
+
+    answers = AnswerStore(answer_objects)
+
+    list_store = ListStore(
+        existing_items=[
+            {
+                'name': 'people',
+                'items': ['xJlKBy', 'RfAGDc'],
+                'primary_person': 'xJlKBy',
+            }
+        ]
+    )
+
+    fake_questionnaire_store.answer_store = answers
+    fake_questionnaire_store.list_store = list_store
+
+    schema = load_schema('test_list_collector_primary_person')
+
+    output = convert_answers(schema, fake_questionnaire_store, routing_path)
+
+    data_dict = json.loads(json.dumps(output['data']['lists'], for_json=True))
+
+    assert data_dict[0]['name'] == 'people'
+    assert 'xJlKBy' in data_dict[0]['items']
+    assert data_dict[0]['primary_person'] == 'xJlKBy'
+
+
+def test_primary_person_not_in_payload_when_not_answered(fake_questionnaire_store):
+    routing_path = [
+        Location(section_id='section-1', block_id='list-collector'),
+        Location(section_id='section-1', block_id='next-interstitial'),
+        Location(section_id='section-1', block_id='another-list-collector-block'),
+        Location(section_id='section-2', block_id='summary'),
+    ]
+
+    answer_objects = [
+        {'answer_id': 'first-name', 'value': '1', 'list_item_id': 'xJlKBy'},
+        {'answer_id': 'last-name', 'value': '1', 'list_item_id': 'xJlKBy'},
+        {'answer_id': 'first-name', 'value': '2', 'list_item_id': 'RfAGDc'},
+        {'answer_id': 'last-name', 'value': '2', 'list_item_id': 'RfAGDc'},
+        {'answer_id': 'anyone-else', 'value': 'No'},
+        {'answer_id': 'another-anyone-else', 'value': 'No'},
+        {'answer_id': 'extraneous-answer', 'value': 'Bad', 'list_item_id': '123'},
+    ]
+
+    answers = AnswerStore(answer_objects)
+
+    list_store = ListStore(
+        existing_items=[{'name': 'people', 'items': ['xJlKBy', 'RfAGDc']}]
+    )
+
+    fake_questionnaire_store.answer_store = answers
+    fake_questionnaire_store.list_store = list_store
+
+    schema = load_schema('test_list_collector')
+
+    output = convert_answers(schema, fake_questionnaire_store, routing_path)
+
+    data_dict = json.loads(json.dumps(output['data']['lists'], for_json=True))
+
+    assert 'primary_person' not in data_dict[0]

--- a/tests/integration/routes/test_dump.py
+++ b/tests/integration/routes/test_dump.py
@@ -90,7 +90,7 @@ class TestDumpSubmission(IntegrationTestCase):
                     'exercise_sid': '789',
                     'schema_name': 'test_radio_mandatory_with_mandatory_other',
                 },
-                'data': [],
+                'data': {'answers': [], 'lists': []},
                 'metadata': {'ru_ref': '123456789012A', 'user_id': 'integration-test'},
             }
         }
@@ -136,7 +136,83 @@ class TestDumpSubmission(IntegrationTestCase):
                     'exercise_sid': '789',
                     'schema_name': 'test_radio_mandatory',
                 },
-                'data': [{'answer_id': 'radio-mandatory-answer', 'value': 'Coffee'}],
+                'data': {
+                    'answers': [
+                        {'answer_id': 'radio-mandatory-answer', 'value': 'Coffee'}
+                    ],
+                    'lists': [],
+                },
+                'metadata': {'ru_ref': '123456789012A', 'user_id': 'integration-test'},
+            }
+        }
+        assert actual == expected
+
+    def test_dump_submission_authenticated_with_role_with_lists(self):
+        # Given I am an authenticated user who has launched a survey
+        # and does have the 'dumper' role in my metadata
+        self.launchSurvey('test_relationships', roles=['dumper'])
+
+        # When I submit my answers
+        self.post({'anyone-else': 'Yes'})
+        self.post({'first-name': 'John', 'last-name': 'Doe'})
+        self.post({'anyone-else': 'No'})
+
+        # And I attempt to dump the submission payload
+        self.get('/dump/submission')
+
+        # Then I get a 200 OK response
+        self.assertStatusOK()
+
+        # And the JSON response contains the data I submitted
+        actual = json.loads(self.getResponseData())
+
+        # tx_id and submitted_at are dynamic; so copy them over
+        expected = {
+            'submission': {
+                'version': '0.0.3',
+                'survey_id': '0',
+                'flushed': False,
+                'origin': 'uk.gov.ons.edc.eq',
+                'type': 'uk.gov.ons.edc.eq:surveyresponse',
+                'tx_id': actual['submission']['tx_id'],
+                'started_at': actual['submission']['started_at'],
+                'submitted_at': actual['submission']['submitted_at'],
+                'case_id': actual['submission']['case_id'],
+                'response_id': '1234567890123456',
+                'questionnaire_id': actual['submission']['questionnaire_id'],
+                'region_code': 'GB-ENG',
+                'channel': 'RH',
+                'case_type': 'HI',
+                'collection': {
+                    'period': '201604',
+                    'exercise_sid': '789',
+                    'schema_name': 'test_relationships',
+                },
+                'data': {
+                    'answers': [
+                        {
+                            'answer_id': 'first-name',
+                            'value': 'John',
+                            'list_item_id': actual['submission']['data']['answers'][0][
+                                'list_item_id'
+                            ],
+                        },
+                        {
+                            'answer_id': 'last-name',
+                            'value': 'Doe',
+                            'list_item_id': actual['submission']['data']['answers'][0][
+                                'list_item_id'
+                            ],
+                        },
+                        {'answer_id': 'anyone-else', 'value': 'No'},
+                    ],
+                    'lists': [
+                        {
+                            'name': 'people',
+                            'items': actual['submission']['data']['lists'][0]['items'],
+                        }
+                    ],
+                },
                 'metadata': {'ru_ref': '123456789012A', 'user_id': 'integration-test'},
             }
         }


### PR DESCRIPTION
### What is the context of this PR?
Amending Census downstream submission data - [See Trello](https://trello.com/c/ed4j3mgZ/2963-sending-census-submission-data-downstream-m).

We currently send the data field in the following format:
```python
data: [{
  answer_id: 'test'
  list_item_id: '123'
  value: 'testing'
}]
```

This was amended to be:
```python
data: {
    answers: [{
    answer_id: 'test'
    list_item_id: '123'
    value: 'testing'
  }],
  lists: [{
    name: 'people',
    items: ['123', 'abc']
  }]
}
```

### How to review 
Use a test schema and check that the 'data' field in the submission data matches the new format shown above.