### PR TITLE
Remove duplicate docker build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ script:
     - printf $(git rev-parse HEAD) > .application-version
     - make travis
     - export TAG=`if [ "$TRAVIS_PULL_REQUEST_BRANCH" == "" ]; then echo "latest"; else echo branch-$(echo $TRAVIS_PULL_REQUEST_BRANCH | sed s:/:-:g); fi`
-    - docker build -t eu.gcr.io/census-eq-ci/eq-survey-runner:"$TAG" .
+    - docker tag eu.gcr.io/census-eq-ci/eq-survey-runner:v3 eu.gcr.io/census-eq-ci/eq-survey-runner:"$TAG"
     - echo "$DOCKER_GCR_PASSWORD" | base64 --decode | docker login -u "$DOCKER_GCR_USERNAME" --password-stdin https://eu.gcr.io
     - echo "Pushing with tag [$TAG]"
     - docker push eu.gcr.io/census-eq-ci/eq-survey-runner:"$TAG"


### PR DESCRIPTION
### What is the context of this PR?

Travis currently runs docker build step for runner twice in every run. Once as part of the run_travis.sh script as docker-compose and then again as part of the .travis.yml under docker. The runner image generated as part of the compose step could be reused, before being pushed to our container registry.

### Changes

This change tags the image build as part of the compose step with the current branch tag and pushes to the registry, instead of triggering a rebuild of the container.

### How to review 

See if you agree with the approach. Ensure travis passes without error.
