### PR TITLE
Removed automatically adding language code query param on getting sch…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,31 @@
 dist: xenial
 sudo: true
 addons:
-  apt:
-    sources:
-      - google-chrome
-    packages:
-      - google-chrome-stable
-      - libsnappy-dev
+    chrome: stable
+    apt:
+        packages:
+            - libsnappy-dev
 language: node_js
 node_js: 6
 env:
-  global:
-    - EQ_RUN_LOCAL_LINT=True
-    - EQ_RUN_LOCAL_TESTS=True
-    - EQ_RUN_DOCKER_UP=True
-    - EQ_RUN_FUNCTIONAL_TESTS=True
-    - EQ_RUN_FUNCTIONAL_TESTS_HEADLESS=True
-    - EQ_DYNAMODB_ENDPOINT=http://localhost:6060
-    - EQ_SUBMITTED_RESPONSES_TABLE_NAME=dev-submitted-responses
-    - EQ_QUESTIONNAIRE_STATE_TABLE_NAME=dev-questionnaire-state
-    - EQ_QUESTIONNAIRE_STATE_DYNAMO_READ=True
-    - EQ_QUESTIONNAIRE_STATE_DYNAMO_WRITE=True
-    - EQ_SESSION_TABLE_NAME=dev-eq-session
-    - EQ_USED_JTI_CLAIM_TABLE_NAME=dev-used-jti-claim
-    - AWS_DEFAULT_REGION=eu-west-1
-    - AWS_ACCESS_KEY_ID=dummy-access-key
-    - AWS_SECRET_ACCESS_KEY=dummy-secret-key
-    # Codacy
-    - secure: q3hyZhRj24C5sT7T0ViTDCwhT8eVjpanTf6BkPPBI43/6NBJeF1vi4/LkfJMQa0qwYibu5zB8jtkk2VsqGRMGvj9fMufOKXGqebOsPYWUJl1MZM3t7OZS57xF9wBUenZwx1oyb/VPrFB56ctGny1XEbF4l47NmbKWD1iMWG1f3Y6PCJ7o8o62v0irmfbdYFTsWjipCQlCrKZm+KVWZD25egIDJMDpq9e0nYNoSW+5fMXDGOtV20/U/rcmW5Lfn06ppJ0C4CaKHuM+MzZtZJwtiCI2TqF0ihQl7ry7YgpqEZLPHQYQ5npIpecxP1f/6ebcAPdKKkJ2Ccutrv/7IFlJo7rWLTB7mzJ4ep11HCdo3mL+JREp1HUJLeEngXFC3lKRXPHKukUxe4Lkz1/g6kdwCUZxajGTwML84FHmqoZxKGMKhMN+0n6rO8wEUR32q4+JbO5z/oQGhtjQZkogq8vWY6+/aq328hsbmy72s23AiX+BQUHqk2QFs3T9FQiqwn4OqqX4JKzmHs838LT+dUTFgH+mWo0lalxa3Pr7cJAwhn97VSnIdU9JTC8RyPWbAHkah78PXlL9guHI1nzQTjTcMm/yTlmtE2NxTSY+ZGIV+O5pcJm3HkAjZvNi/0jjDWwBHs/rZgj1t7Eoueh8dPTSZ12LmqKuBpvkrzLKcs2zt4=
+    global:
+        - EQ_RUN_LOCAL_LINT=True
+        - EQ_RUN_LOCAL_TESTS=True
+        - EQ_RUN_DOCKER_UP=True
+        - EQ_RUN_FUNCTIONAL_TESTS=True
+        - EQ_RUN_FUNCTIONAL_TESTS_HEADLESS=True
+        - EQ_DYNAMODB_ENDPOINT=http://localhost:6060
+        - EQ_SUBMITTED_RESPONSES_TABLE_NAME=dev-submitted-responses
+        - EQ_QUESTIONNAIRE_STATE_TABLE_NAME=dev-questionnaire-state
+        - EQ_QUESTIONNAIRE_STATE_DYNAMO_READ=True
+        - EQ_QUESTIONNAIRE_STATE_DYNAMO_WRITE=True
+        - EQ_SESSION_TABLE_NAME=dev-eq-session
+        - EQ_USED_JTI_CLAIM_TABLE_NAME=dev-used-jti-claim
+        - AWS_DEFAULT_REGION=eu-west-1
+        - AWS_ACCESS_KEY_ID=dummy-access-key
+        - AWS_SECRET_ACCESS_KEY=dummy-secret-key
+        # Codacy
+        - secure: q3hyZhRj24C5sT7T0ViTDCwhT8eVjpanTf6BkPPBI43/6NBJeF1vi4/LkfJMQa0qwYibu5zB8jtkk2VsqGRMGvj9fMufOKXGqebOsPYWUJl1MZM3t7OZS57xF9wBUenZwx1oyb/VPrFB56ctGny1XEbF4l47NmbKWD1iMWG1f3Y6PCJ7o8o62v0irmfbdYFTsWjipCQlCrKZm+KVWZD25egIDJMDpq9e0nYNoSW+5fMXDGOtV20/U/rcmW5Lfn06ppJ0C4CaKHuM+MzZtZJwtiCI2TqF0ihQl7ry7YgpqEZLPHQYQ5npIpecxP1f/6ebcAPdKKkJ2Ccutrv/7IFlJo7rWLTB7mzJ4ep11HCdo3mL+JREp1HUJLeEngXFC3lKRXPHKukUxe4Lkz1/g6kdwCUZxajGTwML84FHmqoZxKGMKhMN+0n6rO8wEUR32q4+JbO5z/oQGhtjQZkogq8vWY6+/aq328hsbmy72s23AiX+BQUHqk2QFs3T9FQiqwn4OqqX4JKzmHs838LT+dUTFgH+mWo0lalxa3Pr7cJAwhn97VSnIdU9JTC8RyPWbAHkah78PXlL9guHI1nzQTjTcMm/yTlmtE2NxTSY+ZGIV+O5pcJm3HkAjZvNi/0jjDWwBHs/rZgj1t7Eoueh8dPTSZ12LmqKuBpvkrzLKcs2zt4=
 before_install:
     - export BOTO_CONFIG=/dev/null # Workaround for https://github.com/travis-ci/travis-ci/issues/7940
     - cd /opt/pyenv/plugins/python-build/../.. && git pull origin master && cd -
@@ -42,8 +40,8 @@ cache:
     - yarn
     - pip
     - directories:
-        - /opt/python/
-        - /home/travis/.local/share/
+          - /opt/python/
+          - /home/travis/.local/share/
 script:
     - set -e
     - yarn compile

--- a/app/utilities/schema.py
+++ b/app/utilities/schema.py
@@ -57,16 +57,12 @@ def _load_schema_file(schema_file, language_code):
 
 @cache.memoize()
 def load_schema_from_url(survey_url, language_code):
-    language_code = language_code or DEFAULT_LANGUAGE_CODE
-    logger.info('loading schema from URL', survey_url=survey_url, language_code=language_code)
 
-    constructed_survey_url = '{}?language={}'.format(survey_url, language_code)
-
-    req = requests.get(constructed_survey_url)
+    req = requests.get(survey_url)
     schema_response = req.content.decode()
 
     if req.status_code == 404:
-        logger.error('no schema exists', survey_url=constructed_survey_url)
+        logger.error('no schema exists', survey_url=survey_url)
         raise NotFound
 
     return QuestionnaireSchema(json.loads(schema_response), language_code)


### PR DESCRIPTION
…ema by url

### What is the context of this PR?
The ability to get a schema by url automatically loads in the `?language=en` query parameter; this should not be the case when we add the ability to get a schema from the survey registry, as we use query parameters to do this. Ideally, we want to be able to just send Runner a URL and it will load in the schema from there.

Spoke to Torrence and to his knowledge RASRM don't use language codes

### How to review 
Ensure tests pass.
