### PR TITLE
Add missing list collector summary to test schema

### DIFF
--- a/data-source/json/test_skip_condition_list.json
+++ b/data-source/json/test_skip_condition_list.json
@@ -133,6 +133,31 @@
                                         }
                                     ]
                                 }
+                            },
+                            "summary": {
+                                "add_link_text": "Add someone to this household",
+                                "empty_list_text": "There are no householders",
+                                "title": "Household members",
+                                "item_title": {
+                                    "text": "{person_name}",
+                                    "placeholders": [
+                                        {
+                                            "placeholder": "person_name",
+                                            "transforms": [
+                                                {
+                                                    "arguments": {
+                                                        "delimiter": " ",
+                                                        "list_to_concatenate": {
+                                                            "identifier": ["first-name", "last-name"],
+                                                            "source": "answers"
+                                                        }
+                                                    },
+                                                    "transform": "concatenate_list"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
                             }
                         },
                         {


### PR DESCRIPTION
### What is the context of this PR?
Adds a missing list collector summary to a test schema, required now https://github.com/ONSdigital/eq-schema-validator/pull/165 has merged.

### How to review 
Check Travis build passes

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
