### PR TITLE
Bugfix patch release of design-system needed to revert <em> issue

### DIFF
--- a/scripts/load_templates.sh
+++ b/scripts/load_templates.sh
@@ -4,7 +4,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 cd "${DIR}"/.. || exit
 
-DESIGN_SYSTEM_VERSION="13.6.10"
+DESIGN_SYSTEM_VERSION="13.6.11"
 
 TEMP_DIR=$(mktemp -d)
 


### PR DESCRIPTION
Fixes issue with incorrect rendering of `<em>` tags in description content:
![image (2)](https://user-images.githubusercontent.com/1754822/66396572-eae7b080-e9d1-11e9-8039-4a1711af5108.png)
