### PR TITLE
Defects on routing

### DIFF
--- a/data-source/jsonnet/england-wales/household/blocks/individual/proxy.jsonnet
+++ b/data-source/jsonnet/england-wales/household/blocks/individual/proxy.jsonnet
@@ -17,7 +17,7 @@ local placeholders = import '../../../lib/placeholders.libsonnet';
       {
         id: 'proxy-answer',
         mandatory: false,
-        default: 'Yes',
+        default: 'No',
         options: [
           {
             label: 'Yes, I am',

--- a/data-source/jsonnet/england-wales/individual/blocks/identity-and-health/arrive_in_country.jsonnet
+++ b/data-source/jsonnet/england-wales/individual/blocks/identity-and-health/arrive_in_country.jsonnet
@@ -59,6 +59,17 @@ function(region_code, census_month_year_date) {
     },
     {
       goto: {
+        block: 'when-arrive-in-uk',
+        when: [
+          {
+            id: 'arrive-in-country-answer',
+            condition: 'not set',
+          },
+        ],
+      },
+    },
+    {
+      goto: {
         block: 'length-of-stay',
         when: [
           {

--- a/data-source/jsonnet/england-wales/individual/blocks/personal-details/term_time_location.jsonnet
+++ b/data-source/jsonnet/england-wales/individual/blocks/personal-details/term_time_location.jsonnet
@@ -193,7 +193,7 @@ local otherNonUkAddressOptions = {
         when: [
           {
             id: 'another-address-answer',
-            condition: 'not set'
+            condition: 'not set',
           },
         ],
       },

--- a/data-source/jsonnet/england-wales/individual/blocks/personal-details/term_time_location.jsonnet
+++ b/data-source/jsonnet/england-wales/individual/blocks/personal-details/term_time_location.jsonnet
@@ -189,6 +189,17 @@ local otherNonUkAddressOptions = {
     },
     {
       goto: {
+        block: 'term-time-address-country',
+        when: [
+          {
+            id: 'another-address-answer',
+            condition: 'not set'
+          },
+        ],
+      },
+    },
+    {
+      goto: {
         group: 'submit-group',
         when: [
           {

--- a/data-source/jsonnet/northern-ireland/household/blocks/individual/proxy.jsonnet
+++ b/data-source/jsonnet/northern-ireland/household/blocks/individual/proxy.jsonnet
@@ -17,7 +17,7 @@ local placeholders = import '../../../lib/placeholders.libsonnet';
       {
         id: 'proxy-answer',
         mandatory: false,
-        default: 'Yes',
+        default: 'No',
         options: [
           {
             label: 'Yes, I am',


### PR DESCRIPTION
### What is the context of this PR?

The default route through a schema is incorrect in certain cases for HH where a comparison is made on a non-mandatory answer. Additionally, the default route for the proxy question for household is incorrect, due being the reverse of what is in individual - 'Are you' vs 'Are you asking on behalf of someone else?'.

### How to review 
Evaluate the routes in the linked trello card and ensure they behave as described.

