### PR TITLE
Add logging to help debug the timeout issues

### DIFF
--- a/app/setup.py
+++ b/app/setup.py
@@ -8,7 +8,7 @@ import boto3
 import redis
 import yaml
 from botocore.config import Config
-from flask import Flask, session as cookie_session
+from flask import Flask, request, session as cookie_session
 from flask_babel import Babel
 from flask_caching import Cache
 from flask_compress import Compress
@@ -145,6 +145,23 @@ def create_app(setting_overrides=None):  # noqa: C901  pylint: disable=too-compl
         request_id = str(uuid4())
         logger.new(request_id=request_id)
 
+        session_cookie_present = False
+        csrf_token_present = False
+        if 'session' in request.cookies:
+            session_cookie_present = True
+            if 'csrf_token' in cookie_session:
+                csrf_token_present = True
+
+        logger.info(
+            'request',
+            method=request.method,
+            url_path=request.full_path,
+            session_cookie_present=session_cookie_present,
+            csrf_token_present=csrf_token_present,
+            cookies=request.cookies,
+            user_agent=request.user_agent.string,
+        )
+
     if application.config['EQ_NEW_RELIC_ENABLED']:
         setup_newrelic()
 
@@ -226,6 +243,19 @@ def create_app(setting_overrides=None):  # noqa: C901  pylint: disable=too-compl
             )
 
             return response
+        return response
+
+    @application.after_request
+    def after_request(response):
+        # We're using the stringified version of the Flask session to get a rough
+        # length for the cookie. The real length won't be known yet as Flask
+        # serialises and adds the cookie header after this method is called.
+        logger.info(
+            'response',
+            status_code=response.status_code,
+            session_cookie_content_length=len(str(cookie_session)),
+            session_modified=cookie_session.modified,
+        )
         return response
 
     return application

--- a/app/setup.py
+++ b/app/setup.py
@@ -8,7 +8,7 @@ import boto3
 import redis
 import yaml
 from botocore.config import Config
-from flask import Flask, request, session as cookie_session
+from flask import Flask, request as flask_request, session as cookie_session
 from flask_babel import Babel
 from flask_caching import Cache
 from flask_compress import Compress
@@ -147,12 +147,12 @@ def create_app(setting_overrides=None):  # noqa: C901  pylint: disable=too-compl
 
         logger.info(
             'request',
-            method=request.method,
-            url_path=request.full_path,
-            session_cookie_present='session' in request.cookies,
+            method=flask_request.method,
+            url_path=flask_request.full_path,
+            session_cookie_present='session' in flask_request.cookies,
             csrf_token_present='csrf_token' in cookie_session,
-            cookies=request.cookies,
-            user_agent=request.user_agent.string,
+            cookies=flask_request.cookies,
+            user_agent=flask_request.user_agent.string,
         )
 
     if application.config['EQ_NEW_RELIC_ENABLED']:
@@ -239,7 +239,7 @@ def create_app(setting_overrides=None):  # noqa: C901  pylint: disable=too-compl
         return response
 
     @application.after_request
-    def after_request(response):
+    def after_request(response):  # pylint: disable=unused-variable
         # We're using the stringified version of the Flask session to get a rough
         # length for the cookie. The real length won't be known yet as Flask
         # serialises and adds the cookie header after this method is called.

--- a/app/setup.py
+++ b/app/setup.py
@@ -145,19 +145,12 @@ def create_app(setting_overrides=None):  # noqa: C901  pylint: disable=too-compl
         request_id = str(uuid4())
         logger.new(request_id=request_id)
 
-        session_cookie_present = False
-        csrf_token_present = False
-        if 'session' in request.cookies:
-            session_cookie_present = True
-            if 'csrf_token' in cookie_session:
-                csrf_token_present = True
-
         logger.info(
             'request',
             method=request.method,
             url_path=request.full_path,
-            session_cookie_present=session_cookie_present,
-            csrf_token_present=csrf_token_present,
+            session_cookie_present='session' in request.cookies,
+            csrf_token_present='csrf_token' in cookie_session,
             cookies=request.cookies,
             user_agent=request.user_agent.string,
         )


### PR DESCRIPTION
### What is the context of this PR?
Adds logging to help debug the timeout issues. We're seeing `The CSRF session token is missing` errors and need to know if it's because the session cookie wasn't sent, or that the `csrf_token` is missing from the session cookie.

### How to review 
- Review the log lines
- Should anything else be logged?
- Try with developer logging off - set `EQ_DEVELOPER_LOGGING=False`
- Deploy to GCP and verify logging works as expected

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
