### PR TITLE
Evaluate section status on list change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,5 @@ templates/layout
 
 # Ignore compiled translation files
 *.mo
+
+.vim/

--- a/app/data_model/progress_store.py
+++ b/app/data_model/progress_store.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Mapping, MutableMapping, Optional
+from typing import List, Set, Tuple, Mapping, MutableMapping, Optional
 
 from app.data_model.progress import Progress
 from app.questionnaire.location import Location
@@ -71,14 +71,14 @@ class ProgressStore:
     def is_section_complete(
         self, section_id: str, list_item_id: Optional[str] = None
     ) -> bool:
-        return (section_id, list_item_id) in self._completed_section_keys()
+        return (section_id, list_item_id) in self.completed_section_keys()
 
-    def _completed_section_keys(self) -> List[Tuple[str, Optional[str]]]:
-        return [
+    def completed_section_keys(self) -> Set[Tuple[str, Optional[str]]]:
+        return {
             section_key
             for section_key, section_progress in self._progress.items()
             if section_progress.status == CompletionStatus.COMPLETED
-        ]
+        }
 
     def update_section_status(
         self, section_status: str, section_id: str, list_item_id: Optional[str] = None

--- a/app/questionnaire/questionnaire_store_updater.py
+++ b/app/questionnaire/questionnaire_store_updater.py
@@ -1,6 +1,6 @@
 from itertools import combinations
 
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Set, Tuple, Union
 
 from app.data_model.answer_store import Answer
 from app.data_model.relationship_store import Relationship, RelationshipStore
@@ -199,6 +199,13 @@ class QuestionnaireStoreUpdater:
         self._progress_store.update_section_status(
             section_status, section_id, list_item_id
         )
+
+    def sections_to_evaluate(self, filter_by: Set[str] = None) -> Union[List, None]:
+        completed_sections = self._progress_store.completed_section_keys()
+        try:
+            return list(completed_sections & filter_by)
+        except TypeError:
+            return list(completed_sections)
 
     def _update_questionnaire_store_with_form_data(self, form_data):
         answer_ids_for_question = self._schema.get_answer_ids_for_question(

--- a/app/questionnaire/router.py
+++ b/app/questionnaire/router.py
@@ -136,12 +136,12 @@ class Router:
         self, routing_path, section_id, list_item_id=None
     ):
         section_key = (section_id, list_item_id)
-
+        completed_locations = self._progress_store.get_completed_locations(
+            section_id=section_id, list_item_id=list_item_id
+        )
         if section_key in self._progress_store:
             for location in routing_path:
-                if location not in self._progress_store.get_completed_locations(
-                    section_id=section_id, list_item_id=list_item_id
-                ):
+                if location not in completed_locations:
                     return location
 
         return routing_path[0]
@@ -150,12 +150,12 @@ class Router:
         self, routing_path, section_id, list_item_id=None
     ):
         section_key = (section_id, list_item_id)
-
+        completed_locations = self._progress_store.get_completed_locations(
+            section_id=section_id, list_item_id=list_item_id
+        )
         if section_key in self._progress_store:
             for location in routing_path[::-1]:
-                if location in self._progress_store.get_completed_locations(
-                    section_id=section_id, list_item_id=list_item_id
-                ):
+                if location in completed_locations:
                     return location
 
     def is_survey_complete(self):

--- a/app/routes/questionnaire.py
+++ b/app/routes/questionnaire.py
@@ -197,11 +197,18 @@ def get_section(schema, questionnaire_store, section_id, list_item_id=None):
             ).url()
         )
 
-    return redirect(
-        router.get_last_complete_location_for_section(
-            routing_path=routing_path, section_id=section_id, list_item_id=list_item_id
-        ).url()
-    )
+    redirect_url = router.get_last_complete_location_for_section(
+        routing_path=routing_path, section_id=section_id, list_item_id=list_item_id
+    ).url()
+
+    if 'section-summary' in redirect_url:
+        return redirect(
+            router.get_first_incomplete_location_for_section(
+                routing_path, section_id=section_id, list_item_id=list_item_id
+            ).url()
+        )
+
+    return redirect(redirect_url)
 
 
 @questionnaire_blueprint.route('<block_id>/', methods=['GET', 'POST'])

--- a/app/views/handlers/block.py
+++ b/app/views/handlers/block.py
@@ -131,10 +131,13 @@ class BlockHandler:
             list_item_id=self._current_location.list_item_id,
         )
 
-    def _update_section_completeness(self, location: Optional[Location] = None):
+    def _update_section_completeness(
+        self, location: Optional[Location] = None, routing_path: Optional = None
+    ):
+        routing_path = routing_path if routing_path else self._routing_path
         section_status = (
             CompletionStatus.COMPLETED
-            if self.path_finder.is_path_complete(self._routing_path)
+            if self.path_finder.is_path_complete(routing_path)
             else CompletionStatus.IN_PROGRESS
         )
 

--- a/app/views/handlers/list_action.py
+++ b/app/views/handlers/list_action.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from app.views.handlers.question import Question
 from app.views.contexts.question import build_question_context
 from app.questionnaire.location import Location
@@ -47,7 +49,32 @@ class ListAction(Question):
             self.parent_location.block_id
         )
         self.questionnaire_store_updater.remove_answers(answer_ids_to_remove)
+        self.evaluate_sections()
         self.questionnaire_store_updater.save()
+
+    def evaluate_sections(self):
+        sections_to_evaluate = self._sections_to_evaluate()
+        section_paths = self._routing_paths(sections_to_evaluate)
+        for section_path in section_paths:
+            self._update_section_completeness(
+                Location(section_path[0][0]), section_path[1]
+            )
+
+    def _sections_to_evaluate(self):
+        list_name = self._schema.get_block(self.rendered_block['parent_id'])['for_list']
+        associated_sections = self._schema.get_sections_associated_to_list_name(
+            list_name
+        )
+        associated_sections = {(element, None) for element in associated_sections}
+        return self.questionnaire_store_updater.sections_to_evaluate(
+            associated_sections
+        )
+
+    def _routing_paths(self, sections_to_evaluate: List[str]):
+        return [
+            (section_id, self.path_finder.routing_path(section_id[0]))
+            for section_id in sections_to_evaluate
+        ]
 
     def _get_location_url(self, block_id):
         if block_id and self._schema.is_block_valid(block_id):

--- a/data-source/json/test_list_change_evaluates_sections.json
+++ b/data-source/json/test_list_change_evaluates_sections.json
@@ -1,0 +1,653 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.3",
+    "survey_id": "0",
+    "title": "Test ListCollector Evaluate Sections",
+    "theme": "default",
+    "description": "A questionnaire to test that changes to a list update section completeness",
+    "metadata": [
+        {
+            "name": "user_id",
+            "type": "string"
+        },
+        {
+            "name": "period_id",
+            "type": "string"
+        },
+        {
+            "name": "ru_name",
+            "type": "string"
+        }
+    ],
+    "hub": {
+        "enabled": true
+    },
+    "sections": [
+        {
+            "id": "who-lives-here",
+            "title": "Who Lives Here",
+            "groups": [
+                {
+                    "id": "group",
+                    "title": "List",
+                    "blocks": [
+                        {
+                            "id": "list-collector",
+                            "type": "ListCollector",
+                            "for_list": "people",
+                            "add_answer": {
+                                "id": "anyone-else",
+                                "value": "Yes"
+                            },
+                            "remove_answer": {
+                                "id": "remove-confirmation",
+                                "value": "Yes"
+                            },
+                            "question": {
+                                "id": "confirmation-question",
+                                "type": "General",
+                                "title": "Does anyone else live here?",
+                                "answers": [
+                                    {
+                                        "id": "anyone-else",
+                                        "mandatory": true,
+                                        "type": "Radio",
+                                        "options": [
+                                            {
+                                                "label": "Yes",
+                                                "value": "Yes"
+                                            },
+                                            {
+                                                "label": "No",
+                                                "value": "No"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "add_block": {
+                                "id": "add-person",
+                                "type": "ListAddQuestion",
+                                "question": {
+                                    "id": "add-question",
+                                    "type": "General",
+                                    "title": "What is the name of the person?",
+                                    "answers": [
+                                        {
+                                            "id": "first-name",
+                                            "label": "First name",
+                                            "mandatory": true,
+                                            "type": "TextField"
+                                        },
+                                        {
+                                            "id": "last-name",
+                                            "label": "Last name",
+                                            "mandatory": true,
+                                            "type": "TextField"
+                                        }
+                                    ]
+                                }
+                            },
+                            "edit_block": {
+                                "id": "edit-person",
+                                "type": "ListEditQuestion",
+                                "question": {
+                                    "id": "edit-question",
+                                    "type": "General",
+                                    "title": "What is the name of the person?",
+                                    "answers": [
+                                        {
+                                            "id": "first-name",
+                                            "label": "First name",
+                                            "mandatory": true,
+                                            "type": "TextField"
+                                        },
+                                        {
+                                            "id": "last-name",
+                                            "label": "Last name",
+                                            "mandatory": true,
+                                            "type": "TextField"
+                                        }
+                                    ]
+                                }
+                            },
+                            "remove_block": {
+                                "id": "remove-person",
+                                "type": "ListRemoveQuestion",
+                                "question": {
+                                    "id": "remove-question",
+                                    "type": "General",
+                                    "title": "Are you sure you want to remove this person?",
+                                    "answers": [
+                                        {
+                                            "id": "remove-confirmation",
+                                            "mandatory": true,
+                                            "type": "Radio",
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "summary": {
+                                "add_link_text": "Add someone to this household",
+                                "empty_list_text": "There are no householders",
+                                "title": "Household members",
+                                "item_title": {
+                                    "text": "{person_name}",
+                                    "placeholders": [
+                                        {
+                                            "placeholder": "person_name",
+                                            "transforms": [
+                                                {
+                                                    "arguments": {
+                                                        "delimiter": " ",
+                                                        "list_to_concatenate": {
+                                                            "identifier": ["first-name", "last-name"],
+                                                            "source": "answers"
+                                                        }
+                                                    },
+                                                    "transform": "concatenate_list"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "groups": [
+                {
+                    "blocks": [
+                        {
+                            "id": "accommodation-type",
+                            "question": {
+                                "answers": [
+                                    {
+                                        "id": "accommodation-type-answer",
+                                        "mandatory": false,
+                                        "options": [
+                                            {
+                                                "label": "Whole house or bungalow",
+                                                "value": "Whole house or bungalow"
+                                            },
+                                            {
+                                                "description": "Including purpose-built flats and flats within converted and shared houses",
+                                                "label": "Flat, maisonette or apartment",
+                                                "value": "Flat, maisonette or apartment"
+                                            },
+                                            {
+                                                "label": "Caravan or other mobile or temporary structure",
+                                                "value": "Caravan or other mobile or temporary structure"
+                                            }
+                                        ],
+                                        "type": "Radio"
+                                    }
+                                ],
+                                "id": "accommodation-type-question",
+                                "title": "What type of accommodation is your house?",
+                                "type": "General"
+                            },
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "type-of-house",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "id": "accommodation-type-answer",
+                                                "value": "Whole house or bungalow"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "type-of-flat",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "id": "accommodation-type-answer",
+                                                "value": "Flat, maisonette or apartment"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "self-contained"
+                                    }
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "type-of-house",
+                            "question": {
+                                "answers": [
+                                    {
+                                        "id": "type-of-house-answer",
+                                        "mandatory": false,
+                                        "options": [
+                                            {
+                                                "label": "Detached",
+                                                "value": "Detached"
+                                            },
+                                            {
+                                                "label": "Semi-detached",
+                                                "value": "Semi-detached"
+                                            },
+                                            {
+                                                "description": "Including end-terrace",
+                                                "label": "Terraced",
+                                                "value": "Terraced"
+                                            }
+                                        ],
+                                        "type": "Radio"
+                                    }
+                                ],
+                                "id": "type-of-house-question",
+                                "title": "Which of the following is your house or bungalow?",
+                                "type": "General"
+                            },
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "self-contained"
+                                    }
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "type-of-flat",
+                            "question": {
+                                "answers": [
+                                    {
+                                        "id": "type-of-flat-answer",
+                                        "mandatory": false,
+                                        "options": [
+                                            {
+                                                "label": "In a purpose-built block of flats or tenement",
+                                                "value": "In a purpose-built block of flats or tenement"
+                                            },
+                                            {
+                                                "description": "Including bedsits",
+                                                "label": "Part of a converted or shared house",
+                                                "value": "Part of a converted or shared house"
+                                            },
+                                            {
+                                                "description": "For example, in an office building, hotel, or over a shop",
+                                                "label": "In a commercial building",
+                                                "value": "In a commercial building"
+                                            }
+                                        ],
+                                        "type": "Radio"
+                                    }
+                                ],
+                                "id": "type-of-flat-question",
+                                "title": "Where is your flat, maisonette or apartment?",
+                                "type": "General"
+                            },
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "self-contained"
+                                    }
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "self-contained",
+                            "question": {
+                                "answers": [
+                                    {
+                                        "id": "self-contained-answer",
+                                        "mandatory": false,
+                                        "options": [
+                                            {
+                                                "label": "Yes",
+                                                "value": "Yes"
+                                            },
+                                            {
+                                                "label": "No, one or more rooms are shared with another household",
+                                                "value": "No"
+                                            }
+                                        ],
+                                        "type": "Radio"
+                                    }
+                                ],
+                                "definitions": [
+                                    {
+                                        "contents": [
+                                            {
+                                                "description": "One person living alone; or a group of people, who are not necessarily related, living at the same address who share cooking facilities and share a living room or sitting room or dining area."
+                                            }
+                                        ],
+                                        "title": "What is a “household”?"
+                                    }
+                                ],
+                                "id": "self-contained-question",
+                                "title": "Are all the rooms in this accommodation, including the kitchen, bathroom and toilet, behind a door that only this household can use?",
+                                "type": "General"
+                            },
+                            "type": "Question"
+                        },
+                        {
+                            "id": "number-of-bedrooms",
+                            "question": {
+                                "answers": [
+                                    {
+                                        "id": "number-of-bedrooms-answer",
+                                        "label": "Number of bedrooms",
+                                        "mandatory": false,
+                                        "max_value": {
+                                            "value": 99
+                                        },
+                                        "type": "Number"
+                                    }
+                                ],
+                                "guidance": {
+                                    "contents": [
+                                        {
+                                            "title": "Include all rooms built or converted for use as bedrooms"
+                                        }
+                                    ]
+                                },
+                                "id": "number-of-bedrooms-question",
+                                "title": "How many bedrooms are available for use only by this household?",
+                                "type": "General"
+                            },
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "central-heating"
+                                    }
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "central-heating",
+                            "question": {
+                                "answers": [
+                                    {
+                                        "id": "central-heating-answer",
+                                        "mandatory": false,
+                                        "options": [
+                                            {
+                                                "label": "No central heating",
+                                                "value": "No central heating"
+                                            },
+                                            {
+                                                "label": "Mains gas",
+                                                "value": "Mains gas"
+                                            },
+                                            {
+                                                "label": "Tank or bottled gas",
+                                                "value": "Tank or bottled gas"
+                                            },
+                                            {
+                                                "description": "Including storage heaters",
+                                                "label": "Electric",
+                                                "value": "Electric"
+                                            },
+                                            {
+                                                "label": "Oil",
+                                                "value": "Oil"
+                                            },
+                                            {
+                                                "description": "For example, logs, waste wood or pellets",
+                                                "label": "Wood",
+                                                "value": "Wood"
+                                            },
+                                            {
+                                                "description": "For example, coal",
+                                                "label": "Solid fuel",
+                                                "value": "Solid fuel"
+                                            },
+                                            {
+                                                "description": "For example, solar thermal or heat pumps",
+                                                "label": "Renewable energy",
+                                                "value": "Renewable energy"
+                                            },
+                                            {
+                                                "label": "District or communal heat networks",
+                                                "value": "District or communal heat networks"
+                                            },
+                                            {
+                                                "label": "Other",
+                                                "value": "Other"
+                                            }
+                                        ],
+                                        "type": "Checkbox"
+                                    }
+                                ],
+                                "guidance": {
+                                    "contents": [
+                                        {
+                                            "title": "Include central heating systems that generate heat for multiple rooms whether or not you use them"
+                                        }
+                                    ]
+                                },
+                                "id": "central-heating-question",
+                                "title": "What type of central heating does your house have?",
+                                "type": "General"
+                            },
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "accommodation-section-summary",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "list": "people",
+                                                "value": 0
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "own-or-rent"
+                                    }
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "own-or-rent",
+                            "question": {
+                                "answers": [
+                                    {
+                                        "id": "own-or-rent-answer",
+                                        "mandatory": true,
+                                        "options": [
+                                            {
+                                                "label": "Owns outright",
+                                                "value": "Owns outright"
+                                            },
+                                            {
+                                                "label": "Owns with a mortgage or loan",
+                                                "value": "Owns with a mortgage or loan"
+                                            },
+                                            {
+                                                "description": "Shared ownership",
+                                                "label": "Part owns and part rents",
+                                                "value": "Part owns and part rents"
+                                            },
+                                            {
+                                                "description": "With or without housing benefit",
+                                                "label": "Rents",
+                                                "value": "Rents"
+                                            },
+                                            {
+                                                "label": "Lives here rent free",
+                                                "value": "Lives here rent free"
+                                            }
+                                        ],
+                                        "type": "Radio"
+                                    }
+                                ],
+                                "id": "own-or-rent-question",
+                                "title": "Does your household own or rent?",
+                                "type": "General"
+                            },
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "number-of-vehicles",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "id": "own-or-rent-answer",
+                                                "value": "Owns outright"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "number-of-vehicles",
+                                        "when": [
+                                            {
+                                                "condition": "equals",
+                                                "id": "own-or-rent-answer",
+                                                "value": "Owns with a mortgage or loan"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "who-rent-from"
+                                    }
+                                }
+                            ],
+                            "type": "Question"
+                        },
+                        {
+                            "id": "who-rent-from",
+                            "question": {
+                                "answers": [
+                                    {
+                                        "id": "who-rent-from-answer",
+                                        "mandatory": false,
+                                        "options": [
+                                            {
+                                                "label": "Housing association, housing co-operative, charitable trust, registered social landlord",
+                                                "value": "Housing association, housing co-operative, charitable trust, registered social landlord"
+                                            },
+                                            {
+                                                "label": "Council or local authority",
+                                                "value": "Council or local authority"
+                                            },
+                                            {
+                                                "label": "Private landlord or letting agency",
+                                                "value": "Private landlord or letting agency"
+                                            },
+                                            {
+                                                "label": "Employer of a household member",
+                                                "value": "Employer of a household member"
+                                            },
+                                            {
+                                                "label": "Relative or friend of a household member",
+                                                "value": "Relative or friend of a household member"
+                                            },
+                                            {
+                                                "label": "Other",
+                                                "value": "Other"
+                                            }
+                                        ],
+                                        "type": "Radio"
+                                    }
+                                ],
+                                "id": "who-rent-from-question",
+                                "title": "Who is your landlord?",
+                                "type": "General"
+                            },
+                            "type": "Question"
+                        },
+                        {
+                            "id": "number-of-vehicles",
+                            "question": {
+                                "answers": [
+                                    {
+                                        "id": "number-of-vehicles-answer",
+                                        "mandatory": false,
+                                        "options": [
+                                            {
+                                                "label": "None",
+                                                "value": "None"
+                                            },
+                                            {
+                                                "label": "1",
+                                                "value": "1"
+                                            },
+                                            {
+                                                "label": "2",
+                                                "value": "2"
+                                            },
+                                            {
+                                                "label": "3",
+                                                "value": "3"
+                                            },
+                                            {
+                                                "description": "Select to enter number",
+                                                "detail_answer": {
+                                                    "id": "number-of-vehicles-answer-other",
+                                                    "label": "Enter the number of cars or vans",
+                                                    "mandatory": false,
+                                                    "max_value": {
+                                                        "value": 20
+                                                    },
+                                                    "type": "Number"
+                                                },
+                                                "label": "4 or more",
+                                                "value": "4 or more"
+                                            }
+                                        ],
+                                        "type": "Radio"
+                                    }
+                                ],
+                                "guidance": {
+                                    "contents": [
+                                        {
+                                            "title": "Include any company cars or vans available for private use."
+                                        }
+                                    ]
+                                },
+                                "id": "number-of-vehicles-question",
+                                "title": "In total, how many cars or vans are owned, or available for use, by members of this household?",
+                                "type": "General"
+                            },
+                            "type": "Question"
+                        },
+                        {
+                            "id": "accommodation-section-summary",
+                            "type": "SectionSummary"
+                        }
+                    ],
+                    "id": "accommodation-group",
+                    "title": ""
+                }
+            ],
+            "id": "accommodation-section",
+            "title": "Household accommodation"
+        }
+    ]
+}

--- a/tests/app/questionnaire/test_questionnaire_schema.py
+++ b/tests/app/questionnaire/test_questionnaire_schema.py
@@ -519,6 +519,116 @@ def test_get_all_questions_for_block_question():
     assert all_questions[0]['answers'][0]['id'] == 'answer1'
 
 
+def test_get_all_when_rules_by_list_name():
+    survey_json = {
+        'sections': [
+            {
+                'id': 'section1',
+                'groups': [
+                    {
+                        'id': 'group1',
+                        'blocks': [
+                            {
+                                'id': 'list-collector',
+                                'type': 'ListCollector',
+                                'for_list': 'list',
+                                'question': {},
+                                'add_block': {
+                                    'id': 'add-block',
+                                    'type': 'ListAddQuestion',
+                                    'question': {},
+                                },
+                                'edit_block': {
+                                    'id': 'edit-block',
+                                    'type': 'ListEditQuestion',
+                                    'question': {},
+                                },
+                                'remove_block': {
+                                    'id': 'remove-block',
+                                    'type': 'ListRemoveQuestion',
+                                    'question': {},
+                                },
+                            }
+                        ],
+                    }
+                ],
+            },
+            {
+                'id': 'section2',
+                'groups': [
+                    {
+                        'id': 'group2',
+                        'blocks': [
+                            {
+                                'type': 'Question',
+                                'id': 'block2',
+                                'question': {
+                                    'answers': [
+                                        {
+                                            'id': 'answer1',
+                                            'mandatory': True,
+                                            'type': 'General',
+                                        }
+                                    ],
+                                    'id': 'question1',
+                                    'title': {'text': 'Does anyone else live here?'},
+                                    'type': 'General',
+                                },
+                                'when': [
+                                    {
+                                        'condition': 'greater than',
+                                        'list': 'list',
+                                        'value': 0,
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            },
+            {
+                'id': 'section3',
+                'groups': [
+                    {
+                        'id': 'group3',
+                        'blocks': [
+                            {
+                                'type': 'Question',
+                                'id': 'block3',
+                                'question': {
+                                    'answers': [
+                                        {
+                                            'id': 'answer1',
+                                            'mandatory': True,
+                                            'type': 'General',
+                                        }
+                                    ],
+                                    'id': 'question1',
+                                    'title': {'text': 'Does anyone else live here?'},
+                                    'type': 'General',
+                                },
+                                'when': [
+                                    {
+                                        'condition': 'greater than',
+                                        'list': 'not-the-list',
+                                        'value': 0,
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            },
+        ]
+    }
+
+    schema = QuestionnaireSchema(survey_json)
+    when_blocks = schema.get_sections_associated_to_list_name('list')
+
+    assert len(when_blocks) == 1
+    assert 'section2' in when_blocks
+
+
 def test_get_all_questions_for_block_question_variants():
     block = {
         'id': 'block1',

--- a/tests/app/questionnaire/test_questionnaire_store_updater.py
+++ b/tests/app/questionnaire/test_questionnaire_store_updater.py
@@ -302,3 +302,41 @@ class TestQuestionnaireStoreUpdater(unittest.TestCase):
                     'test-relationship-collector'
                 )
             )
+
+    def test_sections_to_evaluate_no_filter(self):
+        list_store = fake_list_store()
+        questionnaire_store = MagicMock(
+            spec=QuestionnaireStore,
+            completed_blocks=[],
+            answer_store=self.answer_store,
+            list_store=list_store,
+            progress_store=self.progress_store,
+        )
+        questionnaire_store_updater = QuestionnaireStoreUpdater(
+            self.location, self.schema, questionnaire_store, self.current_question
+        )
+
+        self.progress_store.completed_section_keys = MagicMock()
+        self.progress_store.completed_section_keys.return_value = set(['a', 'b'])
+
+        section_keys = questionnaire_store_updater.sections_to_evaluate()
+        self.assertEqual(sorted(section_keys), ['a', 'b'])
+
+    def test_sections_to_evaluate_with_filter(self):
+        list_store = fake_list_store()
+        questionnaire_store = MagicMock(
+            spec=QuestionnaireStore,
+            completed_blocks=[],
+            answer_store=self.answer_store,
+            list_store=list_store,
+            progress_store=self.progress_store,
+        )
+        questionnaire_store_updater = QuestionnaireStoreUpdater(
+            self.location, self.schema, questionnaire_store, self.current_question
+        )
+
+        self.progress_store.completed_section_keys = MagicMock()
+        self.progress_store.completed_section_keys.return_value = set(['a', 'b'])
+
+        section_keys = questionnaire_store_updater.sections_to_evaluate(set(['a']))
+        self.assertEqual(section_keys, ['a'])

--- a/tests/integration/questionnaire/test_questionnaire_list_change_evaluates_sections.py
+++ b/tests/integration/questionnaire/test_questionnaire_list_change_evaluates_sections.py
@@ -1,0 +1,53 @@
+from tests.integration.integration_test_case import IntegrationTestCase
+
+
+class TestQuestionnaireListChangeEvaluatesSections(IntegrationTestCase):
+    def add_person(self, first_name, last_name):
+        self.post({'anyone-else': 'Yes'})
+        self.post({'first-name': first_name, 'last-name': last_name})
+
+    def get_link(self, rowIndex, text):
+        selector = f'tbody:nth-child({rowIndex}) td:last-child a'
+        selected = self.getHtmlSoup().select(selector)
+
+        filtered = [html for html in selected if text in html.get_text()]
+
+        return filtered[0].get('href')
+
+    def get_previous_link(self):
+        selector = '#top-previous'
+        selected = self.getHtmlSoup().select(selector)
+        return selected[0].get('href')
+
+    def test_happy_path(self):
+        self.launchSurvey('test_list_change_evaluates_sections')
+
+        self.get('/questionnaire/sections/who-lives-here')
+        self.assertEqualUrl('/questionnaire/list-collector/')
+
+        self.post({'anyone-else': 'No'})
+        self.assertEqualUrl('/questionnaire/')
+
+        self.get('/questionnaire/sections/accommodation-section/')
+        self.assertEqualUrl('/questionnaire/accommodation-type/')
+
+        self.post(action='save_continue')
+        self.post(action='save_continue')
+        self.post(action='save_continue')
+        self.post(action='save_continue')
+        self.post()
+        self.assertEqualUrl('/questionnaire/')
+
+        self.get('/questionnaire/sections/who-lives-here')
+        self.assertEqualUrl('/questionnaire/list-collector/')
+
+        self.add_person('John', 'Doe')
+        self.post({'anyone-else': 'No'})
+        self.assertEqualUrl('/questionnaire/')
+
+        self.assertInSelector(
+            'Partially completed', 'tbody:nth-child(2) td:nth-child(2)'
+        )
+
+        self.get('questionnaire/sections/accommodation-section/')
+        self.assertEqualUrl('/questionnaire/own-or-rent/')


### PR DESCRIPTION
### What is the context of this PR?
Section status needs to be re-evaluated on a list change when a section is linked to a list via when rules.

This PR introduces the mechanism for updating the section status on a post to a ListAction block type.

### How to review 
Run the full test suite.
Review code.
