### PR TITLE
Ability to override helm deployment values

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,12 @@ The following environment variables can be set when deploying the app.
 - GOOGLE_TAG_MANAGER_ID *(optional)*
 - GOOGLE_TAG_MANAGER_AUTH *(optional)*
 - GOOGLE_TAG_MANAGER_PREVIEW *(optional)*
+- REQUESTED_CPU_PER_POD *(optional)* - No. of CPUs to request per Pod
+- ROLLING_UPDATE_MAX_UNAVAILABLE *(optional)* - Specifies the maximum number of Pods that can be unavailable during the update process.
+- ROLLING_UPDATE_MAX_SURGE *(optional)* - Specifies the maximum number of Pods that can be created over the desired number of Pods.
+- MIN_REPLICAS *(optional)* - Minimum no. of replicated Pods
+- MAX_REPLICAS *(optional)* - Maximum no. of replicated Pods
+- TARGET_CPU_UTILIZATION_PERCENTAGE *(optional)* - The average CPU utilization usage before auto scaling applies
 
 To deploy the app to the cluster, run the following command:
 

--- a/k8s/deploy_app.sh
+++ b/k8s/deploy_app.sh
@@ -9,6 +9,12 @@ fi
 
 DOCKER_REGISTRY="${DOCKER_REGISTRY:-eu.gcr.io/census-eq-ci}"
 IMAGE_TAG="${IMAGE_TAG:-latest}"
+REQUESTED_CPU_PER_POD="${REQUESTED_CPU_PER_POD:-3}"
+ROLLING_UPDATE_MAX_UNAVAILABLE="${ROLLING_UPDATE_MAX_UNAVAILABLE:-1}"
+ROLLING_UPDATE_MAX_SURGE="${ROLLING_UPDATE_MAX_SURGE:-1}"
+MIN_REPLICAS="${MIN_REPLICAS:-3}"
+MAX_REPLICAS="${MAX_REPLICAS:-10}"
+TARGET_CPU_UTILIZATION_PERCENTAGE="${TARGET_CPU_UTILIZATION_PERCENTAGE:-50}"
 
 helm tiller run \
     helm upgrade --install \
@@ -20,4 +26,10 @@ helm tiller run \
     --set googleTagManagerPreview=${GOOGLE_TAG_MANAGER_PREVIEW} \
     --set image.repository=${DOCKER_REGISTRY}/eq-survey-runner \
     --set image.tag=${IMAGE_TAG} \
-    --set cookieSettingsUrl=${COOKIE_SETTINGS_URL}
+    --set cookieSettingsUrl=${COOKIE_SETTINGS_URL} \
+    --set resources.requests.cpu=${REQUESTED_CPU_PER_POD} \
+    --set rollingUpdate.maxUnavailable=${ROLLING_UPDATE_MAX_UNAVAILABLE} \
+    --set rollingUpdate.maxSurge=${ROLLING_UPDATE_MAX_SURGE} \
+    --set autoscaler.minReplicas=${MIN_REPLICAS} \
+    --set autoscaler.maxReplicas=${MAX_REPLICAS} \
+    --set autoscaler.targetCPUUtilizationPercentage=${TARGET_CPU_UTILIZATION_PERCENTAGE}

--- a/k8s/helm/templates/deployment.yaml
+++ b/k8s/helm/templates/deployment.yaml
@@ -8,12 +8,12 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.autoscaler.minReplicas }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 1
-      maxSurge: 1
+      maxUnavailable: {{ .Values.rollingUpdate.maxUnavailable }}
+      maxSurge: {{ .Values.rollingUpdate.maxSurge }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ .Chart.Name }}

--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -2,8 +2,6 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 3
-
 image:
   repository: eu.gcr.io/census-eq-ci/eq-survey-runner
   tag: latest
@@ -23,9 +21,15 @@ ingress:
 
 resources:
   requests:
-    cpu: "3"
+    cpu: ""
 
 autoscaler:
-    minReplicas: 3
-    maxReplicas: 10
-    targetCPUUtilizationPercentage: 50
+  minReplicas: ""
+  maxReplicas: ""
+  targetCPUUtilizationPercentage: ""
+
+# These values can be an absolute number (for example, 5) or
+# a percentage of desired Pods (for example, 10%). The Kubernetes default value is 25%.
+rollingUpdate:
+  maxUnavailable: ""
+  maxSurge: ""


### PR DESCRIPTION
### What is the context of this PR?
Added the ability to override helm deployment values.

### How to review 
Go to the concourse PR https://github.com/ONSdigital/census-eq-concourse/pull/27 and use this as your branch for eq-survey-runner


