### PR TITLE
Add message on session timeout page for Edge users

### DIFF
--- a/app/routes/errors.py
+++ b/app/routes/errors.py
@@ -68,7 +68,7 @@ def log_exception(error, status_code):
 def _render_error_page(status_code, template=None):
     handle_language()
     template = template or status_code
-    using_edge = 'edge' in request.user_agent.string.lower()
+    using_edge = request.user_agent.browser == 'edge'
 
     return (
         render_template(template=f'errors/{template}', using_edge=using_edge),

--- a/app/routes/errors.py
+++ b/app/routes/errors.py
@@ -67,7 +67,10 @@ def log_exception(error, status_code):
 
 def _render_error_page(status_code, template=None):
     handle_language()
-
     template = template or status_code
+    using_edge = 'edge' in request.user_agent.string.lower()
 
-    return render_template(template=f'errors/{template}'), status_code
+    return (
+        render_template(template=f'errors/{template}', using_edge=using_edge),
+        status_code,
+    )

--- a/templates/errors/session-expired.html
+++ b/templates/errors/session-expired.html
@@ -16,6 +16,7 @@
     "classes": "u-mb-s"
   }) %}
     <p>{{ _("To help protect your information we have signed you out") }}.</p>
+    <p>You will need to <a href="https://census.gov.uk/start/">enter your unique access code</a> to access the census again.</p>
     {% if using_edge %}
     <p>If you have been timed out unexpectedly on more than one occasion, please try using a different browser. If you’re still having problems completing the census, <a href="https://census.gov.uk/contact-us/">contact us</a>.</p>
     {% endif %}

--- a/templates/errors/session-expired.html
+++ b/templates/errors/session-expired.html
@@ -17,7 +17,7 @@
   }) %}
     <p>{{ _("To help protect your information we have signed you out") }}.</p>
     {% if using_edge %}
-    <p>If you have been timed out unexpectedly on more than one occasion, please try using a different browser. If you’re still having problems completing the Census, <a href="https://census.gov.uk/contact-us/">contact us</a>.</p>
+    <p>If you have been timed out unexpectedly on more than one occasion, please try using a different browser. If you’re still having problems completing the census, <a href="https://census.gov.uk/contact-us/">contact us</a>.</p>
     {% endif %}
   {% endcall %}
 

--- a/templates/errors/session-expired.html
+++ b/templates/errors/session-expired.html
@@ -16,6 +16,9 @@
     "classes": "u-mb-s"
   }) %}
     <p>{{ _("To help protect your information we have signed you out") }}.</p>
+    {% if using_edge %}
+    <p>If you have been timed out unexpectedly on more than one occasion, please try using a different browser. If you’re still having problems completing the Census, <a href="https://census.gov.uk/contact-us/">contact us</a>.</p>
+    {% endif %}
   {% endcall %}
 
   {% if account_service_url %}


### PR DESCRIPTION
### What is the context of this PR?
A small percentage of Edge users are experiencing session expired screens when progressing through the Census survey. This pull request adds a message on the session expired page encouraging them to try using another browser if they are experiencing timeouts.

The message hasn't been marked for translation as the user more than likely won't have a cookie and so we won't know what language they were using.

### How to review 
I tested this using Browserstack and my GCP environment. 
- Load the survey
- Remove cookies
- Submit a screen

When using Edge you should see the additional message. When using any other browser you shouldn't.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
