### PR TITLE
fixed the contains any and not contains any rules

### DIFF
--- a/app/questionnaire/rules.py
+++ b/app/questionnaire/rules.py
@@ -77,11 +77,11 @@ def evaluate_condition(condition, answer_value, match_value):
         'contains any':
             lambda answer_value, match_value: answer_and_match
             and isinstance(match_value, list)
-            and bool(set(answer_value) & set(match_value)),
+            and bool(set(answer_value) & set(match_value)) if isinstance(answer_value, list) else answer_value in match_value,
         'not contains any':
             lambda answer_value, match_value: answer_and_match
             and isinstance(match_value, list)
-            and set(answer_value).isdisjoint(set(match_value)),
+            and set(answer_value).isdisjoint(set(match_value)) if isinstance(answer_value, list) else answer_value not in match_value,
         'not contains all':
             lambda answer_value, match_value: isinstance(answer_value, list)
             and isinstance(match_value, list)

--- a/data/en/test_routing_values_array.json
+++ b/data/en/test_routing_values_array.json
@@ -53,7 +53,7 @@
                             }
                         }, {
                             "goto": {
-                                "block": "block-three",
+                                "block": "block-two",
                                 "when": [{
                                     "id": "answer-one",
                                     "condition": "contains any",

--- a/tests/app/questionnaire/test_rules.py
+++ b/tests/app/questionnaire/test_rules.py
@@ -184,20 +184,20 @@ class TestRules(AppContextTestCase):  # pylint: disable=too-many-public-methods
         self.assertFalse(evaluate_rule(when, []))
 
     def test_evaluate_rule_checkbox_contains_any(self):
-        when = {'values': ['a', 'b'], 'condition': 'contains any'}
+        when = {'values': ['aaa', 'bbb'], 'condition': 'contains any'}
 
-        self.assertTrue(evaluate_rule(when, ['a', 'b', 'c']))
-        self.assertTrue(evaluate_rule(when, ['a']))
-        self.assertTrue(evaluate_rule(when, ['b', 'c']))
-        self.assertFalse(evaluate_rule(when, ['c']))
+        self.assertTrue(evaluate_rule(when, ['aaa', 'bbb', 'ccc']))
+        self.assertTrue(evaluate_rule(when, ['aaa']))
+        self.assertTrue(evaluate_rule(when, ['bbb', 'ccc']))
+        self.assertFalse(evaluate_rule(when, ['ccc']))
 
     def test_evaluate_rule_checkbox_not_contains_any(self):
-        when = {'values': ['a', 'b'], 'condition': 'not contains any'}
+        when = {'values': ['aaa', 'bbb'], 'condition': 'not contains any'}
 
-        self.assertTrue(evaluate_rule(when, ['c']))
-        self.assertFalse(evaluate_rule(when, ['b', 'c']))
-        self.assertFalse(evaluate_rule(when, ['a', 'b']))
-        self.assertFalse(evaluate_rule(when, ['a', 'b', 'c']))
+        self.assertTrue(evaluate_rule(when, ['ccc']))
+        self.assertFalse(evaluate_rule(when, ['bbb', 'ccc']))
+        self.assertFalse(evaluate_rule(when, ['aaa', 'bbb']))
+        self.assertFalse(evaluate_rule(when, ['aaa', 'bbb', 'ccc']))
 
     def test_evaluate_rule_checkbox_not_contains_all(self):
         when = {'values': ['a', 'b'], 'condition': 'not contains all'}

--- a/tests/functional/spec/checkbox-routing-with-values.js
+++ b/tests/functional/spec/checkbox-routing-with-values.js
@@ -1,7 +1,6 @@
 const helpers = require('../helpers');
 const PositiveRoutingPage = require('../generated_pages/routing_values_array/block-one.page');
-const AllOfConditionTrue = require('../generated_pages/routing_values_array/block-two.page');
-const AnyOfConditionTrue = require('../generated_pages/routing_values_array/block-three.page');
+const AllAnyOfConditionTrue = require('../generated_pages/routing_values_array/block-two.page');
 const NotAllOfRoutingPage = require('../generated_pages/routing_values_array/block-four.page');
 const NotAllOfConditionTrue = require('../generated_pages/routing_values_array/block-five.page');
 const NotAnyOfRoutingPage = require('../generated_pages/routing_values_array/block-six.page');
@@ -22,12 +21,12 @@ describe('Conditional combined routing.', function() {
       .click(PositiveRoutingPage.box3())
       .click(PositiveRoutingPage.submit())
       // Then
-      .getUrl().should.eventually.contain(AllOfConditionTrue.pageName)
+      .getUrl().should.eventually.contain(AllAnyOfConditionTrue.pageName)
       // Or 
-      .click(AllOfConditionTrue.previous())
+      .click(AllAnyOfConditionTrue.previous())
       .click(PositiveRoutingPage.box4())
       .click(PositiveRoutingPage.submit())
-      .getUrl().should.eventually.contain(AllOfConditionTrue.pageName);
+      .getUrl().should.eventually.contain(AllAnyOfConditionTrue.pageName);
 
   });
 
@@ -38,20 +37,20 @@ describe('Conditional combined routing.', function() {
       .click(PositiveRoutingPage.box1())
       .click(PositiveRoutingPage.submit())
       // Then
-      .getUrl().should.eventually.contain(AnyOfConditionTrue.pageName)
+      .getUrl().should.eventually.contain(AllAnyOfConditionTrue.pageName)
       // Or 
-      .click(AnyOfConditionTrue.previous())
+      .click(AllAnyOfConditionTrue.previous())
       .click(PositiveRoutingPage.box2())
       .click(PositiveRoutingPage.submit())
       // Then
-      .getUrl().should.eventually.contain(AnyOfConditionTrue.pageName)
+      .getUrl().should.eventually.contain(AllAnyOfConditionTrue.pageName)
       // Or 
-      .click(AnyOfConditionTrue.previous())
+      .click(AllAnyOfConditionTrue.previous())
       .click(PositiveRoutingPage.box2())
       .click(PositiveRoutingPage.box3())
       .click(PositiveRoutingPage.submit())
       // Then
-      .getUrl().should.eventually.contain(AnyOfConditionTrue.pageName);
+      .getUrl().should.eventually.contain(AllAnyOfConditionTrue.pageName);
 
 
   });


### PR DESCRIPTION
### What is the context of this PR?
There was an issue where answer_values and match_values could be an array or single value depending on the answer being referenced. This change just ensures both cases are handled. 

### How to review 
New stuff works and edited tests pass.
