### PR TITLE
Update eq-translations to correct commit for latest validator

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -163,7 +163,7 @@
         "eq-translations": {
             "editable": true,
             "git": "https://github.com/ONSDigital/eq-translations.git",
-            "ref": "a7fbf8ca1b3395c99e37226334ab51baea63bb8e"
+            "ref": "8f94a0f9645f10493dbe97e939b2f50dad96a756"
         },
         "flask": {
             "hashes": [


### PR DESCRIPTION
### What is the context of this PR?

Validator is failing on our v3 branch due to the version of eq-translations using an older commit

### How to review 
Check travis passes.
