### PR TITLE
Switch from persistent to session cookies

### DIFF
--- a/app/setup.py
+++ b/app/setup.py
@@ -137,11 +137,6 @@ def create_app(setting_overrides=None):  # noqa: C901  pylint: disable=too-compl
     # request will use the logger context of the previous request.
     @application.before_request
     def before_request():  # pylint: disable=unused-variable
-
-        # While True the session lives for permanent_session_lifetime seconds
-        # Needed to be able to set the client-side cookie expiration
-        cookie_session.permanent = True
-
         request_id = str(uuid4())
         logger.new(request_id=request_id)
 
@@ -429,11 +424,9 @@ def add_blueprints(application):
 
 
 def setup_secure_cookies(application):
-    session_timeout = application.config['EQ_SESSION_TIMEOUT_SECONDS']
     application.secret_key = application.eq['secret_store'].get_secret_by_name(
         'EQ_SECRET_KEY'
     )
-    application.permanent_session_lifetime = timedelta(seconds=session_timeout)
     application.session_interface = SHA256SecureCookieSessionInterface()
 
 

--- a/app/setup.py
+++ b/app/setup.py
@@ -1,7 +1,6 @@
 import copy
 import json
 import logging
-from datetime import timedelta
 from uuid import uuid4
 
 import boto3

--- a/templates/errors/session-expired.html
+++ b/templates/errors/session-expired.html
@@ -16,14 +16,14 @@
     "classes": "u-mb-s"
   }) %}
     <p>{{ _("To help protect your information we have signed you out") }}.</p>
-    <p>You will need to <a href="https://census.gov.uk/start/">enter your unique access code</a> to access the census again.</p>
+    {% if account_service_url %}
+      <p>{{ _('We have saved your progress and you will need to <a href="%(account_service_link)s">enter your unique code</a> to access the survey again.', account_service_link=account_service_url) }}</p>
+    {% else %}
+      <p>{{ _('We have saved your progress and you will need to <a href="%(account_service_link)s">enter your unique code</a> to access the survey again.', account_service_link='https://census.gov.uk/start/') }}</p>
+    {% endif %}
     {% if using_edge %}
-    <p>If you have been timed out unexpectedly on more than one occasion, please try using a different browser. If you’re still having problems completing the census, <a href="https://census.gov.uk/contact-us/">contact us</a>.</p>
+      <p>If you have been timed out unexpectedly on more than one occasion, please try using a different browser. If you’re still having problems completing the census, <a href="https://census.gov.uk/contact-us/">contact us</a>.</p>
     {% endif %}
   {% endcall %}
-
-  {% if account_service_url %}
-    {{ _('We have saved your progress and you will need to <a href="%(account_service_link)s">enter your unique code</a> to access the survey again.', account_service_link=account_service_url) }}
-  {% endif %}
 
 {% endblock %}

--- a/tests/integration/routes/test_cookie.py
+++ b/tests/integration/routes/test_cookie.py
@@ -7,7 +7,6 @@ class TestCookie(IntegrationTestCase):
         cookie = self.getCookie()
 
         self.assertIsNotNone(cookie.get('_fresh'))
-        self.assertIsNotNone(cookie.get('_permanent'))
         self.assertIsNotNone(cookie.get('csrf_token'))
         self.assertIsNotNone(cookie.get('eq-session-id'))
         self.assertIsNotNone(cookie.get('expires_in'))
@@ -15,6 +14,7 @@ class TestCookie(IntegrationTestCase):
         self.assertIsNotNone(cookie.get('theme'))
         self.assertIsNotNone(cookie.get('user_ik'))
         self.assertIsNotNone(cookie.get('account_service_url'))
-        self.assertEqual(len(cookie), 9)
+        self.assertEqual(len(cookie), 8)
 
         self.assertIsNone(cookie.get('user_id'))
+        self.assertIsNone(cookie.get('_permanent'))


### PR DESCRIPTION
### What is the context of this PR?

After investigation into production issues it has been identified that some browsers (predominantly Edge) seem to drop our session cookie randomly. Although we still don't know why this happens (debugging has shown that a valid cookie is sent on the request previous to the one that errors), changing from a permanent cookie (one with an expiry time set) to a session cookie (one that expires when the browser is closed) seems to fix the issue.

Arguably the cookie should always have been a session one. The server side session times out after the timeout period (default is 45 minutes) and keeping the cookie client side means we will still have context like the theme or an account service url that are useful when rendering error screens. The cookie was set to expire prior to us having server side session expiry.

### How to review 
- Check that launching , signing out and resuming work as expected
- Use the `census-rehearsal` branch version of runner to start a survey, switch to this branch and confirm that there is no interruption to the journey.
- Test on a range of browsers

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
