### PR TITLE
Fix CCS translations

### DIFF
--- a/app/translations/cy/ccs_household_gb_eng_cy.po
+++ b/app/translations/cy/ccs_household_gb_eng_cy.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: eq-census\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-10-10 13:52+0100\n"
-"PO-Revision-Date: 2019-10-15 12:33\n"
+"POT-Creation-Date: 2019-10-22 11:16+0100\n"
+"PO-Revision-Date: 2019-10-23 11:20\n"
 "Last-Translator: ONS_Census\n"
 "Language-Team: Welsh\n"
 "MIME-Version: 1.0\n"
@@ -17,45 +17,42 @@ msgstr ""
 "X-Crowdin-File: ccs.pot\n"
 "Language: cy_GB\n"
 
-msgid "Why your answer is important"
-msgstr ""
-
 msgid "Census England Coverage Survey Schema"
 msgstr ""
 
-msgid "All the questions are about the people in your household on 13th October 2019."
-msgstr ""
+msgid "All the questions are about the people in your household on Sunday 13 October 2019."
+msgstr "Mae pob un o’r cwestiynau’n ymwneud â’r bobl a oedd yn eich cartref ddydd Sul 13 Hydref 2019."
 
-msgid "A <em>household</em> is one person living alone, or a group of people (not necessarily related), who share cooking facilities, and share a\n"
-"        living room, <em>OR</em> sitting room, <em>OR</em> dining area."
-msgstr ""
+msgid "A <em>household</em> is one person living alone or a group of people (not necessarily related) who share cooking facilities and share a\n"
+"        living room <em>OR</em> sitting room <em>OR</em> dining area."
+msgstr "Mae <em>cartref</em> yn golygu un person sy’n byw ar ei ben ei hun neu grŵp o bobl (nid oes rhaid iddyn nhw berthyn i’w gilydd) sy’n rhannu cyfleusterau coginio ac yn rhannu ystafell fyw <em>NEU</em> lolfa <em>NEU</em> le bwyta."
 
 msgid "Here are some cards to help with answering the questions."
 msgstr "Dyma gardiau i'ch helpu chi i ateb y cwestiynau."
 
-msgid "Tell respondent to turn to <strong>Showcard 1</strong>"
-msgstr "Dywedwch wrth yr ymatebwr am droi at <strong>Gerdyn Dangos 1</strong>"
-
 msgid "Only interview a person who was usually living at the property on census night."
-msgstr ""
+msgstr "Dylech ond gyfweld â pherson sydd fel arfer yn byw yn yr eiddo ar noson y cyfrifiad."
 
 msgid "If none of those household members are available, you must save and sign out of the survey and return to the address to interview one of them at a later date."
+msgstr "Os nad oes unrhyw un o aelodau’r cartref ar gael, dylech gadw ac allgofnodi o’r arolwg a dychwelyd i’r cyfeiriad i gyfweld ag un ohonyn nhw ar ddiwrnod arall."
+
+msgid "If none of the household members were usually living at the property on census night, you must save and sign out of the survey and complete a paper questionnaire."
+msgstr "Os nad oedd dim un o aelodau'r cartref fel arfer yn byw yn y cartref ar noson y cyfrifiad, mae'n rhaid i chi gadw'r arolwg, allgofnodi a chwblhau holiadur papur."
+
+msgid "Remember to only include those people who share cooking facilities and share a living room or sitting room or dining area"
 msgstr ""
 
-msgid "Enter a full stop(.) if the respondent does not know a person’s \"First name\" or \"Surname\""
+msgid "Include"
+msgstr "Cofiwch"
+
+msgid "A visitor is a person staying overnight in your household who usually lives at another address."
+msgstr "Mae ymwelydd yn golygu person sy’n aros dros nos sydd fel arfer yn byw mewn cyfeiriad arall."
+
+msgid "Remember to include partners and step-children as related."
 msgstr ""
 
-msgid "Tell respondent to turn to <strong>Showcard 2</strong>"
-msgstr "Dywedwch wrth yr ymatebwr am droi at <strong>Gerdyn Dangos 2</strong>"
-
-msgid "Remember to include only those people who share cooking facilities and share a living room or dining area"
-msgstr ""
-
-msgid "In this section, I’m going to ask you about the household and accommodation you were living in on Sunday 13th October 2019."
-msgstr ""
-
-msgid "Tell respondent to turn to <strong>Showcard 3</strong>"
-msgstr "Dywedwch wrth yr ymatebwr am droi at <strong>Gerdyn Dangos 3</strong>"
+msgid "In this section, I’m going to ask you about the household and accommodation you were living in on Sunday 13 October 2019."
+msgstr "Yn yr adran hon, byddaf yn gofyn i chi am y cartref roeddech chi’n byw ynddo ddydd Sul 13 Hydref 2019."
 
 msgid "Including end-terrace"
 msgstr "Gan gynnwys ar y pen"
@@ -66,23 +63,11 @@ msgstr "Gan gynnwys fflatiau un ystafell"
 msgid "For example, in an office building, hotel, or over a shop"
 msgstr "Er enghraifft, mewn adeilad o swyddfeydd, gwesty, neu uwchben siop"
 
-msgid "If \"No\" confirm one or more rooms are shared with another household"
-msgstr "Os \"Nac ydy\", oes un neu fwy o'r ystafelloedd yn cael eu rhannu â chartref arall?"
-
-msgid "Tell respondent to turn to <strong>Showcard 4</strong>"
-msgstr "Dywedwch wrth yr ymatebwr am droi at <strong>Gerdyn Dangos 4</strong>"
-
-msgid "Including shared ownership"
+msgid "Shared ownership"
 msgstr ""
 
-msgid "Tell respondent to turn to <strong>Showcard 5</strong>"
-msgstr "Dywedwch wrth yr ymatebwr am droi at <strong>Gerdyn Dangos 5</strong>"
-
-msgid "Tell respondent to turn to <strong>Showcard 6</strong>"
-msgstr "Dywedwch wrth yr ymatebwr am droi at <strong>Gerdyn Dangos 6</strong>"
-
-msgid "Tell respondent to turn to <strong>Showcard 7</strong>"
-msgstr "Dywedwch wrth yr ymatebwr am droi at <strong>Gerdyn Dangos 7</strong>"
+msgid "With or without housing benefit"
+msgstr "Gyda chymorth budd-dal tai neu hebddo"
 
 msgid "For example, taxing a car, registering to vote, applying for school places"
 msgstr "Er enghraifft, trethu car, cofrestru i bleidleisio, gwneud cais am le mewn ysgol"
@@ -90,59 +75,32 @@ msgstr "Er enghraifft, trethu car, cofrestru i bleidleisio, gwneud cais am le me
 msgid "For example, passports, visas"
 msgstr "Er enghraifft, pasbort, fisa"
 
-msgid "This refers to any interaction you might have with public authorities online, such as DVLA, HMRC, local council or health related services"
-msgstr ""
+msgid "This refers to any interaction you might have with public authorities online, such as DVLA, HMRC, local council or health related services."
+msgstr "Mae hyn yn cyfeirio at unrhyw gysylltiad ag awdurdodau cyhoeddus ar lein, fel DVLA, Cyllid a Thollau Ei Mawrhydi, cyngor lleol neu wasanaethau sy'n ymwneud ag iechyd."
 
-msgid "For example, separate bedsits, annexes, sheds etc. <br><br> If \"Yes\" ensure this accommodation is recorded on the Fieldwork Management Tool and interview household separately"
-msgstr "Er enghraifft, fflat un ystafell ar wahân, anecs, sied ac ati. <br><br> Os \"Oes\" sicrhewch fod y man hwn yn cael ei gofnodi ar yr Adnodd Rheoli Gwaith Maes a chynhaliwch gyfweliad â’r cartref ar wahân"
-
-msgid "Tell respondent to turn to <strong>Showcard 8</strong>"
-msgstr "Dywedwch wrth yr ymatebwr am droi at <strong>Gerdyn Dangos 8</strong>"
-
-msgid "Tell respondent to turn to <strong>Showcard 9</strong>"
-msgstr "Dywedwch wrth yr ymatebwr am droi at <strong>Gerdyn Dangos 9</strong>"
-
-msgid "Your answer will help to support equality and fairness in your community. Councils and government use information on ethnic group to make sure they"
-msgstr ""
+msgid "For example, separate bedsits, annexes, sheds etc."
+msgstr "Er enghraifft, fflat un ystafell ar wahân, anecs, sied ac ati."
 
 msgid "Select to enter answer"
-msgstr ""
-
-msgid "If you had no usual address one year ago, state the address where you were staying"
-msgstr ""
-
-msgid "If they had no usual address one year ago, state the address where they were staying"
-msgstr ""
-
-msgid "Tell respondent to turn to <strong>Showcard 10</strong>"
-msgstr "Dywedwch wrth yr ymatebwr am droi at <strong>Gerdyn Dangos 10</strong>"
+msgstr "Dewiswch i roi ateb"
 
 msgid "Include casual or temporary work, even if only for one hour"
-msgstr ""
-
-msgid "Tell respondent to turn to <strong>Showcard 11</strong>"
-msgstr "Dywedwch wrth yr ymatebwr am droi at <strong>Gerdyn Dangos 11</strong>"
+msgstr "Dylech gynnwys gwaith achlysurol neu dros dro, hyd yn oed os mai dim ond am awr"
 
 msgid "Whether receiving a pension or not"
-msgstr ""
-
-msgid "<em> Tell respondent to turn to showcard 12</em>"
-msgstr ""
+msgstr "Gan dderbyn pensiwn neu beidio"
 
 msgid "Moved since 13 October 2019"
 msgstr "Wedi symud ers 13 Hydref 2019"
 
-msgid "Tell respondent to turn to <strong>Showcard 12</strong>"
-msgstr "Dywedwch wrth yr ymatebwr am droi at <strong>Gerdyn Dangos 12</strong>"
-
 msgid "Voluntary"
-msgstr ""
+msgstr "Gwirfoddol"
 
 msgid "Add someone to this household"
 msgstr "Ychwanegu rhywun at y cartref hwn"
 
 msgid "Add another visitor to this household"
-msgstr ""
+msgstr "Ychwanegu ymwelydd"
 
 msgid "Add a visitor"
 msgstr "Ychwanegu ymwelydd"
@@ -153,6 +111,54 @@ msgstr "Nid oes deiliaid y cartref yma"
 msgid "There are no visitors"
 msgstr "Nid oes ymwelwyr yma"
 
+msgid "Tell respondent to turn to <strong>Showcard 1</strong>"
+msgstr ""
+
+msgid "Enter a full stop (.) if the respondent does not know a person’s “First name” or “Last name”"
+msgstr ""
+
+msgid "Tell respondent to turn to <strong>Showcard 2</strong>"
+msgstr "Dywedwch wrth yr ymatebwr am droi at <strong>Gerdyn Dangos 2</strong>"
+
+msgid "Tell respondent to turn to <strong>Showcard 13</strong>"
+msgstr ""
+
+msgid "Tell respondent to turn to <strong>Showcard 3</strong>"
+msgstr ""
+
+msgid "If “No” confirm one or more rooms are shared with another household"
+msgstr ""
+
+msgid "Tell respondent to turn to <strong>Showcard 4</strong>"
+msgstr ""
+
+msgid "Tell respondent to turn to <strong>Showcard 5</strong>"
+msgstr ""
+
+msgid "Tell respondent to turn to <strong>Showcard 6</strong>"
+msgstr ""
+
+msgid "Tell respondent to turn to <strong>Showcard 7</strong>"
+msgstr ""
+
+msgid "If “Yes” ensure this accommodation is recorded on the Fieldwork Management Tool and interview household separately"
+msgstr ""
+
+msgid "Tell respondent to turn to <strong>Showcard 8</strong>"
+msgstr ""
+
+msgid "Tell respondent to turn to <strong>Showcard 9</strong>"
+msgstr ""
+
+msgid "Tell respondent to turn to <strong>Showcard 10</strong>"
+msgstr ""
+
+msgid "Tell respondent to turn to <strong>Showcard 11</strong>"
+msgstr ""
+
+msgid "Tell respondent to turn to <strong>Showcard 12</strong>"
+msgstr ""
+
 msgid "2019 Census Coverage Survey Test"
 msgstr ""
 
@@ -160,36 +166,33 @@ msgid "People who live here"
 msgstr "Pobl sy'n byw yma"
 
 msgid "Who lives here"
-msgstr ""
+msgstr "Pwy sy'n byw yma"
 
 msgid "Household definition"
-msgstr ""
+msgstr "Diffiniad o gartref"
 
 msgid "What is your full name?"
 msgstr "Beth yw eich enw llawn?"
 
-msgid "Interviewer Note"
-msgstr "Nodyn i’r Cyfwelydd"
-
-msgid "On Sunday 13 October 2019 what was your usual address?"
-msgstr ""
+msgid "<em>Interviewer Note</em>"
+msgstr "<em>Nodyn i'r Cyfwelydd</em>"
 
 msgid "All of the data entered about this person will be deleted"
-msgstr ""
+msgstr "Caiff yr holl ddata sy'n gysylltiedig â'r person hwn eu dileu"
 
 msgid "Household members"
 msgstr "Aelodau o’r cartref"
 
-msgid "Apart from the people already included, is there anyone who was temporarily away or staying that you need to add?"
-msgstr ""
+msgid "Apart from the people already included, is there anyone else who was temporarily away or staying that you need to add?"
+msgstr "Ar wahân i’r bobl sydd wedi’u cynnwys eisoes, oes unrhyw un arall a oedd i ffwrdd o’r cartref dros dro neu’n aros dros dro y mae angen i chi ei ychwanegu?"
 
-msgid "Are any of these people related to each other? Remember to include partners and step-children as related."
-msgstr "Oes unrhyw rai o'r bobl hyn yn perthyn i'w gilydd? Cofiwch gynnwys partneriaid a llysblant fel poblsy'n perthyn."
-
-msgid "Include"
-msgstr "Cofiwch"
+msgid "Are any of these people related to each other?"
+msgstr "Oes unrhyw rai o'r bobl hyn yn perthyn i'w gilydd?"
 
 msgid "Household accommodation"
+msgstr "Y cartref"
+
+msgid "Household and accommodation"
 msgstr "Y cartref"
 
 msgid "Which of the following is your house or bungalow?"
@@ -205,12 +208,12 @@ msgid "In the last year, how have you or your household used online government s
 msgstr "Yn y flwyddyn ddiwethaf, sut ydych chi neueich cartref wedi defnyddio gwasanaethau'r llywodraeth ar lein?"
 
 msgid "Individual Section"
-msgstr ""
+msgstr "Adran Unigol"
 
 msgid "Personal Details"
-msgstr ""
+msgstr "Manylion Personol"
 
-msgid "Are they answering the questions for themselves or on someone else’s behalf?"
+msgid "<em>Interviewer Note:</em> Are they answering the questions for themselves or on someone else’s behalf?"
 msgstr ""
 
 msgid "What is your date of birth?"
@@ -246,32 +249,35 @@ msgstr "Pa un sy’n disgrifio orau eich grŵp ethnig neu eich cefndir arall?"
 msgid "On 13 October 2019, were you a student in full-time education?"
 msgstr "Ar 13 Hydref 2019, oeddech chi’n blentyn ysgol neu’n fyfyriwr mewn addysg amser llawn?"
 
-msgid "During term time, where do you usually live?"
-msgstr ""
+msgid "On 13 October 2019, were you a schoolchild or student in full-time education?"
+msgstr "Ar 13 Hydref 2019, oeddech chi’n blentyn ysgol neu’n fyfyriwr mewn addysg amser llawn?"
 
-msgid "One year ago, on 13 October 2019 what was your usual address?"
-msgstr ""
+msgid "During term time, where did you usually live?"
+msgstr "Yn ystod y tymor, ble oeddech chi’n byw fel arfer?"
 
-msgid "Including the time already you have already spent here, how long do you intend to stay in the United Kingdom?"
+msgid "One year ago, on 13 October 2018, what was your usual address?"
+msgstr "Flwyddyn yn ôl, ar 13 Hydref 2018, beth oedd eich cyfeiriad arferol?"
+
+msgid "Including the time you have already spent here, how long do you intend to stay in the United Kingdom?"
 msgstr ""
 
 msgid "During the week of 7 to 13 October 2019, were you doing any of the following?"
 msgstr "Yn ystod yr wythnos rhwng 7 a 13 Hydref 2019, oeddech chi’n gwneud unrhyw un o’r canlynol?"
 
-msgid "Which of the following describes what you were doing in the week of 7 to 13 October 2019?"
-msgstr ""
+msgid "Which of the following describes what you were doing during the week of 7 to 13 October 2019?"
+msgstr "Pa un o’r canlynol sy’n disgrifio’r hyn roeddech chi’n ei wneud yn ystod yr wythnos rhwng 7 a 13 Hydref 2019?"
 
 msgid "Is there another UK address where you may have been included on a census questionnaire because you were a usual resident, or staying overnight there on Sunday 13 October 2019?"
 msgstr "Oes cyfeiriad arall yn y Deyrnas Unedig y gallech fod wedi cael eich cynnwys ynddo ar holiadur y cyfrifiad am eich bod yn breswylydd arferol, neu'n aros yno dros nos ddydd Sul 13 Hydref 2019?"
 
 msgid "What is the other address where you may have been included on a Census questionnaire?"
-msgstr ""
+msgstr "Beth yw’r cyfeiriad arall y gallech fod wedi cael eich cynnwys ynddo ar holiadur y cyfrifiad?"
 
 msgid "Visitors"
-msgstr ""
+msgstr "Ymwelydd"
 
 msgid "Summary"
-msgstr ""
+msgstr "Crynodeb"
 
 msgid "People from outside the UK who were staying in the UK for <strong>3 months or more</strong>"
 msgstr "Pobl o’r tu allan i’r Deyrnas Unedig a oedd yn aros yn y Deyrnas Unedig am <strong>3 mis neu fwy</strong>"
@@ -285,26 +291,14 @@ msgstr "Carcharorion â dedfryd o <strong>lai na 12 mis</strong>"
 msgid "People expecting to stay in an establishment such as a hospital, care home or hostel for <strong>less than 6 months</strong>"
 msgstr "Pobl a oedd yn disgwyl aros mewn sefydliad fel ysbyty, cartref gofal neu hostel am <strong>lai na 6 mis</strong>"
 
-msgid "People who are temporarily outside the UK for <strong>less than 12 months</strong>"
-msgstr ""
+msgid "People who were temporarily outside the UK for <strong>less than 12 months</strong>"
+msgstr "Pobl a oedd y tu allan i’r Deyrnas Unedig dros dro am <strong>lai na 12 mis</strong>"
 
 msgid "People staying temporarily who did not have another UK address"
 msgstr "Pobl a oedd yn aros dros dro ond oedd heb gyfeiriad arall yn y Deyrnas Unedig"
 
-msgid "People staying here because it is their second address, for example, for work. Their permanent or family home is elsewhere"
-msgstr ""
-
-msgid "People here on holiday"
-msgstr ""
-
-msgid "provide services and share funding fairly"
-msgstr ""
-
-msgid "understand and represent everyone’s interests"
-msgstr ""
-
-msgid "Were you usually living at {address} on 13th October 2019?"
-msgstr ""
+msgid "Were you usually living at {address} on Sunday 13 October 2019?"
+msgstr "Oeddech chi’n byw yn {address} fel arfer ddydd Sul 13 Hydref 2019?"
 
 msgid "Was anyone in your current household usually living at {address} on Sunday 13 October 2019?"
 msgstr "Oedd unrhyw aelod o’ch cartref presennol fel arfer yn byw yn {address} ddydd Sul 13 Hydref 2019?"
@@ -321,16 +315,16 @@ msgstr "Newid manylion ar gyfer {person_name}"
 msgid "Did anyone usually live at {address} on Sunday 13 October 2019?"
 msgstr ""
 
-msgid "Did anyone else live at {address} on Sunday 13 October 2019?"
-msgstr ""
+msgid "Did anyone else usually live at {address} on Sunday 13 October 2019?"
+msgstr "Oedd unrhyw un arall fel arfer yn byw yn {address} ddydd Sul 13 Hydref 2019?"
 
 msgid "Are you sure you want to remove {person_name}?"
 msgstr "Ydych chi'n siŵr eich bod am ddileu {person_name}?"
 
 msgid "{person_name}"
-msgstr ""
+msgstr "{person_name}"
 
-msgid "Were there any visitors staying with your household at {address} on {census_date}? A visitor is a person staying overnight in your household who usually lives at another address."
+msgid "How many visitors were staying in your household at {address} on 13 October 2019?"
 msgstr ""
 
 msgid "What is the name of the visitor staying overnight on {census_date} at {address}?"
@@ -342,14 +336,14 @@ msgstr "Oedd unrhyw ymwelwyr eraill yn aros dros nos ar {census_date} yn {addres
 msgid "Visitors staying overnight on {census_date}"
 msgstr "Ymwelwyr sy’n aros dros nos ar {census_date}"
 
-msgid "What type of accommodation is <em>{address}</em>?"
-msgstr "Pa fath o gartref yw <em>{address}</em>?"
+msgid "What type of accommodation is {address}?"
+msgstr "Pa fath o gartref yw {address}?"
 
 msgid "Are all the rooms at {address}, including the kitchen, bathroom and toilet, behind a door that only this household can use?"
 msgstr "Ydy pob ystafell yn {address}, gan gynnwys y gegin, yr ystafell ymolchi a’r toiled, y tu ôl i ddrws sydd ddim ond yn cael ei ddefnyddio gan aelodau o’r cartref hwn?"
 
-msgid "Does your household own or rent <em>{address}</em>?"
-msgstr "Oes aelod neu aelodau o'ch cartref yn berchen ar <em>{address}</em> neu'n ei rentu?"
+msgid "Does your household own or rent {address}?"
+msgstr "Oes aelod neu aelodau o'ch cartref yn berchen ar {address} neu'n ei rentu?"
 
 msgid "How do you and the people in your household connect to the internet at {address}?"
 msgstr "Sut ydych chi a’r bobl yn eich cartref yn cysylltu â’r rhyngrwyd yn {address}?"
@@ -357,14 +351,14 @@ msgstr "Sut ydych chi a’r bobl yn eich cartref yn cysylltu â’r rhyngrwyd yn
 msgid "Is there any other living accommodation at {address}?"
 msgstr "Oes unrhyw fan arall yn {address} lle mae rhywun yn byw?"
 
-msgid "In this section, I’m going to ask you questions about <strong>{person_name}</strong>."
-msgstr "Yn yr adran hon, byddaf yn gofyn cwestiynau i chi am <strong>{person_name}</strong>."
+msgid "In this section, I’m going to ask you questions about {person_name}."
+msgstr "Yn yr adran hon, byddaf yn gofyn cwestiynau i chi am {person_name}."
 
-msgid "What is <em>{person_name_possessive}</em> date of birth?"
-msgstr "Beth yw dyddiad geni <em>{person_name_possessive}</em>?"
+msgid "What is {person_name_possessive} date of birth?"
+msgstr "Beth yw dyddiad geni {person_name_possessive}?"
 
-msgid "What was <em>{person_name_possessive}</em> on their last birthday?"
-msgstr ""
+msgid "What was {person_name_possessive} age on their last birthday?"
+msgstr "Faint oed oedd {person_name_possessive} ar ei ben-blwydd/phen-blwydd diwethaf?"
 
 msgid "You are {age_in_years} years old. Is this correct?"
 msgstr "Rydych chi’n {age_in_years} oed. Ydy hyn yn gywir?"
@@ -372,74 +366,74 @@ msgstr "Rydych chi’n {age_in_years} oed. Ydy hyn yn gywir?"
 msgid "{person_name} is {age_in_years} years old. Is this correct?"
 msgstr "Mae {person_name} yn {age_in_years} oed. Ydy hyn yn gywir?"
 
-msgid "What is <em>{person_name_possessive}</em> sex?"
-msgstr "Beth yw rhyw <em>{person_name_possessive}</em>?"
+msgid "What is {person_name_possessive} sex?"
+msgstr "Beth yw rhyw {person_name_possessive}?"
 
-msgid "Was <em>{person_name}</em> born in the UK?"
-msgstr "Gafodd <em>{person_name}</em> ei eni/geni yn y Deyrnas Unedig?"
+msgid "Was {person_name} born in the UK?"
+msgstr "Gafodd {person_name} ei eni/geni yn y Deyrnas Unedig?"
 
-msgid "On {census_date}, what is your legal marital or registered civil partnership status?"
+msgid "On {census_date}, what was your legal marital or registered civil partnership status?"
+msgstr "Yn gyfreithiol, beth oedd eich statws priodasol neu statws eich partneriaeth sifil gofrestredig ar {census_date}?"
+
+msgid "On {census_date}, what was {person_name_possessive} legal marital or registered civil partnership status?"
+msgstr "Yn gyfreithiol, beth oedd statws priodasol neu statws partneriaeth sifil gofrestredig {person_name_possessive} ar {census_date}?"
+
+msgid "What is {person_name_possessive} ethnic group?"
+msgstr "Beth yw grŵp ethnig {person_name_possessive}?"
+
+msgid "Which one best describes {person_name_possessive} White ethnic group or background?"
+msgstr "Pa un sy’n disgrifio orau grŵp ethnig neu gefndir Gwyn {person_name_possessive}?"
+
+msgid "Which one best describes {person_name_possessive} Mixed or Multiple ethnic group or background?"
+msgstr "Pa un sy’n disgrifio orau grŵp ethnig neu gefndir Cymysg neu Aml-ethnig {person_name_possessive}?"
+
+msgid "Which one best describes {person_name_possessive} Asian or Asian British ethnic group or background?"
+msgstr "Pa un sy’n disgrifio orau grŵp ethnig neu gefndir Asiaidd neu Asiaidd Prydeinig {person_name_possessive}?"
+
+msgid "Which one best describes {person_name_possessive} Black, Black British, Caribbean or African ethnic group or background?"
+msgstr "Pa un sy’n disgrifio orau grŵp ethnig neu gefndir Du, Du Prydeinig, Caribïaidd neu Affricanaidd {person_name_possessive}?"
+
+msgid "Which one best describes {person_name_possessive} other ethnic group or background?"
+msgstr "Pa un sy’n disgrifio orau grŵp ethnig neu gefndir arall {person_name_possessive}?"
+
+msgid "On 13 October 2019, was {person_name} a student in full-time education?"
+msgstr "Ar 13 Hydref 2019, oedd {person_name} yn blentyn ysgol neu’n fyfyriwr mewn addysg amser llawn?"
+
+msgid "On 13 October 2019, was {person_name} a schoolchild or student in full-time education?"
+msgstr "Ar 13 Hydref 2019, oedd {person_name} yn blentyn ysgol neu’n fyfyriwr mewn addysg amser llawn?"
+
+msgid "During term time, where did {person_name} usually live?"
+msgstr "Yn ystod y tymor, ble oedd {person_name} yn byw fel arfer?"
+
+msgid "One year ago, on 13 October 2018, what was {person_name_possessive} usual address?"
+msgstr "Flwyddyn yn ôl, ar 13 Hydref 2018, beth oedd cyfeiriad arferol {person_name_possessive}?"
+
+msgid "Including the time they have already spent here, how long does {person_name} intend to stay in the United Kingdom?"
+msgstr "Gan gynnwys yr amser y mae wedi’i dreulio yma’n barod, am faint y mae {person_name} yn bwriadu aros yn y Deyrnas Unedig?"
+
+msgid "During the week of 7 to 13 October 2019, was {person_name} doing any of the following?"
+msgstr "Yn ystod yr wythnos rhwng 7 a 13 Hydref, oedd {person_name} yn gwneud unrhyw un o’r canlynol?"
+
+msgid "Which of the following describes what {person_name} was doing during the week of 7 to 13 October 2019?"
+msgstr "Pa un o’r canlynol sy’n disgrifio’r hyn roedd {person_name} yn ei wneud yn ystod yr wythnos rhwng 7 a 13 Hydref 2019?"
+
+msgid "Is there another UK address where {person_name} may have been included on a census questionnaire because they were a usual resident, or staying overnight there on Sunday 13 October 2019?"
+msgstr "Oes cyfeiriad arall yn y Deyrnas Unedig y gallai {person_name} fod wedi cael ei gynnwys/chynnwys ynddo ar holiadur y cyfrifiad am ei fod/bod yn breswylydd arferol, neu'n aros yno dros nos ddydd Sul 13 Hydref 2019?"
+
+msgid "What is the other address where {person_name} may have been included on a Census questionnaire?"
+msgstr "Beth yw'r cyfeiriad arall y gellid bod wedi cynnwys {person_name} ynddo ar holiadur y cyfrifiad?"
+
+msgid "In this section, I’m going to ask you about your visitor, {person_name}."
+msgstr "Yn yr adran hon, byddaf yn gofyn i chi am eich ymwelydd, {person_name}."
+
+msgid "Did {person_name} usually live in the United Kingdom?"
 msgstr ""
 
-msgid "On {census_date}, what is <em>{person_name_possessive}</em> legal marital or registered civil partnership status?"
-msgstr ""
-
-msgid "What is <em>{person_name_possessive}</em> ethnic group?"
-msgstr "Beth yw grŵp ethnig <em>{person_name_possessive}</em>?"
-
-msgid "Which one best describes <em>{person_name_possessive}</em> White ethnic group or background?"
-msgstr "Pa un sy’n disgrifio orau grŵp ethnig neu gefndir Gwyn <em>{person_name_possessive}</em>?"
-
-msgid "Which one best describes <em>{person_name_possessive}</em> Mixed or Multiple ethnic group or background?"
-msgstr "Pa un sy’n disgrifio orau grŵp ethnig neu gefndir Cymysg neu Aml-ethnig <em>{person_name_possessive}</em>?"
-
-msgid "Which one best describes <em>{person_name_possessive}</em> Asian or Asian British ethnic group or background?"
-msgstr "Pa un sy’n disgrifio orau grŵp ethnig neu gefndir Asiaidd neu Asiaidd Prydeinig <em>{person_name_possessive}</em>?"
-
-msgid "Which one best describes <em>{person_name_possessive}</em> Black, Black British, Caribbean or African ethnic group or background?"
-msgstr "Pa un sy’n disgrifio orau grŵp ethnig neu gefndir Du, Du Prydeinig, Caribïaidd neu Affricanaidd <em>{person_name_possessive}</em>?"
-
-msgid "Which one best describes <em>{person_name_possessive}</em> other ethnic group or background?"
-msgstr "Pa un sy’n disgrifio orau grŵp ethnig neu gefndir arall <em>{person_name_possessive}</em>?"
-
-msgid "On 13 October 2019, was <em>{person_name}</em> a student in full-time education?"
-msgstr "Ar 13 Hydref 2019, oedd <em>{person_name}</em> yn blentyn ysgol neu’n fyfyriwr mewn addysg amser llawn?"
-
-msgid "During term time, where does <em>{person_name}</em> usually live?"
-msgstr ""
-
-msgid "One year ago, on 13 October 2019, what was <em>{person_name_possessive}</em> usual address?"
-msgstr "Flwyddyn yn ôl, ar 13 Hydref 2018, beth oedd cyfeiriad arferol <em>{person_name_possessive}</em>?"
-
-msgid "Including the time they have already spent here, how long does <em>{person_name}</em> intend to stay in the United Kingdom?"
-msgstr "Gan gynnwys yr amser y mae wedi’i dreulio yma’n barod, am faint y mae <em>{person_name}</em> yn bwriadu aros yn y Deyrnas Unedig?"
-
-msgid "During the week of 7 to 13 October 2019, was <em>{person_name}</em> doing any of the following?"
-msgstr "Yn ystod yr wythnos rhwng 7 a 13 Hydref, oedd <em>{person_name}</em> yn gwneud unrhyw un o’r canlynol?"
-
-msgid "Which of the following describes what <em>{person_name}</em> was doing during the week of 7 to 13 October 2019?"
-msgstr "Pa un o’r canlynol sy’n disgrifio’r hyn roedd <em>{person_name}</em> yn ei wneud yn ystod yr wythnos rhwng 7 a 13 Hydref 2019?"
-
-msgid "Is there another address {person_name} where you may have been included on a census questionnaire because you were a usual resident, or staying overnight there on Sunday 13 October 2019?"
-msgstr ""
-
-msgid "What is the other address where <em>{person_name}</em> may have been included on a Census questionnaire?"
-msgstr ""
-
-msgid "In this section, I’m going to ask you about your visitor, <strong>{person_name}</strong>."
-msgstr ""
-
-msgid "What was <em>{person_name_possessive}</em> age on their last birthday?"
-msgstr "Faint oed oedd <em>{person_name_possessive}</em> ar ei ben-blwydd/phen-blwydd diwethaf?"
-
-msgid "Did <em>{person_name}</em> usually live in the United Kingdom?"
-msgstr "Oedd <em>{person_name}</em> fel arfer yn byw yn y Deyrnas Unedig?"
-
-msgid "What is <em>{person_name_possessive}</em> usual UK address?"
-msgstr "Beth yw cyfeiriad arferol <em>{person_name_possessive}</em> yn y Deyrnas Unedig?"
+msgid "What is {person_name_possessive} usual UK address?"
+msgstr "Beth yw cyfeiriad arferol {person_name_possessive} yn y Deyrnas Unedig?"
 
 msgid "{person_name} (Visitor)"
-msgstr ""
+msgstr "{person_name} (Ymwelydd)"
 
 #. answer-id: first-name
 msgctxt "Answer for: What is your full name?"
@@ -457,14 +451,14 @@ msgid "Last name"
 msgstr "Last name"
 
 #. answer-id: you-live-here-answer
-msgctxt "Answer for: Were you usually living at {address} on 13th October 2019?"
+msgctxt "Answer for: Were you usually living at {address} on Sunday 13 October 2019?"
 msgid "Yes"
-msgstr ""
+msgstr "Oeddwn"
 
 #. answer-id: you-live-here-answer
-msgctxt "Answer for: Were you usually living at {address} on 13th October 2019?"
+msgctxt "Answer for: Were you usually living at {address} on Sunday 13 October 2019?"
 msgid "No"
-msgstr ""
+msgstr "Nac oeddwn"
 
 #. answer-id: anyone-else-usually-living-answer
 msgctxt "Answer for: Was anyone in your current household usually living at {address} on Sunday 13 October 2019?"
@@ -476,31 +470,6 @@ msgctxt "Answer for: Was anyone in your current household usually living at {add
 msgid "No"
 msgstr "Nac oedd"
 
-#. answer-id: household-usual-address-answer-building
-msgctxt "Answer for: On Sunday 13 October 2019 what was your usual address?"
-msgid "Address line 1"
-msgstr ""
-
-#. answer-id: household-usual-address-answer-street
-msgctxt "Answer for: On Sunday 13 October 2019 what was your usual address?"
-msgid "Address line 2"
-msgstr ""
-
-#. answer-id: household-usual-address-answer-city
-msgctxt "Answer for: On Sunday 13 October 2019 what was your usual address?"
-msgid "Town or city"
-msgstr ""
-
-#. answer-id: household-usual-address-answer-county
-msgctxt "Answer for: On Sunday 13 October 2019 what was your usual address?"
-msgid "County (optional)"
-msgstr ""
-
-#. answer-id: household-usual-address-answer-postcode
-msgctxt "Answer for: On Sunday 13 October 2019 what was your usual address?"
-msgid "Postcode"
-msgstr ""
-
 #. answer-id: first-name
 msgctxt "Answer for: Who do you need to add to {address}?"
 msgid "First name"
@@ -549,78 +518,53 @@ msgstr "Cyfenw"
 #. answer-id: anyone-else-answer
 msgctxt "Answer for: Did anyone usually live at {address} on Sunday 13 October 2019?"
 msgid "Yes"
-msgstr ""
+msgstr "Oedd"
 
 #. answer-id: anyone-else-answer
 msgctxt "Answer for: Did anyone usually live at {address} on Sunday 13 October 2019?"
 msgid "No"
-msgstr ""
+msgstr "Nac oedd"
 
 #. answer-id: anyone-else-answer
-msgctxt "Answer for: Did anyone else live at {address} on Sunday 13 October 2019?"
+msgctxt "Answer for: Did anyone else usually live at {address} on Sunday 13 October 2019?"
 msgid "Yes"
-msgstr ""
+msgstr "Oedd"
 
 #. answer-id: anyone-else-answer
-msgctxt "Answer for: Did anyone else live at {address} on Sunday 13 October 2019?"
+msgctxt "Answer for: Did anyone else usually live at {address} on Sunday 13 October 2019?"
 msgid "No"
-msgstr ""
+msgstr "Nac oedd"
 
 #. answer-id: remove-confirmation
 #. answer-id: anyone-else-temp-away-remove-confirmation
 msgctxt "Answer for: Are you sure you want to remove {person_name}?"
 msgid "Yes, I want to remove this person"
-msgstr ""
+msgstr "Ydw, rwyf am ddileu’r person hwn"
 
 #. answer-id: remove-confirmation
 #. answer-id: anyone-else-temp-away-remove-confirmation
 msgctxt "Answer for: Are you sure you want to remove {person_name}?"
 msgid "No, I do not want to remove this person"
-msgstr ""
+msgstr "Nac ydw, nid wyf am ddileu’r person hwn"
 
 #. answer-id: anyone-else-temp-away-answer
-msgctxt "Answer for: Apart from the people already included, is there anyone who was temporarily away or staying that you need to add?"
+msgctxt "Answer for: Apart from the people already included, is there anyone else who was temporarily away or staying that you need to add?"
 msgid "Yes"
 msgstr "Oes"
 
 #. answer-id: anyone-else-temp-away-answer
-msgctxt "Answer for: Apart from the people already included, is there anyone who was temporarily away or staying that you need to add?"
+msgctxt "Answer for: Apart from the people already included, is there anyone else who was temporarily away or staying that you need to add?"
 msgid "No"
 msgstr "Nac oes"
 
-#. answer-id: relationships-answer
-msgctxt "Answer for: Are any of these people related to each other? Remember to include partners and step-children as related."
-msgid "Yes"
-msgstr "Oes"
-
-#. answer-id: relationships-answer
-msgctxt "Answer for: Are any of these people related to each other? Remember to include partners and step-children as related."
-msgid "No"
+#. answer-id: any-visitors-answer
+msgctxt "Answer for: How many visitors were staying in your household at {address} on 13 October 2019?"
+msgid "1 or more"
 msgstr ""
 
 #. answer-id: any-visitors-answer
-msgctxt "Answer for: Were there any visitors staying with your household at {address} on {census_date}? A visitor is a person staying overnight in your household who usually lives at another address."
-msgid "People who usually live somewhere else in the UK, for example boy/girlfriends, friends or relatives"
-msgstr ""
-
-#. answer-id: any-visitors-answer
-msgctxt "Answer for: Were there any visitors staying with your household at {address} on {census_date}? A visitor is a person staying overnight in your household who usually lives at another address."
-msgid "People staying here because it is their second address, for example, for work. Their permanent or family home is elsewhere"
-msgstr ""
-
-#. answer-id: any-visitors-answer
-msgctxt "Answer for: Were there any visitors staying with your household at {address} on {census_date}? A visitor is a person staying overnight in your household who usually lives at another address."
-msgid "People who usually live outside the UK who are staying in the UK for less than three months"
-msgstr ""
-
-#. answer-id: any-visitors-answer
-msgctxt "Answer for: Were there any visitors staying with your household at {address} on {census_date}? A visitor is a person staying overnight in your household who usually lives at another address."
-msgid "People here on holiday"
-msgstr ""
-
-#. answer-id: any-visitors-answer-exclusive
-msgctxt "Answer for: Were there any visitors staying with your household at {address} on {census_date}? A visitor is a person staying overnight in your household who usually lives at another address."
-msgid "No, there are no visitors staying overnight on 13 October 2019"
+msgctxt "Answer for: How many visitors were staying in your household at {address} on 13 October 2019?"
+msgid "None"
 msgstr ""
 
 #. answer-id: first-name
@@ -653,18 +597,28 @@ msgctxt "Answer for: Are you sure you want to remove {person_name}?"
 msgid "No"
 msgstr "Nac ydw"
 
+#. answer-id: relationships-answer
+msgctxt "Answer for: Are any of these people related to each other?"
+msgid "Yes"
+msgstr "Oes"
+
+#. answer-id: relationships-answer
+msgctxt "Answer for: Are any of these people related to each other?"
+msgid "No, all household members are unrelated"
+msgstr "Nac oes, nid oes neb yn perthyn"
+
 #. answer-id: accommodation-type-answer
-msgctxt "Answer for: What type of accommodation is <em>{address}</em>?"
+msgctxt "Answer for: What type of accommodation is {address}?"
 msgid "Whole house or bungalow"
 msgstr "Tŷ neu fyngalo cyfan"
 
 #. answer-id: accommodation-type-answer
-msgctxt "Answer for: What type of accommodation is <em>{address}</em>?"
+msgctxt "Answer for: What type of accommodation is {address}?"
 msgid "Flat, maisonette or apartment"
 msgstr "Fflat neu maisonette"
 
 #. answer-id: accommodation-type-answer
-msgctxt "Answer for: What type of accommodation is <em>{address}</em>?"
+msgctxt "Answer for: What type of accommodation is {address}?"
 msgid "Caravan or other mobile or temporary structure"
 msgstr "Carafán neu fath arall o gartref symudol neu dros dro"
 
@@ -709,28 +663,28 @@ msgid "No"
 msgstr "Nac ydy"
 
 #. answer-id: own-or-rent-answer
-msgctxt "Answer for: Does your household own or rent <em>{address}</em>?"
+msgctxt "Answer for: Does your household own or rent {address}?"
 msgid "Owns outright"
 msgstr "Yn berchen arno’n gyfan gwbl"
 
 #. answer-id: own-or-rent-answer
-msgctxt "Answer for: Does your household own or rent <em>{address}</em>?"
+msgctxt "Answer for: Does your household own or rent {address}?"
 msgid "Owns with a mortgage or loan"
 msgstr "Yn berchen arno gyda morgais neu fenthyciad"
 
 #. answer-id: own-or-rent-answer
-msgctxt "Answer for: Does your household own or rent <em>{address}</em>?"
-msgid "Part owns and part rents"
-msgstr ""
+msgctxt "Answer for: Does your household own or rent {address}?"
+msgid "Part-owns and part-rents"
+msgstr "Yn berchen arno’n rhannol ac yn ei rentu’n rhannol"
 
 #. answer-id: own-or-rent-answer
-msgctxt "Answer for: Does your household own or rent <em>{address}</em>?"
-msgid "Rents with or without housing benefit"
-msgstr ""
+msgctxt "Answer for: Does your household own or rent {address}?"
+msgid "Rents"
+msgstr "Yn ei rentu"
 
 #. answer-id: own-or-rent-answer
-msgctxt "Answer for: Does your household own or rent <em>{address}</em>?"
-msgid "Lives here rent free"
+msgctxt "Answer for: Does your household own or rent {address}?"
+msgid "Lives here rent-free"
 msgstr "Yn byw yma heb dalu rhent"
 
 #. answer-id: who-rent-from-answer
@@ -814,14 +768,14 @@ msgid "No"
 msgstr "Nac oes"
 
 #. answer-id: proxy-answer
-msgctxt "Answer for: Are they answering the questions for themselves or on someone else's behalf?"
+msgctxt "Answer for: <em>Interviewer Note:</em> Are they answering the questions for themselves or on someone else’s behalf?"
 msgid "Yes, they are answering for themselves"
-msgstr "Ydy, mae’n ateb drosto’i hun"
+msgstr ""
 
 #. answer-id: proxy-answer
-msgctxt "Answer for: Are they answering the questions for themselves or on someone else's behalf?"
+msgctxt "Answer for: <em>Interviewer Note:</em> Are they answering the questions for themselves or on someone else’s behalf?"
 msgid "No, they are answering on someone else’s behalf"
-msgstr "Nac ydy, mae’n ateb ar ran rhywun arall"
+msgstr ""
 
 #. answer-id: date-of-birth-exclusive-answer
 msgctxt "Answer for: What is your date of birth?"
@@ -830,7 +784,7 @@ msgstr "Nid yw’r dyddiad geni yn hysbys"
 
 #. answer-id: date-of-birth-exclusive-answer
 #. answer-id: visitor-date-of-birth-exclusive-answer
-msgctxt "Answer for: What is <em>{person_name_possessive}</em> date of birth?"
+msgctxt "Answer for: What is {person_name_possessive} date of birth?"
 msgid "Date of birth is not known"
 msgstr "Nid yw’r dyddiad geni yn hysbys"
 
@@ -845,24 +799,36 @@ msgid "Estimate"
 msgstr "Amcangyfrif"
 
 #. answer-id: age-last-birthday-answer
-msgctxt "Answer for: What was <em>{person_name_possessive}</em> on their last birthday?"
+#. answer-id: visitor-age-last-birthday-answer
+msgctxt "Answer for: What was {person_name_possessive} age on their last birthday?"
 msgid "Age"
 msgstr "Oed"
 
 #. answer-id: age-estimate-answer
-msgctxt "Answer for: What was <em>{person_name_possessive}</em> on their last birthday?"
+#. answer-id: visitor-age-estimate-answer
+msgctxt "Answer for: What was {person_name_possessive} age on their last birthday?"
 msgid "Estimate"
 msgstr "Amcangyfrif"
 
 #. answer-id: confirm-date-of-birth-answer
 msgctxt "Answer for: You are {age_in_years} years old. Is this correct?"
-msgid "No, I need to change my date of birth"
-msgstr ""
+msgid "Yes"
+msgstr "Ydy"
+
+#. answer-id: confirm-date-of-birth-answer
+msgctxt "Answer for: You are {age_in_years} years old. Is this correct?"
+msgid "No"
+msgstr "Nac ydy"
 
 #. answer-id: confirm-date-of-birth-answer
 msgctxt "Answer for: {person_name} is {age_in_years} years old. Is this correct?"
-msgid "No, I need to change their date of birth"
-msgstr ""
+msgid "Yes"
+msgstr "Ydy"
+
+#. answer-id: confirm-date-of-birth-answer
+msgctxt "Answer for: {person_name} is {age_in_years} years old. Is this correct?"
+msgid "No"
+msgstr "Nac ydy"
 
 #. answer-id: sex-answer
 msgctxt "Answer for: Can I confirm your sex?"
@@ -876,13 +842,13 @@ msgstr "Gwryw"
 
 #. answer-id: sex-answer
 #. answer-id: visitor-sex-answer
-msgctxt "Answer for: What is <em>{person_name_possessive}</em> sex?"
+msgctxt "Answer for: What is {person_name_possessive} sex?"
 msgid "Female"
 msgstr "Benyw"
 
 #. answer-id: sex-answer
 #. answer-id: visitor-sex-answer
-msgctxt "Answer for: What is <em>{person_name_possessive}</em> sex?"
+msgctxt "Answer for: What is {person_name_possessive} sex?"
 msgid "Male"
 msgstr "Gwryw"
 
@@ -897,104 +863,104 @@ msgid "No, born outside the UK"
 msgstr "Naddo, cefais fy ngeni y tu allan i’r Deyrnas Unedig"
 
 #. answer-id: country-of-birth-answer
-msgctxt "Answer for: Was <em>{person_name}</em> born in the UK?"
+msgctxt "Answer for: Was {person_name} born in the UK?"
 msgid "Yes"
 msgstr "Do"
 
 #. answer-id: country-of-birth-answer
-msgctxt "Answer for: Was <em>{person_name}</em> born in the UK?"
+msgctxt "Answer for: Was {person_name} born in the UK?"
 msgid "No, born outside the UK"
 msgstr "Naddo, cafodd ei eni/geni y tu allan i’r Deyrnas Unedig"
 
 #. answer-id: marriage-type-answer
-msgctxt "Answer for: On {census_date}, what is your legal marital or registered civil partnership status?"
+msgctxt "Answer for: On {census_date}, what was your legal marital or registered civil partnership status?"
 msgid "Never married and never registered a civil partnership"
-msgstr ""
+msgstr "Erioed wedi priodi na chofrestru partneriaeth sifil"
 
 #. answer-id: marriage-type-answer
-msgctxt "Answer for: On {census_date}, what is your legal marital or registered civil partnership status?"
+msgctxt "Answer for: On {census_date}, what was your legal marital or registered civil partnership status?"
 msgid "Married"
-msgstr ""
+msgstr "Priod"
 
 #. answer-id: marriage-type-answer
-msgctxt "Answer for: On {census_date}, what is your legal marital or registered civil partnership status?"
+msgctxt "Answer for: On {census_date}, what was your legal marital or registered civil partnership status?"
 msgid "In a registered civil partnership"
-msgstr ""
+msgstr "Mewn partneriaeth sifil gofrestredig"
 
 #. answer-id: marriage-type-answer
-msgctxt "Answer for: On {census_date}, what is your legal marital or registered civil partnership status?"
+msgctxt "Answer for: On {census_date}, what was your legal marital or registered civil partnership status?"
 msgid "Separated, but still legally married"
-msgstr ""
+msgstr "Wedi gwahanu, ond yn gyfreithiol yn dal i fod yn briod"
 
 #. answer-id: marriage-type-answer
-msgctxt "Answer for: On {census_date}, what is your legal marital or registered civil partnership status?"
+msgctxt "Answer for: On {census_date}, what was your legal marital or registered civil partnership status?"
 msgid "Separated, but still legally in a civil partnership"
-msgstr ""
+msgstr "Wedi gwahanu, ond yn gyfreithiol yn dal i fod mewn partneriaeth sifil"
 
 #. answer-id: marriage-type-answer
-msgctxt "Answer for: On {census_date}, what is your legal marital or registered civil partnership status?"
+msgctxt "Answer for: On {census_date}, what was your legal marital or registered civil partnership status?"
 msgid "Divorced"
-msgstr ""
+msgstr "Wedi ysgaru"
 
 #. answer-id: marriage-type-answer
-msgctxt "Answer for: On {census_date}, what is your legal marital or registered civil partnership status?"
+msgctxt "Answer for: On {census_date}, what was your legal marital or registered civil partnership status?"
 msgid "Formerly in a civil partnership which is now legally dissolved"
-msgstr ""
+msgstr "Wedi bod mewn partneriaeth sifil sydd bellach wedi’i diddymu’n gyfreithiol"
 
 #. answer-id: marriage-type-answer
-msgctxt "Answer for: On {census_date}, what is your legal marital or registered civil partnership status?"
+msgctxt "Answer for: On {census_date}, what was your legal marital or registered civil partnership status?"
 msgid "Widowed"
-msgstr ""
+msgstr "Person gweddw"
 
 #. answer-id: marriage-type-answer
-msgctxt "Answer for: On {census_date}, what is your legal marital or registered civil partnership status?"
+msgctxt "Answer for: On {census_date}, what was your legal marital or registered civil partnership status?"
 msgid "Surviving partner from a registered civil partnership"
-msgstr ""
+msgstr "Wedi colli partner sifil cofrestredig drwy farwolaeth"
 
 #. answer-id: marriage-type-answer
-msgctxt "Answer for: On {census_date}, what is <em>{person_name_possessive}</em> legal marital or registered civil partnership status?"
+msgctxt "Answer for: On {census_date}, what was {person_name_possessive} legal marital or registered civil partnership status?"
 msgid "Never married and never registered a civil partnership"
-msgstr ""
+msgstr "Erioed wedi priodi na chofrestru partneriaeth sifil"
 
 #. answer-id: marriage-type-answer
-msgctxt "Answer for: On {census_date}, what is <em>{person_name_possessive}</em> legal marital or registered civil partnership status?"
+msgctxt "Answer for: On {census_date}, what was {person_name_possessive} legal marital or registered civil partnership status?"
 msgid "Married"
-msgstr ""
+msgstr "Priod"
 
 #. answer-id: marriage-type-answer
-msgctxt "Answer for: On {census_date}, what is <em>{person_name_possessive}</em> legal marital or registered civil partnership status?"
+msgctxt "Answer for: On {census_date}, what was {person_name_possessive} legal marital or registered civil partnership status?"
 msgid "In a registered civil partnership"
-msgstr ""
+msgstr "Mewn partneriaeth sifil gofrestredig"
 
 #. answer-id: marriage-type-answer
-msgctxt "Answer for: On {census_date}, what is <em>{person_name_possessive}</em> legal marital or registered civil partnership status?"
+msgctxt "Answer for: On {census_date}, what was {person_name_possessive} legal marital or registered civil partnership status?"
 msgid "Separated, but still legally married"
-msgstr ""
+msgstr "Wedi gwahanu, ond yn gyfreithiol yn dal i fod yn briod"
 
 #. answer-id: marriage-type-answer
-msgctxt "Answer for: On {census_date}, what is <em>{person_name_possessive}</em> legal marital or registered civil partnership status?"
+msgctxt "Answer for: On {census_date}, what was {person_name_possessive} legal marital or registered civil partnership status?"
 msgid "Separated, but still legally in a civil partnership"
-msgstr ""
+msgstr "Wedi gwahanu, ond yn gyfreithiol yn dal i fod mewn partneriaeth sifil"
 
 #. answer-id: marriage-type-answer
-msgctxt "Answer for: On {census_date}, what is <em>{person_name_possessive}</em> legal marital or registered civil partnership status?"
+msgctxt "Answer for: On {census_date}, what was {person_name_possessive} legal marital or registered civil partnership status?"
 msgid "Divorced"
-msgstr ""
+msgstr "Wedi ysgaru"
 
 #. answer-id: marriage-type-answer
-msgctxt "Answer for: On {census_date}, what is <em>{person_name_possessive}</em> legal marital or registered civil partnership status?"
+msgctxt "Answer for: On {census_date}, what was {person_name_possessive} legal marital or registered civil partnership status?"
 msgid "Formerly in a civil partnership which is now legally dissolved"
-msgstr ""
+msgstr "Wedi bod mewn partneriaeth sifil sydd bellach wedi’i diddymu’n gyfreithiol"
 
 #. answer-id: marriage-type-answer
-msgctxt "Answer for: On {census_date}, what is <em>{person_name_possessive}</em> legal marital or registered civil partnership status?"
+msgctxt "Answer for: On {census_date}, what was {person_name_possessive} legal marital or registered civil partnership status?"
 msgid "Widowed"
-msgstr ""
+msgstr "Person gweddw"
 
 #. answer-id: marriage-type-answer
-msgctxt "Answer for: On {census_date}, what is <em>{person_name_possessive}</em> legal marital or registered civil partnership status?"
+msgctxt "Answer for: On {census_date}, what was {person_name_possessive} legal marital or registered civil partnership status?"
 msgid "Surviving partner from a registered civil partnership"
-msgstr ""
+msgstr "Wedi colli partner sifil cofrestredig drwy farwolaeth"
 
 #. answer-id: ethnic-group-answer
 msgctxt "Answer for: What is your ethnic group?"
@@ -1022,33 +988,33 @@ msgid "Other ethnic group"
 msgstr "Grŵp ethnig arall"
 
 #. answer-id: ethnic-group-answer
-msgctxt "Answer for: What is <em>{person_name_possessive}</em> ethnic group?"
+msgctxt "Answer for: What is {person_name_possessive} ethnic group?"
 msgid "White"
 msgstr "Gwyn"
 
 #. answer-id: ethnic-group-answer
-msgctxt "Answer for: What is <em>{person_name_possessive}</em> ethnic group?"
+msgctxt "Answer for: What is {person_name_possessive} ethnic group?"
 msgid "Mixed or Multiple ethnic groups"
 msgstr "Grwpiau Cymysg neu Aml-ethnig"
 
 #. answer-id: ethnic-group-answer
-msgctxt "Answer for: What is <em>{person_name_possessive}</em> ethnic group?"
+msgctxt "Answer for: What is {person_name_possessive} ethnic group?"
 msgid "Asian or Asian British"
 msgstr "Asiaidd neu Asiaidd Prydeinig"
 
 #. answer-id: ethnic-group-answer
-msgctxt "Answer for: What is <em>{person_name_possessive}</em> ethnic group?"
+msgctxt "Answer for: What is {person_name_possessive} ethnic group?"
 msgid "Black, Black British, Caribbean or African"
 msgstr "Du, Du Prydeinig, Caribïaidd neu Affricanaidd"
 
 #. answer-id: ethnic-group-answer
-msgctxt "Answer for: What is <em>{person_name_possessive}</em> ethnic group?"
+msgctxt "Answer for: What is {person_name_possessive} ethnic group?"
 msgid "Other ethnic group"
 msgstr "Grŵp ethnig arall"
 
 #. answer-id: white-ethnic-group-answer
 msgctxt "Answer for: Which one best describes your White ethnic group or background?"
-msgid "Welsh, English, Scottish, Northern Irish or British"
+msgid "English, Welsh, Scottish, Northern Irish or British"
 msgstr "Cymreig, Seisnig, Albanaidd, Gwyddelig Gogledd Iwerddon neu Brydeinig"
 
 #. answer-id: white-ethnic-group-answer
@@ -1077,32 +1043,32 @@ msgid "Enter White background"
 msgstr "Nodwch y cefndir Gwyn"
 
 #. answer-id: white-ethnic-group-answer
-msgctxt "Answer for: Which one best describes <em>{person_name_possessive}</em> White ethnic group or background?"
-msgid "Welsh, English, Scottish, Northern Irish or British"
+msgctxt "Answer for: Which one best describes {person_name_possessive} White ethnic group or background?"
+msgid "English, Welsh, Scottish, Northern Irish or British"
 msgstr "Cymreig, Seisnig, Albanaidd, Gwyddelig Gogledd Iwerddon neu Brydeinig"
 
 #. answer-id: white-ethnic-group-answer
-msgctxt "Answer for: Which one best describes <em>{person_name_possessive}</em> White ethnic group or background?"
+msgctxt "Answer for: Which one best describes {person_name_possessive} White ethnic group or background?"
 msgid "Irish"
 msgstr "Gwyddelig"
 
 #. answer-id: white-ethnic-group-answer
-msgctxt "Answer for: Which one best describes <em>{person_name_possessive}</em> White ethnic group or background?"
+msgctxt "Answer for: Which one best describes {person_name_possessive} White ethnic group or background?"
 msgid "Gypsy or Irish Traveller"
 msgstr "Sipsi neu Deithiwr Gwyddelig"
 
 #. answer-id: white-ethnic-group-answer
-msgctxt "Answer for: Which one best describes <em>{person_name_possessive}</em> White ethnic group or background?"
+msgctxt "Answer for: Which one best describes {person_name_possessive} White ethnic group or background?"
 msgid "Roma"
 msgstr "Roma"
 
 #. answer-id: white-ethnic-group-answer
-msgctxt "Answer for: Which one best describes <em>{person_name_possessive}</em> White ethnic group or background?"
+msgctxt "Answer for: Which one best describes {person_name_possessive} White ethnic group or background?"
 msgid "Any other White background"
 msgstr "Unrhyw gefndir Gwyn arall"
 
 #. answer-id: white-ethnic-group-answer-other
-msgctxt "Answer for: Which one best describes <em>{person_name_possessive}</em> White ethnic group or background?"
+msgctxt "Answer for: Which one best describes {person_name_possessive} White ethnic group or background?"
 msgid "Enter White background"
 msgstr "Nodwch y cefndir Gwyn"
 
@@ -1132,27 +1098,27 @@ msgid "Enter Mixed or Multiple background"
 msgstr "Nodwch y cefndir Cymysg neu Aml-ethnig"
 
 #. answer-id: mixed-ethnic-group-answer
-msgctxt "Answer for: Which one best describes <em>{person_name_possessive}</em> Mixed or Multiple ethnic group or background?"
+msgctxt "Answer for: Which one best describes {person_name_possessive} Mixed or Multiple ethnic group or background?"
 msgid "White and Black Caribbean"
 msgstr "Gwyn a Du Caribïaidd"
 
 #. answer-id: mixed-ethnic-group-answer
-msgctxt "Answer for: Which one best describes <em>{person_name_possessive}</em> Mixed or Multiple ethnic group or background?"
+msgctxt "Answer for: Which one best describes {person_name_possessive} Mixed or Multiple ethnic group or background?"
 msgid "White and Black African"
 msgstr "Gwyn a Du Affricanaidd"
 
 #. answer-id: mixed-ethnic-group-answer
-msgctxt "Answer for: Which one best describes <em>{person_name_possessive}</em> Mixed or Multiple ethnic group or background?"
+msgctxt "Answer for: Which one best describes {person_name_possessive} Mixed or Multiple ethnic group or background?"
 msgid "White and Asian"
 msgstr "Gwyn ac Asiaidd"
 
 #. answer-id: mixed-ethnic-group-answer
-msgctxt "Answer for: Which one best describes <em>{person_name_possessive}</em> Mixed or Multiple ethnic group or background?"
+msgctxt "Answer for: Which one best describes {person_name_possessive} Mixed or Multiple ethnic group or background?"
 msgid "Any other Mixed or Multiple background"
 msgstr "Unrhyw gefndir Cymysg neu Aml-ethnig arall"
 
 #. answer-id: mixed-ethnic-group-answer-other
-msgctxt "Answer for: Which one best describes <em>{person_name_possessive}</em> Mixed or Multiple ethnic group or background?"
+msgctxt "Answer for: Which one best describes {person_name_possessive} Mixed or Multiple ethnic group or background?"
 msgid "Enter Mixed or Multiple background"
 msgstr "Nodwch y cefndir Cymysg neu Aml-ethnig"
 
@@ -1187,32 +1153,32 @@ msgid "Enter Asian background"
 msgstr "Nodwch y cefndir Asiaidd"
 
 #. answer-id: asian-ethnic-group-answer
-msgctxt "Answer for: Which one best describes <em>{person_name_possessive}</em> Asian or Asian British ethnic group or background?"
+msgctxt "Answer for: Which one best describes {person_name_possessive} Asian or Asian British ethnic group or background?"
 msgid "Indian"
 msgstr "Indiaidd"
 
 #. answer-id: asian-ethnic-group-answer
-msgctxt "Answer for: Which one best describes <em>{person_name_possessive}</em> Asian or Asian British ethnic group or background?"
+msgctxt "Answer for: Which one best describes {person_name_possessive} Asian or Asian British ethnic group or background?"
 msgid "Pakistani"
 msgstr "Pacistanaidd"
 
 #. answer-id: asian-ethnic-group-answer
-msgctxt "Answer for: Which one best describes <em>{person_name_possessive}</em> Asian or Asian British ethnic group or background?"
+msgctxt "Answer for: Which one best describes {person_name_possessive} Asian or Asian British ethnic group or background?"
 msgid "Bangladeshi"
 msgstr "Bangladeshaidd"
 
 #. answer-id: asian-ethnic-group-answer
-msgctxt "Answer for: Which one best describes <em>{person_name_possessive}</em> Asian or Asian British ethnic group or background?"
+msgctxt "Answer for: Which one best describes {person_name_possessive} Asian or Asian British ethnic group or background?"
 msgid "Chinese"
 msgstr "Tsieineaidd"
 
 #. answer-id: asian-ethnic-group-answer
-msgctxt "Answer for: Which one best describes <em>{person_name_possessive}</em> Asian or Asian British ethnic group or background?"
+msgctxt "Answer for: Which one best describes {person_name_possessive} Asian or Asian British ethnic group or background?"
 msgid "Any other Asian background"
 msgstr "Unrhyw gefndir Asiaidd arall"
 
 #. answer-id: asian-ethnic-group-answer-other
-msgctxt "Answer for: Which one best describes <em>{person_name_possessive}</em> Asian or Asian British ethnic group or background?"
+msgctxt "Answer for: Which one best describes {person_name_possessive} Asian or Asian British ethnic group or background?"
 msgid "Enter Asian background"
 msgstr "Nodwch y cefndir Asiaidd"
 
@@ -1242,27 +1208,27 @@ msgid "Enter Black, Black British or Caribbean background"
 msgstr "Nodwch y cefndir Du, Du Prydeinig neu Garibïaidd"
 
 #. answer-id: black-ethnic-group-answer
-msgctxt "Answer for: Which one best describes <em>{person_name_possessive}</em> Black, Black British, Caribbean or African ethnic group or background?"
+msgctxt "Answer for: Which one best describes {person_name_possessive} Black, Black British, Caribbean or African ethnic group or background?"
 msgid "Caribbean"
 msgstr "Caribïaidd"
 
 #. answer-id: black-ethnic-group-answer
-msgctxt "Answer for: Which one best describes <em>{person_name_possessive}</em> Black, Black British, Caribbean or African ethnic group or background?"
+msgctxt "Answer for: Which one best describes {person_name_possessive} Black, Black British, Caribbean or African ethnic group or background?"
 msgid "African"
 msgstr "Affricanaidd"
 
 #. answer-id: african-ethnic-group-answer-other
-msgctxt "Answer for: Which one best describes <em>{person_name_possessive}</em> Black, Black British, Caribbean or African ethnic group or background?"
+msgctxt "Answer for: Which one best describes {person_name_possessive} Black, Black British, Caribbean or African ethnic group or background?"
 msgid "Enter African background"
 msgstr "Nodwch y cefndir Affricanaidd"
 
 #. answer-id: black-ethnic-group-answer
-msgctxt "Answer for: Which one best describes <em>{person_name_possessive}</em> Black, Black British, Caribbean or African ethnic group or background?"
+msgctxt "Answer for: Which one best describes {person_name_possessive} Black, Black British, Caribbean or African ethnic group or background?"
 msgid "Any other Black, Black British or Caribbean background"
 msgstr "Unrhyw gefndir Du, Du Prydeinig neu Garibïaidd arall"
 
 #. answer-id: black-ethnic-group-answer-other
-msgctxt "Answer for: Which one best describes <em>{person_name_possessive}</em> Black, Black British, Caribbean or African ethnic group or background?"
+msgctxt "Answer for: Which one best describes {person_name_possessive} Black, Black British, Caribbean or African ethnic group or background?"
 msgid "Enter Black, Black British or Caribbean background"
 msgstr "Nodwch y cefndir Du, Du Prydeinig neu Garibïaidd"
 
@@ -1282,17 +1248,17 @@ msgid "Enter other ethnic group"
 msgstr "Nodwch y grŵp ethnig arall"
 
 #. answer-id: other-ethnic-group-answer
-msgctxt "Answer for: Which one best describes <em>{person_name_possessive}</em> other ethnic group or background?"
+msgctxt "Answer for: Which one best describes {person_name_possessive} other ethnic group or background?"
 msgid "Arab"
 msgstr "Arabaidd"
 
 #. answer-id: other-ethnic-group-answer
-msgctxt "Answer for: Which one best describes <em>{person_name_possessive}</em> other ethnic group or background?"
+msgctxt "Answer for: Which one best describes {person_name_possessive} other ethnic group or background?"
 msgid "Any other ethnic group"
 msgstr "Unrhyw grŵp ethnig arall"
 
 #. answer-id: other-ethnic-group-answer-other
-msgctxt "Answer for: Which one best describes <em>{person_name_possessive}</em> other ethnic group or background?"
+msgctxt "Answer for: Which one best describes {person_name_possessive} other ethnic group or background?"
 msgid "Enter other ethnic group"
 msgstr "Nodwch y grŵp ethnig arall"
 
@@ -1307,62 +1273,82 @@ msgid "No"
 msgstr "Nac oeddwn"
 
 #. answer-id: in-education-answer
-msgctxt "Answer for: On 13 October 2019, was <em>{person_name}</em> a student in full-time education?"
+msgctxt "Answer for: On 13 October 2019, was {person_name} a student in full-time education?"
 msgid "Yes"
 msgstr "Oedd"
 
 #. answer-id: in-education-answer
-msgctxt "Answer for: On 13 October 2019, was <em>{person_name}</em> a student in full-time education?"
+msgctxt "Answer for: On 13 October 2019, was {person_name} a student in full-time education?"
+msgid "No"
+msgstr "Nac oedd"
+
+#. answer-id: in-education-answer
+msgctxt "Answer for: On 13 October 2019, were you a schoolchild or student in full-time education?"
+msgid "Yes"
+msgstr "Oeddwn"
+
+#. answer-id: in-education-answer
+msgctxt "Answer for: On 13 October 2019, were you a schoolchild or student in full-time education?"
+msgid "No"
+msgstr "Nac oeddwn"
+
+#. answer-id: in-education-answer
+msgctxt "Answer for: On 13 October 2019, was {person_name} a schoolchild or student in full-time education?"
+msgid "Yes"
+msgstr "Oedd"
+
+#. answer-id: in-education-answer
+msgctxt "Answer for: On 13 October 2019, was {person_name} a schoolchild or student in full-time education?"
 msgid "No"
 msgstr "Nac oedd"
 
 #. answer-id: term-time-location-answer
-msgctxt "Answer for: During term time, where do you usually live?"
-msgid "Another address"
-msgstr ""
+msgctxt "Answer for: During term time, where did you usually live?"
+msgid "At another address"
+msgstr "Mewn cyfeiriad arall"
 
 #. answer-id: term-time-location-answer
-msgctxt "Answer for: During term time, where does <em>{person_name}</em> usually live?"
-msgid "Another address"
+msgctxt "Answer for: During term time, where did {person_name} usually live?"
+msgid "At another address"
+msgstr "Mewn cyfeiriad arall"
+
+#. answer-id: past-usual-address-household-answer
+msgctxt "Answer for: One year ago, on 13 October 2018, what was your usual address?"
+msgid "Another address in the UK"
+msgstr "Cyfeiriad arall yn y Deyrnas Unedig"
+
+#. answer-id: past-usual-address-household-answer
+msgctxt "Answer for: One year ago, on 13 October 2018, what was your usual address?"
+msgid "An address outside the UK"
+msgstr "Cyfeiriad y tu allan i’r Deyrnas Unedig"
+
+#. answer-id: past-usual-address-household-answer
+msgctxt "Answer for: One year ago, on 13 October 2018, what was {person_name_possessive} usual address?"
+msgid "Another address in the UK"
+msgstr "Cyfeiriad arall yn y Deyrnas Unedig"
+
+#. answer-id: past-usual-address-household-answer
+msgctxt "Answer for: One year ago, on 13 October 2018, what was {person_name_possessive} usual address?"
+msgid "An address outside the UK"
+msgstr "Cyfeiriad y tu allan i’r Deyrnas Unedig"
+
+#. answer-id: length-of-stay-answer
+msgctxt "Answer for: Including the time you have already spent here, how long do you intend to stay in the United Kingdom?"
+msgid "Less than 12 months"
 msgstr ""
 
-#. answer-id: past-usual-address-household-answer
-msgctxt "Answer for: One year ago, on 13 October 2019 what was your usual address?"
-msgid "Another address in the UK"
-msgstr "Cyfeiriad arall yn y Deyrnas Unedig"
-
-#. answer-id: past-usual-address-household-answer
-msgctxt "Answer for: One year ago, on 13 October 2019 what was your usual address?"
-msgid "An address outside the UK"
-msgstr "Cyfeiriad y tu allan i’r Deyrnas Unedig"
-
-#. answer-id: past-usual-address-household-answer
-msgctxt "Answer for: One year ago, on 13 October 2019, what was <em>{person_name_possessive}</em> usual address?"
-msgid "Another address in the UK"
-msgstr "Cyfeiriad arall yn y Deyrnas Unedig"
-
-#. answer-id: past-usual-address-household-answer
-msgctxt "Answer for: One year ago, on 13 October 2019, what was <em>{person_name_possessive}</em> usual address?"
-msgid "An address outside the UK"
-msgstr "Cyfeiriad y tu allan i’r Deyrnas Unedig"
-
 #. answer-id: length-of-stay-answer
-msgctxt "Answer for: Including the time already you have already spent here, how long do you intend to stay in the United Kingdom?"
-msgid "Less than 12 months"
-msgstr "Llai na 12 mis"
-
-#. answer-id: length-of-stay-answer
-msgctxt "Answer for: Including the time already you have already spent here, how long do you intend to stay in the United Kingdom?"
+msgctxt "Answer for: Including the time you have already spent here, how long do you intend to stay in the United Kingdom?"
 msgid "12 months or more"
-msgstr "12 mis neu fwy"
+msgstr ""
 
 #. answer-id: length-of-stay-answer
-msgctxt "Answer for: Including the time they have already spent here, how long does <em>{person_name}</em> intend to stay in the United Kingdom?"
+msgctxt "Answer for: Including the time they have already spent here, how long does {person_name} intend to stay in the United Kingdom?"
 msgid "Less than 12 months"
 msgstr "Llai na 12 mis"
 
 #. answer-id: length-of-stay-answer
-msgctxt "Answer for: Including the time they have already spent here, how long does <em>{person_name}</em> intend to stay in the United Kingdom?"
+msgctxt "Answer for: Including the time they have already spent here, how long does {person_name} intend to stay in the United Kingdom?"
 msgid "12 months or more"
 msgstr "12 mis neu fwy"
 
@@ -1398,82 +1384,82 @@ msgid "None of these apply"
 msgstr "Dim un o'r rhain"
 
 #. answer-id: employment-status-answer
-msgctxt "Answer for: During the week of 7 to 13 October 2019, was <em>{person_name}</em> doing any of the following?"
+msgctxt "Answer for: During the week of 7 to 13 October 2019, was {person_name} doing any of the following?"
 msgid "Working as an employee"
 msgstr "Gwaith cyflogedig"
 
 #. answer-id: employment-status-answer
-msgctxt "Answer for: During the week of 7 to 13 October 2019, was <em>{person_name}</em> doing any of the following?"
+msgctxt "Answer for: During the week of 7 to 13 October 2019, was {person_name} doing any of the following?"
 msgid "Self-employed or freelance"
 msgstr "Gwaith hunangyflogedig neu ar ei liwt ei hun"
 
 #. answer-id: employment-status-answer
-msgctxt "Answer for: During the week of 7 to 13 October 2019, was <em>{person_name}</em> doing any of the following?"
+msgctxt "Answer for: During the week of 7 to 13 October 2019, was {person_name} doing any of the following?"
 msgid "Temporarily away from work ill, on holiday or temporarily laid off"
 msgstr "I ffwrdd o’i waith dros dro yn sâl, ar wyliau, neu wedi’i gadw dros dro o’i waith am na all ei gyflogwr gynnig gwaith ar hyn o bryd"
 
 #. answer-id: employment-status-answer
-msgctxt "Answer for: During the week of 7 to 13 October 2019, was <em>{person_name}</em> doing any of the following?"
+msgctxt "Answer for: During the week of 7 to 13 October 2019, was {person_name} doing any of the following?"
 msgid "On maternity or paternity leave"
 msgstr "Ar gyfnod mamolaeth neu dadolaeth"
 
 #. answer-id: employment-status-answer
-msgctxt "Answer for: During the week of 7 to 13 October 2019, was <em>{person_name}</em> doing any of the following?"
+msgctxt "Answer for: During the week of 7 to 13 October 2019, was {person_name} doing any of the following?"
 msgid "Doing any other kind of paid work"
 msgstr "Unrhyw fath arall o waith am dâl"
 
 #. answer-id: employment-status-answer-exclusive
-msgctxt "Answer for: During the week of 7 to 13 October 2019, was <em>{person_name}</em> doing any of the following?"
+msgctxt "Answer for: During the week of 7 to 13 October 2019, was {person_name} doing any of the following?"
 msgid "None of these apply"
 msgstr "Dim un o’r rhain"
 
 #. answer-id: employment-type-answer
-msgctxt "Answer for: Which of the following describes what you were doing in the week of 7 to 13 October 2019?"
+msgctxt "Answer for: Which of the following describes what you were doing during the week of 7 to 13 October 2019?"
 msgid "Retired"
 msgstr "Wedi ymddeol"
 
 #. answer-id: employment-type-answer
-msgctxt "Answer for: Which of the following describes what you were doing in the week of 7 to 13 October 2019?"
+msgctxt "Answer for: Which of the following describes what you were doing during the week of 7 to 13 October 2019?"
 msgid "Studying"
 msgstr "Astudio"
 
 #. answer-id: employment-type-answer
-msgctxt "Answer for: Which of the following describes what you were doing in the week of 7 to 13 October 2019?"
+msgctxt "Answer for: Which of the following describes what you were doing during the week of 7 to 13 October 2019?"
 msgid "Looking after home or family"
 msgstr "Gofalu am y cartref neu am y teulu"
 
 #. answer-id: employment-type-answer
-msgctxt "Answer for: Which of the following describes what you were doing in the week of 7 to 13 October 2019?"
+msgctxt "Answer for: Which of the following describes what you were doing during the week of 7 to 13 October 2019?"
 msgid "Long-term sick or disabled"
 msgstr "Anabl neu yn sâl am gyfnod hir"
 
 #. answer-id: employment-type-answer
-msgctxt "Answer for: Which of the following describes what you were doing in the week of 7 to 13 October 2019?"
+msgctxt "Answer for: Which of the following describes what you were doing during the week of 7 to 13 October 2019?"
 msgid "Other"
 msgstr "Arall"
 
 #. answer-id: employment-type-answer
-msgctxt "Answer for: Which of the following describes what <em>{person_name}</em> was doing during the week of 7 to 13 October 2019?"
+msgctxt "Answer for: Which of the following describes what {person_name} was doing during the week of 7 to 13 October 2019?"
 msgid "Retired"
 msgstr "Wedi ymddeol"
 
 #. answer-id: employment-type-answer
-msgctxt "Answer for: Which of the following describes what <em>{person_name}</em> was doing during the week of 7 to 13 October 2019?"
+msgctxt "Answer for: Which of the following describes what {person_name} was doing during the week of 7 to 13 October 2019?"
 msgid "Studying"
 msgstr "Astudio"
 
 #. answer-id: employment-type-answer
-msgctxt "Answer for: Which of the following describes what <em>{person_name}</em> was doing during the week of 7 to 13 October 2019?"
+msgctxt "Answer for: Which of the following describes what {person_name} was doing during the week of 7 to 13 October 2019?"
 msgid "Looking after home or family"
 msgstr "Gofalu am y cartref neu am y teulu"
 
 #. answer-id: employment-type-answer
-msgctxt "Answer for: Which of the following describes what <em>{person_name}</em> was doing during the week of 7 to 13 October 2019?"
+msgctxt "Answer for: Which of the following describes what {person_name} was doing during the week of 7 to 13 October 2019?"
 msgid "Long-term sick or disabled"
 msgstr "Anabl neu yn sâl am gyfnod hir"
 
 #. answer-id: employment-type-answer
-msgctxt "Answer for: Which of the following describes what <em>{person_name}</em> was doing during the week of 7 to 13 October 2019?"
+msgctxt "Answer for: Which of the following describes what {person_name} was doing during the week of 7 to 13 October 2019?"
 msgid "Other"
 msgstr "Arall"
 
@@ -1528,182 +1514,162 @@ msgid "There is no other UK address"
 msgstr "Nid oes cyfeiriad arall yn y Deyrnas Unedig"
 
 #. answer-id: another-uk-address-question
-msgctxt "Answer for: Is there another address {person_name} where you may have been included on a census questionnaire because you were a usual resident, or staying overnight there on Sunday 13 October 2019?"
+msgctxt "Answer for: Is there another UK address where {person_name} may have been included on a census questionnaire because they were a usual resident, or staying overnight there on Sunday 13 October 2019?"
 msgid "Previous home"
 msgstr "Cartref blaenorol"
 
 #. answer-id: another-uk-address-question
-msgctxt "Answer for: Is there another address {person_name} where you may have been included on a census questionnaire because you were a usual resident, or staying overnight there on Sunday 13 October 2019?"
+msgctxt "Answer for: Is there another UK address where {person_name} may have been included on a census questionnaire because they were a usual resident, or staying overnight there on Sunday 13 October 2019?"
 msgid "Armed forces base address"
 msgstr "Cyfeiriad un o ganolfannau’r lluoedd arfog"
 
 #. answer-id: another-uk-address-question
-msgctxt "Answer for: Is there another address {person_name} where you may have been included on a census questionnaire because you were a usual resident, or staying overnight there on Sunday 13 October 2019?"
+msgctxt "Answer for: Is there another UK address where {person_name} may have been included on a census questionnaire because they were a usual resident, or staying overnight there on Sunday 13 October 2019?"
 msgid "Another address when working away from home"
 msgstr "Cyfeiriad arall wrth weithio i ffwrdd o'r cartref"
 
 #. answer-id: another-uk-address-question
-msgctxt "Answer for: Is there another address {person_name} where you may have been included on a census questionnaire because you were a usual resident, or staying overnight there on Sunday 13 October 2019?"
+msgctxt "Answer for: Is there another UK address where {person_name} may have been included on a census questionnaire because they were a usual resident, or staying overnight there on Sunday 13 October 2019?"
 msgid "Student’s home address"
 msgstr "Cyfeiriad cartref myfyriwr"
 
 #. answer-id: another-uk-address-question
-msgctxt "Answer for: Is there another address {person_name} where you may have been included on a census questionnaire because you were a usual resident, or staying overnight there on Sunday 13 October 2019?"
+msgctxt "Answer for: Is there another UK address where {person_name} may have been included on a census questionnaire because they were a usual resident, or staying overnight there on Sunday 13 October 2019?"
 msgid "Student’s term-time address"
 msgstr "Cyfeiriad myfyriwr yn ystod y tymor"
 
 #. answer-id: another-uk-address-question
-msgctxt "Answer for: Is there another address {person_name} where you may have been included on a census questionnaire because you were a usual resident, or staying overnight there on Sunday 13 October 2019?"
+msgctxt "Answer for: Is there another UK address where {person_name} may have been included on a census questionnaire because they were a usual resident, or staying overnight there on Sunday 13 October 2019?"
 msgid "Another parent or guardian’s address"
 msgstr "Cyfeiriad rhiant neu warcheidwad arall"
 
 #. answer-id: another-uk-address-question
-msgctxt "Answer for: Is there another address {person_name} where you may have been included on a census questionnaire because you were a usual resident, or staying overnight there on Sunday 13 October 2019?"
+msgctxt "Answer for: Is there another UK address where {person_name} may have been included on a census questionnaire because they were a usual resident, or staying overnight there on Sunday 13 October 2019?"
 msgid "Partner’s address"
 msgstr "Cyfeiriad partner"
 
 #. answer-id: another-uk-address-question
-msgctxt "Answer for: Is there another address {person_name} where you may have been included on a census questionnaire because you were a usual resident, or staying overnight there on Sunday 13 October 2019?"
+msgctxt "Answer for: Is there another UK address where {person_name} may have been included on a census questionnaire because they were a usual resident, or staying overnight there on Sunday 13 October 2019?"
 msgid "Holiday in the UK"
 msgstr "Gwyliau yn y Deyrnas Unedig"
 
 #. answer-id: another-uk-address-question
-msgctxt "Answer for: Is there another address {person_name} where you may have been included on a census questionnaire because you were a usual resident, or staying overnight there on Sunday 13 October 2019?"
+msgctxt "Answer for: Is there another UK address where {person_name} may have been included on a census questionnaire because they were a usual resident, or staying overnight there on Sunday 13 October 2019?"
 msgid "Other UK address"
 msgstr "Cyfeiriad arall yn y Deyrnas Unedig"
 
 #. answer-id: another-uk-address-answer-exclusive
-msgctxt "Answer for: Is there another address {person_name} where you may have been included on a census questionnaire because you were a usual resident, or staying overnight there on Sunday 13 October 2019?"
+msgctxt "Answer for: Is there another UK address where {person_name} may have been included on a census questionnaire because they were a usual resident, or staying overnight there on Sunday 13 October 2019?"
 msgid "There is no other UK address"
 msgstr "Nid oes cyfeiriad arall yn y Deyrnas Unedig"
 
 #. answer-id: other-census-address-answer-building
 msgctxt "Answer for: What is the other address where you may have been included on a Census questionnaire?"
 msgid "Address line 1"
-msgstr ""
+msgstr "Llinell cyfeiriad 1"
 
 #. answer-id: other-census-address-answer-street
 msgctxt "Answer for: What is the other address where you may have been included on a Census questionnaire?"
 msgid "Address line 2"
-msgstr ""
+msgstr "Llinell cyfeiriad 2"
 
 #. answer-id: other-census-address-answer-city
 msgctxt "Answer for: What is the other address where you may have been included on a Census questionnaire?"
 msgid "Town or city"
-msgstr ""
+msgstr "Tref neu ddinas"
 
 #. answer-id: other-census-address-answer-county
 msgctxt "Answer for: What is the other address where you may have been included on a Census questionnaire?"
 msgid "County (optional)"
-msgstr ""
+msgstr "Sir (dewisol)"
 
 #. answer-id: other-census-address-answer-postcode
 msgctxt "Answer for: What is the other address where you may have been included on a Census questionnaire?"
 msgid "Postcode"
-msgstr ""
+msgstr "Cod post"
 
 #. answer-id: other-census-address-answer-building
-msgctxt "Answer for: What is the other address where <em>{person_name}</em> may have been included on a Census questionnaire?"
+msgctxt "Answer for: What is the other address where {person_name} may have been included on a Census questionnaire?"
 msgid "Address line 1"
-msgstr ""
+msgstr "Llinell cyfeiriad 1"
 
 #. answer-id: other-census-address-answer-street
-msgctxt "Answer for: What is the other address where <em>{person_name}</em> may have been included on a Census questionnaire?"
+msgctxt "Answer for: What is the other address where {person_name} may have been included on a Census questionnaire?"
 msgid "Address line 2"
-msgstr ""
+msgstr "Llinell cyfeiriad 2"
 
 #. answer-id: other-census-address-answer-city
-msgctxt "Answer for: What is the other address where <em>{person_name}</em> may have been included on a Census questionnaire?"
+msgctxt "Answer for: What is the other address where {person_name} may have been included on a Census questionnaire?"
 msgid "Town or city"
-msgstr ""
+msgstr "Tref neu ddinas"
 
 #. answer-id: other-census-address-answer-county
-msgctxt "Answer for: What is the other address where <em>{person_name}</em> may have been included on a Census questionnaire?"
+msgctxt "Answer for: What is the other address where {person_name} may have been included on a Census questionnaire?"
 msgid "County (optional)"
-msgstr ""
+msgstr "Sir (dewisol)"
 
 #. answer-id: other-census-address-answer-postcode
-msgctxt "Answer for: What is the other address where <em>{person_name}</em> may have been included on a Census questionnaire?"
+msgctxt "Answer for: What is the other address where {person_name} may have been included on a Census questionnaire?"
 msgid "Postcode"
-msgstr ""
-
-#. answer-id: visitor-age-last-birthday-answer
-msgctxt "Answer for: What was <em>{person_name_possessive}</em> age on their last birthday?"
-msgid "Age"
-msgstr "Oed"
-
-#. answer-id: visitor-age-estimate-answer
-msgctxt "Answer for: What was <em>{person_name_possessive}</em> age on their last birthday?"
-msgid "Estimate"
-msgstr "Amcangyfrif"
+msgstr "Cod post"
 
 #. answer-id: usual-address-household-answer
-msgctxt "Answer for: Did <em>{person_name}</em> usually live in the United Kingdom?"
+msgctxt "Answer for: Did {person_name} usually live in the United Kingdom?"
 msgid "An address in the UK"
-msgstr "Cyfeiriad yn y Deyrnas Unedig"
+msgstr ""
 
 #. answer-id: usual-address-household-answer
-msgctxt "Answer for: Did <em>{person_name}</em> usually live in the United Kingdom?"
+msgctxt "Answer for: Did {person_name} usually live in the United Kingdom?"
 msgid "An address outside the UK"
-msgstr "Cyfeiriad y tu allan i’r Deyrnas Unedig"
+msgstr ""
 
 #. answer-id: usual-address-household-answer-other
-msgctxt "Answer for: Did <em>{person_name}</em> usually live in the United Kingdom?"
+msgctxt "Answer for: Did {person_name} usually live in the United Kingdom?"
 msgid "Enter the current name of the country"
-msgstr "Nodwch enw presennol y wlad"
+msgstr ""
 
 #. answer-id: usual-address-details-answer-building
-msgctxt "Answer for: What is <em>{person_name_possessive}</em> usual UK address?"
+msgctxt "Answer for: What is {person_name_possessive} usual UK address?"
 msgid "Address line 1"
 msgstr "Llinell cyfeiriad 1"
 
 #. answer-id: usual-address-details-answer-street
-msgctxt "Answer for: What is <em>{person_name_possessive}</em> usual UK address?"
+msgctxt "Answer for: What is {person_name_possessive} usual UK address?"
 msgid "Address line 2"
 msgstr "Llinell cyfeiriad 2"
 
 #. answer-id: usual-address-details-answer-city
-msgctxt "Answer for: What is <em>{person_name_possessive}</em> usual UK address?"
+msgctxt "Answer for: What is {person_name_possessive} usual UK address?"
 msgid "Town or city"
 msgstr "Tref neu ddinas"
 
 #. answer-id: usual-address-details-answer-county
-msgctxt "Answer for: What is <em>{person_name_possessive}</em> usual UK address?"
+msgctxt "Answer for: What is {person_name_possessive} usual UK address?"
 msgid "County (optional)"
 msgstr "Sir (dewisol)"
 
 #. answer-id: usual-address-details-answer-postcode
-msgctxt "Answer for: What is <em>{person_name_possessive}</em> usual UK address?"
+msgctxt "Answer for: What is {person_name_possessive} usual UK address?"
 msgid "Postcode"
 msgstr "Cod post"
 
-#. answer-id: confirm-date-of-birth-answer
-msgctxt "Answer for: You are {age_in_years} years old. Is this correct?"
-msgid "Yes, I am {age_in_years} years old"
-msgstr ""
-
-#. answer-id: confirm-date-of-birth-answer
-msgctxt "Answer for: {person_name} is {age_in_years} years old. Is this correct?"
-msgid "Yes, {person_name} is {age_in_years} years old"
-msgstr ""
+#. answer-id: term-time-location-answer
+msgctxt "Answer for: During term time, where did you usually live?"
+msgid "{address}"
+msgstr "{address}"
 
 #. answer-id: term-time-location-answer
-msgctxt "Answer for: During term time, where do you usually live?"
-msgid "{address}"
-msgstr ""
-
-#. answer-id: term-time-location-answer
-msgctxt "Answer for: During term time, where does <em>{person_name}</em> usually live?"
-msgid "{address}"
-msgstr ""
-
-#. answer-id: past-usual-address-household-answer
-msgctxt "Answer for: One year ago, on 13 October 2019 what was your usual address?"
+msgctxt "Answer for: During term time, where did {person_name} usually live?"
 msgid "{address}"
 msgstr "{address}"
 
 #. answer-id: past-usual-address-household-answer
-msgctxt "Answer for: One year ago, on 13 October 2019, what was <em>{person_name_possessive}</em> usual address?"
+msgctxt "Answer for: One year ago, on 13 October 2018, what was your usual address?"
+msgid "{address}"
+msgstr "{address}"
+
+#. answer-id: past-usual-address-household-answer
+msgctxt "Answer for: One year ago, on 13 October 2018, what was {person_name_possessive} usual address?"
 msgid "{address}"
 msgstr "{address}"
 

--- a/app/utilities/schema.py
+++ b/app/utilities/schema.py
@@ -17,6 +17,7 @@ DEFAULT_SCHEMA_DIR = 'data'
 
 LANGUAGES_MAP = {
     'test_language': [['en', 'cy']],
+    'ccs_household_gb_eng': [['en', 'cy']],
     'census_household_gb_wls': [['en', 'cy']],
     'census_individual_gb_wls': [['en', 'cy']],
     'census_household_gb_nir': [['en'], ['en', 'ga'], ['en', 'eo']],

--- a/scripts/translate_schemas.py
+++ b/scripts/translate_schemas.py
@@ -12,7 +12,12 @@ logger.setLevel(logging.DEBUG)
 logger.addHandler(logging.StreamHandler(sys.stdout))
 
 TRANSLATION_MAP = {
-    'cy': ['test_language', 'ccs_household_gb_eng', 'census_individual_gb_wls', 'census_household_gb_wls'],
+    'cy': [
+        'test_language',
+        'ccs_household_gb_eng',
+        'census_individual_gb_wls',
+        'census_household_gb_wls',
+    ],
     'eo': ['census_individual_gb_nir', 'census_household_gb_nir'],
     'ga': ['census_individual_gb_nir', 'census_household_gb_nir'],
 }

--- a/scripts/translate_schemas.py
+++ b/scripts/translate_schemas.py
@@ -12,7 +12,7 @@ logger.setLevel(logging.DEBUG)
 logger.addHandler(logging.StreamHandler(sys.stdout))
 
 TRANSLATION_MAP = {
-    'cy': ['test_language', 'census_individual_gb_wls', 'census_household_gb_wls'],
+    'cy': ['test_language', 'ccs_household_gb_eng', 'census_individual_gb_wls', 'census_household_gb_wls'],
     'eo': ['census_individual_gb_nir', 'census_household_gb_nir'],
     'ga': ['census_individual_gb_nir', 'census_household_gb_nir'],
 }


### PR DESCRIPTION
### What is the context of this PR?
CCS schema was not included in translation map in translate_schemas script and was only displaying static Welsh content. To make it use all Welsh translations from .pot file minor fix was added.

### How to review 
Run `make build`
It should translate 86% of ccs schema content.
Start launcher and choose "ccs_household_gb_eng" schema and Welsh language (don't change the region code).
Check if language toggle button is visible in top right corner.
