### PR TITLE
Update gunicorn workers to 7

### DIFF
--- a/k8s/helm/templates/deployment.yaml
+++ b/k8s/helm/templates/deployment.yaml
@@ -76,7 +76,7 @@ spec:
             - name: EQ_SUBMISSION_BACKEND
               value: gcs
             - name: GUNICORN_WORKERS
-              value: "9"
+              value: "7"
             - name: GUNICORN_KEEP_ALIVE
               value: "650"
             - name: EQ_GCS_SUBMISSION_BUCKET_ID


### PR DESCRIPTION
### What is the context of this PR?
In performance tests it was found that 7 Gunicorns was more efficient than 9, which also ties in the with the idea that you should have 2 times + 1 in relation to CPU used by your application. We have 3 CPU for each runner app, so that also makes 7

### How to review 
Build through Concorse with this branch and make sure everything works

