### PR TITLE
Ensure summary context is rendered using current language code

### DIFF
--- a/app/views/contexts/calculated_summary.py
+++ b/app/views/contexts/calculated_summary.py
@@ -13,7 +13,9 @@ from app.questionnaire.location import Location
 from app.views.contexts.summary.group import Group
 
 
-def build_groups_for_section(answer_store, list_store, metadata, schema, section):
+def build_groups_for_section(
+    answer_store, list_store, metadata, schema, section, language
+):
     path_finder = PathFinder(schema, answer_store, metadata, list_store=list_store)
 
     section_path = path_finder.routing_path(section['id'])
@@ -22,14 +24,21 @@ def build_groups_for_section(answer_store, list_store, metadata, schema, section
 
     return [
         Group(
-            group, section_path, answer_store, list_store, metadata, schema, location
+            group,
+            section_path,
+            answer_store,
+            list_store,
+            metadata,
+            schema,
+            location,
+            language,
         ).serialize()
         for group in section['groups']
     ]
 
 
 def build_view_context_for_calculated_summary(
-    language, schema, answer_store, list_store, metadata, current_location
+    schema, answer_store, list_store, metadata, current_location, language
 ):
     block = schema.get_block(current_location.block_id)
 
@@ -38,7 +47,7 @@ def build_view_context_for_calculated_summary(
     )
 
     groups = build_groups_for_section(
-        answer_store, list_store, metadata, schema, calculated_section
+        answer_store, list_store, metadata, schema, calculated_section, language
     )
 
     formatted_total = _get_formatted_total(

--- a/app/views/contexts/summary/group.py
+++ b/app/views/contexts/summary/group.py
@@ -4,7 +4,15 @@ from app.views.contexts.summary.block import Block
 
 class Group:
     def __init__(
-        self, group_schema, path, answer_store, list_store, metadata, schema, location
+        self,
+        group_schema,
+        path,
+        answer_store,
+        list_store,
+        metadata,
+        schema,
+        location,
+        language,
     ):
         self.id = group_schema['id']
 
@@ -16,7 +24,10 @@ class Group:
             group_schema, path, answer_store, list_store, metadata, schema, location
         )
         self.placeholder_renderer = PlaceholderRenderer(
-            language='en', schema=schema, answer_store=answer_store, metadata=metadata
+            language=language,
+            schema=schema,
+            answer_store=answer_store,
+            metadata=metadata,
         )
 
     @staticmethod

--- a/app/views/contexts/summary_context.py
+++ b/app/views/contexts/summary_context.py
@@ -40,6 +40,7 @@ class SummaryContext:
                 self._metadata,
                 self._schema,
                 location,
+                self._language,
             ).serialize()
             for group in section['groups']
         ]

--- a/app/views/handlers/calculated_summary.py
+++ b/app/views/handlers/calculated_summary.py
@@ -7,10 +7,10 @@ from app.views.contexts.calculated_summary import (
 class CalculatedSummary(Content):
     def get_context(self):
         return build_view_context_for_calculated_summary(
-            self._questionnaire_store.metadata,
             self._schema,
             self._questionnaire_store.answer_store,
             self._questionnaire_store.list_store,
-            self.block['type'],
+            self._questionnaire_store.metadata,
             self._current_location,
+            self._language,
         )

--- a/data-source/json/test_placeholder_full.json
+++ b/data-source/json/test_placeholder_full.json
@@ -38,7 +38,7 @@
                             "question": {
                                 "description": "",
                                 "id": "primary-name-question",
-                                "title": "Please enter your name",
+                                "title": "Please enter a name",
                                 "type": "General",
                                 "answers": [
                                     {
@@ -77,20 +77,31 @@
                                 "description": "",
                                 "id": "dob-question",
                                 "title": {
-                                    "text": "What is the date of birth for {person_name}?",
+                                    "text": "What is {person_name_possessive} date of birth?",
                                     "placeholders": [
                                         {
-                                            "placeholder": "person_name",
+                                            "placeholder": "person_name_possessive",
                                             "transforms": [
                                                 {
-                                                    "transform": "concatenate_list",
                                                     "arguments": {
+                                                        "delimiter": " ",
                                                         "list_to_concatenate": {
-                                                            "source": "answers",
-                                                            "identifier": ["first-name", "last-name"]
-                                                        },
-                                                        "delimiter": " "
-                                                    }
+                                                            "identifier": [
+                                                                "first-name",
+                                                                "last-name"
+                                                            ],
+                                                            "source": "answers"
+                                                        }
+                                                    },
+                                                    "transform": "concatenate_list"
+                                                },
+                                                {
+                                                    "arguments": {
+                                                        "string_to_format": {
+                                                            "source": "previous_transform"
+                                                        }
+                                                    },
+                                                    "transform": "format_possessive"
                                                 }
                                             ]
                                         }
@@ -134,7 +145,10 @@
                                                     "arguments": {
                                                         "list_to_concatenate": {
                                                             "source": "answers",
-                                                            "identifier": ["first-name", "last-name"]
+                                                            "identifier": [
+                                                                "first-name",
+                                                                "last-name"
+                                                            ]
                                                         },
                                                         "delimiter": " "
                                                     }
@@ -178,7 +192,10 @@
                                                                     "arguments": {
                                                                         "list_to_concatenate": {
                                                                             "source": "answers",
-                                                                            "identifier": ["first-name", "last-name"]
+                                                                            "identifier": [
+                                                                                "first-name",
+                                                                                "last-name"
+                                                                            ]
                                                                         },
                                                                         "delimiter": " "
                                                                     }

--- a/tests/app/views/contexts/test_summary_context.py
+++ b/tests/app/views/contexts/test_summary_context.py
@@ -162,12 +162,12 @@ class TestCalculatedSummaryContext(TestStandardSummaryContext):
         )
 
         context = build_view_context_for_calculated_summary(
-            self.metadata,
             self.schema,
             self.answer_store,
             self.list_store,
-            self.block_type,
+            self.metadata,
             current_location,
+            language='en',
         )
 
         self.check_context(context)
@@ -200,12 +200,12 @@ class TestCalculatedSummaryContext(TestStandardSummaryContext):
         skip_answer = Answer('skip-fourth-block-answer', 'Yes')
         self.answer_store.add_or_update(skip_answer)
         context = build_view_context_for_calculated_summary(
-            self.metadata,
             self.schema,
             self.answer_store,
             self.list_store,
-            self.block_type,
+            self.metadata,
             current_location,
+            language='en',
         )
 
         self.check_context(context)
@@ -228,19 +228,19 @@ class TestCalculatedSummaryContext(TestStandardSummaryContext):
             context_summary['calculated_question']['answers'][0]['value'], '£12.00'
         )
 
-    @patch('app.jinja_filters.flask_babel.get_locale', Mock(return_value='en_GB'))
+    @patch('app.jinja_filters.flask_babel.get_locale', Mock(return_value='cy'))
     def test_build_view_context_for_unit_calculated_summary(self):
         current_location = Location(
             section_id='default-section', block_id='unit-total-playback'
         )
 
         context = build_view_context_for_calculated_summary(
-            self.metadata,
             self.schema,
             self.answer_store,
             self.list_store,
-            self.block_type,
+            self.metadata,
             current_location,
+            language='cy',
         )
 
         self.check_context(context)
@@ -268,12 +268,12 @@ class TestCalculatedSummaryContext(TestStandardSummaryContext):
         )
 
         context = build_view_context_for_calculated_summary(
-            self.metadata,
             self.schema,
             self.answer_store,
             self.list_store,
-            self.block_type,
+            self.metadata,
             current_location,
+            language='en',
         )
 
         self.check_context(context)
@@ -295,19 +295,19 @@ class TestCalculatedSummaryContext(TestStandardSummaryContext):
             context_summary['calculated_question']['answers'][0]['value'], '20%'
         )
 
-    @patch('app.jinja_filters.flask_babel.get_locale', Mock(return_value='en_GB'))
+    @patch('app.jinja_filters.flask_babel.get_locale', Mock(return_value='cy'))
     def test_build_view_context_for_number_calculated_summary(self):
         current_location = Location(
             section_id='default-section', block_id='number-total-playback'
         )
 
         context = build_view_context_for_calculated_summary(
-            self.metadata,
             self.schema,
             self.answer_store,
             self.list_store,
-            self.block_type,
+            self.metadata,
             current_location,
+            language='cy',
         )
 
         self.check_context(context)

--- a/tests/integration/questionnaire/test_questionnaire_placeholders.py
+++ b/tests/integration/questionnaire/test_questionnaire_placeholders.py
@@ -4,10 +4,10 @@ from tests.integration.integration_test_case import IntegrationTestCase
 class TestPlaceholders(IntegrationTestCase):
     def test_title_placeholders_rendered_in_summary(self):
         self.launchSurvey('test_placeholder_full')
-        self.assertInBody('Please enter your name')
+        self.assertInBody('Please enter a name')
         self.post({'first-name': 'Kevin', 'last-name': 'Bacon'})
 
-        self.assertInBody('What is the date of birth for ')
+        self.assertInBody('What is Kevin Bacon’s date of birth?')
 
         self.post(
             {
@@ -19,4 +19,32 @@ class TestPlaceholders(IntegrationTestCase):
 
         self.post({'confirm-date-of-birth-answer-proxy': 'Yes'})
 
-        self.assertInBody('What is the date of birth for Kevin Bacon?')
+        self.assertInUrl('/summary/')
+        self.assertInBody('What is Kevin Bacon’s date of birth?')
+
+    def test_title_placeholders_rendered_in_summary_using_correct_language_en(self):
+        self.launchSurvey('test_placeholder_full')
+        self.assertInBody('Please enter a name')
+        self.post({'first-name': 'Kevin', 'last-name': 'Bacon'})
+
+        self.assertInBody('What is Kevin Bacon’s date of birth?')
+
+        self.post(
+            {
+                'date-of-birth-answer-day': 1,
+                'date-of-birth-answer-month': 2,
+                'date-of-birth-answer-year': 1999,
+            }
+        )
+
+        self.post({'confirm-date-of-birth-answer-proxy': 'Yes'})
+
+        self.assertInUrl('/summary/')
+        self.assertInBody('What is Kevin Bacon’s date of birth?')
+        self.assertInBody('1 February 1999')
+
+        self.get(self.last_url + '?language_code=cy')
+
+        self.assertInUrl('/summary/?language_code=cy')
+        self.assertInBody('What is Kevin Bacon date of birth?')
+        self.assertInBody('1 Chwefror 1999')

--- a/tests/integration/questionnaire/test_questionnaire_placeholders.py
+++ b/tests/integration/questionnaire/test_questionnaire_placeholders.py
@@ -22,7 +22,7 @@ class TestPlaceholders(IntegrationTestCase):
         self.assertInUrl('/summary/')
         self.assertInBody('What is Kevin Bacon’s date of birth?')
 
-    def test_title_placeholders_rendered_in_summary_using_correct_language_en(self):
+    def test_title_placeholders_rendered_in_summary_using_correct_language(self):
         self.launchSurvey('test_placeholder_full')
         self.assertInBody('Please enter a name')
         self.post({'first-name': 'Kevin', 'last-name': 'Bacon'})


### PR DESCRIPTION
### What is the context of this PR?
The summary was not rendering context with the current `language_code` in mind. This PR ensures that the current `language_code` is used when rendering the context on the summary.

### How to review 
Ensure:
- When switching languages on the summary, Then the context is rendered in the correct language.

Can be tested using census schemas or `test_placeholder_full`.