### PR TITLE
Allow POST requests to the /session endpoint

### DIFF
--- a/app/routes/session.py
+++ b/app/routes/session.py
@@ -35,7 +35,7 @@ def login_head():
     return '', 204
 
 
-@session_blueprint.route('/session', methods=['GET'])
+@session_blueprint.route('/session', methods=['GET', 'POST'])
 def login():
     """
     Initial url processing - expects a token parameter and then will authenticate this token. Once authenticated

--- a/tests/integration/routes/test_errors.py
+++ b/tests/integration/routes/test_errors.py
@@ -40,13 +40,8 @@ class TestErrors(IntegrationTestCase):
 
     def test_errors_500(self):
         # Given
-        payload_without_account_service_url = self.example_payload.copy()
-        del payload_without_account_service_url['account_service_url']
-        with patch(
-            'tests.integration.create_token.PAYLOAD',
-            payload_without_account_service_url,
-        ):
-            self.launchSurvey('test_percentage')
+        self.launchSurvey('test_percentage')
+
         # When / Then
         # Patch out a class in post to raise an exception so that the application error handler
         # gets called

--- a/tests/integration/session/test_login.py
+++ b/tests/integration/session/test_login.py
@@ -7,13 +7,13 @@ from tests.integration.create_token import PAYLOAD
 from tests.integration.integration_test_case import IntegrationTestCase
 
 
-class TestLogin(IntegrationTestCase):
+class TestLoginWithGetRequest(IntegrationTestCase):
     def test_login_with_no_token_should_be_unauthorized(self):
         # Given
         token = ''
 
         # When
-        self.get('/session?token=' + token)
+        self.get(url=f'/session?token={token}')
 
         # Then
         self.assertStatusUnauthorised()
@@ -23,7 +23,7 @@ class TestLogin(IntegrationTestCase):
         token = '123'
 
         # When
-        self.get('/session?token=' + token)
+        self.get(url=f'/session?token={token}')
 
         # Then
         self.assertStatusForbidden()
@@ -33,7 +33,7 @@ class TestLogin(IntegrationTestCase):
         token = self.token_generator.create_token('test_checkbox')
 
         # When
-        self.get('/session?token=' + token)
+        self.get(url=f'/session?token={token}')
 
         # Then
         self.assertStatusOK()
@@ -42,10 +42,10 @@ class TestLogin(IntegrationTestCase):
     def test_login_with_token_twice_is_unauthorised_when_same_jti_provided(self):
         # Given
         token = self.token_generator.create_token('test_checkbox')
-        self.get('/session?token=' + token)
+        self.get(url=f'/session?token={token}')
 
         # When
-        self.get('/session?token=' + token)
+        self.get(url=f'/session?token={token}')
 
         # Then
         self.assertStatusUnauthorised()
@@ -53,7 +53,7 @@ class TestLogin(IntegrationTestCase):
     def test_login_without_jti_in_token_is_unauthorised(self):
         # Given
         token = self.token_generator.create_token_without_jti('test_checkbox')
-        self.get('/session?token=' + token)
+        self.get(url=f'/session?token={token}')
 
         # Then
         self.assertStatusForbidden()
@@ -63,7 +63,7 @@ class TestLogin(IntegrationTestCase):
         token = self.token_generator.create_token('')
 
         # When
-        self.get('/session?token=' + token)
+        self.get(url=f'/session?token={token}')
 
         # Then
         self.assertStatusForbidden()
@@ -76,7 +76,7 @@ class TestLogin(IntegrationTestCase):
         self._client.head(
             '/session?token=' + token, as_tuple=True, follow_redirects=True
         )
-        self.get('/session?token=' + token)
+        self.get(url=f'/session?token={token}')
 
         # Then
         self.assertStatusOK()
@@ -91,7 +91,7 @@ class TestLogin(IntegrationTestCase):
         token = self.token_generator.generate_token(payload_vars)
 
         # When
-        self.get('/session?token=' + token)
+        self.get(url=f'/session?token={token}')
 
         # Then
         self.assertStatusForbidden()
@@ -100,7 +100,7 @@ class TestLogin(IntegrationTestCase):
         # flag_1 should be a boolean
         token = self.token_generator.create_token('test_metadata_routing', flag_1=123)
 
-        self.get('/session?token=' + token)
+        self.get(url=f'/session?token={token}')
 
         self.assertStatusForbidden()
 
@@ -115,7 +115,7 @@ class TestLogin(IntegrationTestCase):
 
         # When
         with HTTMock(self.survey_url_mock):
-            self.get('/session?token=' + token)
+            self.get(url=f'/session?token={token}')
 
         self.assertStatusOK()
         self.assertInUrl('/questionnaire')
@@ -131,7 +131,7 @@ class TestLogin(IntegrationTestCase):
 
         # When
         with HTTMock(self.survey_url_mock_404):
-            self.get('/session?token=' + token)
+            self.get(url=f'/session?token={token}')
 
         # Then
         self.assertStatusNotFound()
@@ -139,7 +139,7 @@ class TestLogin(IntegrationTestCase):
     def test_login_without_case_id_in_token_is_authorised(self):
         # Given
         token = self.token_generator.create_token_without_case_id('test_textfield')
-        self.get('/session?token=' + token)
+        self.get(url=f'/session?token={token}')
 
         # Then
         self.assertStatusOK()
@@ -149,7 +149,168 @@ class TestLogin(IntegrationTestCase):
         token = self.token_generator.create_token_without_questionnaire_id(
             'textfield_test'
         )
-        self.get('/session?token=' + token)
+        self.get(url=f'/session?token={token}')
+
+        # Then
+        self.assertStatusForbidden()
+
+    @staticmethod
+    @urlmatch(netloc=r'eq-survey-register', path=r'\/my-test-schema')
+    def survey_url_mock(_url, _request):
+        schema_path = get_schema_file_path('test_textarea', language_code='en')
+
+        with open(schema_path, encoding='utf8') as json_data:
+            return json_data.read()
+
+    @staticmethod
+    @urlmatch(netloc=r'eq-survey-register', path=r'\/my-test-schema-not-found')
+    def survey_url_mock_404(_url, _request):
+        return response(404)
+
+
+class TestLoginWIthPostRequest(IntegrationTestCase):
+    def test_login_with_no_token_should_be_unauthorized(self):
+        # Given
+        token = ''
+
+        # When
+        self.post(url=f'/session?token={token}')
+
+        # Then
+        self.assertStatusUnauthorised()
+
+    def test_login_with_invalid_token_should_be_forbidden(self):
+        # Given
+        token = '123'
+
+        # When
+        self.post(url=f'/session?token={token}')
+
+        # Then
+        self.assertStatusForbidden()
+
+    def test_login_with_valid_token_should_redirect_to_survey(self):
+        # Given
+        token = self.token_generator.create_token('test_checkbox')
+
+        # When
+        self.post(url=f'/session?token={token}')
+
+        # Then
+        self.assertStatusOK()
+        self.assertInUrl('/questionnaire')
+
+    def test_login_with_token_twice_is_unauthorised_when_same_jti_provided(self):
+        # Given
+        token = self.token_generator.create_token('test_checkbox')
+        self.post(url=f'/session?token={token}')
+
+        # When
+        self.post(url=f'/session?token={token}')
+
+        # Then
+        self.assertStatusUnauthorised()
+
+    def test_login_without_jti_in_token_is_unauthorised(self):
+        # Given
+        token = self.token_generator.create_token_without_jti('test_checkbox')
+        self.post(url=f'/session?token={token}')
+
+        # Then
+        self.assertStatusForbidden()
+
+    def test_login_with_valid_token_no_schema_name(self):
+        # Given
+        token = self.token_generator.create_token('')
+
+        # When
+        self.post(url=f'/session?token={token}')
+
+        # Then
+        self.assertStatusForbidden()
+
+    def test_http_head_request_to_login_returns_successfully_and_get_still_works(self):
+        # Given
+        token = self.token_generator.create_token('test_checkbox')
+
+        # When
+        self._client.head(
+            '/session?token=' + token, as_tuple=True, follow_redirects=True
+        )
+        self.post(url=f'/session?token={token}')
+
+        # Then
+        self.assertStatusOK()
+        self.assertInUrl('/questionnaire')
+
+    def test_login_with_missing_mandatory_claims_should_be_forbidden(self):
+        # Given
+        payload_vars = PAYLOAD.copy()
+        payload_vars['iat'] = time.time()
+        payload_vars['exp'] = payload_vars['iat'] + float(3600)  # one hour from now
+
+        token = self.token_generator.generate_token(payload_vars)
+
+        # When
+        self.post(url=f'/session?token={token}')
+
+        # Then
+        self.assertStatusForbidden()
+
+    def test_login_with_invalid_questionnaire_claims_should_be_forbidden(self):
+        # flag_1 should be a boolean
+        token = self.token_generator.create_token('test_metadata_routing', flag_1=123)
+
+        self.post(url=f'/session?token={token}')
+
+        self.assertStatusForbidden()
+
+    def test_login_token_with_survey_url_should_redirect_to_survey(self):
+
+        survey_url = 'http://eq-survey-register.url/my-test-schema'
+
+        # Given
+        token = self.token_generator.create_token_with_survey_url(
+            'test_textarea', survey_url
+        )
+
+        # When
+        with HTTMock(self.survey_url_mock):
+            self.post(url=f'/session?token={token}')
+
+        self.assertStatusOK()
+        self.assertInUrl('/questionnaire')
+
+    def test_login_token_with_incorrect_survey_url_results_in_404(self):
+
+        survey_url = 'http://eq-survey-register.url/my-test-schema-not-found'
+
+        # Given
+        token = self.token_generator.create_token_with_survey_url(
+            'test_textarea', survey_url
+        )
+
+        # When
+        with HTTMock(self.survey_url_mock_404):
+            self.post(url=f'/session?token={token}')
+
+        # Then
+        self.assertStatusNotFound()
+
+    def test_login_without_case_id_in_token_is_authorised(self):
+        # Given
+        token = self.token_generator.create_token_without_case_id('test_textfield')
+        self.post(url=f'/session?token={token}')
+
+        # Then
+        self.assertStatusOK()
+
+    def test_login_without_questionnaire_id_in_token_is_unauthorised(self):
+        # Given
+        token = self.token_generator.create_token_without_questionnaire_id(
+            'textfield_test'
+        )
+        self.post(url=f'/session?token={token}')
 
         # Then
         self.assertStatusForbidden()

--- a/tests/integration/session/test_login.py
+++ b/tests/integration/session/test_login.py
@@ -229,7 +229,7 @@ class TestLoginWIthPostRequest(IntegrationTestCase):
         # Then
         self.assertStatusForbidden()
 
-    def test_http_head_request_to_login_returns_successfully_and_get_still_works(self):
+    def test_http_head_request_to_login_returns_successfully_and_post_still_works(self):
         # Given
         token = self.token_generator.create_token('test_checkbox')
 


### PR DESCRIPTION
### What is the context of this PR?
This change allows `POST` requests to the `/session` endpoint to be treated the same as the existing `GET` request. Since go-live, there have been approx 60 eQ launches where the RH 302 request results in Chrome browsers making a POST request to the `/session` endpoint rather than a GET request. The root cause is still unclear but the intermediary fix is to allow `POST` to the session. The change should behave the same way as `GET`request since the user is still required to provide a genuine JWT token to authenticate successfully.

For our use case, we would be better suited to use 303 redirects instead of 302s for both RH and eQ, however, this change is only feasible post-rehearsal.

### How to review 
- Make `POST` requests to the `session` endpoint and ensure it works as expected. Test with both a valid and an invalid token.
