### PR TITLE
Remove content from final summary page

### DIFF
--- a/app/translations/messages.pot
+++ b/app/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-11-04 08:32+0000\n"
+"POT-Creation-Date: 2019-11-06 08:50+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -337,12 +337,6 @@ msgstr ""
 
 #: templates/summary.html:35
 msgid "Please review your answers and confirm these are correct"
-msgstr ""
-
-#: templates/summary.html:64
-msgid ""
-"You will have the opportunity to view and print a copy of your answers "
-"after submitting this survey"
 msgstr ""
 
 #: templates/thank-you.html:4

--- a/templates/summary.html
+++ b/templates/summary.html
@@ -59,9 +59,4 @@
     {% endfor %}
   {% endif %}
 
-  {% if content.summary.is_view_submission_response_enabled %}
-    <div class="u-mt-m u-mb-s u-mb-m@s" data-qa="view-submission-text">
-      <div class="u-fs-r--b">{{ _("You will have the opportunity to view and print a copy of your answers after submitting this survey") }}</div>
-    </div>
-  {% endif %}
 {% endblock -%}


### PR DESCRIPTION
### What is the context of this PR?
This changes the content displayed on "final-summary" page. "View answers after submission" text has been removed. Static translations file is also affected.

### How to review 
Census schemas with "hub and spoke" feature skip "final-summary" page . To test the changes, it's best to go through one of census theme schemas with final summary enabled(e.g "census_individual_gb_en") and default theme schemas(e.g "ecommerce") and check "final-summary" pages. 


