### PR TITLE
3521 fix flush feature

### DIFF
--- a/app/routes/flush.py
+++ b/app/routes/flush.py
@@ -1,3 +1,4 @@
+import simplejson as json
 from flask import Blueprint, Response, request, session, current_app
 from sdc.crypto.encrypter import encrypt
 from sdc.crypto.decrypter import decrypt
@@ -58,8 +59,8 @@ def _submit_data(user):
         )
         full_routing_path = path_finder.full_routing_path()
 
-        message = convert_answers(
-            schema, questionnaire_store, full_routing_path, flushed=True
+        message = json.dumps(
+            convert_answers(schema, questionnaire_store, full_routing_path, flushed=True), for_json=True
         )
         encrypted_message = encrypt(
             message, current_app.eq['key_store'], KEY_PURPOSE_SUBMISSION

--- a/app/routes/flush.py
+++ b/app/routes/flush.py
@@ -60,7 +60,10 @@ def _submit_data(user):
         full_routing_path = path_finder.full_routing_path()
 
         message = json.dumps(
-            convert_answers(schema, questionnaire_store, full_routing_path, flushed=True), for_json=True
+            convert_answers(
+                schema, questionnaire_store, full_routing_path, flushed=True
+            ),
+            for_json=True,
         )
         encrypted_message = encrypt(
             message, current_app.eq['key_store'], KEY_PURPOSE_SUBMISSION

--- a/tests/integration/test_flush_data.py
+++ b/tests/integration/test_flush_data.py
@@ -103,7 +103,8 @@ class TestFlushData(IntegrationTestCase):
         self.encrypt_instance.assert_called_once()  # pylint: disable=no-member
         args = self.encrypt_instance.call_args[0]  # pylint: disable=no-member
 
-        self.assertTrue(args[0]['flushed'])
+        self.assertTrue('"flushed": true' in args[0])
+
 
     @staticmethod
     def get_payload():
@@ -111,9 +112,6 @@ class TestFlushData(IntegrationTestCase):
             'jti': str(uuid.uuid4()),
             'iat': time.time(),
             'exp': time.time() + 1000,
-            'schema_name': 'test_textfield',
-            'collection_exercise_sid': '789',
-            'ru_ref': '123456789012A',
             'response_id': '1234567890123456',
             'roles': ['flusher'],
         }

--- a/tests/integration/test_flush_data.py
+++ b/tests/integration/test_flush_data.py
@@ -105,7 +105,6 @@ class TestFlushData(IntegrationTestCase):
 
         self.assertTrue('"flushed": true' in args[0])
 
-
     @staticmethod
     def get_payload():
         return {


### PR DESCRIPTION
The /flush feature fails as the encryption is expecting a string representation of the message rather than a dict. This change aligns the flusher with submit_answers to use json.dumps to convert the dict to a string of json prior to encryption.

This doesn't get caught by the tests as the encryption is returned by a MagicMock implementation.