### PR TITLE
Fix non-translation of error messages

### DIFF
--- a/app/translations/cy/LC_MESSAGES/messages.po
+++ b/app/translations/cy/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: eq-census\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2019-09-17 09:41+0100\n"
-"PO-Revision-Date: 2019-09-18 09:40\n"
+"PO-Revision-Date: 2019-09-18 11:17\n"
 "Last-Translator: ONS_Census\n"
 "Language-Team: Welsh\n"
 "MIME-Version: 1.0\n"
@@ -368,8 +368,8 @@ msgstr[5] "Mae %(num)s wall ar y dudalen hon"
 #: templates/question.html:22
 msgid "This <strong>must be corrected</strong> to continue"
 msgid_plural "These <strong>must be corrected</strong> to continue"
-msgstr[0] "Mae'n <strong>rhaid cywiro hwn<strong> cyn parhau"
-msgstr[1] "Mae'n <strong>rhaid cywiro'r rhain<strong> cyn parhau"
+msgstr[0] "Mae'n <strong>rhaid cywiro</strong> hwn cyn parhau"
+msgstr[1] "Mae'n <strong>rhaid cywiro'r</strong> rhain cyn parhau"
 msgstr[2] "Mae'n <strong>rhaid cywiro'r</strong> rhain cyn parhau"
 msgstr[3] "Mae'n <strong>rhaid cywiro'r</strong> rhain cyn parhau"
 msgstr[4] "Mae'n <strong>rhaid cywiro'r</strong> rhain cyn parhau"
@@ -435,7 +435,7 @@ msgstr "Cyflwynwyd eich atebion ar gyfer <span>%(ru_name)s</span> (%(trading_as_
 #: templates/view-submission.html:24
 #, python-format
 msgid "Your answers were submitted for <span>%(ru_name)s</span> on %(submitted_time)s"
-msgstr "Cyflwynwyd eich atebion ar gyfer  <span>%(ru_name)s</span> ar %(submitted_time)s"
+msgstr "Cyflwynwyd eich atebion ar gyfer <span>%(ru_name)s</span> ar %(submitted_time)s"
 
 #: templates/view-submission.html:29
 msgid "Transaction ID"
@@ -925,7 +925,7 @@ msgstr "Cafodd rhannau o'r holiadur hwn eu profi ddiwethaf ar 3 Medi 2019 gan y 
 
 #: templates/static/accessibility.html:120
 msgid "<a href='{url}' download>DAC Report - September 2019</a>"
-msgstr "<a href='{url}' download>DAC Report - Medi 2019</a>"
+msgstr "<a href='{url}' download>Adroddiad DAC - Medi 2019</a>"
 
 #: templates/static/accessibility.html:122
 msgid "You can read the last full accessibility test report from 28 June 2019."
@@ -933,7 +933,7 @@ msgstr "Gallwch ddarllen yr adroddiad ar y prawf hygyrchedd llawn diwethaf o 28 
 
 #: templates/static/accessibility.html:124
 msgid "<a href='{url}' download>DAC Report - June 2019</a>"
-msgstr "<a href='{url}' download>DAC Report - Mehefin 2019</a>"
+msgstr "<a href='{url}' download>Adroddiad DAC - Mehefin 2019</a>"
 
 #: templates/static/accessibility.html:126
 msgid "What we’re doing to improve accessibility"
@@ -1134,7 +1134,7 @@ msgstr "Gallwch gysylltu â ni fel a ganlyn:"
 #: templates/static/privacy.html:108
 #, python-format
 msgid "Telephone: %(telephone_number)s"
-msgstr "Ffôn:%(telephone_number)s"
+msgstr "Ffôn: %(telephone_number)s"
 
 #: templates/static/privacy.html:110
 #, python-format
@@ -1160,7 +1160,7 @@ msgstr "Gallwch gysylltu â'r swyddog diogelu data fel a ganlyn:"
 
 #: templates/static/privacy.html:128 templates/static/privacy.html:149
 msgid "Telephone: {telephone_number}"
-msgstr "Ffôn:{telephone_number}"
+msgstr "Ffôn: {telephone_number}"
 
 #: templates/static/privacy.html:130 templates/static/privacy.html:151
 msgid "Email: {email_address}"

--- a/app/validation/error_messages.py
+++ b/app/validation/error_messages.py
@@ -1,51 +1,55 @@
-from flask_babel import gettext
+from flask_babel import lazy_gettext
 
 # Set up default error and warning messages
+# lazy_gettext is used as the string needs to be resolved at runtime
+# for translations to work.
 error_messages = {
-    'MANDATORY_QUESTION': gettext('Enter an answer to continue.'),
-    'MANDATORY_TEXTFIELD': gettext('Enter an answer to continue.'),
-    'MANDATORY_NUMBER': gettext('Enter an answer to continue.'),
-    'MANDATORY_TEXTAREA': gettext('Enter an answer to continue.'),
-    'MANDATORY_RADIO': gettext('Select an answer to continue.'),
-    'MANDATORY_DROPDOWN': gettext('Select an answer to continue.'),
-    'MANDATORY_CHECKBOX': gettext('Select all that apply to continue.'),
-    'MANDATORY_DATE': gettext('Enter a date to continue.'),
-    'MANDATORY_DURATION': gettext('Enter a duration to continue.'),
-    'NUMBER_TOO_SMALL': gettext('Enter an answer more than or equal to %(min)s.'),
-    'NUMBER_TOO_LARGE': gettext('Enter an answer less than or equal to %(max)s.'),
-    'NUMBER_TOO_SMALL_EXCLUSIVE': gettext('Enter an answer more than %(min)s.'),
-    'NUMBER_TOO_LARGE_EXCLUSIVE': gettext('Enter an answer less than %(max)s.'),
-    'TOTAL_SUM_NOT_EQUALS': gettext('Enter answers that add up to %(total)s'),
-    'TOTAL_SUM_NOT_LESS_THAN_OR_EQUALS': gettext(
+    'MANDATORY_QUESTION': lazy_gettext('Enter an answer to continue.'),
+    'MANDATORY_TEXTFIELD': lazy_gettext('Enter an answer to continue.'),
+    'MANDATORY_NUMBER': lazy_gettext('Enter an answer to continue.'),
+    'MANDATORY_TEXTAREA': lazy_gettext('Enter an answer to continue.'),
+    'MANDATORY_RADIO': lazy_gettext('Select an answer to continue.'),
+    'MANDATORY_DROPDOWN': lazy_gettext('Select an answer to continue.'),
+    'MANDATORY_CHECKBOX': lazy_gettext('Select all that apply to continue.'),
+    'MANDATORY_DATE': lazy_gettext('Enter a date to continue.'),
+    'MANDATORY_DURATION': lazy_gettext('Enter a duration to continue.'),
+    'NUMBER_TOO_SMALL': lazy_gettext('Enter an answer more than or equal to %(min)s.'),
+    'NUMBER_TOO_LARGE': lazy_gettext('Enter an answer less than or equal to %(max)s.'),
+    'NUMBER_TOO_SMALL_EXCLUSIVE': lazy_gettext('Enter an answer more than %(min)s.'),
+    'NUMBER_TOO_LARGE_EXCLUSIVE': lazy_gettext('Enter an answer less than %(max)s.'),
+    'TOTAL_SUM_NOT_EQUALS': lazy_gettext('Enter answers that add up to %(total)s'),
+    'TOTAL_SUM_NOT_LESS_THAN_OR_EQUALS': lazy_gettext(
         'Enter answers that add up to or are less than %(total)s'
     ),
-    'TOTAL_SUM_NOT_LESS_THAN': gettext(
+    'TOTAL_SUM_NOT_LESS_THAN': lazy_gettext(
         'Enter answers that add up to less than %(total)s'
     ),
-    'TOTAL_SUM_NOT_GREATER_THAN': gettext(
+    'TOTAL_SUM_NOT_GREATER_THAN': lazy_gettext(
         'Enter answers that add up to greater than %(total)s'
     ),
-    'TOTAL_SUM_NOT_GREATER_THAN_OR_EQUALS': gettext(
+    'TOTAL_SUM_NOT_GREATER_THAN_OR_EQUALS': lazy_gettext(
         'Enter answers that add up to or are greater than %(total)s'
     ),
-    'INVALID_NUMBER': gettext('Enter a number.'),
-    'INVALID_INTEGER': gettext('Enter a whole number.'),
-    'INVALID_DECIMAL': gettext('Enter a number rounded to %(max)d decimal places.'),
-    'MAX_LENGTH_EXCEEDED': gettext(
+    'INVALID_NUMBER': lazy_gettext('Enter a number.'),
+    'INVALID_INTEGER': lazy_gettext('Enter a whole number.'),
+    'INVALID_DECIMAL': lazy_gettext(
+        'Enter a number rounded to %(max)d decimal places.'
+    ),
+    'MAX_LENGTH_EXCEEDED': lazy_gettext(
         'Your answer is too long, it has to be less than %(max)d characters.'
     ),
-    'INVALID_DATE': gettext('Enter a valid date.'),
-    'INVALID_DATE_RANGE': gettext(
+    'INVALID_DATE': lazy_gettext('Enter a valid date.'),
+    'INVALID_DATE_RANGE': lazy_gettext(
         "Enter a 'period to' date later than the 'period from' date."
     ),
-    'INVALID_DURATION': gettext('Enter a valid duration.'),
-    'DATE_PERIOD_TOO_SMALL': gettext(
+    'INVALID_DURATION': lazy_gettext('Enter a valid duration.'),
+    'DATE_PERIOD_TOO_SMALL': lazy_gettext(
         'Enter a reporting period greater than or equal to %(min)s.'
     ),
-    'DATE_PERIOD_TOO_LARGE': gettext(
+    'DATE_PERIOD_TOO_LARGE': lazy_gettext(
         'Enter a reporting period less than or equal to %(max)s.'
     ),
-    'SINGLE_DATE_PERIOD_TOO_EARLY': gettext('Enter a date after %(min)s.'),
-    'SINGLE_DATE_PERIOD_TOO_LATE': gettext('Enter a date before %(max)s.'),
-    'MUTUALLY_EXCLUSIVE': gettext('Remove an answer to continue.'),
+    'SINGLE_DATE_PERIOD_TOO_EARLY': lazy_gettext('Enter a date after %(min)s.'),
+    'SINGLE_DATE_PERIOD_TOO_LATE': lazy_gettext('Enter a date before %(max)s.'),
+    'MUTUALLY_EXCLUSIVE': lazy_gettext('Remove an answer to continue.'),
 }

--- a/tests/integration/routes/test_questionnaire_language.py
+++ b/tests/integration/routes/test_questionnaire_language.py
@@ -57,3 +57,12 @@ class TestQuestionnaireLanguage(IntegrationTestCase):
         self.assertInUrl('/summary/?language_code=cy')
         self.assertInBody('Beth yw dyddiad geni Kevin Bacon?')
         self.assertInBody('1 Chwefror 1999')
+
+    def test_error_messages(self):
+        # load a english survey
+        self.launchSurvey('test_language', language_code='cy')
+        # Submit and check the error message is in Welsh
+        self.post({})
+        self.assertInBody('Mae 1 gwall ar y dudalen hon')
+        self.assertInBody("Mae'n <strong>rhaid cywiro'r</strong> rhain cyn parhau")
+        self.assertInBody('Nodwch ateb i barhau')


### PR DESCRIPTION
### What is the context of this PR?
Fixes non-translation of error messages.

The latest Welsh translations have also been added to fix an issue with no closing `/` for the `strong` tag in the error message.

### How to review 
- Use the test_language survey in Welsh and submit the first question without entering a name. The error message should be "Nodwch ateb i barhau." and not "Enter an answer to continue."

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
