### PR TITLE
Session timeout fix - browserconfig.xml disable

### DIFF
--- a/app/templates/layouts/_base.html
+++ b/app/templates/layouts/_base.html
@@ -11,6 +11,7 @@
     {%- block head %}
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+    <meta name="msapplication-config" content="none"/>
     <title>{% block page_title %}{{ _('ONS Survey') }}{% endblock page_title %}</title>
     <meta content="" name="description">
     <meta content="width=device-width, initial-scale=1" name="viewport">


### PR DESCRIPTION
My investigations have identified from the logs that before each session timeout IE11 sends a browserconfig.xml request to the root of the runner url. I'm believe that this is causing a CSRF mis-match immediately after and then the session timeout.
browserconfig.xml requests are particular to IE11 and windows 8 to get information from a website to update tiles in the windows system. 
https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/platform-apis/dn320426(v=vs.85)?redirectedfrom=MSDN

This fix disables the calls by windows to get the browserconfig.xml.
