### PR TITLE
Remove sign out from thank-you page

### DIFF
--- a/app/routes/questionnaire.py
+++ b/app/routes/questionnaire.py
@@ -4,7 +4,16 @@ import flask_babel
 import humanize
 import simplejson as json
 from dateutil.tz import tzutc
-from flask import Blueprint, g, redirect, request, url_for, current_app, jsonify
+from flask import (
+    Blueprint,
+    g,
+    redirect,
+    request,
+    url_for,
+    current_app,
+    jsonify,
+    session as cookie_session,
+)
 from flask_login import current_user, login_required
 from jwcrypto.common import base64url_decode
 from sdc.crypto.encrypter import encrypt
@@ -317,6 +326,9 @@ def get_thank_you(schema):
         view_submission_duration = humanize.naturaldelta(
             timedelta(seconds=schema.json['view_submitted_response']['duration'])
         )
+
+    cookie_session.pop('account_service_log_out_url', None)
+    cookie_session.pop('account_service_url', None)
 
     return render_template(
         template='thank-you',

--- a/tests/functional/spec/save_sign_out.spec.js
+++ b/tests/functional/spec/save_sign_out.spec.js
@@ -59,7 +59,7 @@ describe('SaveSignOut', function() {
           .click(IntroConfirmationPage.submit())
 
           .getUrl()
-          .getText(IntroThankYouPagePage.signOut()).should.eventually.contain('Sign out');
+          .isExisting(IntroThankYouPagePage.signOut()).should.eventually.be.false;
       });
   });
 

--- a/tests/integration/routes/test_thank_you.py
+++ b/tests/integration/routes/test_thank_you.py
@@ -21,7 +21,7 @@ class TestThankYou(IntegrationTestCase):
         'account_service_url': 'http://upstream.url',
     }
 
-    def test_thank_you_page_sign_out(self):
+    def test_thank_you_page_no_sign_out(self):
         self.launchSurvey('test_currency')
 
         # We fill in our answers
@@ -37,12 +37,9 @@ class TestThankYou(IntegrationTestCase):
         # Submit answers
         self.post(action=None)
 
-        # check we're on the thank you page
+        # check we're on the thank you page and there's no sign out
         self.assertInUrl('thank-you')
-
-        # sign out and check we're on the signed out page
-        self.post(action='sign_out')
-        self.assertEqualUrl('/signed-out')
+        self.assertNotInBody('Sign out')
 
     def test_can_switch_language_on_thank_you_page(self):
         self.launchSurvey('test_language')


### PR DESCRIPTION
### What is the context of this PR?
Removes the sign-out link from the thank-you page.

### How to review 
Test that the sign-out button doesn't appear on the thank-you page.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
