### PR TITLE
Update hub 'view answers' to find section summary anywhere in a section

### DIFF
--- a/app/questionnaire/router.py
+++ b/app/questionnaire/router.py
@@ -44,10 +44,15 @@ class Router:
         current_block_type = self._schema.get_block(location.block_id)['type']
         last_block_location = routing_path[-1]
         last_block_type = self._schema.get_block(last_block_location.block_id)['type']
+        hub_enabled = self._schema.is_hub_enabled()
 
+        # A section summary doesn't always have to be the last block
         if (
-            self._schema.is_hub_enabled()
-            and location.block_id == last_block_location.block_id
+            hub_enabled
+            and (
+                location.block_id == last_block_location.block_id
+                or current_block_type == 'SectionSummary'
+            )
             and self._progress_store.is_section_complete(
                 location.section_id, location.list_item_id
             )
@@ -64,10 +69,9 @@ class Router:
         ):
             return last_block_location.url()
 
-        if self.is_survey_complete():
+        if self.is_survey_complete() and not hub_enabled:
             last_section_id = self._schema.get_section_ids()[-1]
             last_block_id = self._schema.get_last_block_id_for_section(last_section_id)
-
             return Location(section_id=last_section_id, block_id=last_block_id).url()
 
         location_index = routing_path.index(location)
@@ -162,6 +166,11 @@ class Router:
 
         return True
 
+    def get_section_return_location_when_section_complete(
+        self, routing_path
+    ) -> Location:
+        return self._get_location_of_section_summary(routing_path) or routing_path[0]
+
     def _get_allowable_path(self, routing_path):
         """
         The allowable path is the completed path plus the next location
@@ -216,3 +225,9 @@ class Router:
                 if block_type in ['Summary', 'Confirmation']:
                     return True
         return False
+
+    def _get_location_of_section_summary(self, routing_path):
+        for location in routing_path[::-1]:
+            block = self._schema.get_block(location.block_id)
+            if block['type'] == 'SectionSummary':
+                return location

--- a/app/questionnaire/rules.py
+++ b/app/questionnaire/rules.py
@@ -222,6 +222,7 @@ def evaluate_skip_conditions(
     :return: True if the when condition has been met otherwise False
     """
     no_skip_condition = skip_conditions is None or len(skip_conditions) == 0
+
     if no_skip_condition:
         return False
 

--- a/app/routes/questionnaire.py
+++ b/app/routes/questionnaire.py
@@ -172,8 +172,8 @@ def get_section(schema, questionnaire_store, section_id, list_item_id=None):
     if not schema.is_hub_enabled():
         redirect_location = router.get_first_incomplete_location_in_survey()
         return redirect(redirect_location.url())
-
     section = schema.get_section(section_id)
+
     if not section:
         return redirect(url_for('.get_questionnaire'))
 
@@ -185,7 +185,9 @@ def get_section(schema, questionnaire_store, section_id, list_item_id=None):
     )
 
     if section_status == CompletionStatus.COMPLETED:
-        return redirect(routing_path[-1].url())
+        return redirect(
+            router.get_section_return_location_when_section_complete(routing_path).url()
+        )
 
     if section_status == CompletionStatus.NOT_STARTED:
         return redirect(
@@ -259,7 +261,6 @@ def block(schema, questionnaire_store, block_id, list_name=None, list_item_id=No
     block_handler.handle_post()
 
     next_location_url = block_handler.get_next_location_url()
-
     return redirect(next_location_url)
 
 

--- a/data-source/json/test_hub_and_spoke.json
+++ b/data-source/json/test_hub_and_spoke.json
@@ -192,6 +192,89 @@
                     "title": ""
                 }
             ]
-        }
+        },
+        {
+         "groups": [
+            {
+               "blocks": [
+                  {
+                     "id": "does-anyone-live-here",
+                     "question": {
+                        "answers": [
+                           {
+                              "id": "does-anyone-live-here-answer",
+                              "mandatory": true,
+                              "options": [
+                                 {
+                                    "label": "Yes",
+                                    "value": "Yes"
+                                 },
+                                  {
+                                    "label": "No",
+                                    "value": "No"
+                                 }
+                              ],
+                              "type": "Radio"
+                           }
+                        ],
+                        "id": "does-anyone-live-here-question",
+                        "title": "Does anyone live here? ",
+                        "type": "General"
+                     },
+                     "type": "Question"
+                  },
+                   {
+                     "id": "household-summary",
+                     "type": "SectionSummary"
+                  },
+                   {
+                       "id": "how-many-people-live-here",
+                       "question": {
+                           "answers": [
+                               {
+                                   "id": "how-many-people-live-here",
+                                   "mandatory": true,
+                                   "options": [
+                                       {
+                                           "label": "1",
+                                           "value": "1"
+                                       },
+                                       {
+                                           "label": "2",
+                                           "value": "2"
+                                       },
+                                       {
+                                           "label": "3+",
+                                           "value": "3+"
+                                       }
+                                   ],
+                                   "type": "Radio"
+                               }
+                           ],
+                           "id": "how-many-people-live-here-question",
+                           "title": "How many people live here?",
+                           "type": "General"
+                       },
+                       "type": "Question",
+                       "skip_conditions": [
+                                    {
+                                        "when": [
+                                            {
+                                                "id": "does-anyone-live-here-answer",
+                                                "condition": "equals",
+                                                "value": "No"
+                                            }
+                                        ]
+                                    }
+                                ]
+                   }
+               ],
+               "id": "household-question-group",
+               "title": "Household residents"
+            }
+         ],
+         "id": "household-section",
+         "title": "Household residents"
+      }
     ]
 }

--- a/tests/functional/spec/features/hub_and_spoke/hub_and_spoke.spec.js
+++ b/tests/functional/spec/features/hub_and_spoke/hub_and_spoke.spec.js
@@ -2,9 +2,11 @@ const helpers = require('../../../helpers');
 
 const EmploymentStatusBlockPage = require('../../../generated_pages/hub_and_spoke/employment-status.page.js');
 const EmploymentTypeBlockPage = require('../../../generated_pages/hub_and_spoke/employment-type.page.js');
-
+const HouseholdSummary = require('../../../generated_pages/hub_and_spoke/household-summary.page.js');
+const HowManyPeopleLiveHere = require('../../../generated_pages/hub_and_spoke/how-many-people-live-here.page.js');
 const ProxyPage = require('../../../generated_pages/hub_and_spoke/proxy.page.js');
 const AccomodationDetailsSummaryBlockPage = require('../../../generated_pages/hub_and_spoke/accommodation-details-summary.page.js');
+const DoesAnyoneLiveHere = require('../../../generated_pages/hub_and_spoke/does-anyone-live-here.page.js');
 
 const HubPage = require('../../../base_pages/hub.page.js');
 
@@ -140,11 +142,11 @@ describe('Feature: Hub and Spoke', function () {
         .getAttribute(HubPage.summaryRowTitle(1), 'class').should.eventually.contain('summary__item-title--has-icon');
     });
 
-    it('When the user returns to the Hub and clicks the \'View answers\' link on the Hub, Then they should be taken to the last page in that section', function () {
+    it('When the user returns to the Hub and clicks the \'View answers\' link on the Hub, if this no summary they are returned to the first block', function () {
       return browser
         .click(EmploymentTypeBlockPage.submit())
         .click(HubPage.summaryRowLink(1))
-        .getUrl().should.eventually.contain(EmploymentTypeBlockPage.url());
+        .getUrl().should.eventually.contain(EmploymentStatusBlockPage.url());
     });
 
     it('When the user returns to the Hub and continues, Then they should progress to the next section', function () {
@@ -156,7 +158,6 @@ describe('Feature: Hub and Spoke', function () {
     });
 
   });
-
 
   describe('Given a user has completed a section and is on the Hub page', function () {
 
@@ -210,7 +211,11 @@ describe('Feature: Hub and Spoke', function () {
             .click(HubPage.submit())
             .click(ProxyPage.yes())
             .click(ProxyPage.submit())
-            .click(AccomodationDetailsSummaryBlockPage.submit());
+            .click(AccomodationDetailsSummaryBlockPage.submit())
+            .click(HubPage.submit())
+            .click(DoesAnyoneLiveHere.no())
+            .click(DoesAnyoneLiveHere.submit())
+            .click(HouseholdSummary.submit());
         });
     });
 
@@ -250,6 +255,48 @@ describe('Feature: Hub and Spoke', function () {
             .click(EmploymentTypeBlockPage.submit())
             .getUrl().should.eventually.contain(HubPage.url());
        });
+    });
+  });
+
+    describe('Given the user has completed a section with a summary mid section', function () {
+    it('When the user clicks \'View answers\' it will return to that section summary', function () {
+      return helpers.openQuestionnaire('test_hub_and_spoke.json')
+        .then(() => {
+          return browser
+            .click(HubPage.summaryRowLink(3))
+            .click(DoesAnyoneLiveHere.no())
+            .click(DoesAnyoneLiveHere.submit())
+            .click(HouseholdSummary.submit())
+            .click(HubPage.summaryRowLink(3))
+            .getUrl().should.eventually.contain(HouseholdSummary.url());
+       });
+    });
+  });
+    describe('Given a section is complete and the user has been returned to a section summary by clicking the \'View answers\' link ', function () {
+      beforeEach('Complete section', function () {
+      return helpers.openQuestionnaire(hub_and_spoke_schema)
+        .then(() => {
+          return browser
+            .click(HubPage.summaryRowLink(3))
+            .click(DoesAnyoneLiveHere.no())
+            .click(DoesAnyoneLiveHere.submit())
+            .click(HouseholdSummary.submit());
+        });
+    });
+    it('When there are no changes, continue returns directly to the hub', function () {
+          return browser
+            .click(HubPage.summaryRowLink(3))
+            .click(HouseholdSummary.submit())
+            .getUrl().should.eventually.contain(HubPage.url());
+    });
+    it('When there are changes which would set the section to in_progress it routes accordingly', function () {
+          return browser
+            .click(HubPage.summaryRowLink(3))
+            .click(HouseholdSummary.doesAnyoneLiveHereAnswerEdit())
+            .click(DoesAnyoneLiveHere.yes())
+            .click(DoesAnyoneLiveHere.submit())
+            .click(HouseholdSummary.submit())
+            .getUrl().should.eventually.contain(HowManyPeopleLiveHere.url());
     });
   });
 });

--- a/tests/functional/spec/features/repeating_sections/repeating_sections_with_hub_and_spoke.js
+++ b/tests/functional/spec/features/repeating_sections/repeating_sections_with_hub_and_spoke.js
@@ -181,7 +181,11 @@ describe('Feature: Repeating Sections with Hub and Spoke', function () {
 
         // Start section for first visitor
         .click(HubPage.summaryRowLink(1))
-
+        .click(PrimaryPersonPage.submit())
+        .click(PrimaryPersonAddPage.submit())
+        .click(FirstListCollectorPage.submit())
+        .click(SecondListCollectorInterstitialPage.submit())
+        .click(SecondListCollectorPage.submit())
         .getText(SexPage.questionText()).should.eventually.equal('This is the visitors list collector. Add a visitor?')
 
         // Add first visitor
@@ -294,6 +298,11 @@ describe('Feature: Repeating Sections with Hub and Spoke', function () {
     it('When the user adds a new member to the household, Then the Hub should not be in the completed state', function () {
       return browser
         .click(HubPage.summaryRowLink(1))
+        .click(PrimaryPersonPage.submit())
+        .click(PrimaryPersonAddPage.submit())
+        .click(FirstListCollectorPage.submit())
+        .click(SecondListCollectorInterstitialPage.submit())
+        .click(SecondListCollectorPage.submit())
 
         // Add another householder
         .click(VisitorsListCollectorPage.yes())
@@ -323,6 +332,11 @@ describe('Feature: Repeating Sections with Hub and Spoke', function () {
         .isExisting(HubPage.summaryRowState(8)).should.eventually.be.true
 
         .click(HubPage.summaryRowLink(1))
+        .click(PrimaryPersonPage.submit())
+        .click(PrimaryPersonAddPage.submit())
+        .click(FirstListCollectorPage.submit())
+        .click(SecondListCollectorInterstitialPage.submit())
+        .click(SecondListCollectorPage.submit())
 
         // Remove final householder
         .click(VisitorsListCollectorPage.listRemoveLink(3))

--- a/tests/integration/questionnaire/test_questionnaire_hub.py
+++ b/tests/integration/questionnaire/test_questionnaire_hub.py
@@ -57,6 +57,9 @@ class TestQuestionnaireHub(IntegrationTestCase):
         self.post({})
         self.post(action='submit')
         self.post(action='submit')
+        self.post({'does-anyone-live-here-answer': 'No'})
+        self.post(action='submit')
+        self.post(action='submit')
 
         # Then I should see the thank you page
         self.assertEqualUrl('/submitted/thank-you/')


### PR DESCRIPTION
### What is the context of this PR?
Currently if there is a section summary not as the last block in a section, clicking 'view answers' it returns to the last block in the section. This is incorrect and should go back to the last section summary if there is one, or the first block in the section if it doesn't. Additionally if there are no changes on the section then the next location should be the hub. 

N.B The default, back to first block can not return back to the hub if there are no changes as the pickup is section summary or last block. This shouldn't ever be an issue as the intention is always to have a section summary, however as this isn't enforce a default had to be written.

### How to review 
Using test_hub_section_summary.json make sure the 3 sections perform as expected

1. Section one completed- 'view answer' goes to section summary, if there are no changes which affect section completeness, continue returns back to hub. If there are changes which affect section completeness 'continue' will take you back through relationships

2. Section two completed - 'view answers' goes to section summary.

3. Section three completed - 'view answers' goes back to the first block


