### PR TITLE
Fail unit tests if coverage less than 100%

### DIFF
--- a/scripts/run_tests_unit.sh
+++ b/scripts/run_tests_unit.sh
@@ -21,5 +21,5 @@ function display_result {
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-py.test -n auto --cov=app --cov-report html "$@"
+py.test -n auto --cov=app --cov-report html --cov-fail-under=100 "$@"
 display_result $? 3 "Unit tests"


### PR DESCRIPTION
### What is the context of this PR?
Checks test coverage as part of unit tests script. This means that:
- test coverage is tested locally 
- the codecov status checks can be made optional when codecov is experiencing issues without the risk of code coverage dropping

### How to review 
- Remove a test file
- Run `make test-unit`
- Verify that the script fails