### PR TITLE
Don't return list for summaries when items do not exist

### DIFF
--- a/app/views/contexts/summary_context.py
+++ b/app/views/contexts/summary_context.py
@@ -110,24 +110,26 @@ class SummaryContext:
                 list_collector_block['summary'], current_location.list_item_id
             )
 
+            list_items = build_list_items_summary_context(
+                list_collector_block,
+                self._schema,
+                self._answer_store,
+                self._list_store,
+                self._language,
+                return_to=current_location.block_id,
+            )
+
             list_summary = {
                 'title': rendered_summary['title'],
                 'add_link': add_link,
                 'add_link_text': rendered_summary['add_link_text'],
                 'empty_list_text': rendered_summary['empty_list_text'],
-                'list': {
-                    'list_items': build_list_items_summary_context(
-                        list_collector_block,
-                        self._schema,
-                        self._answer_store,
-                        self._list_store,
-                        self._language,
-                        return_to=current_location.block_id,
-                    ),
-                    'editable': True,
-                },
                 'list_name': list_collector_block['for_list'],
             }
+
+            if list_items:
+                list_summary['list'] = {'list_items': list_items, 'editable': True}
+
             list_summaries.append(list_summary)
 
         return list_summaries

--- a/tests/app/views/contexts/test_summary_context.py
+++ b/tests/app/views/contexts/test_summary_context.py
@@ -419,7 +419,6 @@ def test_context_for_driving_question_summary_empty_list():
             'add_link': '/questionnaire/anyone-usually-live-at/',
             'add_link_text': 'Add someone to this household',
             'empty_list_text': 'There are no householders',
-            'list': {'list_items': [], 'editable': True},
             'title': 'Household members',
             'list_name': 'people',
         }


### PR DESCRIPTION
### What is the context of this PR?

Due to the recent refactor of list summary objects, empty list text is not shown on list summaries. 
![list-summary](https://user-images.githubusercontent.com/3598161/68119722-58b4c880-fefb-11e9-8f0e-f26282372c61.png)

### How to review

Check that list summaries are now shown and tests have been appropriately updated.

