### PR TITLE
Update the CCS survey_id

### DIFF
--- a/data-source/jsonnet/england-wales/ccs_household.jsonnet
+++ b/data-source/jsonnet/england-wales/ccs_household.jsonnet
@@ -61,7 +61,7 @@ function(region_code, census_date, census_month_year_date) {
   mime_type: 'application/json/ons/eq',
   schema_version: '0.0.1',
   data_version: '0.0.3',
-  survey_id: 'census',
+  survey_id: 'CCS',
   title: '2019 Census Coverage Survey Test',
   description: 'Census England Coverage Survey Schema',
   theme: 'census',

--- a/data-source/jsonnet/england-wales/ccs_household.jsonnet
+++ b/data-source/jsonnet/england-wales/ccs_household.jsonnet
@@ -61,7 +61,7 @@ function(region_code, census_date, census_month_year_date) {
   mime_type: 'application/json/ons/eq',
   schema_version: '0.0.1',
   data_version: '0.0.3',
-  survey_id: 'CCS',
+  survey_id: 'ccs',
   title: '2019 Census Coverage Survey Test',
   description: 'Census England Coverage Survey Schema',
   theme: 'census',


### PR DESCRIPTION
### What is the context of this PR?
We need to differentiate between the CCS and Census survey_id values in our CCS and census schemas. I have updated the survey_id value for the CCS schema to be 'ccs' (it was previously 'census').

### How to review 
Build the CCS schema and check that the survey_id has the value 'ccs'

