### PR TITLE
Switch from persistent to session cookies

### DIFF
--- a/app/setup.py
+++ b/app/setup.py
@@ -3,14 +3,13 @@ import json
 import logging
 import os
 import sys
-from datetime import timedelta
 from uuid import uuid4
 
 import boto3
 import sqlalchemy
 import yaml
 from botocore.config import Config
-from flask import Flask, url_for, session as cookie_session
+from flask import Flask, url_for
 from flask_babel import Babel
 from flask_caching import Cache
 from flask_talisman import Talisman
@@ -149,10 +148,6 @@ def create_app(setting_overrides=None):  # noqa: C901  pylint: disable=too-compl
 
     @application.before_request
     def before_request():  # pylint: disable=unused-variable
-
-        # While True the session lives for permanent_session_lifetime seconds
-        # Needed to be able to set the client-side cookie expiration
-        cookie_session.permanent = True
 
         request_id = str(uuid4())
         logger.new(request_id=request_id)
@@ -328,9 +323,7 @@ def add_blueprints(application):
 
 
 def setup_secure_cookies(application):
-    session_timeout = application.config['EQ_SESSION_TIMEOUT_SECONDS']
     application.secret_key = application.eq['secret_store'].get_secret_by_name('EQ_SECRET_KEY')
-    application.permanent_session_lifetime = timedelta(seconds=session_timeout)
     application.session_interface = SHA256SecureCookieSessionInterface()
 
 

--- a/tests/app/data_model/test_session_store.py
+++ b/tests/app/data_model/test_session_store.py
@@ -15,7 +15,6 @@ from app.storage import data_access, storage_encryption
 class SessionStoreTest(AppContextTestCase):
     def setUp(self):
         super().setUp()
-        self._app.permanent_session_lifetime = timedelta(seconds=1)
         self.session_store = SessionStore('user_ik', 'pepper')
         self.expires_at = datetime.utcnow() + timedelta(seconds=1)
         self.session_data = SessionData(

--- a/tests/app/framework/survey_runner_test_case.py
+++ b/tests/app/framework/survey_runner_test_case.py
@@ -1,5 +1,4 @@
 import unittest
-from datetime import timedelta
 
 from flask import Flask
 from flask_login import LoginManager
@@ -14,7 +13,6 @@ class SurveyRunnerTestCase(unittest.TestCase):
         application = Flask(__name__)
         application.config['TESTING'] = True
         application.secret_key = 'you will not guess'
-        application.permanent_session_lifetime = timedelta(seconds=1)
 
         login_manager.init_app(application)
         self.application = application

--- a/tests/integration/test_app_create.py
+++ b/tests/integration/test_app_create.py
@@ -58,7 +58,6 @@ class TestCreateApp(unittest.TestCase):
     def test_enforces_secure_session(self):
         application = create_app(self._setting_overrides)
         self.assertTrue(application.secret_key)
-        self.assertTrue(application.permanent_session_lifetime)
         self.assertTrue(application.session_interface)
 
         # This is derived from EQ_ENABLE_SECURE_SESSION_COOKIE which is false

--- a/tests/integration/views/test_cookie.py
+++ b/tests/integration/views/test_cookie.py
@@ -7,13 +7,13 @@ class TestCookie(IntegrationTestCase):
         cookie = self.getCookie()
 
         self.assertIsNotNone(cookie.get('_fresh'))
-        self.assertIsNotNone(cookie.get('_permanent'))
         self.assertIsNotNone(cookie.get('csrf_token'))
         self.assertIsNotNone(cookie.get('eq-session-id'))
         self.assertIsNotNone(cookie.get('expires_in'))
         self.assertIsNotNone(cookie.get('survey_title'))
         self.assertIsNotNone(cookie.get('theme'))
         self.assertIsNotNone(cookie.get('user_ik'))
-        self.assertEqual(len(cookie), 8)
+        self.assertEqual(len(cookie), 7)
 
         self.assertIsNone(cookie.get('user_id'))
+        self.assertIsNone(cookie.get('_permanent'))


### PR DESCRIPTION
After investigation into production issues it has been identified
that some browsers (predominantly Edge) seem to drop our session
cookie randomly. Although we still don't know why this happens
(debugging has shown that a valid cookie is sent on the request
previous to the one that errors), changing from a permanent cookie
(one with an expiry time set) to a session cookie (one that expires
when the browser is closed) seems to fix the issue.

Arguably the cookie should always have been a session one. The
server side session times out after the timeout period (default is
45 minutes) and keeping the cookie client side means we will still
have context like the theme or an account service url that are
useful when rendering error screens. The cookie was set to expire
prior to us having server side session expiry.

Solution based on: https://github.com/ONSdigital/eq-survey-runner/pull/2420