### PR TITLE
Revert Answer Value

### DIFF
--- a/data-source/jsonnet/england-wales/individual/blocks/personal-details/address_type.jsonnet
+++ b/data-source/jsonnet/england-wales/individual/blocks/personal-details/address_type.jsonnet
@@ -32,7 +32,7 @@ local question(title) = {
         },
         {
           label: 'Partner’s address',
-          value: 'Partner’s address',
+          value: "Partner's address",
         },
         {
           label: 'Holiday home',


### PR DESCRIPTION
### What is the context of this PR?
This PR has been raised to revert a change from a dumb to a smart quote in an answer value. This was changed happened as part of [this PR](https://github.com/ONSdigital/eq-survey-runner/pull/2435).

We need to revert this change as we do not want to change any answer values while the rehearsal is still in flight.

### How to review 
Check that the change from the previous PR has been reverted.
