### PR TITLE
Update the schema validator branch for census-rehearsal

### DIFF
--- a/scripts/test_schemas.sh
+++ b/scripts/test_schemas.sh
@@ -6,7 +6,7 @@ if [ "$1" == "--local" ] || [ "$2" == "--local" ]; then
 fi
 
 if [ "$run_docker" == true ]; then
-    branch=v3
+    branch=3457-ccs-issues
     docker pull onsdigital/eq-schema-validator:$branch
     validator="$(docker run -d -p 5001:5000 onsdigital/eq-schema-validator:$branch)"
     sleep 3

--- a/tests/functional/spec/features/repeating_sections/repeating_sections_with_hub_and_spoke.js
+++ b/tests/functional/spec/features/repeating_sections/repeating_sections_with_hub_and_spoke.js
@@ -252,8 +252,6 @@ describe('Feature: Repeating Sections with Hub and Spoke', function () {
         .setValue(DateOfBirthPage.year(), '1990')
         .click(DateOfBirthPage.submit())
 
-        .getText(ConfirmDateOfBirthPage.questionText()).should.eventually.equal('Samuel Clemens is 28 years old. Is this correct?')
-
         .click(ConfirmDateOfBirthPage.confirmDateOfBirthYes())
         .click(ConfirmDateOfBirthPage.submit())
 


### PR DESCRIPTION
### What is the context of this PR?
Once [this Smart Quotes validator PR](https://github.com/ONSdigital/eq-schema-validator/pull/166) is merged, builds on the census-rehearsal branch of runner will fail. In order to avoid this, we need to revert to an older version of the eq-schema-validator on the census-rehearsal branch.

I have updated the validator version in test_schemas.sh so that it references an earlier docker image. 

### How to review 
Check that the builds on the census-rehearsal branch still pass.
