### PR TITLE
Updated qcode and rolled back mbs + construction changes

### DIFF
--- a/data/en/construction_0001.json
+++ b/data/en/construction_0001.json
@@ -6,1548 +6,1802 @@
     "data_version": "0.0.1",
     "survey_id": "228",
     "title": "Monthly Business Survey - Construction and Allied Trades",
-    "sections": [{
+    "sections": [
+        {
             "id": "sectionb1d09333-c7fd-464a-a840-f86056fb32cf",
             "title": "Reporting period",
-            "groups": [{
-                "id": "groupb1d09333-c7fd-464a-a840-f86056fb32cf",
-                "title": "Reporting period",
-                "blocks": [{
-                        "type": "Introduction",
-                        "id": "introduction-block",
-                        "primary_content": [{
-                            "type": "Basic",
-                            "id": "primary",
-                            "content": [{
-                                "description": "<div class=\"panel panel--simple panel--info\"><div class=\"panel__body\"><h2 class=\"venus\">Coronavirus (COVID-19) additional guidance </h2><p><strong>If you have not traded for all, or some, of the period</strong>: still select 'yes, you can provide figures' and enter value of work, even if this is '0'.</br> <strong>Exclude</strong> furlough payments received in figures.</br> <strong>Explain figures</strong> in the comments section to minimise us contacting you and to help us tell an industry story.</p></div></div>",
-                                "list": [
-                                    "Data should relate to all sites in England, Scotland and Wales but excludes Northern Ireland.",
-                                    "You can provide informed estimates if actual figures are not available.",
-                                    "We will treat your data securely and confidentially."
-                                ]
-                            }]
-                        }],
-                        "preview_content": {
-                            "id": "preview",
-                            "title": "Information you need",
-                            "content": [{
-                                    "description": "<a href='https://www.ons.gov.uk/surveys/informationforbusinesses/businesssurveys/monthlybusinesssurveyforconstructionandalliedtrades'><p>View the survey information and questions before you start the survey (external link)</p></a>"
-                                },
+            "groups": [
+                {
+                    "id": "groupb1d09333-c7fd-464a-a840-f86056fb32cf",
+                    "title": "Reporting period",
+                    "blocks": [
+                        {
+                            "type": "Introduction",
+                            "id": "introduction-block",
+                            "primary_content": [
                                 {
-                                    "description": "You will be asked to provide information on the value of work undertaken by your business. Value of work refers to estimates of chargeable work carried out during the month; meaning work started, in progress, or completed."
+                                    "type": "Basic",
+                                    "id": "primary",
+                                    "content": [
+                                        {
+                                            "list": [
+                                                "Data should relate to all sites in England, Scotland and Wales but excludes Northern Ireland.",
+                                                "You can provide informed estimates if actual figures are not available.",
+                                                "We will treat your data securely and confidentially."
+                                            ]
+                                        }
+                                    ]
                                 }
                             ],
-                            "questions": [{
-                                    "question": "Housing Work",
-                                    "content": [{
-                                            "description": "This section asks for information on the value of new builds and repair and maintenance (R&amp;M), improvements and major alterations on housing for public and private sector projects."
-                                        },
-                                        {
-                                            "description": "<strong>Include:</strong>"
-                                        },
-                                        {
-                                            "list": [
-                                                "work on buildings which you hope to sell later for profit (speculative work)",
-                                                "work done by your business on its own premises",
-                                                "fixtures, equipment and tools your business made and used in construction",
-                                                "materials your business used, overheads and profits",
-                                                "labour costs on your payroll"
-                                            ]
-                                        },
-                                        {
-                                            "description": "<strong>Exclude:</strong>"
-                                        },
-                                        {
-                                            "list": [
-                                                "VAT",
-                                                "payments made to subcontractors",
-                                                "payments made to consultants or architects",
-                                                "fixtures, equipment and tools your business made for sale",
-                                                "materials your business sold",
-                                                "value of land"
-                                            ]
-                                        }
-                                    ]
-                                },
+                            "preview_content": {
+                                "id": "preview",
+                                "title": "Information you need",
+                                "content": [
+                                    {
+                                        "description": "You will be asked to provide information on the value of work undertaken by your business. Value of work refers to estimates of chargeable work carried out during the month; meaning work started, in progress, or completed."
+                                    }
+                                ],
+                                "questions": [
+                                    {
+                                        "question": "Housing Work",
+                                        "content": [
+                                            {
+                                                "description": "This section asks for information on the value of new builds and repair and maintenance (R&amp;M), improvements and major alterations on housing for public and private sector projects."
+                                            },
+                                            {
+                                                "description": "<strong>Include:</strong>"
+                                            },
+                                            {
+                                                "list": [
+                                                    "work on buildings which you hope to sell later for profit (speculative work)",
+                                                    "work done by your business on its own premises",
+                                                    "fixtures, equipment and tools your business made and used in construction",
+                                                    "materials your business used, overheads and profits",
+                                                    "labour costs on your payroll"
+                                                ]
+                                            },
+                                            {
+                                                "description": "<strong>Exclude:</strong>"
+                                            },
+                                            {
+                                                "list": [
+                                                    "VAT",
+                                                    "payments made to subcontractors",
+                                                    "payments made to consultants or architects",
+                                                    "fixtures, equipment and tools your business made for sale",
+                                                    "materials your business sold",
+                                                    "value of land"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "question": "Infrastructure",
+                                        "content": [
+                                            {
+                                                "description": "This section asks for information on the value of new infrastructure, and repair and maintenance (R&amp;M) of infrastructure."
+                                            },
+                                            {
+                                                "description": "<strong>Include:</strong>"
+                                            },
+                                            {
+                                                "list": [
+                                                    "work done by your own business on its own business premises",
+                                                    "fixtures, equipment and tools your business made and used in construction",
+                                                    "materials your business used, overheads and profits",
+                                                    "labour costs on your payroll"
+                                                ]
+                                            },
+                                            {
+                                                "description": "<strong>Exclude:</strong>"
+                                            },
+                                            {
+                                                "list": [
+                                                    "VAT",
+                                                    "payments made to subcontractors",
+                                                    "payments made to consultants or architects",
+                                                    "fixtures, equipment and tools your business made for sale",
+                                                    "materials your business sold",
+                                                    "value of land"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "question": "Other construction work",
+                                        "content": [
+                                            {
+                                                "description": "This section asks for information on the value of other construction work carried out on new structures for public, commercial and industrial projects, and repair and maintenance (R&amp;M) of existing structures."
+                                            },
+                                            {
+                                                "description": "<strong>Include:</strong>"
+                                            },
+                                            {
+                                                "list": [
+                                                    "work on buildings which you hope to sell later for profit (speculative work)",
+                                                    "work done by your business on its own premises",
+                                                    "fixtures, equipment and tools your business made and used in construction",
+                                                    "materials your business used, overheads and profits",
+                                                    "labour costs on your payroll"
+                                                ]
+                                            },
+                                            {
+                                                "description": "<strong>Exclude:</strong>"
+                                            },
+                                            {
+                                                "list": [
+                                                    "work on infrastructure",
+                                                    "work on residential buildings",
+                                                    "VAT",
+                                                    "payments made to subcontractors",
+                                                    "payments made to consultants or architects",
+                                                    "fixtures, equipment and tools your business made for sale",
+                                                    "materials your business sold",
+                                                    "value of land"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "question": "Additional comments",
+                                        "content": [
+                                            {
+                                                "description": "Please tell us about any additional comments you have about your data."
+                                            },
+                                            {
+                                                "description": "<strong>For example:</strong>"
+                                            },
+                                            {
+                                                "description": "My figures are <em>lower than usual</em> this month due to:"
+                                            },
+                                            {
+                                                "list": ["adverse weather conditions", "economic downturn", "my business ceasing trading"]
+                                            },
+                                            {
+                                                "description": "My figures are <em>higher than usual</em> this month due to:"
+                                            },
+                                            {
+                                                "list": ["a new contract", "a large contract", "seasonal work"]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "secondary_content": [
                                 {
-                                    "question": "Infrastructure",
-                                    "content": [{
-                                            "description": "This section asks for information on the value of new infrastructure, and repair and maintenance (R&amp;M) of infrastructure."
-                                        },
-                                        {
-                                            "description": "<strong>Include:</strong>"
-                                        },
+                                    "id": "secondary-content",
+                                    "title": "How we use your data",
+                                    "content": [
                                         {
                                             "list": [
-                                                "work done by your own business on its own business premises",
-                                                "fixtures, equipment and tools your business made and used in construction",
-                                                "materials your business used, overheads and profits",
-                                                "labour costs on your payroll"
+                                                "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
+                                                "The information you provide contributes to Gross Domestic Product (GDP). The Monthly Business Survey figures are published monthly in the Output in the Construction Industry Statistical Bulletin."
                                             ]
-                                        },
-                                        {
-                                            "description": "<strong>Exclude:</strong>"
-                                        },
-                                        {
-                                            "list": [
-                                                "VAT",
-                                                "payments made to subcontractors",
-                                                "payments made to consultants or architects",
-                                                "fixtures, equipment and tools your business made for sale",
-                                                "materials your business sold",
-                                                "value of land"
-                                            ]
-                                        }
-                                    ]
-                                },
-                                {
-                                    "question": "Other construction work",
-                                    "content": [{
-                                            "description": "This section asks for information on the value of other construction work carried out on new structures for public, commercial and industrial projects, and repair and maintenance (R&amp;M) of existing structures."
-                                        },
-                                        {
-                                            "description": "<strong>Include:</strong>"
-                                        },
-                                        {
-                                            "list": [
-                                                "work on buildings which you hope to sell later for profit (speculative work)",
-                                                "work done by your business on its own premises",
-                                                "fixtures, equipment and tools your business made and used in construction",
-                                                "materials your business used, overheads and profits",
-                                                "labour costs on your payroll"
-                                            ]
-                                        },
-                                        {
-                                            "description": "<strong>Exclude:</strong>"
-                                        },
-                                        {
-                                            "list": [
-                                                "work on infrastructure",
-                                                "work on residential buildings",
-                                                "VAT",
-                                                "payments made to subcontractors",
-                                                "payments made to consultants or architects",
-                                                "fixtures, equipment and tools your business made for sale",
-                                                "materials your business sold",
-                                                "value of land"
-                                            ]
-                                        }
-                                    ]
-                                },
-                                {
-                                    "question": "Additional comments",
-                                    "content": [{
-                                            "description": "Please tell us about any additional comments you have about your data."
-                                        },
-                                        {
-                                            "description": "<strong>For example:</strong>"
-                                        },
-                                        {
-                                            "description": "My figures are <em>lower than usual</em> this month due to:"
-                                        },
-                                        {
-                                            "list": ["adverse weather conditions", "economic downturn", "my business ceasing trading"]
-                                        },
-                                        {
-                                            "description": "My figures are <em>higher than usual</em> this month due to:"
-                                        },
-                                        {
-                                            "list": ["a new contract", "a large contract", "seasonal work"]
                                         }
                                     ]
                                 }
                             ]
                         },
-                        "secondary_content": [{
-                            "id": "secondary-content",
-                            "title": "How we use your data",
-                            "content": [{
-                                "list": [
-                                    "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
-                                    "The information you provide contributes to Gross Domestic Product (GDP). The Monthly Business Survey figures are published monthly in the Output in the Construction Industry Statistical Bulletin."
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "blockb859977c-01e2-498a-807e-5438af81fdd2",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questionb859977c-01e2-498a-807e-5438af81fdd2",
-                            "title": "Are you able to report for the calendar month {{ metadata['ref_p_start_date'] | format_date }} to {{ metadata['ref_p_end_date'] | format_date }}?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answerdadafe6c-4875-43bc-87e2-6097ff0d106e",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "901",
-                                "options": [{
-                                        "label": "Yes, I can report for this period",
-                                        "value": "Yes, I can report for this period"
-                                    },
-                                    {
-                                        "label": "No, I need to report for a different period",
-                                        "value": "No, I need to report for a different period"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "group": "group7e41e171-26eb-42c0-99ef-b34fa447c363",
-                                    "when": [{
-                                        "id": "answerdadafe6c-4875-43bc-87e2-6097ff0d106e",
-                                        "condition": "contains any",
-                                        "values": ["Yes, I can report for this period"]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block09dffdbc-5a11-424a-8da2-388b91b16e51"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "id": "block09dffdbc-5a11-424a-8da2-388b91b16e51",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question09dffdbc-5a11-424a-8da2-388b91b16e51",
-                            "title": "What dates will you be reporting for?",
-                            "type": "DateRange",
-                            "answers": [{
-                                    "id": "answer440c8850-b115-4f6b-b0f5-52d911dd6ef6from",
-                                    "type": "Date",
-                                    "mandatory": true,
-                                    "label": "From",
-                                    "q_code": "11",
-                                    "minimum": {
-                                        "meta": "ref_p_start_date",
-                                        "offset_by": {
-                                            "days": -19
+                        {
+                            "id": "blockb859977c-01e2-498a-807e-5438af81fdd2",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "questionb859977c-01e2-498a-807e-5438af81fdd2",
+                                    "title": "Are you able to report for the calendar month {{ metadata['ref_p_start_date'] | format_date }} to {{ metadata['ref_p_end_date'] | format_date }}?",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answerdadafe6c-4875-43bc-87e2-6097ff0d106e",
+                                            "mandatory": true,
+                                            "type": "Radio",
+                                            "label": "",
+                                            "description": "",
+                                            "q_code": "901",
+                                            "options": [
+                                                {
+                                                    "label": "Yes, I can report for this period",
+                                                    "value": "Yes, I can report for this period"
+                                                },
+                                                {
+                                                    "label": "No, I need to report for a different period",
+                                                    "value": "No, I need to report for a different period"
+                                                }
+                                            ]
                                         }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "group": "group7e41e171-26eb-42c0-99ef-b34fa447c363",
+                                        "when": [
+                                            {
+                                                "id": "answerdadafe6c-4875-43bc-87e2-6097ff0d106e",
+                                                "condition": "contains any",
+                                                "values": ["Yes, I can report for this period"]
+                                            }
+                                        ]
                                     }
                                 },
                                 {
-                                    "id": "answer440c8850-b115-4f6b-b0f5-52d911dd6ef6to",
-                                    "type": "Date",
-                                    "mandatory": true,
-                                    "label": "To",
-                                    "q_code": "12",
-                                    "maximum": {
-                                        "meta": "ref_p_end_date",
-                                        "offset_by": {
-                                            "days": 20
+                                    "goto": {
+                                        "block": "block09dffdbc-5a11-424a-8da2-388b91b16e51"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block09dffdbc-5a11-424a-8da2-388b91b16e51",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question09dffdbc-5a11-424a-8da2-388b91b16e51",
+                                    "title": "What dates will you be reporting for?",
+                                    "type": "DateRange",
+                                    "answers": [
+                                        {
+                                            "id": "answer440c8850-b115-4f6b-b0f5-52d911dd6ef6from",
+                                            "type": "Date",
+                                            "mandatory": true,
+                                            "label": "From",
+                                            "q_code": "11",
+                                            "minimum": {
+                                                "meta": "ref_p_start_date",
+                                                "offset_by": {
+                                                    "days": -19
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "id": "answer440c8850-b115-4f6b-b0f5-52d911dd6ef6to",
+                                            "type": "Date",
+                                            "mandatory": true,
+                                            "label": "To",
+                                            "q_code": "12",
+                                            "maximum": {
+                                                "meta": "ref_p_end_date",
+                                                "offset_by": {
+                                                    "days": 20
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "period_limits": {
+                                        "minimum": {
+                                            "days": 23
+                                        },
+                                        "maximum": {
+                                            "days": 50
                                         }
                                     }
                                 }
-                            ],
-                            "period_limits": {
-                                "minimum": {
-                                    "days": 23
-                                },
-                                "maximum": {
-                                    "days": 50
-                                }
-                            }
-                        }]
-                    }
-                ]
-            }]
+                            ]
+                        }
+                    ]
+                }
+            ]
         },
         {
             "id": "section7e41e171-26eb-42c0-99ef-b34fa447c363",
             "title": "Value of work",
-            "groups": [{
-                "id": "group7e41e171-26eb-42c0-99ef-b34fa447c363",
-                "title": "Value of work",
-                "blocks": [{
-                        "type": "Interstitial",
-                        "id": "group7e41e171-26eb-42c0-99ef-b34fa447c363-introduction",
-                        "title": "This survey requires you to report the value of work",
-                        "description": "<p>Value of work refers to estimates of <em>chargeable work</em> carried out during the month. This includes work started, work in progress and work completed.</p>"
-                    },
-                    {
-                        "id": "block69ae90ee-65a6-49ef-8ca9-1c55c9eb6688",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question69ae90ee-65a6-49ef-8ca9-1c55c9eb6688",
-                            "title": "During the period {{ format_conditional_date (answers['answer440c8850-b115-4f6b-b0f5-52d911dd6ef6from'], metadata['ref_p_start_date']) }} to {{ format_conditional_date (answers['answer440c8850-b115-4f6b-b0f5-52d911dd6ef6to'], metadata['ref_p_end_date']) }}, what was the <em>total value of all construction work</em> carried out by {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
-                            "description": "<p>If you are a fitter or installer, you are included within the construction industry so should report your figures.</p>",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "new builds and repair and maintenance (R&amp;M) on housing and other residential properties, infrastructure, commercial structures and industrial structures",
-                                            "(speculative) work on buildings which you hope to sell later for profit",
-                                            "work done by your business on its own premises",
-                                            "fixtures, equipment and tools your business made and used in construction",
-                                            "materials your business used, overheads and profits",
-                                            "labour costs on your payroll"
+            "groups": [
+                {
+                    "id": "group7e41e171-26eb-42c0-99ef-b34fa447c363",
+                    "title": "Value of work",
+                    "blocks": [
+                        {
+                            "type": "Interstitial",
+                            "id": "group7e41e171-26eb-42c0-99ef-b34fa447c363-introduction",
+                            "title": "This survey requires you to report the value of work",
+                            "description": "<p>Value of work refers to estimates of <em>chargeable work</em> carried out during the month. This includes work started, work in progress and work completed.</p>"
+                        },
+                        {
+                            "id": "block69ae90ee-65a6-49ef-8ca9-1c55c9eb6688",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question69ae90ee-65a6-49ef-8ca9-1c55c9eb6688",
+                                    "title": "During the period {{ format_conditional_date (answers['answer440c8850-b115-4f6b-b0f5-52d911dd6ef6from'], metadata['ref_p_start_date']) }} to {{ format_conditional_date (answers['answer440c8850-b115-4f6b-b0f5-52d911dd6ef6to'], metadata['ref_p_end_date']) }}, what was the <em>total value of all construction work</em> carried out by {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                                    "description": "<p>If you are a fitter or installer, you are included within the construction industry so should report your figures.</p>",
+                                    "guidance": {
+                                        "content": [
+                                            {
+                                                "description": "<strong>Include:</strong>"
+                                            },
+                                            {
+                                                "list": [
+                                                    "new builds and repair and maintenance (R&amp;M) on housing and other residential properties, infrastructure, commercial structures and industrial structures",
+                                                    "(speculative) work on buildings which you hope to sell later for profit",
+                                                    "work done by your business on its own premises",
+                                                    "fixtures, equipment and tools your business made and used in construction",
+                                                    "materials your business used, overheads and profits",
+                                                    "labour costs on your payroll"
+                                                ]
+                                            },
+                                            {
+                                                "description": "<strong>Exclude:</strong>"
+                                            },
+                                            {
+                                                "list": [
+                                                    "VAT",
+                                                    "payments made to subcontractors",
+                                                    "payments made to consultants or architects",
+                                                    "fixtures, equipment and tools your business made for sale",
+                                                    "materials your business sold",
+                                                    "value of land"
+                                                ]
+                                            }
                                         ]
                                     },
-                                    {
-                                        "description": "<strong>Exclude:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "VAT",
-                                            "payments made to subcontractors",
-                                            "payments made to consultants or architects",
-                                            "fixtures, equipment and tools your business made for sale",
-                                            "materials your business sold",
-                                            "value of land"
+                                    "definitions": [
+                                        {
+                                            "title": "What we mean by \"total value of all construction work\"",
+                                            "content": [
+                                                {
+                                                    "description": "This refers to <em>all work on new structures and repair and maintenance (R&amp;M) on existing structures,</em> carried out on housing, infrastructure, commercial and industrial projects for the public and private sector."
+                                                },
+                                                {
+                                                    "description": "<strong>Examples of housing:</strong>"
+                                                },
+                                                {
+                                                    "list": ["Flats and maisonettes", "New houses", "Other types of residential housing"]
+                                                },
+                                                {
+                                                    "description": "<strong>Examples of infrastructure:</strong>"
+                                                },
+                                                {
+                                                    "list": [
+                                                        "Electricity, such as power stations",
+                                                        "Gas, such as gas works and laying pipelines",
+                                                        "Air transport, harbours, roads, and railways",
+                                                        "Drainage, sewerage, and water such as reservoirs",
+                                                        "Communication"
+                                                    ]
+                                                },
+                                                {
+                                                    "description": "<strong>Examples of commercial and industrial structures:</strong>"
+                                                },
+                                                {
+                                                    "list": [
+                                                        "Offices",
+                                                        "Factories",
+                                                        "Warehouses",
+                                                        "Educational institutions and their halls of residence",
+                                                        "Health facilities",
+                                                        "Entertainment and sports facilities",
+                                                        "Car parks",
+                                                        "Garages and shops",
+                                                        "Any construction work in the coal, oil, agriculture and steel industry"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                            "mandatory": true,
+                                            "type": "Currency",
+                                            "label": "Total value of all work carried out",
+                                            "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
+                                            "q_code": "290",
+                                            "min_value": {
+                                                "value": 0,
+                                                "exclusive": false
+                                            },
+                                            "decimal_places": 2,
+                                            "currency": "GBP"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "group": "groupe9d26530-ad8f-4527-b09c-afacfa0c820a",
+                                        "when": [
+                                            {
+                                                "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                                "condition": "equals",
+                                                "value": 0
+                                            }
                                         ]
                                     }
-                                ]
-                            },
-                            "definitions": [{
-                                "title": "What we mean by \"total value of all construction work\"",
-                                "content": [{
-                                        "description": "This refers to <em>all work on new structures and repair and maintenance (R&amp;M) on existing structures,</em> carried out on housing, infrastructure, commercial and industrial projects for the public and private sector."
-                                    },
-                                    {
-                                        "description": "<strong>Examples of housing:</strong>"
-                                    },
-                                    {
-                                        "list": ["Flats and maisonettes", "New houses", "Other types of residential housing"]
-                                    },
-                                    {
-                                        "description": "<strong>Examples of infrastructure:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "Electricity, such as power stations",
-                                            "Gas, such as gas works and laying pipelines",
-                                            "Air transport, harbours, roads, and railways",
-                                            "Drainage, sewerage, and water such as reservoirs",
-                                            "Communication"
-                                        ]
-                                    },
-                                    {
-                                        "description": "<strong>Examples of commercial and industrial structures:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "Offices",
-                                            "Factories",
-                                            "Warehouses",
-                                            "Educational institutions and their halls of residence",
-                                            "Health facilities",
-                                            "Entertainment and sports facilities",
-                                            "Car parks",
-                                            "Garages and shops",
-                                            "Any construction work in the coal, oil, agriculture and steel industry"
-                                        ]
-                                    }
-                                ]
-                            }],
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
-                                "mandatory": true,
-                                "type": "Currency",
-                                "label": "Total value of all work carried out",
-                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
-                                "q_code": "290",
-                                "min_value": {
-                                    "value": 0,
-                                    "exclusive": false
                                 },
-                                "decimal_places": 2,
-                                "currency": "GBP"
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "group": "groupe9d26530-ad8f-4527-b09c-afacfa0c820a",
-                                    "when": [{
-                                        "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
-                                        "condition": "equals",
-                                        "value": 0
-                                    }]
+                                {
+                                    "goto": {
+                                        "group": "groupe9d26530-ad8f-4527-b09c-afacfa0c820a",
+                                        "when": [
+                                            {
+                                                "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                                "condition": "not set"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "group": "group95c68629-8efd-4913-b465-41b686719d32"
+                                    }
                                 }
-                            },
-                            {
-                                "goto": {
-                                    "group": "groupe9d26530-ad8f-4527-b09c-afacfa0c820a",
-                                    "when": [{
-                                        "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
-                                        "condition": "not set"
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "group": "group95c68629-8efd-4913-b465-41b686719d32"
-                                }
-                            }
-                        ]
-                    }
-                ]
-            }]
+                            ]
+                        }
+                    ]
+                }
+            ]
         },
         {
             "id": "section95c68629-8efd-4913-b465-41b686719d32",
             "title": "Housing work",
-            "groups": [{
-                "id": "group95c68629-8efd-4913-b465-41b686719d32",
-                "title": "Housing work",
-                "blocks": [{
-                        "type": "Interstitial",
-                        "id": "group95c68629-8efd-4913-b465-41b686719d32-introduction",
-                        "title": "Housing work",
-                        "description": "<p>This section asks for information on the value of new builds and repair and maintenance (R&amp;M), improvements and major alterations on housing for public and private sector projects.</p><p>You will be asked to provide information on the value of work undertaken by your business. Value of work refers to estimates of chargeable work carried out during the month; meaning work started, in progress, or completed.</p><p><strong>Include:</strong></p><ul><li>work on buildings which you hope to sell later for profit (speculative work)</li><li>work done by your business on its own premises</li><li>fixtures, equipment and tools your business made and used in construction</li><li>materials your business used, overheads and profits</li><li>labour costs on your payroll</li></ul><p><strong>Exclude:</strong></p><ul><li>VAT</li><li>payments made to subcontractors </li><li>payments made to consultants or architects</li><li>fixtures, equipment and tools your business made for sale</li><li>materials your business sold</li><li>value of land</li></ul>"
-                    },
-                    {
-                        "id": "blockbaffab41-96f6-4f04-901d-5ff18c15bb90",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questionbaffab41-96f6-4f04-901d-5ff18c15bb90",
-                            "title": "During the period {{ format_conditional_date (answers['answer440c8850-b115-4f6b-b0f5-52d911dd6ef6from'], metadata['ref_p_start_date']) }} to {{ format_conditional_date (answers['answer440c8850-b115-4f6b-b0f5-52d911dd6ef6to'], metadata['ref_p_end_date']) }}, did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} carry out any work on <em>housing</em>?",
-                            "description": "<p>If you are a fitter or installer, you are included within the construction industry sector so should report your figures.</p>",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include new builds and repair and maintenance (R&amp;M) of:</strong>"
+            "groups": [
+                {
+                    "id": "group95c68629-8efd-4913-b465-41b686719d32",
+                    "title": "Housing work",
+                    "blocks": [
+                        {
+                            "type": "Interstitial",
+                            "id": "group95c68629-8efd-4913-b465-41b686719d32-introduction",
+                            "title": "Housing work",
+                            "description": "<p>This section asks for information on the value of new builds and repair and maintenance (R&amp;M), improvements and major alterations on housing for public and private sector projects.</p><p>You will be asked to provide information on the value of work undertaken by your business. Value of work refers to estimates of chargeable work carried out during the month; meaning work started, in progress, or completed.</p><p><strong>Include:</strong></p><ul><li>work on buildings which you hope to sell later for profit (speculative work)</li><li>work done by your business on its own premises</li><li>fixtures, equipment and tools your business made and used in construction</li><li>materials your business used, overheads and profits</li><li>labour costs on your payroll</li></ul><p><strong>Exclude:</strong></p><ul><li>VAT</li><li>payments made to subcontractors </li><li>payments made to consultants or architects</li><li>fixtures, equipment and tools your business made for sale</li><li>materials your business sold</li><li>value of land</li></ul>"
+                        },
+                        {
+                            "id": "blockbaffab41-96f6-4f04-901d-5ff18c15bb90",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "questionbaffab41-96f6-4f04-901d-5ff18c15bb90",
+                                    "title": "During the period {{ format_conditional_date (answers['answer440c8850-b115-4f6b-b0f5-52d911dd6ef6from'], metadata['ref_p_start_date']) }} to {{ format_conditional_date (answers['answer440c8850-b115-4f6b-b0f5-52d911dd6ef6to'], metadata['ref_p_end_date']) }}, did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} carry out any work on <em>housing</em>?",
+                                    "description": "<p>If you are a fitter or installer, you are included within the construction industry sector so should report your figures.</p>",
+                                    "guidance": {
+                                        "content": [
+                                            {
+                                                "description": "<strong>Include new builds and repair and maintenance (R&amp;M) of:</strong>"
+                                            },
+                                            {
+                                                "list": ["flats and maisonettes", "new houses", "other types of residential housing"]
+                                            },
+                                            {
+                                                "description": "<strong>Exclude:</strong>"
+                                            },
+                                            {
+                                                "list": ["any work on halls of residence for educational institutions"]
+                                            }
+                                        ]
                                     },
-                                    {
-                                        "list": ["flats and maisonettes", "new houses", "other types of residential housing"]
-                                    },
-                                    {
-                                        "description": "<strong>Exclude:</strong>"
-                                    },
-                                    {
-                                        "list": ["any work on halls of residence for educational institutions"]
-                                    }
-                                ]
-                            },
-                            "definitions": [{
-                                "title": "What we mean by \"work on housing\"",
-                                "content": [{
-                                    "description": "This refers to work on residential buildings. If over half of a building&apos;s floor area is used for residential purposes, it is considered a residential building."
-                                }]
-                            }],
-                            "type": "General",
-                            "answers": [{
-                                "id": "answera75253f4-438c-4bdf-8613-cbfa2a3a1fb6",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "902",
-                                "options": [{
-                                        "label": "Yes, we carried out work on housing",
-                                        "value": "Yes, we carried out work on housing"
-                                    },
-                                    {
-                                        "label": "No, we did not carry out work on housing",
-                                        "value": "No, we did not carry out work on housing"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "blockc102510b-e675-4074-8cdb-d6b8c5729a29",
-                                    "when": [{
-                                        "id": "answera75253f4-438c-4bdf-8613-cbfa2a3a1fb6",
-                                        "condition": "contains any",
-                                        "values": ["Yes, we carried out work on housing"]
-                                    }]
+                                    "definitions": [
+                                        {
+                                            "title": "What we mean by \"work on housing\"",
+                                            "content": [
+                                                {
+                                                    "description": "This refers to work on residential buildings. If over half of a building&apos;s floor area is used for residential purposes, it is considered a residential building."
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answera75253f4-438c-4bdf-8613-cbfa2a3a1fb6",
+                                            "mandatory": true,
+                                            "type": "Radio",
+                                            "label": "",
+                                            "description": "",
+                                            "q_code": "902",
+                                            "options": [
+                                                {
+                                                    "label": "Yes, we carried out work on housing",
+                                                    "value": "Yes, we carried out work on housing"
+                                                },
+                                                {
+                                                    "label": "No, we did not carry out work on housing",
+                                                    "value": "No, we did not carry out work on housing"
+                                                }
+                                            ]
+                                        }
+                                    ]
                                 }
-                            },
-                            {
-                                "goto": {
-                                    "group": "group551ac31e-ba5e-4161-a93e-92a06c53c6ad"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "id": "blockc102510b-e675-4074-8cdb-d6b8c5729a29",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questionc102510b-e675-4074-8cdb-d6b8c5729a29",
-                            "title": "Which sector did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} carry out housing work for?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer35ce4949-ad6d-4137-b28b-ce3b5723831e",
-                                "mandatory": true,
-                                "type": "Checkbox",
-                                "label": "",
-                                "description": "",
-                                "q_code": "d1",
-                                "options": [{
-                                        "label": "Public sector projects",
-                                        "value": "Public sector projects",
-                                        "description": "In the UK, the public sector consists of five sub-sectors: central government, local government, public non-financial corporations, Bank of England, public financial corporations (public sector banks)"
-                                    },
-                                    {
-                                        "label": "Private sector projects",
-                                        "value": "Private sector projects",
-                                        "description": "The private sector refers to the part of the economy that is for profit and is owned by private organisations, for example housing associations, or individuals"
-                                    }
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "blocke9a89f15-d5ad-4698-90ac-aaec447c5a07",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questione9a89f15-d5ad-4698-90ac-aaec447c5a07",
-                            "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of work carried out on <em>new housing builds</em> for <em>public</em> sector projects?",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include:</strong>"
-                                    },
-                                    {
-                                        "list": ["new construction work", "demolition", "site preparation"]
-                                    },
-                                    {
-                                        "description": "<strong>Exclude:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "VAT",
-                                            "repair and maintenance (R&amp;M)",
-                                            "major alterations, for example improvements and extensions",
-                                            "payments made to subcontractors",
-                                            "any work on halls of residence for educational institutions"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "definitions": [{
-                                "title": "What we mean by \"public sector\"",
-                                "content": [{
-                                        "description": "In the UK, the public sector consists of five sub-sectors:"
-                                    },
-                                    {
-                                        "list": [
-                                            "central government",
-                                            "local government",
-                                            "public non-financial corporations",
-                                            "Bank of England",
-                                            "public financial corporations, for example public sector banks"
-                                        ]
-                                    }
-                                ]
-                            }],
-                            "type": "General",
-                            "answers": [{
-                                "id": "answercf9a19af-7bfb-4a55-9372-16987cc23d17",
-                                "mandatory": true,
-                                "type": "Currency",
-                                "label": "New housing builds for public sector projects",
-                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
-                                "q_code": "201",
-                                "max_value": {
-                                    "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
-                                    "exclusive": false
-                                },
-                                "decimal_places": 2,
-                                "currency": "GBP"
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer35ce4949-ad6d-4137-b28b-ce3b5723831e",
-                                "condition": "not contains any",
-                                "values": ["Public sector projects"]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block4e0f51d6-103f-4495-b6ac-e8d21d536769",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question4e0f51d6-103f-4495-b6ac-e8d21d536769",
-                            "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of <em>repair and maintenance (R&amp;M), improvements and major alterations</em> carried out on existing housing for <em>public</em> sector projects?",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "extensions",
-                                            "any work aimed at repairing something which is broken",
-                                            "maintaining something to an existing standard"
-                                        ]
-                                    },
-                                    {
-                                        "description": "<strong>Exclude:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "VAT",
-                                            "payments made to subcontractors",
-                                            "any work on halls of residence for educational institutions"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer9368d5d6-a302-40b1-9211-f9ae4ceee109",
-                                "mandatory": true,
-                                "type": "Currency",
-                                "label": "R&M, improvements and major alterations on existing housing for public sector projects",
-                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
-                                "q_code": "202",
-                                "max_value": {
-                                    "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
-                                    "exclusive": false
-                                },
-                                "decimal_places": 2,
-                                "currency": "GBP"
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer35ce4949-ad6d-4137-b28b-ce3b5723831e",
-                                "condition": "not contains any",
-                                "values": ["Public sector projects"]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block510a45f5-aa4f-4d2d-9268-52ca13e0bb7b",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question510a45f5-aa4f-4d2d-9268-52ca13e0bb7b",
-                            "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of work carried out on <em>new housing builds</em> for <em>private</em> sector projects?",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include:</strong>"
-                                    },
-                                    {
-                                        "list": ["new construction work", "demolition", "site preparation"]
-                                    },
-                                    {
-                                        "description": "<strong>Exclude:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "VAT",
-                                            "R&amp;M",
-                                            "major alterations, for example improvements and extensions",
-                                            "payments made to subcontractors",
-                                            "any work on halls of residence for educational institutions"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "definitions": [{
-                                "title": "What we mean by \"private sector\"",
-                                "content": [{
-                                        "description": "The private sector refers to the part of the economy that is for profit and is owned by private organisations or individuals."
-                                    },
-                                    {
-                                        "description": "<strong>Examples of the private sector:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "Small and medium-sized businesses",
-                                            "Housing associations",
-                                            "Multinationals",
-                                            "Partnerships and sole traders",
-                                            "Households"
-                                        ]
-                                    }
-                                ]
-                            }],
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer24071a9f-30fa-4e1e-bd21-198ba49129b5",
-                                "mandatory": true,
-                                "type": "Currency",
-                                "label": "New housing builds for private sector projects",
-                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
-                                "q_code": "211",
-                                "max_value": {
-                                    "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
-                                    "exclusive": false
-                                },
-                                "decimal_places": 2,
-                                "currency": "GBP"
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer35ce4949-ad6d-4137-b28b-ce3b5723831e",
-                                "condition": "not contains any",
-                                "values": ["Private sector projects"]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block2da3a1a1-9d5d-4ce1-a84e-3f3e1a22fbd9",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question2da3a1a1-9d5d-4ce1-a84e-3f3e1a22fbd9",
-                            "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of <em>R&amp;M, improvements and major alterations</em> carried out on existing housing for <em>private</em> sector projects?",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "extensions",
-                                            "any work aimed at repairing something that is broken",
-                                            "maintaining something to an existing standard"
-                                        ]
-                                    },
-                                    {
-                                        "description": "<strong>Exclude:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "VAT",
-                                            "payments made to subcontractors",
-                                            "any work on halls of residence for educational institutions"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer214ea602-4fbe-4775-ae6b-6b99c9779b62",
-                                "mandatory": true,
-                                "type": "Currency",
-                                "label": "R&M, improvements and major alterations on existing housing for private sector projects",
-                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
-                                "q_code": "212",
-                                "max_value": {
-                                    "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
-                                    "exclusive": false
-                                },
-                                "decimal_places": 2,
-                                "currency": "GBP"
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer35ce4949-ad6d-4137-b28b-ce3b5723831e",
-                                "condition": "not contains any",
-                                "values": ["Private sector projects"]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "blocke2123cd6-0205-45ed-93bc-88ee340e9a13",
-                        "type": "CalculatedSummary",
-                        "titles": [{
-                            "value": "We calculate the <em>total value of housing work</em> to be <em>%(total)s.</em> Is this correct?"
-                        }],
-                        "calculation": {
-                            "calculation_type": "sum",
-                            "answers_to_calculate": [
-                                "answercf9a19af-7bfb-4a55-9372-16987cc23d17",
-                                "answer9368d5d6-a302-40b1-9211-f9ae4ceee109",
-                                "answer24071a9f-30fa-4e1e-bd21-198ba49129b5",
-                                "answer214ea602-4fbe-4775-ae6b-6b99c9779b62"
                             ],
-                            "titles": [{
-                                "value": "Total value of all housing work"
-                            }]
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "blockc102510b-e675-4074-8cdb-d6b8c5729a29",
+                                        "when": [
+                                            {
+                                                "id": "answera75253f4-438c-4bdf-8613-cbfa2a3a1fb6",
+                                                "condition": "contains any",
+                                                "values": ["Yes, we carried out work on housing"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "group": "group551ac31e-ba5e-4161-a93e-92a06c53c6ad"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "id": "blockc102510b-e675-4074-8cdb-d6b8c5729a29",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "questionc102510b-e675-4074-8cdb-d6b8c5729a29",
+                                    "title": "Which sector did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} carry out housing work for?",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer35ce4949-ad6d-4137-b28b-ce3b5723831e",
+                                            "mandatory": true,
+                                            "type": "Checkbox",
+                                            "label": "",
+                                            "description": "",
+                                            "q_code": "d1",
+                                            "options": [
+                                                {
+                                                    "label": "Public sector projects",
+                                                    "value": "Public sector projects",
+                                                    "description": "In the UK, the public sector consists of five sub-sectors: central government, local government, public non-financial corporations, Bank of England, public financial corporations (public sector banks)"
+                                                },
+                                                {
+                                                    "label": "Private sector projects",
+                                                    "value": "Private sector projects",
+                                                    "description": "The private sector refers to the part of the economy that is for profit and is owned by private organisations, for example housing associations, or individuals"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "blocke9a89f15-d5ad-4698-90ac-aaec447c5a07",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "questione9a89f15-d5ad-4698-90ac-aaec447c5a07",
+                                    "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of work carried out on <em>new housing builds</em> for <em>public</em> sector projects?",
+                                    "guidance": {
+                                        "content": [
+                                            {
+                                                "description": "<strong>Include:</strong>"
+                                            },
+                                            {
+                                                "list": ["new construction work", "demolition", "site preparation"]
+                                            },
+                                            {
+                                                "description": "<strong>Exclude:</strong>"
+                                            },
+                                            {
+                                                "list": [
+                                                    "VAT",
+                                                    "repair and maintenance (R&amp;M)",
+                                                    "major alterations, for example improvements and extensions",
+                                                    "payments made to subcontractors",
+                                                    "any work on halls of residence for educational institutions"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "definitions": [
+                                        {
+                                            "title": "What we mean by \"public sector\"",
+                                            "content": [
+                                                {
+                                                    "description": "In the UK, the public sector consists of five sub-sectors:"
+                                                },
+                                                {
+                                                    "list": [
+                                                        "central government",
+                                                        "local government",
+                                                        "public non-financial corporations",
+                                                        "Bank of England",
+                                                        "public financial corporations, for example public sector banks"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answercf9a19af-7bfb-4a55-9372-16987cc23d17",
+                                            "mandatory": true,
+                                            "type": "Currency",
+                                            "label": "New housing builds for public sector projects",
+                                            "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
+                                            "q_code": "201",
+                                            "max_value": {
+                                                "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                                "exclusive": false
+                                            },
+                                            "decimal_places": 2,
+                                            "currency": "GBP"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer35ce4949-ad6d-4137-b28b-ce3b5723831e",
+                                            "condition": "not contains any",
+                                            "values": ["Public sector projects"]
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block4e0f51d6-103f-4495-b6ac-e8d21d536769",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question4e0f51d6-103f-4495-b6ac-e8d21d536769",
+                                    "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of <em>repair and maintenance (R&amp;M), improvements and major alterations</em> carried out on existing housing for <em>public</em> sector projects?",
+                                    "guidance": {
+                                        "content": [
+                                            {
+                                                "description": "<strong>Include:</strong>"
+                                            },
+                                            {
+                                                "list": [
+                                                    "extensions",
+                                                    "any work aimed at repairing something which is broken",
+                                                    "maintaining something to an existing standard"
+                                                ]
+                                            },
+                                            {
+                                                "description": "<strong>Exclude:</strong>"
+                                            },
+                                            {
+                                                "list": [
+                                                    "VAT",
+                                                    "payments made to subcontractors",
+                                                    "any work on halls of residence for educational institutions"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer9368d5d6-a302-40b1-9211-f9ae4ceee109",
+                                            "mandatory": true,
+                                            "type": "Currency",
+                                            "label": "R&M, improvements and major alterations on existing housing for public sector projects",
+                                            "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
+                                            "q_code": "202",
+                                            "max_value": {
+                                                "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                                "exclusive": false
+                                            },
+                                            "decimal_places": 2,
+                                            "currency": "GBP"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer35ce4949-ad6d-4137-b28b-ce3b5723831e",
+                                            "condition": "not contains any",
+                                            "values": ["Public sector projects"]
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block510a45f5-aa4f-4d2d-9268-52ca13e0bb7b",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question510a45f5-aa4f-4d2d-9268-52ca13e0bb7b",
+                                    "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of work carried out on <em>new housing builds</em> for <em>private</em> sector projects?",
+                                    "guidance": {
+                                        "content": [
+                                            {
+                                                "description": "<strong>Include:</strong>"
+                                            },
+                                            {
+                                                "list": ["new construction work", "demolition", "site preparation"]
+                                            },
+                                            {
+                                                "description": "<strong>Exclude:</strong>"
+                                            },
+                                            {
+                                                "list": [
+                                                    "VAT",
+                                                    "R&amp;M",
+                                                    "major alterations, for example improvements and extensions",
+                                                    "payments made to subcontractors",
+                                                    "any work on halls of residence for educational institutions"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "definitions": [
+                                        {
+                                            "title": "What we mean by \"private sector\"",
+                                            "content": [
+                                                {
+                                                    "description": "The private sector refers to the part of the economy that is for profit and is owned by private organisations or individuals."
+                                                },
+                                                {
+                                                    "description": "<strong>Examples of the private sector:</strong>"
+                                                },
+                                                {
+                                                    "list": [
+                                                        "Small and medium-sized businesses",
+                                                        "Housing associations",
+                                                        "Multinationals",
+                                                        "Partnerships and sole traders",
+                                                        "Households"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer24071a9f-30fa-4e1e-bd21-198ba49129b5",
+                                            "mandatory": true,
+                                            "type": "Currency",
+                                            "label": "New housing builds for private sector projects",
+                                            "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
+                                            "q_code": "211",
+                                            "max_value": {
+                                                "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                                "exclusive": false
+                                            },
+                                            "decimal_places": 2,
+                                            "currency": "GBP"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer35ce4949-ad6d-4137-b28b-ce3b5723831e",
+                                            "condition": "not contains any",
+                                            "values": ["Private sector projects"]
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block2da3a1a1-9d5d-4ce1-a84e-3f3e1a22fbd9",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question2da3a1a1-9d5d-4ce1-a84e-3f3e1a22fbd9",
+                                    "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of <em>R&amp;M, improvements and major alterations</em> carried out on existing housing for <em>private</em> sector projects?",
+                                    "guidance": {
+                                        "content": [
+                                            {
+                                                "description": "<strong>Include:</strong>"
+                                            },
+                                            {
+                                                "list": [
+                                                    "extensions",
+                                                    "any work aimed at repairing something that is broken",
+                                                    "maintaining something to an existing standard"
+                                                ]
+                                            },
+                                            {
+                                                "description": "<strong>Exclude:</strong>"
+                                            },
+                                            {
+                                                "list": [
+                                                    "VAT",
+                                                    "payments made to subcontractors",
+                                                    "any work on halls of residence for educational institutions"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer214ea602-4fbe-4775-ae6b-6b99c9779b62",
+                                            "mandatory": true,
+                                            "type": "Currency",
+                                            "label": "R&M, improvements and major alterations on existing housing for private sector projects",
+                                            "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
+                                            "q_code": "212",
+                                            "max_value": {
+                                                "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                                "exclusive": false
+                                            },
+                                            "decimal_places": 2,
+                                            "currency": "GBP"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer35ce4949-ad6d-4137-b28b-ce3b5723831e",
+                                            "condition": "not contains any",
+                                            "values": ["Private sector projects"]
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "blocke2123cd6-0205-45ed-93bc-88ee340e9a13",
+                            "type": "CalculatedSummary",
+                            "titles": [
+                                {
+                                    "value": "We calculate the <em>total value of housing work</em> to be <em>%(total)s.</em> Is this correct?"
+                                }
+                            ],
+                            "calculation": {
+                                "calculation_type": "sum",
+                                "answers_to_calculate": [
+                                    "answercf9a19af-7bfb-4a55-9372-16987cc23d17",
+                                    "answer9368d5d6-a302-40b1-9211-f9ae4ceee109",
+                                    "answer24071a9f-30fa-4e1e-bd21-198ba49129b5",
+                                    "answer214ea602-4fbe-4775-ae6b-6b99c9779b62"
+                                ],
+                                "titles": [
+                                    {
+                                        "value": "Total value of all housing work"
+                                    }
+                                ]
+                            }
                         }
-                    }
-                ],
-                "skip_conditions": [{
-                        "when": [{
-                            "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
-                            "condition": "equals",
-                            "value": 0
-                        }]
-                    },
-                    {
-                        "when": [{
-                            "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
-                            "condition": "not set"
-                        }]
-                    }
-                ]
-            }]
+                    ],
+                    "skip_conditions": [
+                        {
+                            "when": [
+                                {
+                                    "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                    "condition": "equals",
+                                    "value": 0
+                                }
+                            ]
+                        },
+                        {
+                            "when": [
+                                {
+                                    "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                    "condition": "not set"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
         },
         {
             "id": "section551ac31e-ba5e-4161-a93e-92a06c53c6ad",
             "title": "Infrastructure",
-            "groups": [{
-                "id": "group551ac31e-ba5e-4161-a93e-92a06c53c6ad",
-                "title": "Infrastructure",
-                "blocks": [{
-                        "type": "Interstitial",
-                        "id": "group551ac31e-ba5e-4161-a93e-92a06c53c6ad-introduction",
-                        "title": "Infrastructure",
-                        "description": "<p>This section asks for information on the value of new infrastructure, and repair and maintenance (R&amp;M) of existing <em>infrastructure</em>.</p><p>You will be asked to provide information on the value of work undertaken by your business. Value of work refers to estimates of chargeable work carried out during the month; meaning work started, in progress, or completed.</p><p><strong>Include:</strong></p><ul><li>work done by your own business on its own business premises</li><li>fixtures, equipment and tools your business made and used in construction</li><li>materials your business used, overheads and profits</li><li>labour costs on your payroll</li></ul><p><strong>Exclude:</strong></p><ul><li>VAT</li><li>payments made to subcontractors</li><li>payments made to consultants or architects</li><li>fixtures, equipment and tools your business made for sale</li><li>materials your business sold</li><li>value of land</li></ul>"
-                    },
-                    {
-                        "id": "block01c41114-3ca3-432f-b7e6-95f8c702f308",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question01c41114-3ca3-432f-b7e6-95f8c702f308",
-                            "title": "During the period {{ format_conditional_date (answers['answer440c8850-b115-4f6b-b0f5-52d911dd6ef6from'], metadata['ref_p_start_date']) }} to {{ format_conditional_date (answers['answer440c8850-b115-4f6b-b0f5-52d911dd6ef6to'], metadata['ref_p_end_date']) }}, did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} carry out any work on <em>infrastructure</em>?",
-                            "description": "<p>If you are a fitter or installer, you are included within the construction industry sector so should report your figures.</p>",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include:</strong>"
-                                    },
-                                    {
-                                        "list": ["new infrastructure and repair and maintenance (R&amp;M) of infrastructure"]
-                                    },
-                                    {
-                                        "description": "<strong>Exclude:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "work on any residential buildings such as housing, flats or maisonettes",
-                                            "work on any industrial or commercial structures, such as factories, warehouses, offices health facilities or educational facilities"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "definitions": [{
-                                "title": "What we mean by infrastructure",
-                                "content": [{
-                                        "description": "Infrastructure refers to non-residential buildings, facilities, or systems that are fundamental to the functioning of an area."
-                                    },
-                                    {
-                                        "description": "<strong>Examples of infrastructure:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "Electricity, such as power stations",
-                                            "Gas, such as gas works and laying pipelines",
-                                            "Air transport, harbours, roads, and railways",
-                                            "Drainage, sewerage, and water such as reservoirs",
-                                            "Communication"
-                                        ]
-                                    }
-                                ]
-                            }],
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer01c0c84f-7282-42a3-b1c3-13b6d10f39bf",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "903",
-                                "options": [{
-                                        "label": "Yes, we carried out work on infrastructure",
-                                        "value": "Yes, we carried out work on infrastructure"
-                                    },
-                                    {
-                                        "label": "No, we did not carry out work on infrastructure",
-                                        "value": "No, we did not carry out work on infrastructure"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "block8ce84076-2099-4ee2-aa26-79bb386f44a9",
-                                    "when": [{
-                                        "id": "answer01c0c84f-7282-42a3-b1c3-13b6d10f39bf",
-                                        "condition": "contains any",
-                                        "values": ["Yes, we carried out work on infrastructure"]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "group": "group6cc8656d-6877-4685-b9eb-f024a9ae1898"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "id": "block8ce84076-2099-4ee2-aa26-79bb386f44a9",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question8ce84076-2099-4ee2-aa26-79bb386f44a9",
-                            "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of work carried out on <em>new infrastructure</em>?",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "new construction work",
-                                            "demolition",
-                                            "site clearance and preparation",
-                                            "major alterations, for example improvements and extensions"
+            "groups": [
+                {
+                    "id": "group551ac31e-ba5e-4161-a93e-92a06c53c6ad",
+                    "title": "Infrastructure",
+                    "blocks": [
+                        {
+                            "type": "Interstitial",
+                            "id": "group551ac31e-ba5e-4161-a93e-92a06c53c6ad-introduction",
+                            "title": "Infrastructure",
+                            "description": "<p>This section asks for information on the value of new infrastructure, and repair and maintenance (R&amp;M) of existing <em>infrastructure</em>.</p><p>You will be asked to provide information on the value of work undertaken by your business. Value of work refers to estimates of chargeable work carried out during the month; meaning work started, in progress, or completed.</p><p><strong>Include:</strong></p><ul><li>work done by your own business on its own business premises</li><li>fixtures, equipment and tools your business made and used in construction</li><li>materials your business used, overheads and profits</li><li>labour costs on your payroll</li></ul><p><strong>Exclude:</strong></p><ul><li>VAT</li><li>payments made to subcontractors</li><li>payments made to consultants or architects</li><li>fixtures, equipment and tools your business made for sale</li><li>materials your business sold</li><li>value of land</li></ul>"
+                        },
+                        {
+                            "id": "block01c41114-3ca3-432f-b7e6-95f8c702f308",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question01c41114-3ca3-432f-b7e6-95f8c702f308",
+                                    "title": "During the period {{ format_conditional_date (answers['answer440c8850-b115-4f6b-b0f5-52d911dd6ef6from'], metadata['ref_p_start_date']) }} to {{ format_conditional_date (answers['answer440c8850-b115-4f6b-b0f5-52d911dd6ef6to'], metadata['ref_p_end_date']) }}, did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} carry out any work on <em>infrastructure</em>?",
+                                    "description": "<p>If you are a fitter or installer, you are included within the construction industry sector so should report your figures.</p>",
+                                    "guidance": {
+                                        "content": [
+                                            {
+                                                "description": "<strong>Include:</strong>"
+                                            },
+                                            {
+                                                "list": ["new infrastructure and repair and maintenance (R&amp;M) of infrastructure"]
+                                            },
+                                            {
+                                                "description": "<strong>Exclude:</strong>"
+                                            },
+                                            {
+                                                "list": [
+                                                    "work on any residential buildings such as housing, flats or maisonettes",
+                                                    "work on any industrial or commercial structures, such as factories, warehouses, offices health facilities or educational facilities"
+                                                ]
+                                            }
                                         ]
                                     },
-                                    {
-                                        "description": "<strong>Exclude:</strong>"
-                                    },
-                                    {
-                                        "list": ["VAT", "R&amp;M", "payments made to subcontractors"]
-                                    }
-                                ]
-                            },
-                            "definitions": [{
-                                "title": "Examples of infrastructure",
-                                "content": [{
-                                    "list": [
-                                        "Electricity, such as power stations",
-                                        "Gas, such as gas works and laying pipelines",
-                                        "Air transport, harbours, roads, and railways",
-                                        "Drainage, sewerage, and water such as reservoirs",
-                                        "Communication"
+                                    "definitions": [
+                                        {
+                                            "title": "What we mean by infrastructure",
+                                            "content": [
+                                                {
+                                                    "description": "Infrastructure refers to non-residential buildings, facilities, or systems that are fundamental to the functioning of an area."
+                                                },
+                                                {
+                                                    "description": "<strong>Examples of infrastructure:</strong>"
+                                                },
+                                                {
+                                                    "list": [
+                                                        "Electricity, such as power stations",
+                                                        "Gas, such as gas works and laying pipelines",
+                                                        "Air transport, harbours, roads, and railways",
+                                                        "Drainage, sewerage, and water such as reservoirs",
+                                                        "Communication"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer01c0c84f-7282-42a3-b1c3-13b6d10f39bf",
+                                            "mandatory": true,
+                                            "type": "Radio",
+                                            "label": "",
+                                            "description": "",
+                                            "q_code": "903",
+                                            "options": [
+                                                {
+                                                    "label": "Yes, we carried out work on infrastructure",
+                                                    "value": "Yes, we carried out work on infrastructure"
+                                                },
+                                                {
+                                                    "label": "No, we did not carry out work on infrastructure",
+                                                    "value": "No, we did not carry out work on infrastructure"
+                                                }
+                                            ]
+                                        }
                                     ]
-                                }]
-                            }],
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer692af9c8-8773-4a7b-9a21-1830f3dc3401",
-                                "mandatory": true,
-                                "type": "Currency",
-                                "label": "New infrastructure",
-                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
-                                "q_code": "221",
-                                "max_value": {
-                                    "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
-                                    "exclusive": false
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "block8ce84076-2099-4ee2-aa26-79bb386f44a9",
+                                        "when": [
+                                            {
+                                                "id": "answer01c0c84f-7282-42a3-b1c3-13b6d10f39bf",
+                                                "condition": "contains any",
+                                                "values": ["Yes, we carried out work on infrastructure"]
+                                            }
+                                        ]
+                                    }
                                 },
-                                "decimal_places": 2,
-                                "currency": "GBP"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "blockdd878456-07b8-40f5-a3c5-fee1129cb64a",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questiondd878456-07b8-40f5-a3c5-fee1129cb64a",
-                            "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of <em>R&amp;M</em> carried out on existing infrastructure?",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include work aimed at:</strong>"
+                                {
+                                    "goto": {
+                                        "group": "group6cc8656d-6877-4685-b9eb-f024a9ae1898"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block8ce84076-2099-4ee2-aa26-79bb386f44a9",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question8ce84076-2099-4ee2-aa26-79bb386f44a9",
+                                    "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of work carried out on <em>new infrastructure</em>?",
+                                    "guidance": {
+                                        "content": [
+                                            {
+                                                "description": "<strong>Include:</strong>"
+                                            },
+                                            {
+                                                "list": [
+                                                    "new construction work",
+                                                    "demolition",
+                                                    "site clearance and preparation",
+                                                    "major alterations, for example improvements and extensions"
+                                                ]
+                                            },
+                                            {
+                                                "description": "<strong>Exclude:</strong>"
+                                            },
+                                            {
+                                                "list": ["VAT", "R&amp;M", "payments made to subcontractors"]
+                                            }
+                                        ]
                                     },
-                                    {
-                                        "list": ["repairing a fault", "repairing something that is broken", "maintaining an existing standard"]
+                                    "definitions": [
+                                        {
+                                            "title": "Examples of infrastructure",
+                                            "content": [
+                                                {
+                                                    "list": [
+                                                        "Electricity, such as power stations",
+                                                        "Gas, such as gas works and laying pipelines",
+                                                        "Air transport, harbours, roads, and railways",
+                                                        "Drainage, sewerage, and water such as reservoirs",
+                                                        "Communication"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer692af9c8-8773-4a7b-9a21-1830f3dc3401",
+                                            "mandatory": true,
+                                            "type": "Currency",
+                                            "label": "New infrastructure",
+                                            "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
+                                            "q_code": "221",
+                                            "max_value": {
+                                                "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                                "exclusive": false
+                                            },
+                                            "decimal_places": 2,
+                                            "currency": "GBP"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "blockdd878456-07b8-40f5-a3c5-fee1129cb64a",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "questiondd878456-07b8-40f5-a3c5-fee1129cb64a",
+                                    "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of <em>R&amp;M</em> carried out on existing infrastructure?",
+                                    "guidance": {
+                                        "content": [
+                                            {
+                                                "description": "<strong>Include work aimed at:</strong>"
+                                            },
+                                            {
+                                                "list": ["repairing a fault", "repairing something that is broken", "maintaining an existing standard"]
+                                            },
+                                            {
+                                                "description": "<strong> Exclude:</strong>"
+                                            },
+                                            {
+                                                "list": ["major alterations, for example improvements and extensions", "VAT", "payments made to subcontractors"]
+                                            }
+                                        ]
                                     },
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer8561360c-adc9-40b9-b6af-2f85c486fef5",
+                                            "mandatory": true,
+                                            "type": "Currency",
+                                            "label": "R&M carried out on existing infrastructure",
+                                            "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
+                                            "q_code": "222",
+                                            "max_value": {
+                                                "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                                "exclusive": false
+                                            },
+                                            "decimal_places": 2,
+                                            "currency": "GBP"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block319d4417-7383-496a-be67-590f02765e08",
+                            "type": "CalculatedSummary",
+                            "titles": [
+                                {
+                                    "value": "We calculate the <em>total value of infrastructure work</em> carried out to be <em>%(total)s.</em> Is this correct?"
+                                }
+                            ],
+                            "calculation": {
+                                "calculation_type": "sum",
+                                "answers_to_calculate": ["answer692af9c8-8773-4a7b-9a21-1830f3dc3401", "answer8561360c-adc9-40b9-b6af-2f85c486fef5"],
+                                "titles": [
                                     {
-                                        "description": "<strong> Exclude:</strong>"
-                                    },
-                                    {
-                                        "list": ["major alterations, for example improvements and extensions", "VAT", "payments made to subcontractors"]
+                                        "value": "Total value of all infrastructure work"
                                     }
                                 ]
-                            },
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer8561360c-adc9-40b9-b6af-2f85c486fef5",
-                                "mandatory": true,
-                                "type": "Currency",
-                                "label": "R&M carried out on existing infrastructure",
-                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
-                                "q_code": "222",
-                                "max_value": {
-                                    "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
-                                    "exclusive": false
-                                },
-                                "decimal_places": 2,
-                                "currency": "GBP"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block319d4417-7383-496a-be67-590f02765e08",
-                        "type": "CalculatedSummary",
-                        "titles": [{
-                            "value": "We calculate the <em>total value of infrastructure work</em> carried out to be <em>%(total)s.</em> Is this correct?"
-                        }],
-                        "calculation": {
-                            "calculation_type": "sum",
-                            "answers_to_calculate": ["answer692af9c8-8773-4a7b-9a21-1830f3dc3401", "answer8561360c-adc9-40b9-b6af-2f85c486fef5"],
-                            "titles": [{
-                                "value": "Total value of all infrastructure work"
-                            }]
+                            }
                         }
-                    }
-                ],
-                "skip_conditions": [{
-                        "when": [{
-                            "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
-                            "condition": "equals",
-                            "value": 0
-                        }]
-                    },
-                    {
-                        "when": [{
-                            "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
-                            "condition": "not set"
-                        }]
-                    }
-                ]
-            }]
+                    ],
+                    "skip_conditions": [
+                        {
+                            "when": [
+                                {
+                                    "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                    "condition": "equals",
+                                    "value": 0
+                                }
+                            ]
+                        },
+                        {
+                            "when": [
+                                {
+                                    "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                    "condition": "not set"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
         },
         {
             "id": "section6cc8656d-6877-4685-b9eb-f024a9ae1898",
             "title": "Other construction work",
-            "groups": [{
-                "id": "group6cc8656d-6877-4685-b9eb-f024a9ae1898",
-                "title": "Other construction work",
-                "blocks": [{
-                        "type": "Interstitial",
-                        "id": "group6cc8656d-6877-4685-b9eb-f024a9ae1898-introduction",
-                        "title": "Other construction work",
-                        "description": "<p>This section asks for information on the value of <em>other construction work</em> carried out on new structures for public, commercial and industrial projects, and repair and maintenance (R&amp;M) of existing structures.</p><p>You will be asked to provide information on the value of work undertaken by your business. Value of work refers to estimates of chargeable work carried out during the month; meaning work started, in progress, or completed. </p><p><strong>Include:</strong></p><ul><li>work on buildings which you hope to sell later for profit (speculative work)</li><li>work done by your business on its own premises</li><li>fixtures, equipment and tools your business made and used in construction</li><li>materials your business used, overheads and profits</li><li>labour costs on your payroll</li></ul><p> <strong>Exclude:</strong></p><ul><li>work on infrastructure</li><li>work on residential buildings, for example housing, flats and maisonettes</li><li>VAT</li><li>payments made to subcontractors</li><li>payments made to consultants or architects</li><li>fixtures, equipment and tools your business made for sale</li><li>materials your business sold</li><li>value of land</li></ul>"
-                    },
-                    {
-                        "id": "block92bf4040-ae9c-4245-889c-c11ec6d52ce4",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question92bf4040-ae9c-4245-889c-c11ec6d52ce4",
-                            "title": "During the period {{ format_conditional_date (answers['answer440c8850-b115-4f6b-b0f5-52d911dd6ef6from'], metadata['ref_p_start_date']) }} to {{ format_conditional_date (answers['answer440c8850-b115-4f6b-b0f5-52d911dd6ef6to'], metadata['ref_p_end_date']) }}, did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} carry out any <em>other construction work</em>?",
-                            "description": "<p>If you are a fitter or installer, you are included within the construction industry sector so should report your figures.</p>",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Exclude:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "work on residential buildings, for example housing, flats and maisonettes, except halls of residence for educational institutions",
-                                            "work on infrastructure"
+            "groups": [
+                {
+                    "id": "group6cc8656d-6877-4685-b9eb-f024a9ae1898",
+                    "title": "Other construction work",
+                    "blocks": [
+                        {
+                            "type": "Interstitial",
+                            "id": "group6cc8656d-6877-4685-b9eb-f024a9ae1898-introduction",
+                            "title": "Other construction work",
+                            "description": "<p>This section asks for information on the value of <em>other construction work</em> carried out on new structures for public, commercial and industrial projects, and repair and maintenance (R&amp;M) of existing structures.</p><p>You will be asked to provide information on the value of work undertaken by your business. Value of work refers to estimates of chargeable work carried out during the month; meaning work started, in progress, or completed. </p><p><strong>Include:</strong></p><ul><li>work on buildings which you hope to sell later for profit (speculative work)</li><li>work done by your business on its own premises</li><li>fixtures, equipment and tools your business made and used in construction</li><li>materials your business used, overheads and profits</li><li>labour costs on your payroll</li></ul><p> <strong>Exclude:</strong></p><ul><li>work on infrastructure</li><li>work on residential buildings, for example housing, flats and maisonettes</li><li>VAT</li><li>payments made to subcontractors</li><li>payments made to consultants or architects</li><li>fixtures, equipment and tools your business made for sale</li><li>materials your business sold</li><li>value of land</li></ul>"
+                        },
+                        {
+                            "id": "block92bf4040-ae9c-4245-889c-c11ec6d52ce4",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question92bf4040-ae9c-4245-889c-c11ec6d52ce4",
+                                    "title": "During the period {{ format_conditional_date (answers['answer440c8850-b115-4f6b-b0f5-52d911dd6ef6from'], metadata['ref_p_start_date']) }} to {{ format_conditional_date (answers['answer440c8850-b115-4f6b-b0f5-52d911dd6ef6to'], metadata['ref_p_end_date']) }}, did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} carry out any <em>other construction work</em>?",
+                                    "description": "<p>If you are a fitter or installer, you are included within the construction industry sector so should report your figures.</p>",
+                                    "guidance": {
+                                        "content": [
+                                            {
+                                                "description": "<strong>Exclude:</strong>"
+                                            },
+                                            {
+                                                "list": [
+                                                    "work on residential buildings, for example housing, flats and maisonettes, except halls of residence for educational institutions",
+                                                    "work on infrastructure"
+                                                ]
+                                            }
                                         ]
-                                    }
-                                ]
-                            },
-                            "definitions": [{
-                                "title": "Examples of other construction work",
-                                "content": [{
-                                    "list": [
-                                        "Industrial structures, such as factories and warehouses",
-                                        "Commercial structures, such as agricultural structures, offices, parks, health facilities and educational institutions",
-                                        "Public structures, such educational institutions, offices, health facilities, sport facilities or entertainment facilities"
+                                    },
+                                    "definitions": [
+                                        {
+                                            "title": "Examples of other construction work",
+                                            "content": [
+                                                {
+                                                    "list": [
+                                                        "Industrial structures, such as factories and warehouses",
+                                                        "Commercial structures, such as agricultural structures, offices, parks, health facilities and educational institutions",
+                                                        "Public structures, such educational institutions, offices, health facilities, sport facilities or entertainment facilities"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer50ae0d8f-dd41-43ab-8e29-431028500270",
+                                            "mandatory": true,
+                                            "type": "Radio",
+                                            "label": "",
+                                            "description": "",
+                                            "q_code": "904",
+                                            "options": [
+                                                {
+                                                    "label": "Yes, we carried out other construction work",
+                                                    "value": "Yes, we carried out other construction work"
+                                                },
+                                                {
+                                                    "label": "No, we did not carry out other construction work",
+                                                    "value": "No, we did not carry out other construction work"
+                                                }
+                                            ]
+                                        }
                                     ]
-                                }]
-                            }],
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer50ae0d8f-dd41-43ab-8e29-431028500270",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "904",
-                                "options": [{
-                                        "label": "Yes, we carried out other construction work",
-                                        "value": "Yes, we carried out other construction work"
-                                    },
-                                    {
-                                        "label": "No, we did not carry out other construction work",
-                                        "value": "No, we did not carry out other construction work"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "blockcb22fe8e-4000-418d-b0f1-ca57306a2c0e",
-                                    "when": [{
-                                        "id": "answer50ae0d8f-dd41-43ab-8e29-431028500270",
-                                        "condition": "contains any",
-                                        "values": ["Yes, we carried out other construction work"]
-                                    }]
                                 }
-                            },
-                            {
-                                "goto": {
-                                    "group": "groupe9d26530-ad8f-4527-b09c-afacfa0c820a"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "id": "blockcb22fe8e-4000-418d-b0f1-ca57306a2c0e",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questioncb22fe8e-4000-418d-b0f1-ca57306a2c0e",
-                            "title": "Which sector did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} carry out other construction work for?",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Exclude:</strong>"
-                                    },
-                                    {
-                                        "list": ["work on residential buildings, for example housing, flats and maisonettes", "work on infrastructure"]
-                                    }
-                                ]
-                            },
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer27e92f6a-21af-4432-b94c-5157746ebc9e",
-                                "mandatory": true,
-                                "type": "Checkbox",
-                                "label": "",
-                                "description": "",
-                                "q_code": "d2",
-                                "options": [{
-                                        "label": "Public sector projects",
-                                        "value": "Public sector projects",
-                                        "description": "The public sector consists central government, local government, public non-financial corporations, Bank of England and public financial corporations."
-                                    },
-                                    {
-                                        "label": "Private commercial sector projects",
-                                        "value": "Private commercial sector projects",
-                                        "description": "Part of the economy that includes all businesses and agriculture, except those businesses involved in manufacturing and  transport"
-                                    },
-                                    {
-                                        "label": "Private industrial sector projects",
-                                        "value": "Private industrial sector projects",
-                                        "description": "Part of the economy that includes businesses involved in manufacturing and transport"
-                                    }
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block6128bff1-69b5-4914-b49a-11facc75a178",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question6128bff1-69b5-4914-b49a-11facc75a178",
-                            "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of work carried out on <em>other new structures</em> for <em>public</em> sector projects?",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong> Include:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "new construction work",
-                                            "demolition",
-                                            "site preparation",
-                                            "major alterations, for example improvements and extensions"
-                                        ]
-                                    },
-                                    {
-                                        "description": "<strong>Exclude:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "work on infrastructure",
-                                            "work on residential buildings, for example housing, flats and maisonettes",
-                                            "VAT",
-                                            "R&amp;M",
-                                            "payments made to subcontractors"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "definitions": [{
-                                "title": "What we mean by \"other new structures\"",
-                                "content": [{
-                                        "description": "This refers to work on new non-residential structures. If over half of a building&apos;s floor area is used for non-residential purposes, it is considered a non-residential building."
-                                    },
-                                    {
-                                        "description": "<strong>Examples of other public sector structures:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "Offices",
-                                            "Factories",
-                                            "Warehouses",
-                                            "Educational institutions and their halls of residence",
-                                            "Health facilities",
-                                            "Entertainment and sports facilities"
-                                        ]
-                                    }
-                                ]
-                            }],
-                            "type": "General",
-                            "answers": [{
-                                "id": "answerdb018dc4-8664-4587-a038-12a468da441b",
-                                "mandatory": true,
-                                "type": "Currency",
-                                "label": "Other new structures for public sector projects",
-                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
-                                "q_code": "231",
-                                "max_value": {
-                                    "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
-                                    "exclusive": false
-                                },
-                                "decimal_places": 2,
-                                "currency": "GBP"
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer27e92f6a-21af-4432-b94c-5157746ebc9e",
-                                "condition": "not contains any",
-                                "values": ["Public sector projects"]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block1fa2f7bd-0644-434a-a706-32931d727147",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question1fa2f7bd-0644-434a-a706-32931d727147",
-                            "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of <em>R&amp;M</em> carried out on other existing structures for <em>public</em> sector projects?",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include work aimed at:</strong>"
-                                    },
-                                    {
-                                        "list": ["repairing something which is broken", "maintaining an existing standard"]
-                                    },
-                                    {
-                                        "description": "<strong>Exclude:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "work on infrastructure",
-                                            "work on residential buildings, for example housing, flats and maisonettes",
-                                            "major alterations, for example improvements and extensions",
-                                            "VAT",
-                                            "payments made to subcontractors"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "definitions": [{
-                                "title": "What we mean by \"other existing structures\"",
-                                "content": [{
-                                        "description": "This refers to work on existing non-residential structures. If over half of a building&apos;s floor area is used for non-residential purposes, it is considered a non-residential building."
-                                    },
-                                    {
-                                        "description": "<strong>Examples of other public sector structures:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "Offices",
-                                            "Factories",
-                                            "Warehouses",
-                                            "Educational institutions and their halls of residence",
-                                            "Health facilities",
-                                            "Entertainment and sports facilities"
-                                        ]
-                                    }
-                                ]
-                            }],
-                            "type": "General",
-                            "answers": [{
-                                "id": "answerc541b81f-6402-4934-821d-dc961bea86bf",
-                                "mandatory": true,
-                                "type": "Currency",
-                                "label": "R&M on other existing structures for public sector projects",
-                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
-                                "q_code": "232",
-                                "max_value": {
-                                    "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
-                                    "exclusive": false
-                                },
-                                "decimal_places": 2,
-                                "currency": "GBP"
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer27e92f6a-21af-4432-b94c-5157746ebc9e",
-                                "condition": "not contains any",
-                                "values": ["Public sector projects"]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block3159dcad-c87b-4afa-860e-291c4d4b1414",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question3159dcad-c87b-4afa-860e-291c4d4b1414",
-                            "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of work carried out on <em>new structures</em> for <em>private commercial</em> sector projects?",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "new construction work",
-                                            "demolition",
-                                            "site preparation",
-                                            "major alterations, for example improvements and extensions"
-                                        ]
-                                    },
-                                    {
-                                        "description": "<strong>Exclude:</strong>"
-                                    },
-                                    {
-                                        "list": ["VAT", "R&amp;M", "payments made to subcontractors"]
-                                    }
-                                ]
-                            },
-                            "definitions": [{
-                                "title": "What we mean by the \"private commercial sector\"",
-                                "content": [{
-                                        "description": "This sector refers to part of the economy that  includes all businesses, except those involved in manufacturing and transport."
-                                    },
-                                    {
-                                        "description": "<strong>Examples of private commercial sector structures:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "Any construction work for the agriculture industry",
-                                            "Offices",
-                                            "Factories",
-                                            "Health facilities",
-                                            "Entertainment and sports facilities",
-                                            "Car parks",
-                                            "Educational institutions and their halls of residence",
-                                            "Garages and shops"
-                                        ]
-                                    }
-                                ]
-                            }],
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer1a8a2700-9428-425a-97da-d81ce4eaf4a3",
-                                "mandatory": true,
-                                "type": "Currency",
-                                "label": "New structures for private commercial sector projects",
-                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
-                                "q_code": "241",
-                                "max_value": {
-                                    "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
-                                    "exclusive": false
-                                },
-                                "decimal_places": 2,
-                                "currency": "GBP"
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer27e92f6a-21af-4432-b94c-5157746ebc9e",
-                                "condition": "not contains any",
-                                "values": ["Private commercial sector projects"]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block4bc9c90a-5ef9-427a-b98a-03b9ffbd38d7",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question4bc9c90a-5ef9-427a-b98a-03b9ffbd38d7",
-                            "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of work carried out on <em>new structures</em> for <em>private industrial</em> sector projects?",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "new construction work",
-                                            "demolition",
-                                            "site preparation",
-                                            "major alterations, for example improvements and extensions"
-                                        ]
-                                    },
-                                    {
-                                        "description": "<strong>Exclude:</strong>"
-                                    },
-                                    {
-                                        "list": ["VAT", "R&amp;M", "payments made to subcontractors"]
-                                    }
-                                ]
-                            },
-                            "definitions": [{
-                                "title": "What we mean by the \"private industrial sector\"",
-                                "content": [{
-                                        "description": "This sector refers to part of the economy that includes businesses involved in manufacturing and transport, excluding agriculture."
-                                    },
-                                    {
-                                        "description": "<strong>Examples of private industrial sector structures:</strong>"
-                                    },
-                                    {
-                                        "list": ["Factories", "Warehouses", "Any construction work in the coal, oil and steel industry"]
-                                    }
-                                ]
-                            }],
-                            "type": "General",
-                            "answers": [{
-                                "id": "answera11da5a9-892d-42f0-bb19-b3781974d741",
-                                "mandatory": true,
-                                "type": "Currency",
-                                "label": "New structures for private industrial sector projects",
-                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
-                                "q_code": "242",
-                                "max_value": {
-                                    "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
-                                    "exclusive": false
-                                },
-                                "decimal_places": 2,
-                                "currency": "GBP"
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer27e92f6a-21af-4432-b94c-5157746ebc9e",
-                                "condition": "not contains any",
-                                "values": ["Private industrial sector projects"]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "blockf475e0c0-b547-496d-a1bc-5402e5987d70",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questionf475e0c0-b547-496d-a1bc-5402e5987d70",
-                            "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of <em>R&amp;M</em> carried out on existing structures for <em>private industrial and/or private commercial </em>sector projects?",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include work aimed at:</strong>"
-                                    },
-                                    {
-                                        "list": ["repairing something that is broken", "maintaining an existing standard"]
-                                    },
-                                    {
-                                        "description": "<strong>Exclude:</strong>"
-                                    },
-                                    {
-                                        "list": ["major alterations, for example improvements and extensions", "VAT", "payments made to subcontractors"]
-                                    }
-                                ]
-                            },
-                            "definitions": [{
-                                "title": "Examples of private industrial and private commercial sector structures",
-                                "content": [{
-                                        "description": "<strong>Private commercial sector structures:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "Any construction work for the agriculture industry",
-                                            "Offices",
-                                            "Factories",
-                                            "Health facilities",
-                                            "Entertainment and sports facilities",
-                                            "Car parks",
-                                            "Educational institutions and their halls of residence",
-                                            "Garages and shops"
-                                        ]
-                                    },
-                                    {
-                                        "description": "<strong>Private industrial sector structures:</strong>"
-                                    },
-                                    {
-                                        "list": ["Factories", "Warehouses", "Any construction work in the coal, oil and steel industry"]
-                                    }
-                                ]
-                            }],
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer1e0761db-01e8-4ea7-a738-f6144be456b5",
-                                "mandatory": true,
-                                "type": "Currency",
-                                "label": "R&M for existing private industrial and/or private commercial sector projects",
-                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
-                                "q_code": "243",
-                                "max_value": {
-                                    "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
-                                    "exclusive": false
-                                },
-                                "decimal_places": 2,
-                                "currency": "GBP"
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer27e92f6a-21af-4432-b94c-5157746ebc9e",
-                                "condition": "not contains any",
-                                "values": ["Private commercial sector projects", "Private industrial sector projects"]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block3887799c-2d55-48f8-a52d-ee363054106e",
-                        "type": "CalculatedSummary",
-                        "titles": [{
-                            "value": "We calculate the <em>total value of other construction work</em> carried out to be <em>%(total)s.</em> Is this correct?"
-                        }],
-                        "calculation": {
-                            "calculation_type": "sum",
-                            "answers_to_calculate": [
-                                "answerdb018dc4-8664-4587-a038-12a468da441b",
-                                "answerc541b81f-6402-4934-821d-dc961bea86bf",
-                                "answer1a8a2700-9428-425a-97da-d81ce4eaf4a3",
-                                "answera11da5a9-892d-42f0-bb19-b3781974d741",
-                                "answer1e0761db-01e8-4ea7-a738-f6144be456b5"
                             ],
-                            "titles": [{
-                                "value": "Total value of all other construction work"
-                            }]
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "blockcb22fe8e-4000-418d-b0f1-ca57306a2c0e",
+                                        "when": [
+                                            {
+                                                "id": "answer50ae0d8f-dd41-43ab-8e29-431028500270",
+                                                "condition": "contains any",
+                                                "values": ["Yes, we carried out other construction work"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "group": "groupe9d26530-ad8f-4527-b09c-afacfa0c820a"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "id": "blockcb22fe8e-4000-418d-b0f1-ca57306a2c0e",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "questioncb22fe8e-4000-418d-b0f1-ca57306a2c0e",
+                                    "title": "Which sector did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} carry out other construction work for?",
+                                    "guidance": {
+                                        "content": [
+                                            {
+                                                "description": "<strong>Exclude:</strong>"
+                                            },
+                                            {
+                                                "list": ["work on residential buildings, for example housing, flats and maisonettes", "work on infrastructure"]
+                                            }
+                                        ]
+                                    },
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer27e92f6a-21af-4432-b94c-5157746ebc9e",
+                                            "mandatory": true,
+                                            "type": "Checkbox",
+                                            "label": "",
+                                            "description": "",
+                                            "q_code": "d2",
+                                            "options": [
+                                                {
+                                                    "label": "Public sector projects",
+                                                    "value": "Public sector projects",
+                                                    "description": "The public sector consists central government, local government, public non-financial corporations, Bank of England and public financial corporations."
+                                                },
+                                                {
+                                                    "label": "Private commercial sector projects",
+                                                    "value": "Private commercial sector projects",
+                                                    "description": "Part of the economy that includes all businesses and agriculture, except those businesses involved in manufacturing and  transport"
+                                                },
+                                                {
+                                                    "label": "Private industrial sector projects",
+                                                    "value": "Private industrial sector projects",
+                                                    "description": "Part of the economy that includes businesses involved in manufacturing and transport"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block6128bff1-69b5-4914-b49a-11facc75a178",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question6128bff1-69b5-4914-b49a-11facc75a178",
+                                    "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of work carried out on <em>other new structures</em> for <em>public</em> sector projects?",
+                                    "guidance": {
+                                        "content": [
+                                            {
+                                                "description": "<strong> Include:</strong>"
+                                            },
+                                            {
+                                                "list": [
+                                                    "new construction work",
+                                                    "demolition",
+                                                    "site preparation",
+                                                    "major alterations, for example improvements and extensions"
+                                                ]
+                                            },
+                                            {
+                                                "description": "<strong>Exclude:</strong>"
+                                            },
+                                            {
+                                                "list": [
+                                                    "work on infrastructure",
+                                                    "work on residential buildings, for example housing, flats and maisonettes",
+                                                    "VAT",
+                                                    "R&amp;M",
+                                                    "payments made to subcontractors"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "definitions": [
+                                        {
+                                            "title": "What we mean by \"other new structures\"",
+                                            "content": [
+                                                {
+                                                    "description": "This refers to work on new non-residential structures. If over half of a building&apos;s floor area is used for non-residential purposes, it is considered a non-residential building."
+                                                },
+                                                {
+                                                    "description": "<strong>Examples of other public sector structures:</strong>"
+                                                },
+                                                {
+                                                    "list": [
+                                                        "Offices",
+                                                        "Factories",
+                                                        "Warehouses",
+                                                        "Educational institutions and their halls of residence",
+                                                        "Health facilities",
+                                                        "Entertainment and sports facilities"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answerdb018dc4-8664-4587-a038-12a468da441b",
+                                            "mandatory": true,
+                                            "type": "Currency",
+                                            "label": "Other new structures for public sector projects",
+                                            "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
+                                            "q_code": "231",
+                                            "max_value": {
+                                                "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                                "exclusive": false
+                                            },
+                                            "decimal_places": 2,
+                                            "currency": "GBP"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer27e92f6a-21af-4432-b94c-5157746ebc9e",
+                                            "condition": "not contains any",
+                                            "values": ["Public sector projects"]
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block1fa2f7bd-0644-434a-a706-32931d727147",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question1fa2f7bd-0644-434a-a706-32931d727147",
+                                    "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of <em>R&amp;M</em> carried out on other existing structures for <em>public</em> sector projects?",
+                                    "guidance": {
+                                        "content": [
+                                            {
+                                                "description": "<strong>Include work aimed at:</strong>"
+                                            },
+                                            {
+                                                "list": ["repairing something which is broken", "maintaining an existing standard"]
+                                            },
+                                            {
+                                                "description": "<strong>Exclude:</strong>"
+                                            },
+                                            {
+                                                "list": [
+                                                    "work on infrastructure",
+                                                    "work on residential buildings, for example housing, flats and maisonettes",
+                                                    "major alterations, for example improvements and extensions",
+                                                    "VAT",
+                                                    "payments made to subcontractors"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "definitions": [
+                                        {
+                                            "title": "What we mean by \"other existing structures\"",
+                                            "content": [
+                                                {
+                                                    "description": "This refers to work on existing non-residential structures. If over half of a building&apos;s floor area is used for non-residential purposes, it is considered a non-residential building."
+                                                },
+                                                {
+                                                    "description": "<strong>Examples of other public sector structures:</strong>"
+                                                },
+                                                {
+                                                    "list": [
+                                                        "Offices",
+                                                        "Factories",
+                                                        "Warehouses",
+                                                        "Educational institutions and their halls of residence",
+                                                        "Health facilities",
+                                                        "Entertainment and sports facilities"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answerc541b81f-6402-4934-821d-dc961bea86bf",
+                                            "mandatory": true,
+                                            "type": "Currency",
+                                            "label": "R&M on other existing structures for public sector projects",
+                                            "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
+                                            "q_code": "232",
+                                            "max_value": {
+                                                "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                                "exclusive": false
+                                            },
+                                            "decimal_places": 2,
+                                            "currency": "GBP"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer27e92f6a-21af-4432-b94c-5157746ebc9e",
+                                            "condition": "not contains any",
+                                            "values": ["Public sector projects"]
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block3159dcad-c87b-4afa-860e-291c4d4b1414",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question3159dcad-c87b-4afa-860e-291c4d4b1414",
+                                    "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of work carried out on <em>new structures</em> for <em>private commercial</em> sector projects?",
+                                    "guidance": {
+                                        "content": [
+                                            {
+                                                "description": "<strong>Include:</strong>"
+                                            },
+                                            {
+                                                "list": [
+                                                    "new construction work",
+                                                    "demolition",
+                                                    "site preparation",
+                                                    "major alterations, for example improvements and extensions"
+                                                ]
+                                            },
+                                            {
+                                                "description": "<strong>Exclude:</strong>"
+                                            },
+                                            {
+                                                "list": ["VAT", "R&amp;M", "payments made to subcontractors"]
+                                            }
+                                        ]
+                                    },
+                                    "definitions": [
+                                        {
+                                            "title": "What we mean by the \"private commercial sector\"",
+                                            "content": [
+                                                {
+                                                    "description": "This sector refers to part of the economy that  includes all businesses, except those involved in manufacturing and transport."
+                                                },
+                                                {
+                                                    "description": "<strong>Examples of private commercial sector structures:</strong>"
+                                                },
+                                                {
+                                                    "list": [
+                                                        "Any construction work for the agriculture industry",
+                                                        "Offices",
+                                                        "Factories",
+                                                        "Health facilities",
+                                                        "Entertainment and sports facilities",
+                                                        "Car parks",
+                                                        "Educational institutions and their halls of residence",
+                                                        "Garages and shops"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer1a8a2700-9428-425a-97da-d81ce4eaf4a3",
+                                            "mandatory": true,
+                                            "type": "Currency",
+                                            "label": "New structures for private commercial sector projects",
+                                            "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
+                                            "q_code": "241",
+                                            "max_value": {
+                                                "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                                "exclusive": false
+                                            },
+                                            "decimal_places": 2,
+                                            "currency": "GBP"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer27e92f6a-21af-4432-b94c-5157746ebc9e",
+                                            "condition": "not contains any",
+                                            "values": ["Private commercial sector projects"]
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block4bc9c90a-5ef9-427a-b98a-03b9ffbd38d7",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question4bc9c90a-5ef9-427a-b98a-03b9ffbd38d7",
+                                    "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of work carried out on <em>new structures</em> for <em>private industrial</em> sector projects?",
+                                    "guidance": {
+                                        "content": [
+                                            {
+                                                "description": "<strong>Include:</strong>"
+                                            },
+                                            {
+                                                "list": [
+                                                    "new construction work",
+                                                    "demolition",
+                                                    "site preparation",
+                                                    "major alterations, for example improvements and extensions"
+                                                ]
+                                            },
+                                            {
+                                                "description": "<strong>Exclude:</strong>"
+                                            },
+                                            {
+                                                "list": ["VAT", "R&amp;M", "payments made to subcontractors"]
+                                            }
+                                        ]
+                                    },
+                                    "definitions": [
+                                        {
+                                            "title": "What we mean by the \"private industrial sector\"",
+                                            "content": [
+                                                {
+                                                    "description": "This sector refers to part of the economy that includes businesses involved in manufacturing and transport, excluding agriculture."
+                                                },
+                                                {
+                                                    "description": "<strong>Examples of private industrial sector structures:</strong>"
+                                                },
+                                                {
+                                                    "list": ["Factories", "Warehouses", "Any construction work in the coal, oil and steel industry"]
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answera11da5a9-892d-42f0-bb19-b3781974d741",
+                                            "mandatory": true,
+                                            "type": "Currency",
+                                            "label": "New structures for private industrial sector projects",
+                                            "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
+                                            "q_code": "242",
+                                            "max_value": {
+                                                "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                                "exclusive": false
+                                            },
+                                            "decimal_places": 2,
+                                            "currency": "GBP"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer27e92f6a-21af-4432-b94c-5157746ebc9e",
+                                            "condition": "not contains any",
+                                            "values": ["Private industrial sector projects"]
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "blockf475e0c0-b547-496d-a1bc-5402e5987d70",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "questionf475e0c0-b547-496d-a1bc-5402e5987d70",
+                                    "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of <em>R&amp;M</em> carried out on existing structures for <em>private industrial and/or private commercial </em>sector projects?",
+                                    "guidance": {
+                                        "content": [
+                                            {
+                                                "description": "<strong>Include work aimed at:</strong>"
+                                            },
+                                            {
+                                                "list": ["repairing something that is broken", "maintaining an existing standard"]
+                                            },
+                                            {
+                                                "description": "<strong>Exclude:</strong>"
+                                            },
+                                            {
+                                                "list": ["major alterations, for example improvements and extensions", "VAT", "payments made to subcontractors"]
+                                            }
+                                        ]
+                                    },
+                                    "definitions": [
+                                        {
+                                            "title": "Examples of private industrial and private commercial sector structures",
+                                            "content": [
+                                                {
+                                                    "description": "<strong>Private commercial sector structures:</strong>"
+                                                },
+                                                {
+                                                    "list": [
+                                                        "Any construction work for the agriculture industry",
+                                                        "Offices",
+                                                        "Factories",
+                                                        "Health facilities",
+                                                        "Entertainment and sports facilities",
+                                                        "Car parks",
+                                                        "Educational institutions and their halls of residence",
+                                                        "Garages and shops"
+                                                    ]
+                                                },
+                                                {
+                                                    "description": "<strong>Private industrial sector structures:</strong>"
+                                                },
+                                                {
+                                                    "list": ["Factories", "Warehouses", "Any construction work in the coal, oil and steel industry"]
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer1e0761db-01e8-4ea7-a738-f6144be456b5",
+                                            "mandatory": true,
+                                            "type": "Currency",
+                                            "label": "R&M for existing private industrial and/or private commercial sector projects",
+                                            "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
+                                            "q_code": "243",
+                                            "max_value": {
+                                                "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                                "exclusive": false
+                                            },
+                                            "decimal_places": 2,
+                                            "currency": "GBP"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer27e92f6a-21af-4432-b94c-5157746ebc9e",
+                                            "condition": "not contains any",
+                                            "values": ["Private commercial sector projects", "Private industrial sector projects"]
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block3887799c-2d55-48f8-a52d-ee363054106e",
+                            "type": "CalculatedSummary",
+                            "titles": [
+                                {
+                                    "value": "We calculate the <em>total value of other construction work</em> carried out to be <em>%(total)s.</em> Is this correct?"
+                                }
+                            ],
+                            "calculation": {
+                                "calculation_type": "sum",
+                                "answers_to_calculate": [
+                                    "answerdb018dc4-8664-4587-a038-12a468da441b",
+                                    "answerc541b81f-6402-4934-821d-dc961bea86bf",
+                                    "answer1a8a2700-9428-425a-97da-d81ce4eaf4a3",
+                                    "answera11da5a9-892d-42f0-bb19-b3781974d741",
+                                    "answer1e0761db-01e8-4ea7-a738-f6144be456b5"
+                                ],
+                                "titles": [
+                                    {
+                                        "value": "Total value of all other construction work"
+                                    }
+                                ]
+                            }
                         }
-                    }
-                ],
-                "skip_conditions": [{
-                        "when": [{
-                            "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
-                            "condition": "equals",
-                            "value": 0
-                        }]
-                    },
-                    {
-                        "when": [{
-                            "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
-                            "condition": "not set"
-                        }]
-                    }
-                ]
-            }]
+                    ],
+                    "skip_conditions": [
+                        {
+                            "when": [
+                                {
+                                    "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                    "condition": "equals",
+                                    "value": 0
+                                }
+                            ]
+                        },
+                        {
+                            "when": [
+                                {
+                                    "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                    "condition": "not set"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
         },
         {
             "id": "sectione9d26530-ad8f-4527-b09c-afacfa0c820a",
             "title": "Comments",
-            "groups": [{
+            "groups": [
+                {
                     "id": "groupe9d26530-ad8f-4527-b09c-afacfa0c820a",
                     "title": "Comments",
-                    "blocks": [{
-                        "id": "block37d73422-28cc-4beb-99ce-b099e612f6af",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question37d73422-28cc-4beb-99ce-b099e612f6af",
-                            "title": "Please explain any changes in your figures from the previous return, if applicable.",
-                            "description": "<p>If you provide comments we are less likely to contact you with data queries.</p>",
-                            "definitions": [{
-                                "title": "Examples of commentary",
-                                "content": [{
-                                        "description": "My figures are <em>lower than usual</em> this month due to:"
-                                    },
-                                    {
-                                        "list": ["adverse weather conditions", "economic downturn", "my business ceasing trading"]
-                                    },
-                                    {
-                                        "description": "My figures are <em>higher than usual</em> this month due to:"
-                                    },
-                                    {
-                                        "list": ["a new contract", "a large contract", "seasonal work"]
-                                    }
-                                ]
-                            }],
-                            "type": "General",
-                            "answers": [{
-                                "id": "answerd55fa781-60be-431b-a9c7-6b29d1c0e28b",
-                                "mandatory": false,
-                                "type": "TextArea",
-                                "label": "Comments",
-                                "description": "",
-                                "q_code": "146",
-                                "max_length": 2000
-                            }]
-                        }]
-                    }]
+                    "blocks": [
+                        {
+                            "id": "block37d73422-28cc-4beb-99ce-b099e612f6af",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question37d73422-28cc-4beb-99ce-b099e612f6af",
+                                    "title": "Please explain any changes in your figures from the previous return, if applicable.",
+                                    "description": "<p>If you provide comments we are less likely to contact you with data queries.</p>",
+                                    "definitions": [
+                                        {
+                                            "title": "Examples of commentary",
+                                            "content": [
+                                                {
+                                                    "description": "My figures are <em>lower than usual</em> this month due to:"
+                                                },
+                                                {
+                                                    "list": ["adverse weather conditions", "economic downturn", "my business ceasing trading"]
+                                                },
+                                                {
+                                                    "description": "My figures are <em>higher than usual</em> this month due to:"
+                                                },
+                                                {
+                                                    "list": ["a new contract", "a large contract", "seasonal work"]
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answerd55fa781-60be-431b-a9c7-6b29d1c0e28b",
+                                            "mandatory": false,
+                                            "type": "TextArea",
+                                            "label": "Comments",
+                                            "description": "",
+                                            "q_code": "146",
+                                            "max_length": 2000
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
                 },
                 {
                     "id": "summary-group",
                     "title": "Summary",
-                    "blocks": [{
-                        "type": "Summary",
-                        "id": "summary-block"
-                    }]
+                    "blocks": [
+                        {
+                            "type": "Summary",
+                            "id": "summary-block"
+                        }
+                    ]
                 }
             ]
         }
@@ -1557,7 +1811,8 @@
     "navigation": {
         "visible": true
     },
-    "metadata": [{
+    "metadata": [
+        {
             "name": "user_id",
             "validator": "string"
         },

--- a/data/en/construction_0001.json
+++ b/data/en/construction_0001.json
@@ -6,1802 +6,1543 @@
     "data_version": "0.0.1",
     "survey_id": "228",
     "title": "Monthly Business Survey - Construction and Allied Trades",
-    "sections": [
-        {
+    "sections": [{
             "id": "sectionb1d09333-c7fd-464a-a840-f86056fb32cf",
             "title": "Reporting period",
-            "groups": [
-                {
-                    "id": "groupb1d09333-c7fd-464a-a840-f86056fb32cf",
-                    "title": "Reporting period",
-                    "blocks": [
-                        {
-                            "type": "Introduction",
-                            "id": "introduction-block",
-                            "primary_content": [
-                                {
-                                    "type": "Basic",
-                                    "id": "primary",
-                                    "content": [
+            "groups": [{
+                "id": "groupb1d09333-c7fd-464a-a840-f86056fb32cf",
+                "title": "Reporting period",
+                "blocks": [{
+                        "type": "Introduction",
+                        "id": "introduction-block",
+                        "primary_content": [{
+                            "type": "Basic",
+                            "id": "primary",
+                            "content": [{
+                                "list": [
+                                    "Data should relate to all sites in England, Scotland and Wales but excludes Northern Ireland.",
+                                    "You can provide informed estimates if actual figures are not available.",
+                                    "We will treat your data securely and confidentially."
+                                ]
+                            }]
+                        }],
+                        "preview_content": {
+                            "id": "preview",
+                            "title": "Information you need",
+                            "content": [{
+                                "description": "You will be asked to provide information on the value of work undertaken by your business. Value of work refers to estimates of chargeable work carried out during the month; meaning work started, in progress, or completed."
+                            }],
+                            "questions": [{
+                                    "question": "Housing Work",
+                                    "content": [{
+                                            "description": "This section asks for information on the value of new builds and repair and maintenance (R&amp;M), improvements and major alterations on housing for public and private sector projects."
+                                        },
+                                        {
+                                            "description": "<strong>Include:</strong>"
+                                        },
                                         {
                                             "list": [
-                                                "Data should relate to all sites in England, Scotland and Wales but excludes Northern Ireland.",
-                                                "You can provide informed estimates if actual figures are not available.",
-                                                "We will treat your data securely and confidentially."
+                                                "work on buildings which you hope to sell later for profit (speculative work)",
+                                                "work done by your business on its own premises",
+                                                "fixtures, equipment and tools your business made and used in construction",
+                                                "materials your business used, overheads and profits",
+                                                "labour costs on your payroll"
+                                            ]
+                                        },
+                                        {
+                                            "description": "<strong>Exclude:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "VAT",
+                                                "payments made to subcontractors",
+                                                "payments made to consultants or architects",
+                                                "fixtures, equipment and tools your business made for sale",
+                                                "materials your business sold",
+                                                "value of land"
                                             ]
                                         }
                                     ]
-                                }
-                            ],
-                            "preview_content": {
-                                "id": "preview",
-                                "title": "Information you need",
-                                "content": [
-                                    {
-                                        "description": "You will be asked to provide information on the value of work undertaken by your business. Value of work refers to estimates of chargeable work carried out during the month; meaning work started, in progress, or completed."
-                                    }
-                                ],
-                                "questions": [
-                                    {
-                                        "question": "Housing Work",
-                                        "content": [
-                                            {
-                                                "description": "This section asks for information on the value of new builds and repair and maintenance (R&amp;M), improvements and major alterations on housing for public and private sector projects."
-                                            },
-                                            {
-                                                "description": "<strong>Include:</strong>"
-                                            },
-                                            {
-                                                "list": [
-                                                    "work on buildings which you hope to sell later for profit (speculative work)",
-                                                    "work done by your business on its own premises",
-                                                    "fixtures, equipment and tools your business made and used in construction",
-                                                    "materials your business used, overheads and profits",
-                                                    "labour costs on your payroll"
-                                                ]
-                                            },
-                                            {
-                                                "description": "<strong>Exclude:</strong>"
-                                            },
-                                            {
-                                                "list": [
-                                                    "VAT",
-                                                    "payments made to subcontractors",
-                                                    "payments made to consultants or architects",
-                                                    "fixtures, equipment and tools your business made for sale",
-                                                    "materials your business sold",
-                                                    "value of land"
-                                                ]
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "question": "Infrastructure",
-                                        "content": [
-                                            {
-                                                "description": "This section asks for information on the value of new infrastructure, and repair and maintenance (R&amp;M) of infrastructure."
-                                            },
-                                            {
-                                                "description": "<strong>Include:</strong>"
-                                            },
-                                            {
-                                                "list": [
-                                                    "work done by your own business on its own business premises",
-                                                    "fixtures, equipment and tools your business made and used in construction",
-                                                    "materials your business used, overheads and profits",
-                                                    "labour costs on your payroll"
-                                                ]
-                                            },
-                                            {
-                                                "description": "<strong>Exclude:</strong>"
-                                            },
-                                            {
-                                                "list": [
-                                                    "VAT",
-                                                    "payments made to subcontractors",
-                                                    "payments made to consultants or architects",
-                                                    "fixtures, equipment and tools your business made for sale",
-                                                    "materials your business sold",
-                                                    "value of land"
-                                                ]
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "question": "Other construction work",
-                                        "content": [
-                                            {
-                                                "description": "This section asks for information on the value of other construction work carried out on new structures for public, commercial and industrial projects, and repair and maintenance (R&amp;M) of existing structures."
-                                            },
-                                            {
-                                                "description": "<strong>Include:</strong>"
-                                            },
-                                            {
-                                                "list": [
-                                                    "work on buildings which you hope to sell later for profit (speculative work)",
-                                                    "work done by your business on its own premises",
-                                                    "fixtures, equipment and tools your business made and used in construction",
-                                                    "materials your business used, overheads and profits",
-                                                    "labour costs on your payroll"
-                                                ]
-                                            },
-                                            {
-                                                "description": "<strong>Exclude:</strong>"
-                                            },
-                                            {
-                                                "list": [
-                                                    "work on infrastructure",
-                                                    "work on residential buildings",
-                                                    "VAT",
-                                                    "payments made to subcontractors",
-                                                    "payments made to consultants or architects",
-                                                    "fixtures, equipment and tools your business made for sale",
-                                                    "materials your business sold",
-                                                    "value of land"
-                                                ]
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "question": "Additional comments",
-                                        "content": [
-                                            {
-                                                "description": "Please tell us about any additional comments you have about your data."
-                                            },
-                                            {
-                                                "description": "<strong>For example:</strong>"
-                                            },
-                                            {
-                                                "description": "My figures are <em>lower than usual</em> this month due to:"
-                                            },
-                                            {
-                                                "list": ["adverse weather conditions", "economic downturn", "my business ceasing trading"]
-                                            },
-                                            {
-                                                "description": "My figures are <em>higher than usual</em> this month due to:"
-                                            },
-                                            {
-                                                "list": ["a new contract", "a large contract", "seasonal work"]
-                                            }
-                                        ]
-                                    }
-                                ]
-                            },
-                            "secondary_content": [
+                                },
                                 {
-                                    "id": "secondary-content",
-                                    "title": "How we use your data",
-                                    "content": [
+                                    "question": "Infrastructure",
+                                    "content": [{
+                                            "description": "This section asks for information on the value of new infrastructure, and repair and maintenance (R&amp;M) of infrastructure."
+                                        },
+                                        {
+                                            "description": "<strong>Include:</strong>"
+                                        },
                                         {
                                             "list": [
-                                                "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
-                                                "The information you provide contributes to Gross Domestic Product (GDP). The Monthly Business Survey figures are published monthly in the Output in the Construction Industry Statistical Bulletin."
+                                                "work done by your own business on its own business premises",
+                                                "fixtures, equipment and tools your business made and used in construction",
+                                                "materials your business used, overheads and profits",
+                                                "labour costs on your payroll"
                                             ]
+                                        },
+                                        {
+                                            "description": "<strong>Exclude:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "VAT",
+                                                "payments made to subcontractors",
+                                                "payments made to consultants or architects",
+                                                "fixtures, equipment and tools your business made for sale",
+                                                "materials your business sold",
+                                                "value of land"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": "Other construction work",
+                                    "content": [{
+                                            "description": "This section asks for information on the value of other construction work carried out on new structures for public, commercial and industrial projects, and repair and maintenance (R&amp;M) of existing structures."
+                                        },
+                                        {
+                                            "description": "<strong>Include:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "work on buildings which you hope to sell later for profit (speculative work)",
+                                                "work done by your business on its own premises",
+                                                "fixtures, equipment and tools your business made and used in construction",
+                                                "materials your business used, overheads and profits",
+                                                "labour costs on your payroll"
+                                            ]
+                                        },
+                                        {
+                                            "description": "<strong>Exclude:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "work on infrastructure",
+                                                "work on residential buildings",
+                                                "VAT",
+                                                "payments made to subcontractors",
+                                                "payments made to consultants or architects",
+                                                "fixtures, equipment and tools your business made for sale",
+                                                "materials your business sold",
+                                                "value of land"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": "Additional comments",
+                                    "content": [{
+                                            "description": "Please tell us about any additional comments you have about your data."
+                                        },
+                                        {
+                                            "description": "<strong>For example:</strong>"
+                                        },
+                                        {
+                                            "description": "My figures are <em>lower than usual</em> this month due to:"
+                                        },
+                                        {
+                                            "list": ["adverse weather conditions", "economic downturn", "my business ceasing trading"]
+                                        },
+                                        {
+                                            "description": "My figures are <em>higher than usual</em> this month due to:"
+                                        },
+                                        {
+                                            "list": ["a new contract", "a large contract", "seasonal work"]
                                         }
                                     ]
                                 }
                             ]
                         },
-                        {
-                            "id": "blockb859977c-01e2-498a-807e-5438af81fdd2",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "questionb859977c-01e2-498a-807e-5438af81fdd2",
-                                    "title": "Are you able to report for the calendar month {{ metadata['ref_p_start_date'] | format_date }} to {{ metadata['ref_p_end_date'] | format_date }}?",
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answerdadafe6c-4875-43bc-87e2-6097ff0d106e",
-                                            "mandatory": true,
-                                            "type": "Radio",
-                                            "label": "",
-                                            "description": "",
-                                            "q_code": "901",
-                                            "options": [
-                                                {
-                                                    "label": "Yes, I can report for this period",
-                                                    "value": "Yes, I can report for this period"
-                                                },
-                                                {
-                                                    "label": "No, I need to report for a different period",
-                                                    "value": "No, I need to report for a different period"
-                                                }
-                                            ]
-                                        }
-                                    ]
+                        "secondary_content": [{
+                            "id": "secondary-content",
+                            "title": "How we use your data",
+                            "content": [{
+                                "list": [
+                                    "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
+                                    "The information you provide contributes to Gross Domestic Product (GDP). The Monthly Business Survey figures are published monthly in the Output in the Construction Industry Statistical Bulletin."
+                                ]
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "blockb859977c-01e2-498a-807e-5438af81fdd2",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "questionb859977c-01e2-498a-807e-5438af81fdd2",
+                            "title": "Are you able to report for the calendar month {{ metadata['ref_p_start_date'] | format_date }} to {{ metadata['ref_p_end_date'] | format_date }}?",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answerdadafe6c-4875-43bc-87e2-6097ff0d106e",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "label": "",
+                                "description": "",
+                                "q_code": "901",
+                                "options": [{
+                                        "label": "Yes, I can report for this period",
+                                        "value": "Yes, I can report for this period"
+                                    },
+                                    {
+                                        "label": "No, I need to report for a different period",
+                                        "value": "No, I need to report for a different period"
+                                    }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "group": "group7e41e171-26eb-42c0-99ef-b34fa447c363",
+                                    "when": [{
+                                        "id": "answerdadafe6c-4875-43bc-87e2-6097ff0d106e",
+                                        "condition": "contains any",
+                                        "values": ["Yes, I can report for this period"]
+                                    }]
                                 }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "group": "group7e41e171-26eb-42c0-99ef-b34fa447c363",
-                                        "when": [
-                                            {
-                                                "id": "answerdadafe6c-4875-43bc-87e2-6097ff0d106e",
-                                                "condition": "contains any",
-                                                "values": ["Yes, I can report for this period"]
-                                            }
-                                        ]
+                            },
+                            {
+                                "goto": {
+                                    "block": "block09dffdbc-5a11-424a-8da2-388b91b16e51"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "block09dffdbc-5a11-424a-8da2-388b91b16e51",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question09dffdbc-5a11-424a-8da2-388b91b16e51",
+                            "title": "What dates will you be reporting for?",
+                            "type": "DateRange",
+                            "answers": [{
+                                    "id": "answer440c8850-b115-4f6b-b0f5-52d911dd6ef6from",
+                                    "type": "Date",
+                                    "mandatory": true,
+                                    "label": "From",
+                                    "q_code": "11",
+                                    "minimum": {
+                                        "meta": "ref_p_start_date",
+                                        "offset_by": {
+                                            "days": -19
+                                        }
                                     }
                                 },
                                 {
-                                    "goto": {
-                                        "block": "block09dffdbc-5a11-424a-8da2-388b91b16e51"
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block09dffdbc-5a11-424a-8da2-388b91b16e51",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question09dffdbc-5a11-424a-8da2-388b91b16e51",
-                                    "title": "What dates will you be reporting for?",
-                                    "type": "DateRange",
-                                    "answers": [
-                                        {
-                                            "id": "answer440c8850-b115-4f6b-b0f5-52d911dd6ef6from",
-                                            "type": "Date",
-                                            "mandatory": true,
-                                            "label": "From",
-                                            "q_code": "11",
-                                            "minimum": {
-                                                "meta": "ref_p_start_date",
-                                                "offset_by": {
-                                                    "days": -19
-                                                }
-                                            }
-                                        },
-                                        {
-                                            "id": "answer440c8850-b115-4f6b-b0f5-52d911dd6ef6to",
-                                            "type": "Date",
-                                            "mandatory": true,
-                                            "label": "To",
-                                            "q_code": "12",
-                                            "maximum": {
-                                                "meta": "ref_p_end_date",
-                                                "offset_by": {
-                                                    "days": 20
-                                                }
-                                            }
-                                        }
-                                    ],
-                                    "period_limits": {
-                                        "minimum": {
-                                            "days": 23
-                                        },
-                                        "maximum": {
-                                            "days": 50
+                                    "id": "answer440c8850-b115-4f6b-b0f5-52d911dd6ef6to",
+                                    "type": "Date",
+                                    "mandatory": true,
+                                    "label": "To",
+                                    "q_code": "12",
+                                    "maximum": {
+                                        "meta": "ref_p_end_date",
+                                        "offset_by": {
+                                            "days": 20
                                         }
                                     }
                                 }
-                            ]
-                        }
-                    ]
-                }
-            ]
+                            ],
+                            "period_limits": {
+                                "minimum": {
+                                    "days": 23
+                                },
+                                "maximum": {
+                                    "days": 50
+                                }
+                            }
+                        }]
+                    }
+                ]
+            }]
         },
         {
             "id": "section7e41e171-26eb-42c0-99ef-b34fa447c363",
             "title": "Value of work",
-            "groups": [
-                {
-                    "id": "group7e41e171-26eb-42c0-99ef-b34fa447c363",
-                    "title": "Value of work",
-                    "blocks": [
-                        {
-                            "type": "Interstitial",
-                            "id": "group7e41e171-26eb-42c0-99ef-b34fa447c363-introduction",
-                            "title": "This survey requires you to report the value of work",
-                            "description": "<p>Value of work refers to estimates of <em>chargeable work</em> carried out during the month. This includes work started, work in progress and work completed.</p>"
-                        },
-                        {
-                            "id": "block69ae90ee-65a6-49ef-8ca9-1c55c9eb6688",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question69ae90ee-65a6-49ef-8ca9-1c55c9eb6688",
-                                    "title": "During the period {{ format_conditional_date (answers['answer440c8850-b115-4f6b-b0f5-52d911dd6ef6from'], metadata['ref_p_start_date']) }} to {{ format_conditional_date (answers['answer440c8850-b115-4f6b-b0f5-52d911dd6ef6to'], metadata['ref_p_end_date']) }}, what was the <em>total value of all construction work</em> carried out by {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
-                                    "description": "<p>If you are a fitter or installer, you are included within the construction industry so should report your figures.</p>",
-                                    "guidance": {
-                                        "content": [
-                                            {
-                                                "description": "<strong>Include:</strong>"
-                                            },
-                                            {
-                                                "list": [
-                                                    "new builds and repair and maintenance (R&amp;M) on housing and other residential properties, infrastructure, commercial structures and industrial structures",
-                                                    "(speculative) work on buildings which you hope to sell later for profit",
-                                                    "work done by your business on its own premises",
-                                                    "fixtures, equipment and tools your business made and used in construction",
-                                                    "materials your business used, overheads and profits",
-                                                    "labour costs on your payroll"
-                                                ]
-                                            },
-                                            {
-                                                "description": "<strong>Exclude:</strong>"
-                                            },
-                                            {
-                                                "list": [
-                                                    "VAT",
-                                                    "payments made to subcontractors",
-                                                    "payments made to consultants or architects",
-                                                    "fixtures, equipment and tools your business made for sale",
-                                                    "materials your business sold",
-                                                    "value of land"
-                                                ]
-                                            }
+            "groups": [{
+                "id": "group7e41e171-26eb-42c0-99ef-b34fa447c363",
+                "title": "Value of work",
+                "blocks": [{
+                        "type": "Interstitial",
+                        "id": "group7e41e171-26eb-42c0-99ef-b34fa447c363-introduction",
+                        "title": "This survey requires you to report the value of work",
+                        "description": "<p>Value of work refers to estimates of <em>chargeable work</em> carried out during the month. This includes work started, work in progress and work completed.</p>"
+                    },
+                    {
+                        "id": "block69ae90ee-65a6-49ef-8ca9-1c55c9eb6688",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question69ae90ee-65a6-49ef-8ca9-1c55c9eb6688",
+                            "title": "During the period {{ format_conditional_date (answers['answer440c8850-b115-4f6b-b0f5-52d911dd6ef6from'], metadata['ref_p_start_date']) }} to {{ format_conditional_date (answers['answer440c8850-b115-4f6b-b0f5-52d911dd6ef6to'], metadata['ref_p_end_date']) }}, what was the <em>total value of all construction work</em> carried out by {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                            "description": "<p>If you are a fitter or installer, you are included within the construction industry so should report your figures.</p>",
+                            "guidance": {
+                                "content": [{
+                                        "description": "<strong>Include:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "new builds and repair and maintenance (R&amp;M) on housing and other residential properties, infrastructure, commercial structures and industrial structures",
+                                            "(speculative) work on buildings which you hope to sell later for profit",
+                                            "work done by your business on its own premises",
+                                            "fixtures, equipment and tools your business made and used in construction",
+                                            "materials your business used, overheads and profits",
+                                            "labour costs on your payroll"
                                         ]
                                     },
-                                    "definitions": [
-                                        {
-                                            "title": "What we mean by \"total value of all construction work\"",
-                                            "content": [
-                                                {
-                                                    "description": "This refers to <em>all work on new structures and repair and maintenance (R&amp;M) on existing structures,</em> carried out on housing, infrastructure, commercial and industrial projects for the public and private sector."
-                                                },
-                                                {
-                                                    "description": "<strong>Examples of housing:</strong>"
-                                                },
-                                                {
-                                                    "list": ["Flats and maisonettes", "New houses", "Other types of residential housing"]
-                                                },
-                                                {
-                                                    "description": "<strong>Examples of infrastructure:</strong>"
-                                                },
-                                                {
-                                                    "list": [
-                                                        "Electricity, such as power stations",
-                                                        "Gas, such as gas works and laying pipelines",
-                                                        "Air transport, harbours, roads, and railways",
-                                                        "Drainage, sewerage, and water such as reservoirs",
-                                                        "Communication"
-                                                    ]
-                                                },
-                                                {
-                                                    "description": "<strong>Examples of commercial and industrial structures:</strong>"
-                                                },
-                                                {
-                                                    "list": [
-                                                        "Offices",
-                                                        "Factories",
-                                                        "Warehouses",
-                                                        "Educational institutions and their halls of residence",
-                                                        "Health facilities",
-                                                        "Entertainment and sports facilities",
-                                                        "Car parks",
-                                                        "Garages and shops",
-                                                        "Any construction work in the coal, oil, agriculture and steel industry"
-                                                    ]
-                                                }
-                                            ]
-                                        }
-                                    ],
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
-                                            "mandatory": true,
-                                            "type": "Currency",
-                                            "label": "Total value of all work carried out",
-                                            "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
-                                            "q_code": "290",
-                                            "min_value": {
-                                                "value": 0,
-                                                "exclusive": false
-                                            },
-                                            "decimal_places": 2,
-                                            "currency": "GBP"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "group": "groupe9d26530-ad8f-4527-b09c-afacfa0c820a",
-                                        "when": [
-                                            {
-                                                "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
-                                                "condition": "equals",
-                                                "value": 0
-                                            }
+                                    {
+                                        "description": "<strong>Exclude:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "VAT",
+                                            "payments made to subcontractors",
+                                            "payments made to consultants or architects",
+                                            "fixtures, equipment and tools your business made for sale",
+                                            "materials your business sold",
+                                            "value of land"
                                         ]
                                     }
-                                },
-                                {
-                                    "goto": {
-                                        "group": "groupe9d26530-ad8f-4527-b09c-afacfa0c820a",
-                                        "when": [
-                                            {
-                                                "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
-                                                "condition": "not set"
-                                            }
+                                ]
+                            },
+                            "definitions": [{
+                                "title": "What we mean by \"total value of all construction work\"",
+                                "content": [{
+                                        "description": "This refers to <em>all work on new structures and repair and maintenance (R&amp;M) on existing structures,</em> carried out on housing, infrastructure, commercial and industrial projects for the public and private sector."
+                                    },
+                                    {
+                                        "description": "<strong>Examples of housing:</strong>"
+                                    },
+                                    {
+                                        "list": ["Flats and maisonettes", "New houses", "Other types of residential housing"]
+                                    },
+                                    {
+                                        "description": "<strong>Examples of infrastructure:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "Electricity, such as power stations",
+                                            "Gas, such as gas works and laying pipelines",
+                                            "Air transport, harbours, roads, and railways",
+                                            "Drainage, sewerage, and water such as reservoirs",
+                                            "Communication"
+                                        ]
+                                    },
+                                    {
+                                        "description": "<strong>Examples of commercial and industrial structures:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "Offices",
+                                            "Factories",
+                                            "Warehouses",
+                                            "Educational institutions and their halls of residence",
+                                            "Health facilities",
+                                            "Entertainment and sports facilities",
+                                            "Car parks",
+                                            "Garages and shops",
+                                            "Any construction work in the coal, oil, agriculture and steel industry"
                                         ]
                                     }
+                                ]
+                            }],
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                "mandatory": true,
+                                "type": "Currency",
+                                "label": "Total value of all work carried out",
+                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
+                                "q_code": "290",
+                                "min_value": {
+                                    "value": 0,
+                                    "exclusive": false
                                 },
-                                {
-                                    "goto": {
-                                        "group": "group95c68629-8efd-4913-b465-41b686719d32"
-                                    }
+                                "decimal_places": 2,
+                                "currency": "GBP"
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "group": "groupe9d26530-ad8f-4527-b09c-afacfa0c820a",
+                                    "when": [{
+                                        "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                        "condition": "equals",
+                                        "value": 0
+                                    }]
                                 }
-                            ]
-                        }
-                    ]
-                }
-            ]
+                            },
+                            {
+                                "goto": {
+                                    "group": "groupe9d26530-ad8f-4527-b09c-afacfa0c820a",
+                                    "when": [{
+                                        "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                        "condition": "not set"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "group": "group95c68629-8efd-4913-b465-41b686719d32"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }]
         },
         {
             "id": "section95c68629-8efd-4913-b465-41b686719d32",
             "title": "Housing work",
-            "groups": [
-                {
-                    "id": "group95c68629-8efd-4913-b465-41b686719d32",
-                    "title": "Housing work",
-                    "blocks": [
-                        {
-                            "type": "Interstitial",
-                            "id": "group95c68629-8efd-4913-b465-41b686719d32-introduction",
-                            "title": "Housing work",
-                            "description": "<p>This section asks for information on the value of new builds and repair and maintenance (R&amp;M), improvements and major alterations on housing for public and private sector projects.</p><p>You will be asked to provide information on the value of work undertaken by your business. Value of work refers to estimates of chargeable work carried out during the month; meaning work started, in progress, or completed.</p><p><strong>Include:</strong></p><ul><li>work on buildings which you hope to sell later for profit (speculative work)</li><li>work done by your business on its own premises</li><li>fixtures, equipment and tools your business made and used in construction</li><li>materials your business used, overheads and profits</li><li>labour costs on your payroll</li></ul><p><strong>Exclude:</strong></p><ul><li>VAT</li><li>payments made to subcontractors </li><li>payments made to consultants or architects</li><li>fixtures, equipment and tools your business made for sale</li><li>materials your business sold</li><li>value of land</li></ul>"
-                        },
-                        {
-                            "id": "blockbaffab41-96f6-4f04-901d-5ff18c15bb90",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "questionbaffab41-96f6-4f04-901d-5ff18c15bb90",
-                                    "title": "During the period {{ format_conditional_date (answers['answer440c8850-b115-4f6b-b0f5-52d911dd6ef6from'], metadata['ref_p_start_date']) }} to {{ format_conditional_date (answers['answer440c8850-b115-4f6b-b0f5-52d911dd6ef6to'], metadata['ref_p_end_date']) }}, did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} carry out any work on <em>housing</em>?",
-                                    "description": "<p>If you are a fitter or installer, you are included within the construction industry sector so should report your figures.</p>",
-                                    "guidance": {
-                                        "content": [
-                                            {
-                                                "description": "<strong>Include new builds and repair and maintenance (R&amp;M) of:</strong>"
-                                            },
-                                            {
-                                                "list": ["flats and maisonettes", "new houses", "other types of residential housing"]
-                                            },
-                                            {
-                                                "description": "<strong>Exclude:</strong>"
-                                            },
-                                            {
-                                                "list": ["any work on halls of residence for educational institutions"]
-                                            }
-                                        ]
+            "groups": [{
+                "id": "group95c68629-8efd-4913-b465-41b686719d32",
+                "title": "Housing work",
+                "blocks": [{
+                        "type": "Interstitial",
+                        "id": "group95c68629-8efd-4913-b465-41b686719d32-introduction",
+                        "title": "Housing work",
+                        "description": "<p>This section asks for information on the value of new builds and repair and maintenance (R&amp;M), improvements and major alterations on housing for public and private sector projects.</p><p>You will be asked to provide information on the value of work undertaken by your business. Value of work refers to estimates of chargeable work carried out during the month; meaning work started, in progress, or completed.</p><p><strong>Include:</strong></p><ul><li>work on buildings which you hope to sell later for profit (speculative work)</li><li>work done by your business on its own premises</li><li>fixtures, equipment and tools your business made and used in construction</li><li>materials your business used, overheads and profits</li><li>labour costs on your payroll</li></ul><p><strong>Exclude:</strong></p><ul><li>VAT</li><li>payments made to subcontractors </li><li>payments made to consultants or architects</li><li>fixtures, equipment and tools your business made for sale</li><li>materials your business sold</li><li>value of land</li></ul>"
+                    },
+                    {
+                        "id": "blockbaffab41-96f6-4f04-901d-5ff18c15bb90",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "questionbaffab41-96f6-4f04-901d-5ff18c15bb90",
+                            "title": "During the period {{ format_conditional_date (answers['answer440c8850-b115-4f6b-b0f5-52d911dd6ef6from'], metadata['ref_p_start_date']) }} to {{ format_conditional_date (answers['answer440c8850-b115-4f6b-b0f5-52d911dd6ef6to'], metadata['ref_p_end_date']) }}, did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} carry out any work on <em>housing</em>?",
+                            "description": "<p>If you are a fitter or installer, you are included within the construction industry sector so should report your figures.</p>",
+                            "guidance": {
+                                "content": [{
+                                        "description": "<strong>Include new builds and repair and maintenance (R&amp;M) of:</strong>"
                                     },
-                                    "definitions": [
-                                        {
-                                            "title": "What we mean by \"work on housing\"",
-                                            "content": [
-                                                {
-                                                    "description": "This refers to work on residential buildings. If over half of a building&apos;s floor area is used for residential purposes, it is considered a residential building."
-                                                }
-                                            ]
-                                        }
-                                    ],
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answera75253f4-438c-4bdf-8613-cbfa2a3a1fb6",
-                                            "mandatory": true,
-                                            "type": "Radio",
-                                            "label": "",
-                                            "description": "",
-                                            "q_code": "902",
-                                            "options": [
-                                                {
-                                                    "label": "Yes, we carried out work on housing",
-                                                    "value": "Yes, we carried out work on housing"
-                                                },
-                                                {
-                                                    "label": "No, we did not carry out work on housing",
-                                                    "value": "No, we did not carry out work on housing"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "block": "blockc102510b-e675-4074-8cdb-d6b8c5729a29",
-                                        "when": [
-                                            {
-                                                "id": "answera75253f4-438c-4bdf-8613-cbfa2a3a1fb6",
-                                                "condition": "contains any",
-                                                "values": ["Yes, we carried out work on housing"]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "group": "group551ac31e-ba5e-4161-a93e-92a06c53c6ad"
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "id": "blockc102510b-e675-4074-8cdb-d6b8c5729a29",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "questionc102510b-e675-4074-8cdb-d6b8c5729a29",
-                                    "title": "Which sector did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} carry out housing work for?",
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer35ce4949-ad6d-4137-b28b-ce3b5723831e",
-                                            "mandatory": true,
-                                            "type": "Checkbox",
-                                            "label": "",
-                                            "description": "",
-                                            "q_code": "d1",
-                                            "options": [
-                                                {
-                                                    "label": "Public sector projects",
-                                                    "value": "Public sector projects",
-                                                    "description": "In the UK, the public sector consists of five sub-sectors: central government, local government, public non-financial corporations, Bank of England, public financial corporations (public sector banks)"
-                                                },
-                                                {
-                                                    "label": "Private sector projects",
-                                                    "value": "Private sector projects",
-                                                    "description": "The private sector refers to the part of the economy that is for profit and is owned by private organisations, for example housing associations, or individuals"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "blocke9a89f15-d5ad-4698-90ac-aaec447c5a07",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "questione9a89f15-d5ad-4698-90ac-aaec447c5a07",
-                                    "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of work carried out on <em>new housing builds</em> for <em>public</em> sector projects?",
-                                    "guidance": {
-                                        "content": [
-                                            {
-                                                "description": "<strong>Include:</strong>"
-                                            },
-                                            {
-                                                "list": ["new construction work", "demolition", "site preparation"]
-                                            },
-                                            {
-                                                "description": "<strong>Exclude:</strong>"
-                                            },
-                                            {
-                                                "list": [
-                                                    "VAT",
-                                                    "repair and maintenance (R&amp;M)",
-                                                    "major alterations, for example improvements and extensions",
-                                                    "payments made to subcontractors",
-                                                    "any work on halls of residence for educational institutions"
-                                                ]
-                                            }
-                                        ]
-                                    },
-                                    "definitions": [
-                                        {
-                                            "title": "What we mean by \"public sector\"",
-                                            "content": [
-                                                {
-                                                    "description": "In the UK, the public sector consists of five sub-sectors:"
-                                                },
-                                                {
-                                                    "list": [
-                                                        "central government",
-                                                        "local government",
-                                                        "public non-financial corporations",
-                                                        "Bank of England",
-                                                        "public financial corporations, for example public sector banks"
-                                                    ]
-                                                }
-                                            ]
-                                        }
-                                    ],
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answercf9a19af-7bfb-4a55-9372-16987cc23d17",
-                                            "mandatory": true,
-                                            "type": "Currency",
-                                            "label": "New housing builds for public sector projects",
-                                            "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
-                                            "q_code": "201",
-                                            "max_value": {
-                                                "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
-                                                "exclusive": false
-                                            },
-                                            "decimal_places": 2,
-                                            "currency": "GBP"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer35ce4949-ad6d-4137-b28b-ce3b5723831e",
-                                            "condition": "not contains any",
-                                            "values": ["Public sector projects"]
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block4e0f51d6-103f-4495-b6ac-e8d21d536769",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question4e0f51d6-103f-4495-b6ac-e8d21d536769",
-                                    "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of <em>repair and maintenance (R&amp;M), improvements and major alterations</em> carried out on existing housing for <em>public</em> sector projects?",
-                                    "guidance": {
-                                        "content": [
-                                            {
-                                                "description": "<strong>Include:</strong>"
-                                            },
-                                            {
-                                                "list": [
-                                                    "extensions",
-                                                    "any work aimed at repairing something which is broken",
-                                                    "maintaining something to an existing standard"
-                                                ]
-                                            },
-                                            {
-                                                "description": "<strong>Exclude:</strong>"
-                                            },
-                                            {
-                                                "list": [
-                                                    "VAT",
-                                                    "payments made to subcontractors",
-                                                    "any work on halls of residence for educational institutions"
-                                                ]
-                                            }
-                                        ]
-                                    },
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer9368d5d6-a302-40b1-9211-f9ae4ceee109",
-                                            "mandatory": true,
-                                            "type": "Currency",
-                                            "label": "R&M, improvements and major alterations on existing housing for public sector projects",
-                                            "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
-                                            "q_code": "202",
-                                            "max_value": {
-                                                "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
-                                                "exclusive": false
-                                            },
-                                            "decimal_places": 2,
-                                            "currency": "GBP"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer35ce4949-ad6d-4137-b28b-ce3b5723831e",
-                                            "condition": "not contains any",
-                                            "values": ["Public sector projects"]
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block510a45f5-aa4f-4d2d-9268-52ca13e0bb7b",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question510a45f5-aa4f-4d2d-9268-52ca13e0bb7b",
-                                    "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of work carried out on <em>new housing builds</em> for <em>private</em> sector projects?",
-                                    "guidance": {
-                                        "content": [
-                                            {
-                                                "description": "<strong>Include:</strong>"
-                                            },
-                                            {
-                                                "list": ["new construction work", "demolition", "site preparation"]
-                                            },
-                                            {
-                                                "description": "<strong>Exclude:</strong>"
-                                            },
-                                            {
-                                                "list": [
-                                                    "VAT",
-                                                    "R&amp;M",
-                                                    "major alterations, for example improvements and extensions",
-                                                    "payments made to subcontractors",
-                                                    "any work on halls of residence for educational institutions"
-                                                ]
-                                            }
-                                        ]
-                                    },
-                                    "definitions": [
-                                        {
-                                            "title": "What we mean by \"private sector\"",
-                                            "content": [
-                                                {
-                                                    "description": "The private sector refers to the part of the economy that is for profit and is owned by private organisations or individuals."
-                                                },
-                                                {
-                                                    "description": "<strong>Examples of the private sector:</strong>"
-                                                },
-                                                {
-                                                    "list": [
-                                                        "Small and medium-sized businesses",
-                                                        "Housing associations",
-                                                        "Multinationals",
-                                                        "Partnerships and sole traders",
-                                                        "Households"
-                                                    ]
-                                                }
-                                            ]
-                                        }
-                                    ],
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer24071a9f-30fa-4e1e-bd21-198ba49129b5",
-                                            "mandatory": true,
-                                            "type": "Currency",
-                                            "label": "New housing builds for private sector projects",
-                                            "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
-                                            "q_code": "211",
-                                            "max_value": {
-                                                "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
-                                                "exclusive": false
-                                            },
-                                            "decimal_places": 2,
-                                            "currency": "GBP"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer35ce4949-ad6d-4137-b28b-ce3b5723831e",
-                                            "condition": "not contains any",
-                                            "values": ["Private sector projects"]
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block2da3a1a1-9d5d-4ce1-a84e-3f3e1a22fbd9",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question2da3a1a1-9d5d-4ce1-a84e-3f3e1a22fbd9",
-                                    "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of <em>R&amp;M, improvements and major alterations</em> carried out on existing housing for <em>private</em> sector projects?",
-                                    "guidance": {
-                                        "content": [
-                                            {
-                                                "description": "<strong>Include:</strong>"
-                                            },
-                                            {
-                                                "list": [
-                                                    "extensions",
-                                                    "any work aimed at repairing something that is broken",
-                                                    "maintaining something to an existing standard"
-                                                ]
-                                            },
-                                            {
-                                                "description": "<strong>Exclude:</strong>"
-                                            },
-                                            {
-                                                "list": [
-                                                    "VAT",
-                                                    "payments made to subcontractors",
-                                                    "any work on halls of residence for educational institutions"
-                                                ]
-                                            }
-                                        ]
-                                    },
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer214ea602-4fbe-4775-ae6b-6b99c9779b62",
-                                            "mandatory": true,
-                                            "type": "Currency",
-                                            "label": "R&M, improvements and major alterations on existing housing for private sector projects",
-                                            "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
-                                            "q_code": "212",
-                                            "max_value": {
-                                                "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
-                                                "exclusive": false
-                                            },
-                                            "decimal_places": 2,
-                                            "currency": "GBP"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer35ce4949-ad6d-4137-b28b-ce3b5723831e",
-                                            "condition": "not contains any",
-                                            "values": ["Private sector projects"]
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "blocke2123cd6-0205-45ed-93bc-88ee340e9a13",
-                            "type": "CalculatedSummary",
-                            "titles": [
-                                {
-                                    "value": "We calculate the <em>total value of housing work</em> to be <em>%(total)s.</em> Is this correct?"
-                                }
-                            ],
-                            "calculation": {
-                                "calculation_type": "sum",
-                                "answers_to_calculate": [
-                                    "answercf9a19af-7bfb-4a55-9372-16987cc23d17",
-                                    "answer9368d5d6-a302-40b1-9211-f9ae4ceee109",
-                                    "answer24071a9f-30fa-4e1e-bd21-198ba49129b5",
-                                    "answer214ea602-4fbe-4775-ae6b-6b99c9779b62"
-                                ],
-                                "titles": [
                                     {
-                                        "value": "Total value of all housing work"
+                                        "list": ["flats and maisonettes", "new houses", "other types of residential housing"]
+                                    },
+                                    {
+                                        "description": "<strong>Exclude:</strong>"
+                                    },
+                                    {
+                                        "list": ["any work on halls of residence for educational institutions"]
                                     }
                                 ]
+                            },
+                            "definitions": [{
+                                "title": "What we mean by \"work on housing\"",
+                                "content": [{
+                                    "description": "This refers to work on residential buildings. If over half of a building&apos;s floor area is used for residential purposes, it is considered a residential building."
+                                }]
+                            }],
+                            "type": "General",
+                            "answers": [{
+                                "id": "answera75253f4-438c-4bdf-8613-cbfa2a3a1fb6",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "label": "",
+                                "description": "",
+                                "q_code": "902",
+                                "options": [{
+                                        "label": "Yes, we carried out work on housing",
+                                        "value": "Yes, we carried out work on housing"
+                                    },
+                                    {
+                                        "label": "No, we did not carry out work on housing",
+                                        "value": "No, we did not carry out work on housing"
+                                    }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "blockc102510b-e675-4074-8cdb-d6b8c5729a29",
+                                    "when": [{
+                                        "id": "answera75253f4-438c-4bdf-8613-cbfa2a3a1fb6",
+                                        "condition": "contains any",
+                                        "values": ["Yes, we carried out work on housing"]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "group": "group551ac31e-ba5e-4161-a93e-92a06c53c6ad"
+                                }
                             }
+                        ]
+                    },
+                    {
+                        "id": "blockc102510b-e675-4074-8cdb-d6b8c5729a29",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "questionc102510b-e675-4074-8cdb-d6b8c5729a29",
+                            "title": "Which sector did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} carry out housing work for?",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer35ce4949-ad6d-4137-b28b-ce3b5723831e",
+                                "mandatory": true,
+                                "type": "Checkbox",
+                                "label": "",
+                                "description": "",
+                                "q_code": "d1",
+                                "options": [{
+                                        "label": "Public sector projects",
+                                        "value": "Public sector projects",
+                                        "description": "In the UK, the public sector consists of five sub-sectors: central government, local government, public non-financial corporations, Bank of England, public financial corporations (public sector banks)"
+                                    },
+                                    {
+                                        "label": "Private sector projects",
+                                        "value": "Private sector projects",
+                                        "description": "The private sector refers to the part of the economy that is for profit and is owned by private organisations, for example housing associations, or individuals"
+                                    }
+                                ]
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "blocke9a89f15-d5ad-4698-90ac-aaec447c5a07",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "questione9a89f15-d5ad-4698-90ac-aaec447c5a07",
+                            "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of work carried out on <em>new housing builds</em> for <em>public</em> sector projects?",
+                            "guidance": {
+                                "content": [{
+                                        "description": "<strong>Include:</strong>"
+                                    },
+                                    {
+                                        "list": ["new construction work", "demolition", "site preparation"]
+                                    },
+                                    {
+                                        "description": "<strong>Exclude:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "VAT",
+                                            "repair and maintenance (R&amp;M)",
+                                            "major alterations, for example improvements and extensions",
+                                            "payments made to subcontractors",
+                                            "any work on halls of residence for educational institutions"
+                                        ]
+                                    }
+                                ]
+                            },
+                            "definitions": [{
+                                "title": "What we mean by \"public sector\"",
+                                "content": [{
+                                        "description": "In the UK, the public sector consists of five sub-sectors:"
+                                    },
+                                    {
+                                        "list": [
+                                            "central government",
+                                            "local government",
+                                            "public non-financial corporations",
+                                            "Bank of England",
+                                            "public financial corporations, for example public sector banks"
+                                        ]
+                                    }
+                                ]
+                            }],
+                            "type": "General",
+                            "answers": [{
+                                "id": "answercf9a19af-7bfb-4a55-9372-16987cc23d17",
+                                "mandatory": true,
+                                "type": "Currency",
+                                "label": "New housing builds for public sector projects",
+                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
+                                "q_code": "201",
+                                "max_value": {
+                                    "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                    "exclusive": false
+                                },
+                                "decimal_places": 2,
+                                "currency": "GBP"
+                            }]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer35ce4949-ad6d-4137-b28b-ce3b5723831e",
+                                "condition": "not contains any",
+                                "values": ["Public sector projects"]
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block4e0f51d6-103f-4495-b6ac-e8d21d536769",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question4e0f51d6-103f-4495-b6ac-e8d21d536769",
+                            "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of <em>repair and maintenance (R&amp;M), improvements and major alterations</em> carried out on existing housing for <em>public</em> sector projects?",
+                            "guidance": {
+                                "content": [{
+                                        "description": "<strong>Include:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "extensions",
+                                            "any work aimed at repairing something which is broken",
+                                            "maintaining something to an existing standard"
+                                        ]
+                                    },
+                                    {
+                                        "description": "<strong>Exclude:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "VAT",
+                                            "payments made to subcontractors",
+                                            "any work on halls of residence for educational institutions"
+                                        ]
+                                    }
+                                ]
+                            },
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer9368d5d6-a302-40b1-9211-f9ae4ceee109",
+                                "mandatory": true,
+                                "type": "Currency",
+                                "label": "R&M, improvements and major alterations on existing housing for public sector projects",
+                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
+                                "q_code": "202",
+                                "max_value": {
+                                    "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                    "exclusive": false
+                                },
+                                "decimal_places": 2,
+                                "currency": "GBP"
+                            }]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer35ce4949-ad6d-4137-b28b-ce3b5723831e",
+                                "condition": "not contains any",
+                                "values": ["Public sector projects"]
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block510a45f5-aa4f-4d2d-9268-52ca13e0bb7b",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question510a45f5-aa4f-4d2d-9268-52ca13e0bb7b",
+                            "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of work carried out on <em>new housing builds</em> for <em>private</em> sector projects?",
+                            "guidance": {
+                                "content": [{
+                                        "description": "<strong>Include:</strong>"
+                                    },
+                                    {
+                                        "list": ["new construction work", "demolition", "site preparation"]
+                                    },
+                                    {
+                                        "description": "<strong>Exclude:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "VAT",
+                                            "R&amp;M",
+                                            "major alterations, for example improvements and extensions",
+                                            "payments made to subcontractors",
+                                            "any work on halls of residence for educational institutions"
+                                        ]
+                                    }
+                                ]
+                            },
+                            "definitions": [{
+                                "title": "What we mean by \"private sector\"",
+                                "content": [{
+                                        "description": "The private sector refers to the part of the economy that is for profit and is owned by private organisations or individuals."
+                                    },
+                                    {
+                                        "description": "<strong>Examples of the private sector:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "Small and medium-sized businesses",
+                                            "Housing associations",
+                                            "Multinationals",
+                                            "Partnerships and sole traders",
+                                            "Households"
+                                        ]
+                                    }
+                                ]
+                            }],
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer24071a9f-30fa-4e1e-bd21-198ba49129b5",
+                                "mandatory": true,
+                                "type": "Currency",
+                                "label": "New housing builds for private sector projects",
+                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
+                                "q_code": "211",
+                                "max_value": {
+                                    "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                    "exclusive": false
+                                },
+                                "decimal_places": 2,
+                                "currency": "GBP"
+                            }]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer35ce4949-ad6d-4137-b28b-ce3b5723831e",
+                                "condition": "not contains any",
+                                "values": ["Private sector projects"]
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block2da3a1a1-9d5d-4ce1-a84e-3f3e1a22fbd9",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question2da3a1a1-9d5d-4ce1-a84e-3f3e1a22fbd9",
+                            "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of <em>R&amp;M, improvements and major alterations</em> carried out on existing housing for <em>private</em> sector projects?",
+                            "guidance": {
+                                "content": [{
+                                        "description": "<strong>Include:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "extensions",
+                                            "any work aimed at repairing something that is broken",
+                                            "maintaining something to an existing standard"
+                                        ]
+                                    },
+                                    {
+                                        "description": "<strong>Exclude:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "VAT",
+                                            "payments made to subcontractors",
+                                            "any work on halls of residence for educational institutions"
+                                        ]
+                                    }
+                                ]
+                            },
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer214ea602-4fbe-4775-ae6b-6b99c9779b62",
+                                "mandatory": true,
+                                "type": "Currency",
+                                "label": "R&M, improvements and major alterations on existing housing for private sector projects",
+                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
+                                "q_code": "212",
+                                "max_value": {
+                                    "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                    "exclusive": false
+                                },
+                                "decimal_places": 2,
+                                "currency": "GBP"
+                            }]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer35ce4949-ad6d-4137-b28b-ce3b5723831e",
+                                "condition": "not contains any",
+                                "values": ["Private sector projects"]
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "blocke2123cd6-0205-45ed-93bc-88ee340e9a13",
+                        "type": "CalculatedSummary",
+                        "titles": [{
+                            "value": "We calculate the <em>total value of housing work</em> to be <em>%(total)s.</em> Is this correct?"
+                        }],
+                        "calculation": {
+                            "calculation_type": "sum",
+                            "answers_to_calculate": [
+                                "answercf9a19af-7bfb-4a55-9372-16987cc23d17",
+                                "answer9368d5d6-a302-40b1-9211-f9ae4ceee109",
+                                "answer24071a9f-30fa-4e1e-bd21-198ba49129b5",
+                                "answer214ea602-4fbe-4775-ae6b-6b99c9779b62"
+                            ],
+                            "titles": [{
+                                "value": "Total value of all housing work"
+                            }]
                         }
-                    ],
-                    "skip_conditions": [
-                        {
-                            "when": [
-                                {
-                                    "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
-                                    "condition": "equals",
-                                    "value": 0
-                                }
-                            ]
-                        },
-                        {
-                            "when": [
-                                {
-                                    "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
-                                    "condition": "not set"
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ]
+                    }
+                ],
+                "skip_conditions": [{
+                        "when": [{
+                            "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                            "condition": "equals",
+                            "value": 0
+                        }]
+                    },
+                    {
+                        "when": [{
+                            "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                            "condition": "not set"
+                        }]
+                    }
+                ]
+            }]
         },
         {
             "id": "section551ac31e-ba5e-4161-a93e-92a06c53c6ad",
             "title": "Infrastructure",
-            "groups": [
-                {
-                    "id": "group551ac31e-ba5e-4161-a93e-92a06c53c6ad",
-                    "title": "Infrastructure",
-                    "blocks": [
-                        {
-                            "type": "Interstitial",
-                            "id": "group551ac31e-ba5e-4161-a93e-92a06c53c6ad-introduction",
-                            "title": "Infrastructure",
-                            "description": "<p>This section asks for information on the value of new infrastructure, and repair and maintenance (R&amp;M) of existing <em>infrastructure</em>.</p><p>You will be asked to provide information on the value of work undertaken by your business. Value of work refers to estimates of chargeable work carried out during the month; meaning work started, in progress, or completed.</p><p><strong>Include:</strong></p><ul><li>work done by your own business on its own business premises</li><li>fixtures, equipment and tools your business made and used in construction</li><li>materials your business used, overheads and profits</li><li>labour costs on your payroll</li></ul><p><strong>Exclude:</strong></p><ul><li>VAT</li><li>payments made to subcontractors</li><li>payments made to consultants or architects</li><li>fixtures, equipment and tools your business made for sale</li><li>materials your business sold</li><li>value of land</li></ul>"
-                        },
-                        {
-                            "id": "block01c41114-3ca3-432f-b7e6-95f8c702f308",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question01c41114-3ca3-432f-b7e6-95f8c702f308",
-                                    "title": "During the period {{ format_conditional_date (answers['answer440c8850-b115-4f6b-b0f5-52d911dd6ef6from'], metadata['ref_p_start_date']) }} to {{ format_conditional_date (answers['answer440c8850-b115-4f6b-b0f5-52d911dd6ef6to'], metadata['ref_p_end_date']) }}, did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} carry out any work on <em>infrastructure</em>?",
-                                    "description": "<p>If you are a fitter or installer, you are included within the construction industry sector so should report your figures.</p>",
-                                    "guidance": {
-                                        "content": [
-                                            {
-                                                "description": "<strong>Include:</strong>"
-                                            },
-                                            {
-                                                "list": ["new infrastructure and repair and maintenance (R&amp;M) of infrastructure"]
-                                            },
-                                            {
-                                                "description": "<strong>Exclude:</strong>"
-                                            },
-                                            {
-                                                "list": [
-                                                    "work on any residential buildings such as housing, flats or maisonettes",
-                                                    "work on any industrial or commercial structures, such as factories, warehouses, offices health facilities or educational facilities"
-                                                ]
-                                            }
-                                        ]
+            "groups": [{
+                "id": "group551ac31e-ba5e-4161-a93e-92a06c53c6ad",
+                "title": "Infrastructure",
+                "blocks": [{
+                        "type": "Interstitial",
+                        "id": "group551ac31e-ba5e-4161-a93e-92a06c53c6ad-introduction",
+                        "title": "Infrastructure",
+                        "description": "<p>This section asks for information on the value of new infrastructure, and repair and maintenance (R&amp;M) of existing <em>infrastructure</em>.</p><p>You will be asked to provide information on the value of work undertaken by your business. Value of work refers to estimates of chargeable work carried out during the month; meaning work started, in progress, or completed.</p><p><strong>Include:</strong></p><ul><li>work done by your own business on its own business premises</li><li>fixtures, equipment and tools your business made and used in construction</li><li>materials your business used, overheads and profits</li><li>labour costs on your payroll</li></ul><p><strong>Exclude:</strong></p><ul><li>VAT</li><li>payments made to subcontractors</li><li>payments made to consultants or architects</li><li>fixtures, equipment and tools your business made for sale</li><li>materials your business sold</li><li>value of land</li></ul>"
+                    },
+                    {
+                        "id": "block01c41114-3ca3-432f-b7e6-95f8c702f308",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question01c41114-3ca3-432f-b7e6-95f8c702f308",
+                            "title": "During the period {{ format_conditional_date (answers['answer440c8850-b115-4f6b-b0f5-52d911dd6ef6from'], metadata['ref_p_start_date']) }} to {{ format_conditional_date (answers['answer440c8850-b115-4f6b-b0f5-52d911dd6ef6to'], metadata['ref_p_end_date']) }}, did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} carry out any work on <em>infrastructure</em>?",
+                            "description": "<p>If you are a fitter or installer, you are included within the construction industry sector so should report your figures.</p>",
+                            "guidance": {
+                                "content": [{
+                                        "description": "<strong>Include:</strong>"
                                     },
-                                    "definitions": [
-                                        {
-                                            "title": "What we mean by infrastructure",
-                                            "content": [
-                                                {
-                                                    "description": "Infrastructure refers to non-residential buildings, facilities, or systems that are fundamental to the functioning of an area."
-                                                },
-                                                {
-                                                    "description": "<strong>Examples of infrastructure:</strong>"
-                                                },
-                                                {
-                                                    "list": [
-                                                        "Electricity, such as power stations",
-                                                        "Gas, such as gas works and laying pipelines",
-                                                        "Air transport, harbours, roads, and railways",
-                                                        "Drainage, sewerage, and water such as reservoirs",
-                                                        "Communication"
-                                                    ]
-                                                }
-                                            ]
-                                        }
-                                    ],
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer01c0c84f-7282-42a3-b1c3-13b6d10f39bf",
-                                            "mandatory": true,
-                                            "type": "Radio",
-                                            "label": "",
-                                            "description": "",
-                                            "q_code": "903",
-                                            "options": [
-                                                {
-                                                    "label": "Yes, we carried out work on infrastructure",
-                                                    "value": "Yes, we carried out work on infrastructure"
-                                                },
-                                                {
-                                                    "label": "No, we did not carry out work on infrastructure",
-                                                    "value": "No, we did not carry out work on infrastructure"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "block": "block8ce84076-2099-4ee2-aa26-79bb386f44a9",
-                                        "when": [
-                                            {
-                                                "id": "answer01c0c84f-7282-42a3-b1c3-13b6d10f39bf",
-                                                "condition": "contains any",
-                                                "values": ["Yes, we carried out work on infrastructure"]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "group": "group6cc8656d-6877-4685-b9eb-f024a9ae1898"
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block8ce84076-2099-4ee2-aa26-79bb386f44a9",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question8ce84076-2099-4ee2-aa26-79bb386f44a9",
-                                    "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of work carried out on <em>new infrastructure</em>?",
-                                    "guidance": {
-                                        "content": [
-                                            {
-                                                "description": "<strong>Include:</strong>"
-                                            },
-                                            {
-                                                "list": [
-                                                    "new construction work",
-                                                    "demolition",
-                                                    "site clearance and preparation",
-                                                    "major alterations, for example improvements and extensions"
-                                                ]
-                                            },
-                                            {
-                                                "description": "<strong>Exclude:</strong>"
-                                            },
-                                            {
-                                                "list": ["VAT", "R&amp;M", "payments made to subcontractors"]
-                                            }
-                                        ]
-                                    },
-                                    "definitions": [
-                                        {
-                                            "title": "Examples of infrastructure",
-                                            "content": [
-                                                {
-                                                    "list": [
-                                                        "Electricity, such as power stations",
-                                                        "Gas, such as gas works and laying pipelines",
-                                                        "Air transport, harbours, roads, and railways",
-                                                        "Drainage, sewerage, and water such as reservoirs",
-                                                        "Communication"
-                                                    ]
-                                                }
-                                            ]
-                                        }
-                                    ],
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer692af9c8-8773-4a7b-9a21-1830f3dc3401",
-                                            "mandatory": true,
-                                            "type": "Currency",
-                                            "label": "New infrastructure",
-                                            "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
-                                            "q_code": "221",
-                                            "max_value": {
-                                                "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
-                                                "exclusive": false
-                                            },
-                                            "decimal_places": 2,
-                                            "currency": "GBP"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "blockdd878456-07b8-40f5-a3c5-fee1129cb64a",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "questiondd878456-07b8-40f5-a3c5-fee1129cb64a",
-                                    "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of <em>R&amp;M</em> carried out on existing infrastructure?",
-                                    "guidance": {
-                                        "content": [
-                                            {
-                                                "description": "<strong>Include work aimed at:</strong>"
-                                            },
-                                            {
-                                                "list": ["repairing a fault", "repairing something that is broken", "maintaining an existing standard"]
-                                            },
-                                            {
-                                                "description": "<strong> Exclude:</strong>"
-                                            },
-                                            {
-                                                "list": ["major alterations, for example improvements and extensions", "VAT", "payments made to subcontractors"]
-                                            }
-                                        ]
-                                    },
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer8561360c-adc9-40b9-b6af-2f85c486fef5",
-                                            "mandatory": true,
-                                            "type": "Currency",
-                                            "label": "R&M carried out on existing infrastructure",
-                                            "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
-                                            "q_code": "222",
-                                            "max_value": {
-                                                "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
-                                                "exclusive": false
-                                            },
-                                            "decimal_places": 2,
-                                            "currency": "GBP"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block319d4417-7383-496a-be67-590f02765e08",
-                            "type": "CalculatedSummary",
-                            "titles": [
-                                {
-                                    "value": "We calculate the <em>total value of infrastructure work</em> carried out to be <em>%(total)s.</em> Is this correct?"
-                                }
-                            ],
-                            "calculation": {
-                                "calculation_type": "sum",
-                                "answers_to_calculate": ["answer692af9c8-8773-4a7b-9a21-1830f3dc3401", "answer8561360c-adc9-40b9-b6af-2f85c486fef5"],
-                                "titles": [
                                     {
-                                        "value": "Total value of all infrastructure work"
+                                        "list": ["new infrastructure and repair and maintenance (R&amp;M) of infrastructure"]
+                                    },
+                                    {
+                                        "description": "<strong>Exclude:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "work on any residential buildings such as housing, flats or maisonettes",
+                                            "work on any industrial or commercial structures, such as factories, warehouses, offices health facilities or educational facilities"
+                                        ]
                                     }
                                 ]
+                            },
+                            "definitions": [{
+                                "title": "What we mean by infrastructure",
+                                "content": [{
+                                        "description": "Infrastructure refers to non-residential buildings, facilities, or systems that are fundamental to the functioning of an area."
+                                    },
+                                    {
+                                        "description": "<strong>Examples of infrastructure:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "Electricity, such as power stations",
+                                            "Gas, such as gas works and laying pipelines",
+                                            "Air transport, harbours, roads, and railways",
+                                            "Drainage, sewerage, and water such as reservoirs",
+                                            "Communication"
+                                        ]
+                                    }
+                                ]
+                            }],
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer01c0c84f-7282-42a3-b1c3-13b6d10f39bf",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "label": "",
+                                "description": "",
+                                "q_code": "903",
+                                "options": [{
+                                        "label": "Yes, we carried out work on infrastructure",
+                                        "value": "Yes, we carried out work on infrastructure"
+                                    },
+                                    {
+                                        "label": "No, we did not carry out work on infrastructure",
+                                        "value": "No, we did not carry out work on infrastructure"
+                                    }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "block8ce84076-2099-4ee2-aa26-79bb386f44a9",
+                                    "when": [{
+                                        "id": "answer01c0c84f-7282-42a3-b1c3-13b6d10f39bf",
+                                        "condition": "contains any",
+                                        "values": ["Yes, we carried out work on infrastructure"]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "group": "group6cc8656d-6877-4685-b9eb-f024a9ae1898"
+                                }
                             }
+                        ]
+                    },
+                    {
+                        "id": "block8ce84076-2099-4ee2-aa26-79bb386f44a9",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question8ce84076-2099-4ee2-aa26-79bb386f44a9",
+                            "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of work carried out on <em>new infrastructure</em>?",
+                            "guidance": {
+                                "content": [{
+                                        "description": "<strong>Include:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "new construction work",
+                                            "demolition",
+                                            "site clearance and preparation",
+                                            "major alterations, for example improvements and extensions"
+                                        ]
+                                    },
+                                    {
+                                        "description": "<strong>Exclude:</strong>"
+                                    },
+                                    {
+                                        "list": ["VAT", "R&amp;M", "payments made to subcontractors"]
+                                    }
+                                ]
+                            },
+                            "definitions": [{
+                                "title": "Examples of infrastructure",
+                                "content": [{
+                                    "list": [
+                                        "Electricity, such as power stations",
+                                        "Gas, such as gas works and laying pipelines",
+                                        "Air transport, harbours, roads, and railways",
+                                        "Drainage, sewerage, and water such as reservoirs",
+                                        "Communication"
+                                    ]
+                                }]
+                            }],
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer692af9c8-8773-4a7b-9a21-1830f3dc3401",
+                                "mandatory": true,
+                                "type": "Currency",
+                                "label": "New infrastructure",
+                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
+                                "q_code": "221",
+                                "max_value": {
+                                    "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                    "exclusive": false
+                                },
+                                "decimal_places": 2,
+                                "currency": "GBP"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "blockdd878456-07b8-40f5-a3c5-fee1129cb64a",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "questiondd878456-07b8-40f5-a3c5-fee1129cb64a",
+                            "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of <em>R&amp;M</em> carried out on existing infrastructure?",
+                            "guidance": {
+                                "content": [{
+                                        "description": "<strong>Include work aimed at:</strong>"
+                                    },
+                                    {
+                                        "list": ["repairing a fault", "repairing something that is broken", "maintaining an existing standard"]
+                                    },
+                                    {
+                                        "description": "<strong> Exclude:</strong>"
+                                    },
+                                    {
+                                        "list": ["major alterations, for example improvements and extensions", "VAT", "payments made to subcontractors"]
+                                    }
+                                ]
+                            },
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer8561360c-adc9-40b9-b6af-2f85c486fef5",
+                                "mandatory": true,
+                                "type": "Currency",
+                                "label": "R&M carried out on existing infrastructure",
+                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
+                                "q_code": "222",
+                                "max_value": {
+                                    "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                    "exclusive": false
+                                },
+                                "decimal_places": 2,
+                                "currency": "GBP"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block319d4417-7383-496a-be67-590f02765e08",
+                        "type": "CalculatedSummary",
+                        "titles": [{
+                            "value": "We calculate the <em>total value of infrastructure work</em> carried out to be <em>%(total)s.</em> Is this correct?"
+                        }],
+                        "calculation": {
+                            "calculation_type": "sum",
+                            "answers_to_calculate": ["answer692af9c8-8773-4a7b-9a21-1830f3dc3401", "answer8561360c-adc9-40b9-b6af-2f85c486fef5"],
+                            "titles": [{
+                                "value": "Total value of all infrastructure work"
+                            }]
                         }
-                    ],
-                    "skip_conditions": [
-                        {
-                            "when": [
-                                {
-                                    "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
-                                    "condition": "equals",
-                                    "value": 0
-                                }
-                            ]
-                        },
-                        {
-                            "when": [
-                                {
-                                    "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
-                                    "condition": "not set"
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ]
+                    }
+                ],
+                "skip_conditions": [{
+                        "when": [{
+                            "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                            "condition": "equals",
+                            "value": 0
+                        }]
+                    },
+                    {
+                        "when": [{
+                            "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                            "condition": "not set"
+                        }]
+                    }
+                ]
+            }]
         },
         {
             "id": "section6cc8656d-6877-4685-b9eb-f024a9ae1898",
             "title": "Other construction work",
-            "groups": [
-                {
-                    "id": "group6cc8656d-6877-4685-b9eb-f024a9ae1898",
-                    "title": "Other construction work",
-                    "blocks": [
-                        {
-                            "type": "Interstitial",
-                            "id": "group6cc8656d-6877-4685-b9eb-f024a9ae1898-introduction",
-                            "title": "Other construction work",
-                            "description": "<p>This section asks for information on the value of <em>other construction work</em> carried out on new structures for public, commercial and industrial projects, and repair and maintenance (R&amp;M) of existing structures.</p><p>You will be asked to provide information on the value of work undertaken by your business. Value of work refers to estimates of chargeable work carried out during the month; meaning work started, in progress, or completed. </p><p><strong>Include:</strong></p><ul><li>work on buildings which you hope to sell later for profit (speculative work)</li><li>work done by your business on its own premises</li><li>fixtures, equipment and tools your business made and used in construction</li><li>materials your business used, overheads and profits</li><li>labour costs on your payroll</li></ul><p> <strong>Exclude:</strong></p><ul><li>work on infrastructure</li><li>work on residential buildings, for example housing, flats and maisonettes</li><li>VAT</li><li>payments made to subcontractors</li><li>payments made to consultants or architects</li><li>fixtures, equipment and tools your business made for sale</li><li>materials your business sold</li><li>value of land</li></ul>"
-                        },
-                        {
-                            "id": "block92bf4040-ae9c-4245-889c-c11ec6d52ce4",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question92bf4040-ae9c-4245-889c-c11ec6d52ce4",
-                                    "title": "During the period {{ format_conditional_date (answers['answer440c8850-b115-4f6b-b0f5-52d911dd6ef6from'], metadata['ref_p_start_date']) }} to {{ format_conditional_date (answers['answer440c8850-b115-4f6b-b0f5-52d911dd6ef6to'], metadata['ref_p_end_date']) }}, did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} carry out any <em>other construction work</em>?",
-                                    "description": "<p>If you are a fitter or installer, you are included within the construction industry sector so should report your figures.</p>",
-                                    "guidance": {
-                                        "content": [
-                                            {
-                                                "description": "<strong>Exclude:</strong>"
-                                            },
-                                            {
-                                                "list": [
-                                                    "work on residential buildings, for example housing, flats and maisonettes, except halls of residence for educational institutions",
-                                                    "work on infrastructure"
-                                                ]
-                                            }
-                                        ]
+            "groups": [{
+                "id": "group6cc8656d-6877-4685-b9eb-f024a9ae1898",
+                "title": "Other construction work",
+                "blocks": [{
+                        "type": "Interstitial",
+                        "id": "group6cc8656d-6877-4685-b9eb-f024a9ae1898-introduction",
+                        "title": "Other construction work",
+                        "description": "<p>This section asks for information on the value of <em>other construction work</em> carried out on new structures for public, commercial and industrial projects, and repair and maintenance (R&amp;M) of existing structures.</p><p>You will be asked to provide information on the value of work undertaken by your business. Value of work refers to estimates of chargeable work carried out during the month; meaning work started, in progress, or completed. </p><p><strong>Include:</strong></p><ul><li>work on buildings which you hope to sell later for profit (speculative work)</li><li>work done by your business on its own premises</li><li>fixtures, equipment and tools your business made and used in construction</li><li>materials your business used, overheads and profits</li><li>labour costs on your payroll</li></ul><p> <strong>Exclude:</strong></p><ul><li>work on infrastructure</li><li>work on residential buildings, for example housing, flats and maisonettes</li><li>VAT</li><li>payments made to subcontractors</li><li>payments made to consultants or architects</li><li>fixtures, equipment and tools your business made for sale</li><li>materials your business sold</li><li>value of land</li></ul>"
+                    },
+                    {
+                        "id": "block92bf4040-ae9c-4245-889c-c11ec6d52ce4",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question92bf4040-ae9c-4245-889c-c11ec6d52ce4",
+                            "title": "During the period {{ format_conditional_date (answers['answer440c8850-b115-4f6b-b0f5-52d911dd6ef6from'], metadata['ref_p_start_date']) }} to {{ format_conditional_date (answers['answer440c8850-b115-4f6b-b0f5-52d911dd6ef6to'], metadata['ref_p_end_date']) }}, did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} carry out any <em>other construction work</em>?",
+                            "description": "<p>If you are a fitter or installer, you are included within the construction industry sector so should report your figures.</p>",
+                            "guidance": {
+                                "content": [{
+                                        "description": "<strong>Exclude:</strong>"
                                     },
-                                    "definitions": [
-                                        {
-                                            "title": "Examples of other construction work",
-                                            "content": [
-                                                {
-                                                    "list": [
-                                                        "Industrial structures, such as factories and warehouses",
-                                                        "Commercial structures, such as agricultural structures, offices, parks, health facilities and educational institutions",
-                                                        "Public structures, such educational institutions, offices, health facilities, sport facilities or entertainment facilities"
-                                                    ]
-                                                }
-                                            ]
-                                        }
-                                    ],
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer50ae0d8f-dd41-43ab-8e29-431028500270",
-                                            "mandatory": true,
-                                            "type": "Radio",
-                                            "label": "",
-                                            "description": "",
-                                            "q_code": "904",
-                                            "options": [
-                                                {
-                                                    "label": "Yes, we carried out other construction work",
-                                                    "value": "Yes, we carried out other construction work"
-                                                },
-                                                {
-                                                    "label": "No, we did not carry out other construction work",
-                                                    "value": "No, we did not carry out other construction work"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "block": "blockcb22fe8e-4000-418d-b0f1-ca57306a2c0e",
-                                        "when": [
-                                            {
-                                                "id": "answer50ae0d8f-dd41-43ab-8e29-431028500270",
-                                                "condition": "contains any",
-                                                "values": ["Yes, we carried out other construction work"]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "group": "groupe9d26530-ad8f-4527-b09c-afacfa0c820a"
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "id": "blockcb22fe8e-4000-418d-b0f1-ca57306a2c0e",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "questioncb22fe8e-4000-418d-b0f1-ca57306a2c0e",
-                                    "title": "Which sector did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} carry out other construction work for?",
-                                    "guidance": {
-                                        "content": [
-                                            {
-                                                "description": "<strong>Exclude:</strong>"
-                                            },
-                                            {
-                                                "list": ["work on residential buildings, for example housing, flats and maisonettes", "work on infrastructure"]
-                                            }
-                                        ]
-                                    },
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer27e92f6a-21af-4432-b94c-5157746ebc9e",
-                                            "mandatory": true,
-                                            "type": "Checkbox",
-                                            "label": "",
-                                            "description": "",
-                                            "q_code": "d2",
-                                            "options": [
-                                                {
-                                                    "label": "Public sector projects",
-                                                    "value": "Public sector projects",
-                                                    "description": "The public sector consists central government, local government, public non-financial corporations, Bank of England and public financial corporations."
-                                                },
-                                                {
-                                                    "label": "Private commercial sector projects",
-                                                    "value": "Private commercial sector projects",
-                                                    "description": "Part of the economy that includes all businesses and agriculture, except those businesses involved in manufacturing and  transport"
-                                                },
-                                                {
-                                                    "label": "Private industrial sector projects",
-                                                    "value": "Private industrial sector projects",
-                                                    "description": "Part of the economy that includes businesses involved in manufacturing and transport"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block6128bff1-69b5-4914-b49a-11facc75a178",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question6128bff1-69b5-4914-b49a-11facc75a178",
-                                    "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of work carried out on <em>other new structures</em> for <em>public</em> sector projects?",
-                                    "guidance": {
-                                        "content": [
-                                            {
-                                                "description": "<strong> Include:</strong>"
-                                            },
-                                            {
-                                                "list": [
-                                                    "new construction work",
-                                                    "demolition",
-                                                    "site preparation",
-                                                    "major alterations, for example improvements and extensions"
-                                                ]
-                                            },
-                                            {
-                                                "description": "<strong>Exclude:</strong>"
-                                            },
-                                            {
-                                                "list": [
-                                                    "work on infrastructure",
-                                                    "work on residential buildings, for example housing, flats and maisonettes",
-                                                    "VAT",
-                                                    "R&amp;M",
-                                                    "payments made to subcontractors"
-                                                ]
-                                            }
-                                        ]
-                                    },
-                                    "definitions": [
-                                        {
-                                            "title": "What we mean by \"other new structures\"",
-                                            "content": [
-                                                {
-                                                    "description": "This refers to work on new non-residential structures. If over half of a building&apos;s floor area is used for non-residential purposes, it is considered a non-residential building."
-                                                },
-                                                {
-                                                    "description": "<strong>Examples of other public sector structures:</strong>"
-                                                },
-                                                {
-                                                    "list": [
-                                                        "Offices",
-                                                        "Factories",
-                                                        "Warehouses",
-                                                        "Educational institutions and their halls of residence",
-                                                        "Health facilities",
-                                                        "Entertainment and sports facilities"
-                                                    ]
-                                                }
-                                            ]
-                                        }
-                                    ],
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answerdb018dc4-8664-4587-a038-12a468da441b",
-                                            "mandatory": true,
-                                            "type": "Currency",
-                                            "label": "Other new structures for public sector projects",
-                                            "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
-                                            "q_code": "231",
-                                            "max_value": {
-                                                "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
-                                                "exclusive": false
-                                            },
-                                            "decimal_places": 2,
-                                            "currency": "GBP"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer27e92f6a-21af-4432-b94c-5157746ebc9e",
-                                            "condition": "not contains any",
-                                            "values": ["Public sector projects"]
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block1fa2f7bd-0644-434a-a706-32931d727147",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question1fa2f7bd-0644-434a-a706-32931d727147",
-                                    "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of <em>R&amp;M</em> carried out on other existing structures for <em>public</em> sector projects?",
-                                    "guidance": {
-                                        "content": [
-                                            {
-                                                "description": "<strong>Include work aimed at:</strong>"
-                                            },
-                                            {
-                                                "list": ["repairing something which is broken", "maintaining an existing standard"]
-                                            },
-                                            {
-                                                "description": "<strong>Exclude:</strong>"
-                                            },
-                                            {
-                                                "list": [
-                                                    "work on infrastructure",
-                                                    "work on residential buildings, for example housing, flats and maisonettes",
-                                                    "major alterations, for example improvements and extensions",
-                                                    "VAT",
-                                                    "payments made to subcontractors"
-                                                ]
-                                            }
-                                        ]
-                                    },
-                                    "definitions": [
-                                        {
-                                            "title": "What we mean by \"other existing structures\"",
-                                            "content": [
-                                                {
-                                                    "description": "This refers to work on existing non-residential structures. If over half of a building&apos;s floor area is used for non-residential purposes, it is considered a non-residential building."
-                                                },
-                                                {
-                                                    "description": "<strong>Examples of other public sector structures:</strong>"
-                                                },
-                                                {
-                                                    "list": [
-                                                        "Offices",
-                                                        "Factories",
-                                                        "Warehouses",
-                                                        "Educational institutions and their halls of residence",
-                                                        "Health facilities",
-                                                        "Entertainment and sports facilities"
-                                                    ]
-                                                }
-                                            ]
-                                        }
-                                    ],
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answerc541b81f-6402-4934-821d-dc961bea86bf",
-                                            "mandatory": true,
-                                            "type": "Currency",
-                                            "label": "R&M on other existing structures for public sector projects",
-                                            "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
-                                            "q_code": "232",
-                                            "max_value": {
-                                                "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
-                                                "exclusive": false
-                                            },
-                                            "decimal_places": 2,
-                                            "currency": "GBP"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer27e92f6a-21af-4432-b94c-5157746ebc9e",
-                                            "condition": "not contains any",
-                                            "values": ["Public sector projects"]
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block3159dcad-c87b-4afa-860e-291c4d4b1414",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question3159dcad-c87b-4afa-860e-291c4d4b1414",
-                                    "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of work carried out on <em>new structures</em> for <em>private commercial</em> sector projects?",
-                                    "guidance": {
-                                        "content": [
-                                            {
-                                                "description": "<strong>Include:</strong>"
-                                            },
-                                            {
-                                                "list": [
-                                                    "new construction work",
-                                                    "demolition",
-                                                    "site preparation",
-                                                    "major alterations, for example improvements and extensions"
-                                                ]
-                                            },
-                                            {
-                                                "description": "<strong>Exclude:</strong>"
-                                            },
-                                            {
-                                                "list": ["VAT", "R&amp;M", "payments made to subcontractors"]
-                                            }
-                                        ]
-                                    },
-                                    "definitions": [
-                                        {
-                                            "title": "What we mean by the \"private commercial sector\"",
-                                            "content": [
-                                                {
-                                                    "description": "This sector refers to part of the economy that  includes all businesses, except those involved in manufacturing and transport."
-                                                },
-                                                {
-                                                    "description": "<strong>Examples of private commercial sector structures:</strong>"
-                                                },
-                                                {
-                                                    "list": [
-                                                        "Any construction work for the agriculture industry",
-                                                        "Offices",
-                                                        "Factories",
-                                                        "Health facilities",
-                                                        "Entertainment and sports facilities",
-                                                        "Car parks",
-                                                        "Educational institutions and their halls of residence",
-                                                        "Garages and shops"
-                                                    ]
-                                                }
-                                            ]
-                                        }
-                                    ],
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer1a8a2700-9428-425a-97da-d81ce4eaf4a3",
-                                            "mandatory": true,
-                                            "type": "Currency",
-                                            "label": "New structures for private commercial sector projects",
-                                            "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
-                                            "q_code": "241",
-                                            "max_value": {
-                                                "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
-                                                "exclusive": false
-                                            },
-                                            "decimal_places": 2,
-                                            "currency": "GBP"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer27e92f6a-21af-4432-b94c-5157746ebc9e",
-                                            "condition": "not contains any",
-                                            "values": ["Private commercial sector projects"]
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block4bc9c90a-5ef9-427a-b98a-03b9ffbd38d7",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question4bc9c90a-5ef9-427a-b98a-03b9ffbd38d7",
-                                    "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of work carried out on <em>new structures</em> for <em>private industrial</em> sector projects?",
-                                    "guidance": {
-                                        "content": [
-                                            {
-                                                "description": "<strong>Include:</strong>"
-                                            },
-                                            {
-                                                "list": [
-                                                    "new construction work",
-                                                    "demolition",
-                                                    "site preparation",
-                                                    "major alterations, for example improvements and extensions"
-                                                ]
-                                            },
-                                            {
-                                                "description": "<strong>Exclude:</strong>"
-                                            },
-                                            {
-                                                "list": ["VAT", "R&amp;M", "payments made to subcontractors"]
-                                            }
-                                        ]
-                                    },
-                                    "definitions": [
-                                        {
-                                            "title": "What we mean by the \"private industrial sector\"",
-                                            "content": [
-                                                {
-                                                    "description": "This sector refers to part of the economy that includes businesses involved in manufacturing and transport, excluding agriculture."
-                                                },
-                                                {
-                                                    "description": "<strong>Examples of private industrial sector structures:</strong>"
-                                                },
-                                                {
-                                                    "list": ["Factories", "Warehouses", "Any construction work in the coal, oil and steel industry"]
-                                                }
-                                            ]
-                                        }
-                                    ],
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answera11da5a9-892d-42f0-bb19-b3781974d741",
-                                            "mandatory": true,
-                                            "type": "Currency",
-                                            "label": "New structures for private industrial sector projects",
-                                            "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
-                                            "q_code": "242",
-                                            "max_value": {
-                                                "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
-                                                "exclusive": false
-                                            },
-                                            "decimal_places": 2,
-                                            "currency": "GBP"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer27e92f6a-21af-4432-b94c-5157746ebc9e",
-                                            "condition": "not contains any",
-                                            "values": ["Private industrial sector projects"]
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "blockf475e0c0-b547-496d-a1bc-5402e5987d70",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "questionf475e0c0-b547-496d-a1bc-5402e5987d70",
-                                    "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of <em>R&amp;M</em> carried out on existing structures for <em>private industrial and/or private commercial </em>sector projects?",
-                                    "guidance": {
-                                        "content": [
-                                            {
-                                                "description": "<strong>Include work aimed at:</strong>"
-                                            },
-                                            {
-                                                "list": ["repairing something that is broken", "maintaining an existing standard"]
-                                            },
-                                            {
-                                                "description": "<strong>Exclude:</strong>"
-                                            },
-                                            {
-                                                "list": ["major alterations, for example improvements and extensions", "VAT", "payments made to subcontractors"]
-                                            }
-                                        ]
-                                    },
-                                    "definitions": [
-                                        {
-                                            "title": "Examples of private industrial and private commercial sector structures",
-                                            "content": [
-                                                {
-                                                    "description": "<strong>Private commercial sector structures:</strong>"
-                                                },
-                                                {
-                                                    "list": [
-                                                        "Any construction work for the agriculture industry",
-                                                        "Offices",
-                                                        "Factories",
-                                                        "Health facilities",
-                                                        "Entertainment and sports facilities",
-                                                        "Car parks",
-                                                        "Educational institutions and their halls of residence",
-                                                        "Garages and shops"
-                                                    ]
-                                                },
-                                                {
-                                                    "description": "<strong>Private industrial sector structures:</strong>"
-                                                },
-                                                {
-                                                    "list": ["Factories", "Warehouses", "Any construction work in the coal, oil and steel industry"]
-                                                }
-                                            ]
-                                        }
-                                    ],
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer1e0761db-01e8-4ea7-a738-f6144be456b5",
-                                            "mandatory": true,
-                                            "type": "Currency",
-                                            "label": "R&M for existing private industrial and/or private commercial sector projects",
-                                            "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
-                                            "q_code": "243",
-                                            "max_value": {
-                                                "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
-                                                "exclusive": false
-                                            },
-                                            "decimal_places": 2,
-                                            "currency": "GBP"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer27e92f6a-21af-4432-b94c-5157746ebc9e",
-                                            "condition": "not contains any",
-                                            "values": ["Private commercial sector projects", "Private industrial sector projects"]
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block3887799c-2d55-48f8-a52d-ee363054106e",
-                            "type": "CalculatedSummary",
-                            "titles": [
-                                {
-                                    "value": "We calculate the <em>total value of other construction work</em> carried out to be <em>%(total)s.</em> Is this correct?"
-                                }
-                            ],
-                            "calculation": {
-                                "calculation_type": "sum",
-                                "answers_to_calculate": [
-                                    "answerdb018dc4-8664-4587-a038-12a468da441b",
-                                    "answerc541b81f-6402-4934-821d-dc961bea86bf",
-                                    "answer1a8a2700-9428-425a-97da-d81ce4eaf4a3",
-                                    "answera11da5a9-892d-42f0-bb19-b3781974d741",
-                                    "answer1e0761db-01e8-4ea7-a738-f6144be456b5"
-                                ],
-                                "titles": [
                                     {
-                                        "value": "Total value of all other construction work"
+                                        "list": [
+                                            "work on residential buildings, for example housing, flats and maisonettes, except halls of residence for educational institutions",
+                                            "work on infrastructure"
+                                        ]
                                     }
                                 ]
+                            },
+                            "definitions": [{
+                                "title": "Examples of other construction work",
+                                "content": [{
+                                    "list": [
+                                        "Industrial structures, such as factories and warehouses",
+                                        "Commercial structures, such as agricultural structures, offices, parks, health facilities and educational institutions",
+                                        "Public structures, such educational institutions, offices, health facilities, sport facilities or entertainment facilities"
+                                    ]
+                                }]
+                            }],
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer50ae0d8f-dd41-43ab-8e29-431028500270",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "label": "",
+                                "description": "",
+                                "q_code": "904",
+                                "options": [{
+                                        "label": "Yes, we carried out other construction work",
+                                        "value": "Yes, we carried out other construction work"
+                                    },
+                                    {
+                                        "label": "No, we did not carry out other construction work",
+                                        "value": "No, we did not carry out other construction work"
+                                    }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "blockcb22fe8e-4000-418d-b0f1-ca57306a2c0e",
+                                    "when": [{
+                                        "id": "answer50ae0d8f-dd41-43ab-8e29-431028500270",
+                                        "condition": "contains any",
+                                        "values": ["Yes, we carried out other construction work"]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "group": "groupe9d26530-ad8f-4527-b09c-afacfa0c820a"
+                                }
                             }
+                        ]
+                    },
+                    {
+                        "id": "blockcb22fe8e-4000-418d-b0f1-ca57306a2c0e",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "questioncb22fe8e-4000-418d-b0f1-ca57306a2c0e",
+                            "title": "Which sector did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} carry out other construction work for?",
+                            "guidance": {
+                                "content": [{
+                                        "description": "<strong>Exclude:</strong>"
+                                    },
+                                    {
+                                        "list": ["work on residential buildings, for example housing, flats and maisonettes", "work on infrastructure"]
+                                    }
+                                ]
+                            },
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer27e92f6a-21af-4432-b94c-5157746ebc9e",
+                                "mandatory": true,
+                                "type": "Checkbox",
+                                "label": "",
+                                "description": "",
+                                "q_code": "d2",
+                                "options": [{
+                                        "label": "Public sector projects",
+                                        "value": "Public sector projects",
+                                        "description": "The public sector consists central government, local government, public non-financial corporations, Bank of England and public financial corporations."
+                                    },
+                                    {
+                                        "label": "Private commercial sector projects",
+                                        "value": "Private commercial sector projects",
+                                        "description": "Part of the economy that includes all businesses and agriculture, except those businesses involved in manufacturing and  transport"
+                                    },
+                                    {
+                                        "label": "Private industrial sector projects",
+                                        "value": "Private industrial sector projects",
+                                        "description": "Part of the economy that includes businesses involved in manufacturing and transport"
+                                    }
+                                ]
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block6128bff1-69b5-4914-b49a-11facc75a178",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question6128bff1-69b5-4914-b49a-11facc75a178",
+                            "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of work carried out on <em>other new structures</em> for <em>public</em> sector projects?",
+                            "guidance": {
+                                "content": [{
+                                        "description": "<strong> Include:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "new construction work",
+                                            "demolition",
+                                            "site preparation",
+                                            "major alterations, for example improvements and extensions"
+                                        ]
+                                    },
+                                    {
+                                        "description": "<strong>Exclude:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "work on infrastructure",
+                                            "work on residential buildings, for example housing, flats and maisonettes",
+                                            "VAT",
+                                            "R&amp;M",
+                                            "payments made to subcontractors"
+                                        ]
+                                    }
+                                ]
+                            },
+                            "definitions": [{
+                                "title": "What we mean by \"other new structures\"",
+                                "content": [{
+                                        "description": "This refers to work on new non-residential structures. If over half of a building&apos;s floor area is used for non-residential purposes, it is considered a non-residential building."
+                                    },
+                                    {
+                                        "description": "<strong>Examples of other public sector structures:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "Offices",
+                                            "Factories",
+                                            "Warehouses",
+                                            "Educational institutions and their halls of residence",
+                                            "Health facilities",
+                                            "Entertainment and sports facilities"
+                                        ]
+                                    }
+                                ]
+                            }],
+                            "type": "General",
+                            "answers": [{
+                                "id": "answerdb018dc4-8664-4587-a038-12a468da441b",
+                                "mandatory": true,
+                                "type": "Currency",
+                                "label": "Other new structures for public sector projects",
+                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
+                                "q_code": "231",
+                                "max_value": {
+                                    "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                    "exclusive": false
+                                },
+                                "decimal_places": 2,
+                                "currency": "GBP"
+                            }]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer27e92f6a-21af-4432-b94c-5157746ebc9e",
+                                "condition": "not contains any",
+                                "values": ["Public sector projects"]
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block1fa2f7bd-0644-434a-a706-32931d727147",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question1fa2f7bd-0644-434a-a706-32931d727147",
+                            "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of <em>R&amp;M</em> carried out on other existing structures for <em>public</em> sector projects?",
+                            "guidance": {
+                                "content": [{
+                                        "description": "<strong>Include work aimed at:</strong>"
+                                    },
+                                    {
+                                        "list": ["repairing something which is broken", "maintaining an existing standard"]
+                                    },
+                                    {
+                                        "description": "<strong>Exclude:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "work on infrastructure",
+                                            "work on residential buildings, for example housing, flats and maisonettes",
+                                            "major alterations, for example improvements and extensions",
+                                            "VAT",
+                                            "payments made to subcontractors"
+                                        ]
+                                    }
+                                ]
+                            },
+                            "definitions": [{
+                                "title": "What we mean by \"other existing structures\"",
+                                "content": [{
+                                        "description": "This refers to work on existing non-residential structures. If over half of a building&apos;s floor area is used for non-residential purposes, it is considered a non-residential building."
+                                    },
+                                    {
+                                        "description": "<strong>Examples of other public sector structures:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "Offices",
+                                            "Factories",
+                                            "Warehouses",
+                                            "Educational institutions and their halls of residence",
+                                            "Health facilities",
+                                            "Entertainment and sports facilities"
+                                        ]
+                                    }
+                                ]
+                            }],
+                            "type": "General",
+                            "answers": [{
+                                "id": "answerc541b81f-6402-4934-821d-dc961bea86bf",
+                                "mandatory": true,
+                                "type": "Currency",
+                                "label": "R&M on other existing structures for public sector projects",
+                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
+                                "q_code": "232",
+                                "max_value": {
+                                    "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                    "exclusive": false
+                                },
+                                "decimal_places": 2,
+                                "currency": "GBP"
+                            }]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer27e92f6a-21af-4432-b94c-5157746ebc9e",
+                                "condition": "not contains any",
+                                "values": ["Public sector projects"]
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block3159dcad-c87b-4afa-860e-291c4d4b1414",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question3159dcad-c87b-4afa-860e-291c4d4b1414",
+                            "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of work carried out on <em>new structures</em> for <em>private commercial</em> sector projects?",
+                            "guidance": {
+                                "content": [{
+                                        "description": "<strong>Include:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "new construction work",
+                                            "demolition",
+                                            "site preparation",
+                                            "major alterations, for example improvements and extensions"
+                                        ]
+                                    },
+                                    {
+                                        "description": "<strong>Exclude:</strong>"
+                                    },
+                                    {
+                                        "list": ["VAT", "R&amp;M", "payments made to subcontractors"]
+                                    }
+                                ]
+                            },
+                            "definitions": [{
+                                "title": "What we mean by the \"private commercial sector\"",
+                                "content": [{
+                                        "description": "This sector refers to part of the economy that  includes all businesses, except those involved in manufacturing and transport."
+                                    },
+                                    {
+                                        "description": "<strong>Examples of private commercial sector structures:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "Any construction work for the agriculture industry",
+                                            "Offices",
+                                            "Factories",
+                                            "Health facilities",
+                                            "Entertainment and sports facilities",
+                                            "Car parks",
+                                            "Educational institutions and their halls of residence",
+                                            "Garages and shops"
+                                        ]
+                                    }
+                                ]
+                            }],
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer1a8a2700-9428-425a-97da-d81ce4eaf4a3",
+                                "mandatory": true,
+                                "type": "Currency",
+                                "label": "New structures for private commercial sector projects",
+                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
+                                "q_code": "241",
+                                "max_value": {
+                                    "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                    "exclusive": false
+                                },
+                                "decimal_places": 2,
+                                "currency": "GBP"
+                            }]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer27e92f6a-21af-4432-b94c-5157746ebc9e",
+                                "condition": "not contains any",
+                                "values": ["Private commercial sector projects"]
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block4bc9c90a-5ef9-427a-b98a-03b9ffbd38d7",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question4bc9c90a-5ef9-427a-b98a-03b9ffbd38d7",
+                            "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of work carried out on <em>new structures</em> for <em>private industrial</em> sector projects?",
+                            "guidance": {
+                                "content": [{
+                                        "description": "<strong>Include:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "new construction work",
+                                            "demolition",
+                                            "site preparation",
+                                            "major alterations, for example improvements and extensions"
+                                        ]
+                                    },
+                                    {
+                                        "description": "<strong>Exclude:</strong>"
+                                    },
+                                    {
+                                        "list": ["VAT", "R&amp;M", "payments made to subcontractors"]
+                                    }
+                                ]
+                            },
+                            "definitions": [{
+                                "title": "What we mean by the \"private industrial sector\"",
+                                "content": [{
+                                        "description": "This sector refers to part of the economy that includes businesses involved in manufacturing and transport, excluding agriculture."
+                                    },
+                                    {
+                                        "description": "<strong>Examples of private industrial sector structures:</strong>"
+                                    },
+                                    {
+                                        "list": ["Factories", "Warehouses", "Any construction work in the coal, oil and steel industry"]
+                                    }
+                                ]
+                            }],
+                            "type": "General",
+                            "answers": [{
+                                "id": "answera11da5a9-892d-42f0-bb19-b3781974d741",
+                                "mandatory": true,
+                                "type": "Currency",
+                                "label": "New structures for private industrial sector projects",
+                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
+                                "q_code": "242",
+                                "max_value": {
+                                    "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                    "exclusive": false
+                                },
+                                "decimal_places": 2,
+                                "currency": "GBP"
+                            }]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer27e92f6a-21af-4432-b94c-5157746ebc9e",
+                                "condition": "not contains any",
+                                "values": ["Private industrial sector projects"]
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "blockf475e0c0-b547-496d-a1bc-5402e5987d70",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "questionf475e0c0-b547-496d-a1bc-5402e5987d70",
+                            "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of <em>R&amp;M</em> carried out on existing structures for <em>private industrial and/or private commercial </em>sector projects?",
+                            "guidance": {
+                                "content": [{
+                                        "description": "<strong>Include work aimed at:</strong>"
+                                    },
+                                    {
+                                        "list": ["repairing something that is broken", "maintaining an existing standard"]
+                                    },
+                                    {
+                                        "description": "<strong>Exclude:</strong>"
+                                    },
+                                    {
+                                        "list": ["major alterations, for example improvements and extensions", "VAT", "payments made to subcontractors"]
+                                    }
+                                ]
+                            },
+                            "definitions": [{
+                                "title": "Examples of private industrial and private commercial sector structures",
+                                "content": [{
+                                        "description": "<strong>Private commercial sector structures:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "Any construction work for the agriculture industry",
+                                            "Offices",
+                                            "Factories",
+                                            "Health facilities",
+                                            "Entertainment and sports facilities",
+                                            "Car parks",
+                                            "Educational institutions and their halls of residence",
+                                            "Garages and shops"
+                                        ]
+                                    },
+                                    {
+                                        "description": "<strong>Private industrial sector structures:</strong>"
+                                    },
+                                    {
+                                        "list": ["Factories", "Warehouses", "Any construction work in the coal, oil and steel industry"]
+                                    }
+                                ]
+                            }],
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer1e0761db-01e8-4ea7-a738-f6144be456b5",
+                                "mandatory": true,
+                                "type": "Currency",
+                                "label": "R&M for existing private industrial and/or private commercial sector projects",
+                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
+                                "q_code": "243",
+                                "max_value": {
+                                    "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                    "exclusive": false
+                                },
+                                "decimal_places": 2,
+                                "currency": "GBP"
+                            }]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer27e92f6a-21af-4432-b94c-5157746ebc9e",
+                                "condition": "not contains any",
+                                "values": ["Private commercial sector projects", "Private industrial sector projects"]
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block3887799c-2d55-48f8-a52d-ee363054106e",
+                        "type": "CalculatedSummary",
+                        "titles": [{
+                            "value": "We calculate the <em>total value of other construction work</em> carried out to be <em>%(total)s.</em> Is this correct?"
+                        }],
+                        "calculation": {
+                            "calculation_type": "sum",
+                            "answers_to_calculate": [
+                                "answerdb018dc4-8664-4587-a038-12a468da441b",
+                                "answerc541b81f-6402-4934-821d-dc961bea86bf",
+                                "answer1a8a2700-9428-425a-97da-d81ce4eaf4a3",
+                                "answera11da5a9-892d-42f0-bb19-b3781974d741",
+                                "answer1e0761db-01e8-4ea7-a738-f6144be456b5"
+                            ],
+                            "titles": [{
+                                "value": "Total value of all other construction work"
+                            }]
                         }
-                    ],
-                    "skip_conditions": [
-                        {
-                            "when": [
-                                {
-                                    "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
-                                    "condition": "equals",
-                                    "value": 0
-                                }
-                            ]
-                        },
-                        {
-                            "when": [
-                                {
-                                    "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
-                                    "condition": "not set"
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ]
+                    }
+                ],
+                "skip_conditions": [{
+                        "when": [{
+                            "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                            "condition": "equals",
+                            "value": 0
+                        }]
+                    },
+                    {
+                        "when": [{
+                            "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                            "condition": "not set"
+                        }]
+                    }
+                ]
+            }]
         },
         {
             "id": "sectione9d26530-ad8f-4527-b09c-afacfa0c820a",
             "title": "Comments",
-            "groups": [
-                {
+            "groups": [{
                     "id": "groupe9d26530-ad8f-4527-b09c-afacfa0c820a",
                     "title": "Comments",
-                    "blocks": [
-                        {
-                            "id": "block37d73422-28cc-4beb-99ce-b099e612f6af",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question37d73422-28cc-4beb-99ce-b099e612f6af",
-                                    "title": "Please explain any changes in your figures from the previous return, if applicable.",
-                                    "description": "<p>If you provide comments we are less likely to contact you with data queries.</p>",
-                                    "definitions": [
-                                        {
-                                            "title": "Examples of commentary",
-                                            "content": [
-                                                {
-                                                    "description": "My figures are <em>lower than usual</em> this month due to:"
-                                                },
-                                                {
-                                                    "list": ["adverse weather conditions", "economic downturn", "my business ceasing trading"]
-                                                },
-                                                {
-                                                    "description": "My figures are <em>higher than usual</em> this month due to:"
-                                                },
-                                                {
-                                                    "list": ["a new contract", "a large contract", "seasonal work"]
-                                                }
-                                            ]
-                                        }
-                                    ],
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answerd55fa781-60be-431b-a9c7-6b29d1c0e28b",
-                                            "mandatory": false,
-                                            "type": "TextArea",
-                                            "label": "Comments",
-                                            "description": "",
-                                            "q_code": "146",
-                                            "max_length": 2000
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
-                    ]
+                    "blocks": [{
+                        "id": "block37d73422-28cc-4beb-99ce-b099e612f6af",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question37d73422-28cc-4beb-99ce-b099e612f6af",
+                            "title": "Please explain any changes in your figures from the previous return, if applicable.",
+                            "description": "<p>If you provide comments we are less likely to contact you with data queries.</p>",
+                            "definitions": [{
+                                "title": "Examples of commentary",
+                                "content": [{
+                                        "description": "My figures are <em>lower than usual</em> this month due to:"
+                                    },
+                                    {
+                                        "list": ["adverse weather conditions", "economic downturn", "my business ceasing trading"]
+                                    },
+                                    {
+                                        "description": "My figures are <em>higher than usual</em> this month due to:"
+                                    },
+                                    {
+                                        "list": ["a new contract", "a large contract", "seasonal work"]
+                                    }
+                                ]
+                            }],
+                            "type": "General",
+                            "answers": [{
+                                "id": "answerd55fa781-60be-431b-a9c7-6b29d1c0e28b",
+                                "mandatory": false,
+                                "type": "TextArea",
+                                "label": "Comments",
+                                "description": "",
+                                "q_code": "146",
+                                "max_length": 2000
+                            }]
+                        }]
+                    }]
                 },
                 {
                     "id": "summary-group",
                     "title": "Summary",
-                    "blocks": [
-                        {
-                            "type": "Summary",
-                            "id": "summary-block"
-                        }
-                    ]
+                    "blocks": [{
+                        "type": "Summary",
+                        "id": "summary-block"
+                    }]
                 }
             ]
         }
@@ -1811,8 +1552,7 @@
     "navigation": {
         "visible": true
     },
-    "metadata": [
-        {
+    "metadata": [{
             "name": "user_id",
             "validator": "string"
         },

--- a/data/en/construction_0001_prototype.json
+++ b/data/en/construction_0001_prototype.json
@@ -1,0 +1,1589 @@
+{
+    "eq_id": "construction_0001",
+    "form_type": "0001",
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.1",
+    "survey_id": "228",
+    "title": "Monthly Business Survey - Construction and Allied Trades",
+    "sections": [{
+            "id": "sectionb1d09333-c7fd-464a-a840-f86056fb32cf",
+            "title": "Reporting period",
+            "groups": [{
+                "id": "groupb1d09333-c7fd-464a-a840-f86056fb32cf",
+                "title": "Reporting period",
+                "blocks": [{
+                        "type": "Introduction",
+                        "id": "introduction-block",
+                        "primary_content": [{
+                            "type": "Basic",
+                            "id": "primary",
+                            "content": [{
+                                "description": "<div class=\"panel panel--simple panel--info\"><div class=\"panel__body\"><h2 class=\"venus\">Coronavirus (COVID-19) additional guidance </h2><p><strong>If you have not traded for all, or some, of the period</strong>: still select 'yes, you can provide figures' and enter value of work, even if this is '0'.</br> <strong>Exclude</strong> furlough payments received in figures.</br> <strong>Explain figures</strong> in the comments section to minimise us contacting you and to help us tell an industry story.</p></div></div>",
+                                "list": [
+                                    "Data should relate to all sites in England, Scotland and Wales but excludes Northern Ireland.",
+                                    "You can provide informed estimates if actual figures are not available.",
+                                    "We will treat your data securely and confidentially."
+                                ]
+                            }]
+                        }],
+                        "preview_content": {
+                            "id": "preview",
+                            "title": "Information you need",
+                            "content": [{
+                                    "description": "<a href='https://www.ons.gov.uk/surveys/informationforbusinesses/businesssurveys/monthlybusinesssurveyforconstructionandalliedtrades'><p>View the survey information and questions before you start the survey (external link)</p></a>"
+                                },
+                                {
+                                    "description": "You will be asked to provide information on the value of work undertaken by your business. Value of work refers to estimates of chargeable work carried out during the month; meaning work started, in progress, or completed."
+                                }
+                            ],
+                            "questions": [{
+                                    "question": "Housing Work",
+                                    "content": [{
+                                            "description": "This section asks for information on the value of new builds and repair and maintenance (R&amp;M), improvements and major alterations on housing for public and private sector projects."
+                                        },
+                                        {
+                                            "description": "<strong>Include:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "work on buildings which you hope to sell later for profit (speculative work)",
+                                                "work done by your business on its own premises",
+                                                "fixtures, equipment and tools your business made and used in construction",
+                                                "materials your business used, overheads and profits",
+                                                "labour costs on your payroll"
+                                            ]
+                                        },
+                                        {
+                                            "description": "<strong>Exclude:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "VAT",
+                                                "payments made to subcontractors",
+                                                "payments made to consultants or architects",
+                                                "fixtures, equipment and tools your business made for sale",
+                                                "materials your business sold",
+                                                "value of land"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": "Infrastructure",
+                                    "content": [{
+                                            "description": "This section asks for information on the value of new infrastructure, and repair and maintenance (R&amp;M) of infrastructure."
+                                        },
+                                        {
+                                            "description": "<strong>Include:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "work done by your own business on its own business premises",
+                                                "fixtures, equipment and tools your business made and used in construction",
+                                                "materials your business used, overheads and profits",
+                                                "labour costs on your payroll"
+                                            ]
+                                        },
+                                        {
+                                            "description": "<strong>Exclude:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "VAT",
+                                                "payments made to subcontractors",
+                                                "payments made to consultants or architects",
+                                                "fixtures, equipment and tools your business made for sale",
+                                                "materials your business sold",
+                                                "value of land"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": "Other construction work",
+                                    "content": [{
+                                            "description": "This section asks for information on the value of other construction work carried out on new structures for public, commercial and industrial projects, and repair and maintenance (R&amp;M) of existing structures."
+                                        },
+                                        {
+                                            "description": "<strong>Include:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "work on buildings which you hope to sell later for profit (speculative work)",
+                                                "work done by your business on its own premises",
+                                                "fixtures, equipment and tools your business made and used in construction",
+                                                "materials your business used, overheads and profits",
+                                                "labour costs on your payroll"
+                                            ]
+                                        },
+                                        {
+                                            "description": "<strong>Exclude:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "work on infrastructure",
+                                                "work on residential buildings",
+                                                "VAT",
+                                                "payments made to subcontractors",
+                                                "payments made to consultants or architects",
+                                                "fixtures, equipment and tools your business made for sale",
+                                                "materials your business sold",
+                                                "value of land"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": "Additional comments",
+                                    "content": [{
+                                            "description": "Please tell us about any additional comments you have about your data."
+                                        },
+                                        {
+                                            "description": "<strong>For example:</strong>"
+                                        },
+                                        {
+                                            "description": "My figures are <em>lower than usual</em> this month due to:"
+                                        },
+                                        {
+                                            "list": ["adverse weather conditions", "economic downturn", "my business ceasing trading"]
+                                        },
+                                        {
+                                            "description": "My figures are <em>higher than usual</em> this month due to:"
+                                        },
+                                        {
+                                            "list": ["a new contract", "a large contract", "seasonal work"]
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        "secondary_content": [{
+                            "id": "secondary-content",
+                            "title": "How we use your data",
+                            "content": [{
+                                "list": [
+                                    "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
+                                    "The information you provide contributes to Gross Domestic Product (GDP). The Monthly Business Survey figures are published monthly in the Output in the Construction Industry Statistical Bulletin."
+                                ]
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "blockb859977c-01e2-498a-807e-5438af81fdd2",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "questionb859977c-01e2-498a-807e-5438af81fdd2",
+                            "title": "Are you able to report for the calendar month {{ metadata['ref_p_start_date'] | format_date }} to {{ metadata['ref_p_end_date'] | format_date }}?",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answerdadafe6c-4875-43bc-87e2-6097ff0d106e",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "label": "",
+                                "description": "",
+                                "q_code": "901",
+                                "options": [{
+                                        "label": "Yes, I can report for this period",
+                                        "value": "Yes, I can report for this period"
+                                    },
+                                    {
+                                        "label": "No, I need to report for a different period",
+                                        "value": "No, I need to report for a different period"
+                                    }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "group": "group7e41e171-26eb-42c0-99ef-b34fa447c363",
+                                    "when": [{
+                                        "id": "answerdadafe6c-4875-43bc-87e2-6097ff0d106e",
+                                        "condition": "contains any",
+                                        "values": ["Yes, I can report for this period"]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "block09dffdbc-5a11-424a-8da2-388b91b16e51"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "block09dffdbc-5a11-424a-8da2-388b91b16e51",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question09dffdbc-5a11-424a-8da2-388b91b16e51",
+                            "title": "What dates will you be reporting for?",
+                            "type": "DateRange",
+                            "answers": [{
+                                    "id": "answer440c8850-b115-4f6b-b0f5-52d911dd6ef6from",
+                                    "type": "Date",
+                                    "mandatory": true,
+                                    "label": "From",
+                                    "q_code": "11",
+                                    "minimum": {
+                                        "meta": "ref_p_start_date",
+                                        "offset_by": {
+                                            "days": -19
+                                        }
+                                    }
+                                },
+                                {
+                                    "id": "answer440c8850-b115-4f6b-b0f5-52d911dd6ef6to",
+                                    "type": "Date",
+                                    "mandatory": true,
+                                    "label": "To",
+                                    "q_code": "12",
+                                    "maximum": {
+                                        "meta": "ref_p_end_date",
+                                        "offset_by": {
+                                            "days": 20
+                                        }
+                                    }
+                                }
+                            ],
+                            "period_limits": {
+                                "minimum": {
+                                    "days": 23
+                                },
+                                "maximum": {
+                                    "days": 50
+                                }
+                            }
+                        }]
+                    }
+                ]
+            }]
+        },
+        {
+            "id": "section7e41e171-26eb-42c0-99ef-b34fa447c363",
+            "title": "Value of work",
+            "groups": [{
+                "id": "group7e41e171-26eb-42c0-99ef-b34fa447c363",
+                "title": "Value of work",
+                "blocks": [{
+                        "type": "Interstitial",
+                        "id": "group7e41e171-26eb-42c0-99ef-b34fa447c363-introduction",
+                        "title": "This survey requires you to report the value of work",
+                        "description": "<p>Value of work refers to estimates of <em>chargeable work</em> carried out during the month. This includes work started, work in progress and work completed.</p>"
+                    },
+                    {
+                        "id": "block69ae90ee-65a6-49ef-8ca9-1c55c9eb6688",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question69ae90ee-65a6-49ef-8ca9-1c55c9eb6688",
+                            "title": "During the period {{ format_conditional_date (answers['answer440c8850-b115-4f6b-b0f5-52d911dd6ef6from'], metadata['ref_p_start_date']) }} to {{ format_conditional_date (answers['answer440c8850-b115-4f6b-b0f5-52d911dd6ef6to'], metadata['ref_p_end_date']) }}, what was the <em>total value of all construction work</em> carried out by {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                            "description": "<p>If you are a fitter or installer, you are included within the construction industry so should report your figures.</p>",
+                            "guidance": {
+                                "content": [{
+                                        "description": "<strong>Include:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "new builds and repair and maintenance (R&amp;M) on housing and other residential properties, infrastructure, commercial structures and industrial structures",
+                                            "(speculative) work on buildings which you hope to sell later for profit",
+                                            "work done by your business on its own premises",
+                                            "fixtures, equipment and tools your business made and used in construction",
+                                            "materials your business used, overheads and profits",
+                                            "labour costs on your payroll"
+                                        ]
+                                    },
+                                    {
+                                        "description": "<strong>Exclude:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "VAT",
+                                            "payments made to subcontractors",
+                                            "payments made to consultants or architects",
+                                            "fixtures, equipment and tools your business made for sale",
+                                            "materials your business sold",
+                                            "value of land"
+                                        ]
+                                    }
+                                ]
+                            },
+                            "definitions": [{
+                                "title": "What we mean by \"total value of all construction work\"",
+                                "content": [{
+                                        "description": "This refers to <em>all work on new structures and repair and maintenance (R&amp;M) on existing structures,</em> carried out on housing, infrastructure, commercial and industrial projects for the public and private sector."
+                                    },
+                                    {
+                                        "description": "<strong>Examples of housing:</strong>"
+                                    },
+                                    {
+                                        "list": ["Flats and maisonettes", "New houses", "Other types of residential housing"]
+                                    },
+                                    {
+                                        "description": "<strong>Examples of infrastructure:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "Electricity, such as power stations",
+                                            "Gas, such as gas works and laying pipelines",
+                                            "Air transport, harbours, roads, and railways",
+                                            "Drainage, sewerage, and water such as reservoirs",
+                                            "Communication"
+                                        ]
+                                    },
+                                    {
+                                        "description": "<strong>Examples of commercial and industrial structures:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "Offices",
+                                            "Factories",
+                                            "Warehouses",
+                                            "Educational institutions and their halls of residence",
+                                            "Health facilities",
+                                            "Entertainment and sports facilities",
+                                            "Car parks",
+                                            "Garages and shops",
+                                            "Any construction work in the coal, oil, agriculture and steel industry"
+                                        ]
+                                    }
+                                ]
+                            }],
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                "mandatory": true,
+                                "type": "Currency",
+                                "label": "Total value of all work carried out",
+                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
+                                "q_code": "290",
+                                "min_value": {
+                                    "value": 0,
+                                    "exclusive": false
+                                },
+                                "decimal_places": 2,
+                                "currency": "GBP"
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "group": "groupe9d26530-ad8f-4527-b09c-afacfa0c820a",
+                                    "when": [{
+                                        "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                        "condition": "equals",
+                                        "value": 0
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "group": "groupe9d26530-ad8f-4527-b09c-afacfa0c820a",
+                                    "when": [{
+                                        "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                        "condition": "not set"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "group": "group95c68629-8efd-4913-b465-41b686719d32"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }]
+        },
+        {
+            "id": "section95c68629-8efd-4913-b465-41b686719d32",
+            "title": "Housing work",
+            "groups": [{
+                "id": "group95c68629-8efd-4913-b465-41b686719d32",
+                "title": "Housing work",
+                "blocks": [{
+                        "type": "Interstitial",
+                        "id": "group95c68629-8efd-4913-b465-41b686719d32-introduction",
+                        "title": "Housing work",
+                        "description": "<p>This section asks for information on the value of new builds and repair and maintenance (R&amp;M), improvements and major alterations on housing for public and private sector projects.</p><p>You will be asked to provide information on the value of work undertaken by your business. Value of work refers to estimates of chargeable work carried out during the month; meaning work started, in progress, or completed.</p><p><strong>Include:</strong></p><ul><li>work on buildings which you hope to sell later for profit (speculative work)</li><li>work done by your business on its own premises</li><li>fixtures, equipment and tools your business made and used in construction</li><li>materials your business used, overheads and profits</li><li>labour costs on your payroll</li></ul><p><strong>Exclude:</strong></p><ul><li>VAT</li><li>payments made to subcontractors </li><li>payments made to consultants or architects</li><li>fixtures, equipment and tools your business made for sale</li><li>materials your business sold</li><li>value of land</li></ul>"
+                    },
+                    {
+                        "id": "blockbaffab41-96f6-4f04-901d-5ff18c15bb90",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "questionbaffab41-96f6-4f04-901d-5ff18c15bb90",
+                            "title": "During the period {{ format_conditional_date (answers['answer440c8850-b115-4f6b-b0f5-52d911dd6ef6from'], metadata['ref_p_start_date']) }} to {{ format_conditional_date (answers['answer440c8850-b115-4f6b-b0f5-52d911dd6ef6to'], metadata['ref_p_end_date']) }}, did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} carry out any work on <em>housing</em>?",
+                            "description": "<p>If you are a fitter or installer, you are included within the construction industry sector so should report your figures.</p>",
+                            "guidance": {
+                                "content": [{
+                                        "description": "<strong>Include new builds and repair and maintenance (R&amp;M) of:</strong>"
+                                    },
+                                    {
+                                        "list": ["flats and maisonettes", "new houses", "other types of residential housing"]
+                                    },
+                                    {
+                                        "description": "<strong>Exclude:</strong>"
+                                    },
+                                    {
+                                        "list": ["any work on halls of residence for educational institutions"]
+                                    }
+                                ]
+                            },
+                            "definitions": [{
+                                "title": "What we mean by \"work on housing\"",
+                                "content": [{
+                                    "description": "This refers to work on residential buildings. If over half of a building&apos;s floor area is used for residential purposes, it is considered a residential building."
+                                }]
+                            }],
+                            "type": "General",
+                            "answers": [{
+                                "id": "answera75253f4-438c-4bdf-8613-cbfa2a3a1fb6",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "label": "",
+                                "description": "",
+                                "q_code": "902",
+                                "options": [{
+                                        "label": "Yes, we carried out work on housing",
+                                        "value": "Yes, we carried out work on housing"
+                                    },
+                                    {
+                                        "label": "No, we did not carry out work on housing",
+                                        "value": "No, we did not carry out work on housing"
+                                    }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "blockc102510b-e675-4074-8cdb-d6b8c5729a29",
+                                    "when": [{
+                                        "id": "answera75253f4-438c-4bdf-8613-cbfa2a3a1fb6",
+                                        "condition": "contains any",
+                                        "values": ["Yes, we carried out work on housing"]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "group": "group551ac31e-ba5e-4161-a93e-92a06c53c6ad"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "blockc102510b-e675-4074-8cdb-d6b8c5729a29",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "questionc102510b-e675-4074-8cdb-d6b8c5729a29",
+                            "title": "Which sector did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} carry out housing work for?",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer35ce4949-ad6d-4137-b28b-ce3b5723831e",
+                                "mandatory": true,
+                                "type": "Checkbox",
+                                "label": "",
+                                "description": "",
+                                "q_code": "d1",
+                                "options": [{
+                                        "label": "Public sector projects",
+                                        "value": "Public sector projects",
+                                        "description": "In the UK, the public sector consists of five sub-sectors: central government, local government, public non-financial corporations, Bank of England, public financial corporations (public sector banks)"
+                                    },
+                                    {
+                                        "label": "Private sector projects",
+                                        "value": "Private sector projects",
+                                        "description": "The private sector refers to the part of the economy that is for profit and is owned by private organisations, for example housing associations, or individuals"
+                                    }
+                                ]
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "blocke9a89f15-d5ad-4698-90ac-aaec447c5a07",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "questione9a89f15-d5ad-4698-90ac-aaec447c5a07",
+                            "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of work carried out on <em>new housing builds</em> for <em>public</em> sector projects?",
+                            "guidance": {
+                                "content": [{
+                                        "description": "<strong>Include:</strong>"
+                                    },
+                                    {
+                                        "list": ["new construction work", "demolition", "site preparation"]
+                                    },
+                                    {
+                                        "description": "<strong>Exclude:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "VAT",
+                                            "repair and maintenance (R&amp;M)",
+                                            "major alterations, for example improvements and extensions",
+                                            "payments made to subcontractors",
+                                            "any work on halls of residence for educational institutions"
+                                        ]
+                                    }
+                                ]
+                            },
+                            "definitions": [{
+                                "title": "What we mean by \"public sector\"",
+                                "content": [{
+                                        "description": "In the UK, the public sector consists of five sub-sectors:"
+                                    },
+                                    {
+                                        "list": [
+                                            "central government",
+                                            "local government",
+                                            "public non-financial corporations",
+                                            "Bank of England",
+                                            "public financial corporations, for example public sector banks"
+                                        ]
+                                    }
+                                ]
+                            }],
+                            "type": "General",
+                            "answers": [{
+                                "id": "answercf9a19af-7bfb-4a55-9372-16987cc23d17",
+                                "mandatory": true,
+                                "type": "Currency",
+                                "label": "New housing builds for public sector projects",
+                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
+                                "q_code": "201",
+                                "max_value": {
+                                    "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                    "exclusive": false
+                                },
+                                "decimal_places": 2,
+                                "currency": "GBP"
+                            }]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer35ce4949-ad6d-4137-b28b-ce3b5723831e",
+                                "condition": "not contains any",
+                                "values": ["Public sector projects"]
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block4e0f51d6-103f-4495-b6ac-e8d21d536769",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question4e0f51d6-103f-4495-b6ac-e8d21d536769",
+                            "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of <em>repair and maintenance (R&amp;M), improvements and major alterations</em> carried out on existing housing for <em>public</em> sector projects?",
+                            "guidance": {
+                                "content": [{
+                                        "description": "<strong>Include:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "extensions",
+                                            "any work aimed at repairing something which is broken",
+                                            "maintaining something to an existing standard"
+                                        ]
+                                    },
+                                    {
+                                        "description": "<strong>Exclude:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "VAT",
+                                            "payments made to subcontractors",
+                                            "any work on halls of residence for educational institutions"
+                                        ]
+                                    }
+                                ]
+                            },
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer9368d5d6-a302-40b1-9211-f9ae4ceee109",
+                                "mandatory": true,
+                                "type": "Currency",
+                                "label": "R&M, improvements and major alterations on existing housing for public sector projects",
+                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
+                                "q_code": "202",
+                                "max_value": {
+                                    "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                    "exclusive": false
+                                },
+                                "decimal_places": 2,
+                                "currency": "GBP"
+                            }]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer35ce4949-ad6d-4137-b28b-ce3b5723831e",
+                                "condition": "not contains any",
+                                "values": ["Public sector projects"]
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block510a45f5-aa4f-4d2d-9268-52ca13e0bb7b",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question510a45f5-aa4f-4d2d-9268-52ca13e0bb7b",
+                            "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of work carried out on <em>new housing builds</em> for <em>private</em> sector projects?",
+                            "guidance": {
+                                "content": [{
+                                        "description": "<strong>Include:</strong>"
+                                    },
+                                    {
+                                        "list": ["new construction work", "demolition", "site preparation"]
+                                    },
+                                    {
+                                        "description": "<strong>Exclude:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "VAT",
+                                            "R&amp;M",
+                                            "major alterations, for example improvements and extensions",
+                                            "payments made to subcontractors",
+                                            "any work on halls of residence for educational institutions"
+                                        ]
+                                    }
+                                ]
+                            },
+                            "definitions": [{
+                                "title": "What we mean by \"private sector\"",
+                                "content": [{
+                                        "description": "The private sector refers to the part of the economy that is for profit and is owned by private organisations or individuals."
+                                    },
+                                    {
+                                        "description": "<strong>Examples of the private sector:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "Small and medium-sized businesses",
+                                            "Housing associations",
+                                            "Multinationals",
+                                            "Partnerships and sole traders",
+                                            "Households"
+                                        ]
+                                    }
+                                ]
+                            }],
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer24071a9f-30fa-4e1e-bd21-198ba49129b5",
+                                "mandatory": true,
+                                "type": "Currency",
+                                "label": "New housing builds for private sector projects",
+                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
+                                "q_code": "211",
+                                "max_value": {
+                                    "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                    "exclusive": false
+                                },
+                                "decimal_places": 2,
+                                "currency": "GBP"
+                            }]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer35ce4949-ad6d-4137-b28b-ce3b5723831e",
+                                "condition": "not contains any",
+                                "values": ["Private sector projects"]
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block2da3a1a1-9d5d-4ce1-a84e-3f3e1a22fbd9",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question2da3a1a1-9d5d-4ce1-a84e-3f3e1a22fbd9",
+                            "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of <em>R&amp;M, improvements and major alterations</em> carried out on existing housing for <em>private</em> sector projects?",
+                            "guidance": {
+                                "content": [{
+                                        "description": "<strong>Include:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "extensions",
+                                            "any work aimed at repairing something that is broken",
+                                            "maintaining something to an existing standard"
+                                        ]
+                                    },
+                                    {
+                                        "description": "<strong>Exclude:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "VAT",
+                                            "payments made to subcontractors",
+                                            "any work on halls of residence for educational institutions"
+                                        ]
+                                    }
+                                ]
+                            },
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer214ea602-4fbe-4775-ae6b-6b99c9779b62",
+                                "mandatory": true,
+                                "type": "Currency",
+                                "label": "R&M, improvements and major alterations on existing housing for private sector projects",
+                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
+                                "q_code": "212",
+                                "max_value": {
+                                    "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                    "exclusive": false
+                                },
+                                "decimal_places": 2,
+                                "currency": "GBP"
+                            }]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer35ce4949-ad6d-4137-b28b-ce3b5723831e",
+                                "condition": "not contains any",
+                                "values": ["Private sector projects"]
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "blocke2123cd6-0205-45ed-93bc-88ee340e9a13",
+                        "type": "CalculatedSummary",
+                        "titles": [{
+                            "value": "We calculate the <em>total value of housing work</em> to be <em>%(total)s.</em> Is this correct?"
+                        }],
+                        "calculation": {
+                            "calculation_type": "sum",
+                            "answers_to_calculate": [
+                                "answercf9a19af-7bfb-4a55-9372-16987cc23d17",
+                                "answer9368d5d6-a302-40b1-9211-f9ae4ceee109",
+                                "answer24071a9f-30fa-4e1e-bd21-198ba49129b5",
+                                "answer214ea602-4fbe-4775-ae6b-6b99c9779b62"
+                            ],
+                            "titles": [{
+                                "value": "Total value of all housing work"
+                            }]
+                        }
+                    }
+                ],
+                "skip_conditions": [{
+                        "when": [{
+                            "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                            "condition": "equals",
+                            "value": 0
+                        }]
+                    },
+                    {
+                        "when": [{
+                            "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                            "condition": "not set"
+                        }]
+                    }
+                ]
+            }]
+        },
+        {
+            "id": "section551ac31e-ba5e-4161-a93e-92a06c53c6ad",
+            "title": "Infrastructure",
+            "groups": [{
+                "id": "group551ac31e-ba5e-4161-a93e-92a06c53c6ad",
+                "title": "Infrastructure",
+                "blocks": [{
+                        "type": "Interstitial",
+                        "id": "group551ac31e-ba5e-4161-a93e-92a06c53c6ad-introduction",
+                        "title": "Infrastructure",
+                        "description": "<p>This section asks for information on the value of new infrastructure, and repair and maintenance (R&amp;M) of existing <em>infrastructure</em>.</p><p>You will be asked to provide information on the value of work undertaken by your business. Value of work refers to estimates of chargeable work carried out during the month; meaning work started, in progress, or completed.</p><p><strong>Include:</strong></p><ul><li>work done by your own business on its own business premises</li><li>fixtures, equipment and tools your business made and used in construction</li><li>materials your business used, overheads and profits</li><li>labour costs on your payroll</li></ul><p><strong>Exclude:</strong></p><ul><li>VAT</li><li>payments made to subcontractors</li><li>payments made to consultants or architects</li><li>fixtures, equipment and tools your business made for sale</li><li>materials your business sold</li><li>value of land</li></ul>"
+                    },
+                    {
+                        "id": "block01c41114-3ca3-432f-b7e6-95f8c702f308",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question01c41114-3ca3-432f-b7e6-95f8c702f308",
+                            "title": "During the period {{ format_conditional_date (answers['answer440c8850-b115-4f6b-b0f5-52d911dd6ef6from'], metadata['ref_p_start_date']) }} to {{ format_conditional_date (answers['answer440c8850-b115-4f6b-b0f5-52d911dd6ef6to'], metadata['ref_p_end_date']) }}, did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} carry out any work on <em>infrastructure</em>?",
+                            "description": "<p>If you are a fitter or installer, you are included within the construction industry sector so should report your figures.</p>",
+                            "guidance": {
+                                "content": [{
+                                        "description": "<strong>Include:</strong>"
+                                    },
+                                    {
+                                        "list": ["new infrastructure and repair and maintenance (R&amp;M) of infrastructure"]
+                                    },
+                                    {
+                                        "description": "<strong>Exclude:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "work on any residential buildings such as housing, flats or maisonettes",
+                                            "work on any industrial or commercial structures, such as factories, warehouses, offices health facilities or educational facilities"
+                                        ]
+                                    }
+                                ]
+                            },
+                            "definitions": [{
+                                "title": "What we mean by infrastructure",
+                                "content": [{
+                                        "description": "Infrastructure refers to non-residential buildings, facilities, or systems that are fundamental to the functioning of an area."
+                                    },
+                                    {
+                                        "description": "<strong>Examples of infrastructure:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "Electricity, such as power stations",
+                                            "Gas, such as gas works and laying pipelines",
+                                            "Air transport, harbours, roads, and railways",
+                                            "Drainage, sewerage, and water such as reservoirs",
+                                            "Communication"
+                                        ]
+                                    }
+                                ]
+                            }],
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer01c0c84f-7282-42a3-b1c3-13b6d10f39bf",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "label": "",
+                                "description": "",
+                                "q_code": "903",
+                                "options": [{
+                                        "label": "Yes, we carried out work on infrastructure",
+                                        "value": "Yes, we carried out work on infrastructure"
+                                    },
+                                    {
+                                        "label": "No, we did not carry out work on infrastructure",
+                                        "value": "No, we did not carry out work on infrastructure"
+                                    }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "block8ce84076-2099-4ee2-aa26-79bb386f44a9",
+                                    "when": [{
+                                        "id": "answer01c0c84f-7282-42a3-b1c3-13b6d10f39bf",
+                                        "condition": "contains any",
+                                        "values": ["Yes, we carried out work on infrastructure"]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "group": "group6cc8656d-6877-4685-b9eb-f024a9ae1898"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "block8ce84076-2099-4ee2-aa26-79bb386f44a9",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question8ce84076-2099-4ee2-aa26-79bb386f44a9",
+                            "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of work carried out on <em>new infrastructure</em>?",
+                            "guidance": {
+                                "content": [{
+                                        "description": "<strong>Include:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "new construction work",
+                                            "demolition",
+                                            "site clearance and preparation",
+                                            "major alterations, for example improvements and extensions"
+                                        ]
+                                    },
+                                    {
+                                        "description": "<strong>Exclude:</strong>"
+                                    },
+                                    {
+                                        "list": ["VAT", "R&amp;M", "payments made to subcontractors"]
+                                    }
+                                ]
+                            },
+                            "definitions": [{
+                                "title": "Examples of infrastructure",
+                                "content": [{
+                                    "list": [
+                                        "Electricity, such as power stations",
+                                        "Gas, such as gas works and laying pipelines",
+                                        "Air transport, harbours, roads, and railways",
+                                        "Drainage, sewerage, and water such as reservoirs",
+                                        "Communication"
+                                    ]
+                                }]
+                            }],
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer692af9c8-8773-4a7b-9a21-1830f3dc3401",
+                                "mandatory": true,
+                                "type": "Currency",
+                                "label": "New infrastructure",
+                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
+                                "q_code": "221",
+                                "max_value": {
+                                    "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                    "exclusive": false
+                                },
+                                "decimal_places": 2,
+                                "currency": "GBP"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "blockdd878456-07b8-40f5-a3c5-fee1129cb64a",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "questiondd878456-07b8-40f5-a3c5-fee1129cb64a",
+                            "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of <em>R&amp;M</em> carried out on existing infrastructure?",
+                            "guidance": {
+                                "content": [{
+                                        "description": "<strong>Include work aimed at:</strong>"
+                                    },
+                                    {
+                                        "list": ["repairing a fault", "repairing something that is broken", "maintaining an existing standard"]
+                                    },
+                                    {
+                                        "description": "<strong> Exclude:</strong>"
+                                    },
+                                    {
+                                        "list": ["major alterations, for example improvements and extensions", "VAT", "payments made to subcontractors"]
+                                    }
+                                ]
+                            },
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer8561360c-adc9-40b9-b6af-2f85c486fef5",
+                                "mandatory": true,
+                                "type": "Currency",
+                                "label": "R&M carried out on existing infrastructure",
+                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
+                                "q_code": "222",
+                                "max_value": {
+                                    "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                    "exclusive": false
+                                },
+                                "decimal_places": 2,
+                                "currency": "GBP"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block319d4417-7383-496a-be67-590f02765e08",
+                        "type": "CalculatedSummary",
+                        "titles": [{
+                            "value": "We calculate the <em>total value of infrastructure work</em> carried out to be <em>%(total)s.</em> Is this correct?"
+                        }],
+                        "calculation": {
+                            "calculation_type": "sum",
+                            "answers_to_calculate": ["answer692af9c8-8773-4a7b-9a21-1830f3dc3401", "answer8561360c-adc9-40b9-b6af-2f85c486fef5"],
+                            "titles": [{
+                                "value": "Total value of all infrastructure work"
+                            }]
+                        }
+                    }
+                ],
+                "skip_conditions": [{
+                        "when": [{
+                            "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                            "condition": "equals",
+                            "value": 0
+                        }]
+                    },
+                    {
+                        "when": [{
+                            "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                            "condition": "not set"
+                        }]
+                    }
+                ]
+            }]
+        },
+        {
+            "id": "section6cc8656d-6877-4685-b9eb-f024a9ae1898",
+            "title": "Other construction work",
+            "groups": [{
+                "id": "group6cc8656d-6877-4685-b9eb-f024a9ae1898",
+                "title": "Other construction work",
+                "blocks": [{
+                        "type": "Interstitial",
+                        "id": "group6cc8656d-6877-4685-b9eb-f024a9ae1898-introduction",
+                        "title": "Other construction work",
+                        "description": "<p>This section asks for information on the value of <em>other construction work</em> carried out on new structures for public, commercial and industrial projects, and repair and maintenance (R&amp;M) of existing structures.</p><p>You will be asked to provide information on the value of work undertaken by your business. Value of work refers to estimates of chargeable work carried out during the month; meaning work started, in progress, or completed. </p><p><strong>Include:</strong></p><ul><li>work on buildings which you hope to sell later for profit (speculative work)</li><li>work done by your business on its own premises</li><li>fixtures, equipment and tools your business made and used in construction</li><li>materials your business used, overheads and profits</li><li>labour costs on your payroll</li></ul><p> <strong>Exclude:</strong></p><ul><li>work on infrastructure</li><li>work on residential buildings, for example housing, flats and maisonettes</li><li>VAT</li><li>payments made to subcontractors</li><li>payments made to consultants or architects</li><li>fixtures, equipment and tools your business made for sale</li><li>materials your business sold</li><li>value of land</li></ul>"
+                    },
+                    {
+                        "id": "block92bf4040-ae9c-4245-889c-c11ec6d52ce4",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question92bf4040-ae9c-4245-889c-c11ec6d52ce4",
+                            "title": "During the period {{ format_conditional_date (answers['answer440c8850-b115-4f6b-b0f5-52d911dd6ef6from'], metadata['ref_p_start_date']) }} to {{ format_conditional_date (answers['answer440c8850-b115-4f6b-b0f5-52d911dd6ef6to'], metadata['ref_p_end_date']) }}, did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} carry out any <em>other construction work</em>?",
+                            "description": "<p>If you are a fitter or installer, you are included within the construction industry sector so should report your figures.</p>",
+                            "guidance": {
+                                "content": [{
+                                        "description": "<strong>Exclude:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "work on residential buildings, for example housing, flats and maisonettes, except halls of residence for educational institutions",
+                                            "work on infrastructure"
+                                        ]
+                                    }
+                                ]
+                            },
+                            "definitions": [{
+                                "title": "Examples of other construction work",
+                                "content": [{
+                                    "list": [
+                                        "Industrial structures, such as factories and warehouses",
+                                        "Commercial structures, such as agricultural structures, offices, parks, health facilities and educational institutions",
+                                        "Public structures, such educational institutions, offices, health facilities, sport facilities or entertainment facilities"
+                                    ]
+                                }]
+                            }],
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer50ae0d8f-dd41-43ab-8e29-431028500270",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "label": "",
+                                "description": "",
+                                "q_code": "904",
+                                "options": [{
+                                        "label": "Yes, we carried out other construction work",
+                                        "value": "Yes, we carried out other construction work"
+                                    },
+                                    {
+                                        "label": "No, we did not carry out other construction work",
+                                        "value": "No, we did not carry out other construction work"
+                                    }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "blockcb22fe8e-4000-418d-b0f1-ca57306a2c0e",
+                                    "when": [{
+                                        "id": "answer50ae0d8f-dd41-43ab-8e29-431028500270",
+                                        "condition": "contains any",
+                                        "values": ["Yes, we carried out other construction work"]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "group": "groupe9d26530-ad8f-4527-b09c-afacfa0c820a"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "blockcb22fe8e-4000-418d-b0f1-ca57306a2c0e",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "questioncb22fe8e-4000-418d-b0f1-ca57306a2c0e",
+                            "title": "Which sector did {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} carry out other construction work for?",
+                            "guidance": {
+                                "content": [{
+                                        "description": "<strong>Exclude:</strong>"
+                                    },
+                                    {
+                                        "list": ["work on residential buildings, for example housing, flats and maisonettes", "work on infrastructure"]
+                                    }
+                                ]
+                            },
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer27e92f6a-21af-4432-b94c-5157746ebc9e",
+                                "mandatory": true,
+                                "type": "Checkbox",
+                                "label": "",
+                                "description": "",
+                                "q_code": "d2",
+                                "options": [{
+                                        "label": "Public sector projects",
+                                        "value": "Public sector projects",
+                                        "description": "The public sector consists central government, local government, public non-financial corporations, Bank of England and public financial corporations."
+                                    },
+                                    {
+                                        "label": "Private commercial sector projects",
+                                        "value": "Private commercial sector projects",
+                                        "description": "Part of the economy that includes all businesses and agriculture, except those businesses involved in manufacturing and  transport"
+                                    },
+                                    {
+                                        "label": "Private industrial sector projects",
+                                        "value": "Private industrial sector projects",
+                                        "description": "Part of the economy that includes businesses involved in manufacturing and transport"
+                                    }
+                                ]
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block6128bff1-69b5-4914-b49a-11facc75a178",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question6128bff1-69b5-4914-b49a-11facc75a178",
+                            "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of work carried out on <em>other new structures</em> for <em>public</em> sector projects?",
+                            "guidance": {
+                                "content": [{
+                                        "description": "<strong> Include:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "new construction work",
+                                            "demolition",
+                                            "site preparation",
+                                            "major alterations, for example improvements and extensions"
+                                        ]
+                                    },
+                                    {
+                                        "description": "<strong>Exclude:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "work on infrastructure",
+                                            "work on residential buildings, for example housing, flats and maisonettes",
+                                            "VAT",
+                                            "R&amp;M",
+                                            "payments made to subcontractors"
+                                        ]
+                                    }
+                                ]
+                            },
+                            "definitions": [{
+                                "title": "What we mean by \"other new structures\"",
+                                "content": [{
+                                        "description": "This refers to work on new non-residential structures. If over half of a building&apos;s floor area is used for non-residential purposes, it is considered a non-residential building."
+                                    },
+                                    {
+                                        "description": "<strong>Examples of other public sector structures:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "Offices",
+                                            "Factories",
+                                            "Warehouses",
+                                            "Educational institutions and their halls of residence",
+                                            "Health facilities",
+                                            "Entertainment and sports facilities"
+                                        ]
+                                    }
+                                ]
+                            }],
+                            "type": "General",
+                            "answers": [{
+                                "id": "answerdb018dc4-8664-4587-a038-12a468da441b",
+                                "mandatory": true,
+                                "type": "Currency",
+                                "label": "Other new structures for public sector projects",
+                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
+                                "q_code": "231",
+                                "max_value": {
+                                    "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                    "exclusive": false
+                                },
+                                "decimal_places": 2,
+                                "currency": "GBP"
+                            }]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer27e92f6a-21af-4432-b94c-5157746ebc9e",
+                                "condition": "not contains any",
+                                "values": ["Public sector projects"]
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block1fa2f7bd-0644-434a-a706-32931d727147",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question1fa2f7bd-0644-434a-a706-32931d727147",
+                            "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of <em>R&amp;M</em> carried out on other existing structures for <em>public</em> sector projects?",
+                            "guidance": {
+                                "content": [{
+                                        "description": "<strong>Include work aimed at:</strong>"
+                                    },
+                                    {
+                                        "list": ["repairing something which is broken", "maintaining an existing standard"]
+                                    },
+                                    {
+                                        "description": "<strong>Exclude:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "work on infrastructure",
+                                            "work on residential buildings, for example housing, flats and maisonettes",
+                                            "major alterations, for example improvements and extensions",
+                                            "VAT",
+                                            "payments made to subcontractors"
+                                        ]
+                                    }
+                                ]
+                            },
+                            "definitions": [{
+                                "title": "What we mean by \"other existing structures\"",
+                                "content": [{
+                                        "description": "This refers to work on existing non-residential structures. If over half of a building&apos;s floor area is used for non-residential purposes, it is considered a non-residential building."
+                                    },
+                                    {
+                                        "description": "<strong>Examples of other public sector structures:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "Offices",
+                                            "Factories",
+                                            "Warehouses",
+                                            "Educational institutions and their halls of residence",
+                                            "Health facilities",
+                                            "Entertainment and sports facilities"
+                                        ]
+                                    }
+                                ]
+                            }],
+                            "type": "General",
+                            "answers": [{
+                                "id": "answerc541b81f-6402-4934-821d-dc961bea86bf",
+                                "mandatory": true,
+                                "type": "Currency",
+                                "label": "R&M on other existing structures for public sector projects",
+                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
+                                "q_code": "232",
+                                "max_value": {
+                                    "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                    "exclusive": false
+                                },
+                                "decimal_places": 2,
+                                "currency": "GBP"
+                            }]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer27e92f6a-21af-4432-b94c-5157746ebc9e",
+                                "condition": "not contains any",
+                                "values": ["Public sector projects"]
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block3159dcad-c87b-4afa-860e-291c4d4b1414",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question3159dcad-c87b-4afa-860e-291c4d4b1414",
+                            "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of work carried out on <em>new structures</em> for <em>private commercial</em> sector projects?",
+                            "guidance": {
+                                "content": [{
+                                        "description": "<strong>Include:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "new construction work",
+                                            "demolition",
+                                            "site preparation",
+                                            "major alterations, for example improvements and extensions"
+                                        ]
+                                    },
+                                    {
+                                        "description": "<strong>Exclude:</strong>"
+                                    },
+                                    {
+                                        "list": ["VAT", "R&amp;M", "payments made to subcontractors"]
+                                    }
+                                ]
+                            },
+                            "definitions": [{
+                                "title": "What we mean by the \"private commercial sector\"",
+                                "content": [{
+                                        "description": "This sector refers to part of the economy that  includes all businesses, except those involved in manufacturing and transport."
+                                    },
+                                    {
+                                        "description": "<strong>Examples of private commercial sector structures:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "Any construction work for the agriculture industry",
+                                            "Offices",
+                                            "Factories",
+                                            "Health facilities",
+                                            "Entertainment and sports facilities",
+                                            "Car parks",
+                                            "Educational institutions and their halls of residence",
+                                            "Garages and shops"
+                                        ]
+                                    }
+                                ]
+                            }],
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer1a8a2700-9428-425a-97da-d81ce4eaf4a3",
+                                "mandatory": true,
+                                "type": "Currency",
+                                "label": "New structures for private commercial sector projects",
+                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
+                                "q_code": "241",
+                                "max_value": {
+                                    "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                    "exclusive": false
+                                },
+                                "decimal_places": 2,
+                                "currency": "GBP"
+                            }]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer27e92f6a-21af-4432-b94c-5157746ebc9e",
+                                "condition": "not contains any",
+                                "values": ["Private commercial sector projects"]
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block4bc9c90a-5ef9-427a-b98a-03b9ffbd38d7",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question4bc9c90a-5ef9-427a-b98a-03b9ffbd38d7",
+                            "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of work carried out on <em>new structures</em> for <em>private industrial</em> sector projects?",
+                            "guidance": {
+                                "content": [{
+                                        "description": "<strong>Include:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "new construction work",
+                                            "demolition",
+                                            "site preparation",
+                                            "major alterations, for example improvements and extensions"
+                                        ]
+                                    },
+                                    {
+                                        "description": "<strong>Exclude:</strong>"
+                                    },
+                                    {
+                                        "list": ["VAT", "R&amp;M", "payments made to subcontractors"]
+                                    }
+                                ]
+                            },
+                            "definitions": [{
+                                "title": "What we mean by the \"private industrial sector\"",
+                                "content": [{
+                                        "description": "This sector refers to part of the economy that includes businesses involved in manufacturing and transport, excluding agriculture."
+                                    },
+                                    {
+                                        "description": "<strong>Examples of private industrial sector structures:</strong>"
+                                    },
+                                    {
+                                        "list": ["Factories", "Warehouses", "Any construction work in the coal, oil and steel industry"]
+                                    }
+                                ]
+                            }],
+                            "type": "General",
+                            "answers": [{
+                                "id": "answera11da5a9-892d-42f0-bb19-b3781974d741",
+                                "mandatory": true,
+                                "type": "Currency",
+                                "label": "New structures for private industrial sector projects",
+                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
+                                "q_code": "242",
+                                "max_value": {
+                                    "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                    "exclusive": false
+                                },
+                                "decimal_places": 2,
+                                "currency": "GBP"
+                            }]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer27e92f6a-21af-4432-b94c-5157746ebc9e",
+                                "condition": "not contains any",
+                                "values": ["Private industrial sector projects"]
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "blockf475e0c0-b547-496d-a1bc-5402e5987d70",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "questionf475e0c0-b547-496d-a1bc-5402e5987d70",
+                            "title": "Of the {{ format_currency(answers['answer24502b57-1962-4d88-b3a1-40facd7f0661'], 'GBP') }} total, what was the value of <em>R&amp;M</em> carried out on existing structures for <em>private industrial and/or private commercial </em>sector projects?",
+                            "guidance": {
+                                "content": [{
+                                        "description": "<strong>Include work aimed at:</strong>"
+                                    },
+                                    {
+                                        "list": ["repairing something that is broken", "maintaining an existing standard"]
+                                    },
+                                    {
+                                        "description": "<strong>Exclude:</strong>"
+                                    },
+                                    {
+                                        "list": ["major alterations, for example improvements and extensions", "VAT", "payments made to subcontractors"]
+                                    }
+                                ]
+                            },
+                            "definitions": [{
+                                "title": "Examples of private industrial and private commercial sector structures",
+                                "content": [{
+                                        "description": "<strong>Private commercial sector structures:</strong>"
+                                    },
+                                    {
+                                        "list": [
+                                            "Any construction work for the agriculture industry",
+                                            "Offices",
+                                            "Factories",
+                                            "Health facilities",
+                                            "Entertainment and sports facilities",
+                                            "Car parks",
+                                            "Educational institutions and their halls of residence",
+                                            "Garages and shops"
+                                        ]
+                                    },
+                                    {
+                                        "description": "<strong>Private industrial sector structures:</strong>"
+                                    },
+                                    {
+                                        "list": ["Factories", "Warehouses", "Any construction work in the coal, oil and steel industry"]
+                                    }
+                                ]
+                            }],
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer1e0761db-01e8-4ea7-a738-f6144be456b5",
+                                "mandatory": true,
+                                "type": "Currency",
+                                "label": "R&M for existing private industrial and/or private commercial sector projects",
+                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for 56,000.",
+                                "q_code": "243",
+                                "max_value": {
+                                    "answer_id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                                    "exclusive": false
+                                },
+                                "decimal_places": 2,
+                                "currency": "GBP"
+                            }]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer27e92f6a-21af-4432-b94c-5157746ebc9e",
+                                "condition": "not contains any",
+                                "values": ["Private commercial sector projects", "Private industrial sector projects"]
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block3887799c-2d55-48f8-a52d-ee363054106e",
+                        "type": "CalculatedSummary",
+                        "titles": [{
+                            "value": "We calculate the <em>total value of other construction work</em> carried out to be <em>%(total)s.</em> Is this correct?"
+                        }],
+                        "calculation": {
+                            "calculation_type": "sum",
+                            "answers_to_calculate": [
+                                "answerdb018dc4-8664-4587-a038-12a468da441b",
+                                "answerc541b81f-6402-4934-821d-dc961bea86bf",
+                                "answer1a8a2700-9428-425a-97da-d81ce4eaf4a3",
+                                "answera11da5a9-892d-42f0-bb19-b3781974d741",
+                                "answer1e0761db-01e8-4ea7-a738-f6144be456b5"
+                            ],
+                            "titles": [{
+                                "value": "Total value of all other construction work"
+                            }]
+                        }
+                    }
+                ],
+                "skip_conditions": [{
+                        "when": [{
+                            "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                            "condition": "equals",
+                            "value": 0
+                        }]
+                    },
+                    {
+                        "when": [{
+                            "id": "answer24502b57-1962-4d88-b3a1-40facd7f0661",
+                            "condition": "not set"
+                        }]
+                    }
+                ]
+            }]
+        },
+        {
+            "id": "sectione9d26530-ad8f-4527-b09c-afacfa0c820a",
+            "title": "Comments",
+            "groups": [{
+                    "id": "groupe9d26530-ad8f-4527-b09c-afacfa0c820a",
+                    "title": "Comments",
+                    "blocks": [{
+                        "id": "block37d73422-28cc-4beb-99ce-b099e612f6af",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question37d73422-28cc-4beb-99ce-b099e612f6af",
+                            "title": "Please explain any changes in your figures from the previous return, if applicable.",
+                            "description": "<p>If you provide comments we are less likely to contact you with data queries.</p>",
+                            "definitions": [{
+                                "title": "Examples of commentary",
+                                "content": [{
+                                        "description": "My figures are <em>lower than usual</em> this month due to:"
+                                    },
+                                    {
+                                        "list": ["adverse weather conditions", "economic downturn", "my business ceasing trading"]
+                                    },
+                                    {
+                                        "description": "My figures are <em>higher than usual</em> this month due to:"
+                                    },
+                                    {
+                                        "list": ["a new contract", "a large contract", "seasonal work"]
+                                    }
+                                ]
+                            }],
+                            "type": "General",
+                            "answers": [{
+                                "id": "answerd55fa781-60be-431b-a9c7-6b29d1c0e28b",
+                                "mandatory": false,
+                                "type": "TextArea",
+                                "label": "Comments",
+                                "description": "",
+                                "q_code": "146",
+                                "max_length": 2000
+                            }]
+                        }]
+                    }]
+                },
+                {
+                    "id": "summary-group",
+                    "title": "Summary",
+                    "blocks": [{
+                        "type": "Summary",
+                        "id": "summary-block"
+                    }]
+                }
+            ]
+        }
+    ],
+    "theme": "default",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
+    "navigation": {
+        "visible": true
+    },
+    "metadata": [{
+            "name": "user_id",
+            "validator": "string"
+        },
+        {
+            "name": "period_id",
+            "validator": "string"
+        },
+        {
+            "name": "ru_name",
+            "validator": "string"
+        },
+        {
+            "name": "trad_as",
+            "validator": "optional_string"
+        },
+        {
+            "name": "ref_p_start_date",
+            "validator": "date"
+        },
+        {
+            "name": "ref_p_end_date",
+            "validator": "date"
+        }
+    ],
+    "view_submitted_response": {
+        "enabled": true,
+        "duration": 900
+    }
+}

--- a/data/en/covid_0001.json
+++ b/data/en/covid_0001.json
@@ -6,5755 +6,6793 @@
     "data_version": "0.0.1",
     "survey_id": "283",
     "title": "Business Impact of Coronavirus (COVID-19) Survey",
-    "sections": [{
+    "sections": [
+        {
             "id": "section07aa7033-76e4-41b4-81e4-a957831a5a42",
             "title": "Trading status of your business",
-            "groups": [{
-                "id": "group07aa7033-76e4-41b4-81e4-a957831a5a42",
-                "title": "Trading status of your business",
-                "blocks": [{
-                        "type": "Introduction",
-                        "id": "introduction-block",
-                        "primary_content": [{
-                            "type": "Basic",
-                            "id": "primary",
-                            "content": [{
-                                    "list": [
-                                        "Your response helps us to provide real-time information during the coronavirus (COVID-19) pandemic.",
-                                        "This is so the government has the information it needs to manage the UK&#x2019;s response."
-                                    ]
-                                },
+            "groups": [
+                {
+                    "id": "group07aa7033-76e4-41b4-81e4-a957831a5a42",
+                    "title": "Trading status of your business",
+                    "blocks": [
+                        {
+                            "type": "Introduction",
+                            "id": "introduction-block",
+                            "primary_content": [
                                 {
-                                    "description": "<strong>Thank you for completing this survey at this challenging time.</strong>"
-                                }
-                            ]
-                        }],
-                        "preview_content": {
-                            "id": "preview",
-                            "title": "Information you need",
-                            "content": [{
-                                "description": "<a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/surveys/informationforbusinesses/businesssurveys/thequestionsonthebusinessimpactofcoronaviruscovid19survey'>View the questions before you start the survey (external link)</a>",
-                                "list": [
-                                    "Information should relate to the UK.",
-                                    "We will treat your information securely and confidentially.",
-                                    "This survey is refreshed every two weeks. To avoid losing data, please submit by the return date and before the next fortnightly survey is published."
-                                ]
-                            }],
-                            "questions": [{
-                                    "question": "Trading status of your business",
-                                    "content": [{
-                                        "description": "This section asks for general information on the business&apos;s trading status."
-                                    }]
-                                },
-                                {
-                                    "question": "Turnover and online sales",
-                                    "content": [{
-                                        "description": "This section asks for information on any changes to the business&apos;s turnover in the last two weeks and any changes to its online sales and activities."
-                                    }]
-                                },
-                                {
-                                    "question": "Postponed or cancelled bookings, services and events",
-                                    "content": [{
-                                        "description": "This section asks for information about how the business is managing postponed or cancelled bookings, services and events sold to customers during the coronavirus (COVID-19) pandemic."
-                                    }]
-                                },
-                                {
-                                    "question": "Exporting, importing and UK trade",
-                                    "content": [{
-                                        "description": "This section asks for information about the business&apos;s importing and exporting activities."
-                                    }]
-                                },
-                                {
-                                    "question": "UK supply chain",
-                                    "content": [{
-                                        "description": "This section asks for information about the availability of materials, goods and services within the UK."
-                                    }]
-                                },
-                                {
-                                    "question": "Prices of materials, goods and services",
-                                    "content": [{
-                                        "description": "This section asks for information on any changes to the prices of goods and services bought or sold by the business in the last two weeks."
-                                    }]
-                                },
-                                {
-                                    "question": "Stock and capital expenditure",
-                                    "content": [{
-                                        "description": "This section asks for information about how the coronavirus (COVID-19) pandemic may have affected the business&apos;s stock and capital expenditure."
-                                    }]
-                                },
-                                {
-                                    "question": "Innovation",
-                                    "content": [{
-                                        "description": "This section asks for information about any new or improved innovations made by the business during the coronavirus (COVID-19) pandemic."
-                                    }]
-                                },
-                                {
-                                    "question": "Access to financial support",
-                                    "content": [{
-                                            "description": "This section asks for information on:"
-                                        },
+                                    "type": "Basic",
+                                    "id": "primary",
+                                    "content": [
                                         {
                                             "list": [
-                                                "any applications that the business made for government financial initiatives or schemes",
-                                                "any applications the business intends to make for government initiatives or schemes",
-                                                "any applications for non-government financial support"
+                                                "Your response helps us to provide real-time information during the coronavirus (COVID-19) pandemic.",
+                                                "This is so the government has the information it needs to manage the UK&#x2019;s response."
+                                            ]
+                                        },
+                                        {
+                                            "description": "<strong>Thank you for completing this survey at this challenging time.</strong>"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "preview_content": {
+                                "id": "preview",
+                                "title": "Information you need",
+                                "content": [
+                                    {
+                                        "description": "<a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/surveys/informationforbusinesses/businesssurveys/thequestionsonthebusinessimpactofcoronaviruscovid19survey'>View the questions before you start the survey (external link)</a>",
+                                        "list": [
+                                            "Information should relate to the UK.",
+                                            "We will treat your information securely and confidentially.",
+                                            "This survey is refreshed every two weeks. To avoid losing data, please submit by the return date and before the next fortnightly survey is published."
+                                        ]
+                                    }
+                                ],
+                                "questions": [
+                                    {
+                                        "question": "Trading status of your business",
+                                        "content": [
+                                            {
+                                                "description": "This section asks for general information on the business&apos;s trading status."
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "question": "Turnover and online sales",
+                                        "content": [
+                                            {
+                                                "description": "This section asks for information on any changes to the business&apos;s turnover in the last two weeks and any changes to its online sales and activities."
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "question": "Postponed or cancelled bookings, services and events",
+                                        "content": [
+                                            {
+                                                "description": "This section asks for information about how the business is managing postponed or cancelled bookings, services and events sold to customers during the coronavirus (COVID-19) pandemic."
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "question": "Exporting, importing and UK trade",
+                                        "content": [
+                                            {
+                                                "description": "This section asks for information about the business&apos;s importing and exporting activities."
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "question": "UK supply chain",
+                                        "content": [
+                                            {
+                                                "description": "This section asks for information about the availability of materials, goods and services within the UK."
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "question": "Prices of materials, goods and services",
+                                        "content": [
+                                            {
+                                                "description": "This section asks for information on any changes to the prices of goods and services bought or sold by the business in the last two weeks."
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "question": "Stock and capital expenditure",
+                                        "content": [
+                                            {
+                                                "description": "This section asks for information about how the coronavirus (COVID-19) pandemic may have affected the business&apos;s stock and capital expenditure."
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "question": "Innovation",
+                                        "content": [
+                                            {
+                                                "description": "This section asks for information about any new or improved innovations made by the business during the coronavirus (COVID-19) pandemic."
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "question": "Access to financial support",
+                                        "content": [
+                                            {
+                                                "description": "This section asks for information on:"
+                                            },
+                                            {
+                                                "list": [
+                                                    "any applications that the business made for government financial initiatives or schemes",
+                                                    "any applications the business intends to make for government initiatives or schemes",
+                                                    "any applications for non-government financial support"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "question": "Operational performance",
+                                        "content": [
+                                            {
+                                                "description": "This section asks for information about the business&apos;s workforce such as the:"
+                                            },
+                                            {
+                                                "list": [
+                                                    "percentage on, for example, furlough leave or working remotely",
+                                                    "percentage returning from furlough or remote working, or would be made permanently redundant",
+                                                    "percentage of furloughed staff receiving top-ups in addition to the Coronavirus Job Retention Scheme (CJRS) payment",
+                                                    "number of vacancies"
+                                                ]
+                                            },
+                                            {
+                                                "description": "It also asks about safety measures in the workplace."
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "secondary_content": [
+                                {
+                                    "id": "secondary-content",
+                                    "title": ""
+                                }
+                            ]
+                        },
+                        {
+                            "type": "Interstitial",
+                            "id": "group07aa7033-76e4-41b4-81e4-a957831a5a42-introduction",
+                            "title": "Trading status of your business",
+                            "description": "<p>This section asks for general information on the business&apos;s trading status.</p>"
+                        },
+                        {
+                            "id": "blockbe7effcb-8832-4733-90b4-b699fcffa38a",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "questionbe7effcb-8832-4733-90b4-b699fcffa38a",
+                                    "title": "Which of the following statements best describes {{ metadata['ru_name'] }}&apos;s trading status?",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "mandatory": true,
+                                            "type": "Radio",
+                                            "label": "",
+                                            "description": "",
+                                            "q_code": "32",
+                                            "options": [
+                                                {
+                                                    "label": "Currently trading and has been for more than the last two weeks",
+                                                    "value": "Currently trading and has been for more than the last two weeks"
+                                                },
+                                                {
+                                                    "label": "Started trading within the last two weeks after a pause in trading",
+                                                    "value": "Started trading within the last two weeks after a pause in trading"
+                                                },
+                                                {
+                                                    "label": "Paused trading but intends to restart in the next two weeks",
+                                                    "value": "Paused trading but intends to restart in the next two weeks"
+                                                },
+                                                {
+                                                    "label": "Paused trading and does not intend to restart in the next two weeks",
+                                                    "value": "Paused trading and does not intend to restart in the next two weeks"
+                                                },
+                                                {
+                                                    "label": "Permanently ceased trading",
+                                                    "value": "Permanently ceased trading"
+                                                }
                                             ]
                                         }
                                     ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "block2bf9c26a-511c-466b-b889-f936535bef7f",
+                                        "when": [
+                                            {
+                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                                "condition": "contains any",
+                                                "values": [
+                                                    "Currently trading and has been for more than the last two weeks",
+                                                    "Started trading within the last two weeks after a pause in trading",
+                                                    "Paused trading but intends to restart in the next two weeks",
+                                                    "Paused trading and does not intend to restart in the next two weeks"
+                                                ]
+                                            }
+                                        ]
+                                    }
                                 },
                                 {
-                                    "question": "Operational performance",
-                                    "content": [{
-                                            "description": "This section asks for information about the business&apos;s workforce such as the:"
-                                        },
+                                    "goto": {
+                                        "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block2bf9c26a-511c-466b-b889-f936535bef7f",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question2bf9c26a-511c-466b-b889-f936535bef7f",
+                                    "title": "<em>Where in the UK</em> are {{ metadata['ru_name'] }}&apos;s sites located?",
+                                    "description": "<p>The UK consists of England, Northern Ireland, Scotland and Wales. </p>",
+                                    "type": "MutuallyExclusive",
+                                    "mandatory": true,
+                                    "answers": [
                                         {
-                                            "list": [
-                                                "percentage on, for example, furlough leave or working remotely",
-                                                "percentage returning from furlough or remote working, or would be made permanently redundant",
-                                                "percentage of furloughed staff receiving top-ups in addition to the Coronavirus Job Retention Scheme (CJRS) payment",
-                                                "number of vacancies"
+                                            "id": "answere866cf73-a3a4-4d61-8f0c-1a05f09e1c75",
+                                            "mandatory": false,
+                                            "type": "Checkbox",
+                                            "label": "Select all that apply",
+                                            "description": "",
+                                            "options": [
+                                                {
+                                                    "label": "Northern Ireland",
+                                                    "value": "Northern Ireland",
+                                                    "q_code": "1241"
+                                                },
+                                                {
+                                                    "label": "Scotland",
+                                                    "value": "Scotland",
+                                                    "q_code": "1242"
+                                                },
+                                                {
+                                                    "label": "Wales",
+                                                    "value": "Wales",
+                                                    "q_code": "1243"
+                                                },
+                                                {
+                                                    "label": "East of England",
+                                                    "value": "East of England",
+                                                    "q_code": "1244"
+                                                },
+                                                {
+                                                    "label": "East Midlands",
+                                                    "value": "East Midlands",
+                                                    "q_code": "1245"
+                                                },
+                                                {
+                                                    "label": "Greater London",
+                                                    "value": "Greater London",
+                                                    "q_code": "1246"
+                                                },
+                                                {
+                                                    "label": "North East of England",
+                                                    "value": "North East of England",
+                                                    "q_code": "1247"
+                                                },
+                                                {
+                                                    "label": "North West of England",
+                                                    "value": "North West of England",
+                                                    "q_code": "1248"
+                                                },
+                                                {
+                                                    "label": "South East of England",
+                                                    "value": "South East of England",
+                                                    "q_code": "1249"
+                                                },
+                                                {
+                                                    "label": "South West of England",
+                                                    "value": "South West of England",
+                                                    "q_code": "12410"
+                                                },
+                                                {
+                                                    "label": "West Midlands",
+                                                    "value": "West Midlands",
+                                                    "q_code": "12411"
+                                                },
+                                                {
+                                                    "label": "Yorkshire and The Humber",
+                                                    "value": "Yorkshire and The Humber",
+                                                    "q_code": "12412"
+                                                },
+                                                {
+                                                    "label": "Not sure",
+                                                    "value": "Not sure",
+                                                    "q_code": "12413"
+                                                }
                                             ]
                                         },
                                         {
-                                            "description": "It also asks about safety measures in the workplace."
+                                            "id": "answere866cf73-a3a4-4d61-8f0c-1a05f09e1c75-exclusive",
+                                            "mandatory": false,
+                                            "type": "Checkbox",
+                                            "description": "",
+                                            "options": [
+                                                {
+                                                    "label": "Not applicable",
+                                                    "value": "Not applicable",
+                                                    "q_code": "1240"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "group": "groupaf9cbebb-ec7e-4a68-b46d-2b7d081d16d7",
+                                        "when": [
+                                            {
+                                                "id": "answere866cf73-a3a4-4d61-8f0c-1a05f09e1c75",
+                                                "condition": "contains any",
+                                                "values": ["Not sure"]
+                                            },
+                                            {
+                                                "id": "answere866cf73-a3a4-4d61-8f0c-1a05f09e1c75-exclusive",
+                                                "condition": "contains any",
+                                                "values": ["Not applicable"]
+                                            },
+                                            {
+                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                                "condition": "contains any",
+                                                "values": [
+                                                    "Paused trading but intends to restart in the next two weeks",
+                                                    "Paused trading and does not intend to restart in the next two weeks"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "group": "group281e76fe-1287-43af-bfe9-e1a53be6476e",
+                                        "when": [
+                                            {
+                                                "id": "answere866cf73-a3a4-4d61-8f0c-1a05f09e1c75",
+                                                "condition": "contains any",
+                                                "values": ["Not sure"]
+                                            },
+                                            {
+                                                "id": "answere866cf73-a3a4-4d61-8f0c-1a05f09e1c75-exclusive",
+                                                "condition": "contains any",
+                                                "values": ["Not applicable"]
+                                            },
+                                            {
+                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                                "condition": "contains any",
+                                                "values": [
+                                                    "Currently trading and has been for more than the last two weeks",
+                                                    "Started trading within the last two weeks after a pause in trading"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "blockae8d1838-da63-4805-b596-6b55fdb86447",
+                                        "when": [
+                                            {
+                                                "id": "answere866cf73-a3a4-4d61-8f0c-1a05f09e1c75",
+                                                "condition": "contains any",
+                                                "values": [
+                                                    "Northern Ireland",
+                                                    "Scotland",
+                                                    "Wales",
+                                                    "East of England",
+                                                    "East Midlands",
+                                                    "Greater London",
+                                                    "North East of England",
+                                                    "North West of England",
+                                                    "South East of England",
+                                                    "South West of England",
+                                                    "West Midlands",
+                                                    "Yorkshire and The Humber"
+                                                ]
+                                            },
+                                            {
+                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                                "condition": "contains any",
+                                                "values": [
+                                                    "Currently trading and has been for more than the last two weeks",
+                                                    "Started trading within the last two weeks after a pause in trading",
+                                                    "Paused trading but intends to restart in the next two weeks",
+                                                    "Paused trading and does not intend to restart in the next two weeks"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
                                         }
                                     ]
                                 }
                             ]
                         },
-                        "secondary_content": [{
-                            "id": "secondary-content",
-                            "title": ""
-                        }]
-                    },
-                    {
-                        "type": "Interstitial",
-                        "id": "group07aa7033-76e4-41b4-81e4-a957831a5a42-introduction",
-                        "title": "Trading status of your business",
-                        "description": "<p>This section asks for general information on the business&apos;s trading status.</p>"
-                    },
-                    {
-                        "id": "blockbe7effcb-8832-4733-90b4-b699fcffa38a",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questionbe7effcb-8832-4733-90b4-b699fcffa38a",
-                            "title": "Which of the following statements best describes {{ metadata['ru_name'] }}&apos;s trading status?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "32",
-                                "options": [{
-                                        "label": "Currently trading and has been for more than the last two weeks",
-                                        "value": "Currently trading and has been for more than the last two weeks"
-                                    },
-                                    {
-                                        "label": "Started trading within the last two weeks after a pause in trading",
-                                        "value": "Started trading within the last two weeks after a pause in trading"
-                                    },
-                                    {
-                                        "label": "Paused trading but intends to restart in the next two weeks",
-                                        "value": "Paused trading but intends to restart in the next two weeks"
-                                    },
-                                    {
-                                        "label": "Paused trading and does not intend to restart in the next two weeks",
-                                        "value": "Paused trading and does not intend to restart in the next two weeks"
-                                    },
-                                    {
-                                        "label": "Permanently ceased trading",
-                                        "value": "Permanently ceased trading"
+                        {
+                            "id": "blockae8d1838-da63-4805-b596-6b55fdb86447",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "questionae8d1838-da63-4805-b596-6b55fdb86447",
+                                    "title": "Where in the UK are {{ metadata['ru_name'] }}&apos;s <em>sites currently paused or ceased trading</em>?",
+                                    "description": "<p>Select all the regions where the majority of the business&apos;s sites are paused or ceased trading.</p>",
+                                    "type": "MutuallyExclusive",
+                                    "mandatory": true,
+                                    "answers": [
+                                        {
+                                            "id": "answer59821270-1fd0-4719-b72b-46923591d46a",
+                                            "mandatory": false,
+                                            "type": "Checkbox",
+                                            "label": "Select all that apply",
+                                            "description": "",
+                                            "options": [
+                                                {
+                                                    "label": "Northern Ireland",
+                                                    "value": "Northern Ireland",
+                                                    "q_code": "1141"
+                                                },
+                                                {
+                                                    "label": "Scotland",
+                                                    "value": "Scotland",
+                                                    "q_code": "1142"
+                                                },
+                                                {
+                                                    "label": "Wales",
+                                                    "value": "Wales",
+                                                    "q_code": "1143"
+                                                },
+                                                {
+                                                    "label": "East of England",
+                                                    "value": "East of England",
+                                                    "q_code": "1144"
+                                                },
+                                                {
+                                                    "label": "East Midlands",
+                                                    "value": "East Midlands",
+                                                    "q_code": "1145"
+                                                },
+                                                {
+                                                    "label": "Greater London",
+                                                    "value": "Greater London",
+                                                    "q_code": "1146"
+                                                },
+                                                {
+                                                    "label": "North East of England",
+                                                    "value": "North East of England",
+                                                    "q_code": "1147"
+                                                },
+                                                {
+                                                    "label": "North West of England",
+                                                    "value": "North West of England",
+                                                    "q_code": "1148"
+                                                },
+                                                {
+                                                    "label": "South East of England",
+                                                    "value": "South East of England",
+                                                    "q_code": "1149"
+                                                },
+                                                {
+                                                    "label": "South West of England",
+                                                    "value": "South West of England",
+                                                    "q_code": "11410"
+                                                },
+                                                {
+                                                    "label": "West Midlands",
+                                                    "value": "West Midlands",
+                                                    "q_code": "11411"
+                                                },
+                                                {
+                                                    "label": "Yorkshire and The Humber",
+                                                    "value": "Yorkshire and The Humber",
+                                                    "q_code": "11412"
+                                                },
+                                                {
+                                                    "label": "Not sure",
+                                                    "value": "Not sure",
+                                                    "q_code": "11413"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "id": "answer59821270-1fd0-4719-b72b-46923591d46a-exclusive",
+                                            "mandatory": false,
+                                            "type": "Checkbox",
+                                            "description": "",
+                                            "options": [
+                                                {
+                                                    "label": "None of our sites are currently paused or ceased trading",
+                                                    "value": "None of our sites are currently paused or ceased trading",
+                                                    "q_code": "1140"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "group": "groupaf9cbebb-ec7e-4a68-b46d-2b7d081d16d7",
+                                        "when": [
+                                            {
+                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                                "condition": "contains any",
+                                                "values": [
+                                                    "Paused trading but intends to restart in the next two weeks",
+                                                    "Paused trading and does not intend to restart in the next two weeks"
+                                                ]
+                                            }
+                                        ]
                                     }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "block2bf9c26a-511c-466b-b889-f936535bef7f",
-                                    "when": [{
-                                        "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                        "condition": "contains any",
-                                        "values": [
-                                            "Currently trading and has been for more than the last two weeks",
-                                            "Started trading within the last two weeks after a pause in trading",
-                                            "Paused trading but intends to restart in the next two weeks",
-                                            "Paused trading and does not intend to restart in the next two weeks"
-                                        ]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "id": "block2bf9c26a-511c-466b-b889-f936535bef7f",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question2bf9c26a-511c-466b-b889-f936535bef7f",
-                            "title": "<em>Where in the UK</em> are {{ metadata['ru_name'] }}&apos;s sites located?",
-                            "description": "<p>The UK consists of England, Northern Ireland, Scotland and Wales. </p>",
-                            "type": "MutuallyExclusive",
-                            "mandatory": true,
-                            "answers": [{
-                                    "id": "answere866cf73-a3a4-4d61-8f0c-1a05f09e1c75",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "label": "Select all that apply",
-                                    "description": "",
-                                    "options": [{
-                                            "label": "Northern Ireland",
-                                            "value": "Northern Ireland",
-                                            "q_code": "1241"
-                                        },
-                                        {
-                                            "label": "Scotland",
-                                            "value": "Scotland",
-                                            "q_code": "1242"
-                                        },
-                                        {
-                                            "label": "Wales",
-                                            "value": "Wales",
-                                            "q_code": "1243"
-                                        },
-                                        {
-                                            "label": "East of England",
-                                            "value": "East of England",
-                                            "q_code": "1244"
-                                        },
-                                        {
-                                            "label": "East Midlands",
-                                            "value": "East Midlands",
-                                            "q_code": "1245"
-                                        },
-                                        {
-                                            "label": "Greater London",
-                                            "value": "Greater London",
-                                            "q_code": "1246"
-                                        },
-                                        {
-                                            "label": "North East of England",
-                                            "value": "North East of England",
-                                            "q_code": "1247"
-                                        },
-                                        {
-                                            "label": "North West of England",
-                                            "value": "North West of England",
-                                            "q_code": "1248"
-                                        },
-                                        {
-                                            "label": "South East of England",
-                                            "value": "South East of England",
-                                            "q_code": "1249"
-                                        },
-                                        {
-                                            "label": "South West of England",
-                                            "value": "South West of England",
-                                            "q_code": "12410"
-                                        },
-                                        {
-                                            "label": "West Midlands",
-                                            "value": "West Midlands",
-                                            "q_code": "12411"
-                                        },
-                                        {
-                                            "label": "Yorkshire and The Humber",
-                                            "value": "Yorkshire and The Humber",
-                                            "q_code": "12412"
-                                        },
-                                        {
-                                            "label": "Not sure",
-                                            "value": "Not sure",
-                                            "q_code": "12413"
-                                        }
-                                    ]
                                 },
                                 {
-                                    "id": "answere866cf73-a3a4-4d61-8f0c-1a05f09e1c75-exclusive",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "description": "",
-                                    "options": [{
-                                        "label": "Not applicable",
-                                        "value": "Not applicable",
-                                        "q_code": "1240"
-                                    }]
-                                }
-                            ]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "group": "groupaf9cbebb-ec7e-4a68-b46d-2b7d081d16d7",
-                                    "when": [{
-                                            "id": "answere866cf73-a3a4-4d61-8f0c-1a05f09e1c75",
-                                            "condition": "contains any",
-                                            "values": ["Not sure"]
-                                        },
-                                        {
-                                            "id": "answere866cf73-a3a4-4d61-8f0c-1a05f09e1c75-exclusive",
-                                            "condition": "contains any",
-                                            "values": ["Not applicable"]
-                                        },
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "contains any",
-                                            "values": [
-                                                "Paused trading but intends to restart in the next two weeks",
-                                                "Paused trading and does not intend to restart in the next two weeks"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "group": "group281e76fe-1287-43af-bfe9-e1a53be6476e",
-                                    "when": [{
-                                            "id": "answere866cf73-a3a4-4d61-8f0c-1a05f09e1c75",
-                                            "condition": "contains any",
-                                            "values": ["Not sure"]
-                                        },
-                                        {
-                                            "id": "answere866cf73-a3a4-4d61-8f0c-1a05f09e1c75-exclusive",
-                                            "condition": "contains any",
-                                            "values": ["Not applicable"]
-                                        },
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "contains any",
-                                            "values": [
-                                                "Currently trading and has been for more than the last two weeks",
-                                                "Started trading within the last two weeks after a pause in trading"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "blockae8d1838-da63-4805-b596-6b55fdb86447",
-                                    "when": [{
-                                            "id": "answere866cf73-a3a4-4d61-8f0c-1a05f09e1c75",
-                                            "condition": "contains any",
-                                            "values": [
-                                                "Northern Ireland",
-                                                "Scotland",
-                                                "Wales",
-                                                "East of England",
-                                                "East Midlands",
-                                                "Greater London",
-                                                "North East of England",
-                                                "North West of England",
-                                                "South East of England",
-                                                "South West of England",
-                                                "West Midlands",
-                                                "Yorkshire and The Humber"
-                                            ]
-                                        },
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "contains any",
-                                            "values": [
-                                                "Currently trading and has been for more than the last two weeks",
-                                                "Started trading within the last two weeks after a pause in trading",
-                                                "Paused trading but intends to restart in the next two weeks",
-                                                "Paused trading and does not intend to restart in the next two weeks"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "blockae8d1838-da63-4805-b596-6b55fdb86447",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questionae8d1838-da63-4805-b596-6b55fdb86447",
-                            "title": "Where in the UK are {{ metadata['ru_name'] }}&apos;s <em>sites currently paused or ceased trading</em>?",
-                            "description": "<p>Select all the regions where the majority of the business&apos;s sites are paused or ceased trading.</p>",
-                            "type": "MutuallyExclusive",
-                            "mandatory": true,
-                            "answers": [{
-                                    "id": "answer59821270-1fd0-4719-b72b-46923591d46a",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "label": "Select all that apply",
-                                    "description": "",
-                                    "options": [{
-                                            "label": "Northern Ireland",
-                                            "value": "Northern Ireland",
-                                            "q_code": "1141"
-                                        },
-                                        {
-                                            "label": "Scotland",
-                                            "value": "Scotland",
-                                            "q_code": "1142"
-                                        },
-                                        {
-                                            "label": "Wales",
-                                            "value": "Wales",
-                                            "q_code": "1143"
-                                        },
-                                        {
-                                            "label": "East of England",
-                                            "value": "East of England",
-                                            "q_code": "1144"
-                                        },
-                                        {
-                                            "label": "East Midlands",
-                                            "value": "East Midlands",
-                                            "q_code": "1145"
-                                        },
-                                        {
-                                            "label": "Greater London",
-                                            "value": "Greater London",
-                                            "q_code": "1146"
-                                        },
-                                        {
-                                            "label": "North East of England",
-                                            "value": "North East of England",
-                                            "q_code": "1147"
-                                        },
-                                        {
-                                            "label": "North West of England",
-                                            "value": "North West of England",
-                                            "q_code": "1148"
-                                        },
-                                        {
-                                            "label": "South East of England",
-                                            "value": "South East of England",
-                                            "q_code": "1149"
-                                        },
-                                        {
-                                            "label": "South West of England",
-                                            "value": "South West of England",
-                                            "q_code": "11410"
-                                        },
-                                        {
-                                            "label": "West Midlands",
-                                            "value": "West Midlands",
-                                            "q_code": "11411"
-                                        },
-                                        {
-                                            "label": "Yorkshire and The Humber",
-                                            "value": "Yorkshire and The Humber",
-                                            "q_code": "11412"
-                                        },
-                                        {
-                                            "label": "Not sure",
-                                            "value": "Not sure",
-                                            "q_code": "11413"
-                                        }
-                                    ]
+                                    "goto": {
+                                        "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8",
+                                        "when": [
+                                            {
+                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                                "condition": "contains any",
+                                                "values": ["Permanently ceased trading"]
+                                            }
+                                        ]
+                                    }
                                 },
                                 {
-                                    "id": "answer59821270-1fd0-4719-b72b-46923591d46a-exclusive",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "description": "",
-                                    "options": [{
-                                        "label": "None of our sites are currently paused or ceased trading",
-                                        "value": "None of our sites are currently paused or ceased trading",
-                                        "q_code": "1140"
-                                    }]
+                                    "goto": {
+                                        "group": "group281e76fe-1287-43af-bfe9-e1a53be6476e"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
                                 }
                             ]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "group": "groupaf9cbebb-ec7e-4a68-b46d-2b7d081d16d7",
-                                    "when": [{
-                                        "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                        "condition": "contains any",
-                                        "values": [
-                                            "Paused trading but intends to restart in the next two weeks",
-                                            "Paused trading and does not intend to restart in the next two weeks"
-                                        ]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8",
-                                    "when": [{
-                                        "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                        "condition": "contains any",
-                                        "values": ["Permanently ceased trading"]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "group": "group281e76fe-1287-43af-bfe9-e1a53be6476e"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    }
-                ]
-            }]
+                        }
+                    ]
+                }
+            ]
         },
         {
             "id": "section281e76fe-1287-43af-bfe9-e1a53be6476e",
             "title": "Turnover and online sales",
-            "groups": [{
-                "id": "group281e76fe-1287-43af-bfe9-e1a53be6476e",
-                "title": "Turnover and online sales",
-                "blocks": [{
-                        "type": "Interstitial",
-                        "id": "group281e76fe-1287-43af-bfe9-e1a53be6476e-introduction",
-                        "title": "Turnover and online sales",
-                        "description": "<p>This section asks for information about how the coronavirus (COVID-19) pandemic may have affected the business&apos;s turnover in the last two weeks, and about online sales and activity.</p>",
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block9361fa44-7f22-47da-bdd0-16e104300487",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question9361fa44-7f22-47da-bdd0-16e104300487",
-                            "title": "<em>In the last two weeks</em>, how has the coronavirus (COVID-19) pandemic affected {{ metadata['ru_name'] }}&apos;s turnover, compared with normal expectations for this time of year?",
-                            "description": "<p>You can provide a rough estimate.</p>",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Exclude:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "change expected due to seasonal effects",
-                                            "change expected due to normal patterns of business activity"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer0581e398-f9ab-4597-a1a6-c67d8f96289f",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "3",
-                                "options": [{
-                                        "label": "Turnover has increased by more than 50%",
-                                        "value": "Turnover has increased by more than 50%"
-                                    },
-                                    {
-                                        "label": "Turnover has increased between 20% and 50%",
-                                        "value": "Turnover has increased between 20% and 50%"
-                                    },
-                                    {
-                                        "label": "Turnover has increased by up to 20%",
-                                        "value": "Turnover has increased by up to 20%"
-                                    },
-                                    {
-                                        "label": "Turnover has not been affected",
-                                        "value": "Turnover has not been affected"
-                                    },
-                                    {
-                                        "label": "Turnover has decreased by up to 20%",
-                                        "value": "Turnover has decreased by up to 20%"
-                                    },
-                                    {
-                                        "label": "Turnover has decreased between 20% and 50%",
-                                        "value": "Turnover has decreased between 20% and 50%"
-                                    },
-                                    {
-                                        "label": "Turnover has decreased by more than 50%",
-                                        "value": "Turnover has decreased by more than 50%"
-                                    },
-                                    {
-                                        "label": "Not sure",
-                                        "value": "Not sure"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "block07ea7679-53f4-40e7-be6c-01e0615e3672",
-                                    "when": [{
-                                        "id": "answer0581e398-f9ab-4597-a1a6-c67d8f96289f",
-                                        "condition": "contains any",
-                                        "values": ["Turnover has not been affected", "Not sure"]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block0bf14da5-6919-4507-8542-5d71be2e6ac1"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block0bf14da5-6919-4507-8542-5d71be2e6ac1",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question0bf14da5-6919-4507-8542-5d71be2e6ac1",
-                            "title": "Please explain in more detail how the coronavirus (COVID-19) pandemic affected {{ metadata['ru_name'] }}&apos;s turnover in the last two weeks",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answerb27dfc7c-ac12-4c9f-ba1c-29b51878d877",
-                                "mandatory": true,
-                                "type": "TextArea",
-                                "label": "Comments",
-                                "description": "",
-                                "q_code": "5",
-                                "max_length": 2000
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block07ea7679-53f4-40e7-be6c-01e0615e3672",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question07ea7679-53f4-40e7-be6c-01e0615e3672",
-                            "title": "What are your expectations about {{ metadata['ru_name'] }}&apos;s turnover in the <em>next two weeks</em>?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer887d6dad-b184-4301-9670-89440001359b",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "6",
-                                "options": [{
-                                        "label": "Expect turnover to substantially increase",
-                                        "value": "Expect turnover to substantially increase"
-                                    },
-                                    {
-                                        "label": "Expect turnover to increase a little",
-                                        "value": "Expect turnover to increase a little"
-                                    },
-                                    {
-                                        "label": "Expect turnover to stay the same",
-                                        "value": "Expect turnover to stay the same"
-                                    },
-                                    {
-                                        "label": "Expect turnover to decrease a little",
-                                        "value": "Expect turnover to decrease a little"
-                                    },
-                                    {
-                                        "label": "Expect turnover to substantially decrease",
-                                        "value": "Expect turnover to substantially decrease"
-                                    },
-                                    {
-                                        "label": "Not sure",
-                                        "value": "Not sure"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "blockd54d2485-7d02-4e67-90be-30c13dc1c230",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questiond54d2485-7d02-4e67-90be-30c13dc1c230",
-                            "title": "Prior to the coronavirus (COVID-19) pandemic, did {{ metadata['ru_name'] }} <em>sell goods or services online</em>?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer65cee25e-1d83-4d68-8a73-6e60780d9522",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "94",
-                                "options": [{
-                                        "label": "Yes",
-                                        "value": "Yes"
-                                    },
-                                    {
-                                        "label": "No",
-                                        "value": "No"
-                                    },
-                                    {
-                                        "label": "Not sure",
-                                        "value": "Not sure"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "blockf2734939-baaf-4284-a007-befe2e5bf96d",
-                                    "when": [{
-                                        "id": "answer65cee25e-1d83-4d68-8a73-6e60780d9522",
-                                        "condition": "contains any",
-                                        "values": ["Yes"]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block61e1cc56-3e05-4222-ad07-5792ddba769d"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block61e1cc56-3e05-4222-ad07-5792ddba769d",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question61e1cc56-3e05-4222-ad07-5792ddba769d",
-                            "title": "Has {{ metadata['ru_name'] }} <em>started</em> selling goods or services online during the coronavirus (COVID-19) pandemic?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer66776e6d-9e34-42ab-b6cf-fb8ea954c3ec",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "95",
-                                "options": [{
-                                        "label": "Yes",
-                                        "value": "Yes"
-                                    },
-                                    {
-                                        "label": "No",
-                                        "value": "No"
-                                    },
-                                    {
-                                        "label": "Not sure",
-                                        "value": "Not sure"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "blockf2734939-baaf-4284-a007-befe2e5bf96d",
-                                    "when": [{
-                                        "id": "answer66776e6d-9e34-42ab-b6cf-fb8ea954c3ec",
-                                        "condition": "contains any",
-                                        "values": ["Yes"]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block0c9d4096-3307-453d-8427-e5f0fcdd9a87"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "blockf2734939-baaf-4284-a007-befe2e5bf96d",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questionf2734939-baaf-4284-a007-befe2e5bf96d",
-                            "title": "How have {{ metadata['ru_name'] }}&apos;s online sales of goods or services changed in the <em>last two weeks</em>?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer8602d2d3-f3cc-417b-9a3d-0141d9f9dc39",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "75",
-                                "options": [{
-                                        "label": "Online sales have increased",
-                                        "value": "Online sales have increased"
-                                    },
-                                    {
-                                        "label": "Online sales have stayed the same",
-                                        "value": "Online sales have stayed the same"
-                                    },
-                                    {
-                                        "label": "Online sales have continued, but decreased",
-                                        "value": "Online sales have continued, but decreased"
-                                    },
-                                    {
-                                        "label": "The business stopped selling goods or services online",
-                                        "value": "The business stopped selling goods or services online"
-                                    },
-                                    {
-                                        "label": "Not sure",
-                                        "value": "Not sure"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block0c9d4096-3307-453d-8427-e5f0fcdd9a87",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question0c9d4096-3307-453d-8427-e5f0fcdd9a87",
-                            "title": "Has {{ metadata['ru_name'] }} used any of the following <em>online services</em> to support business operations during the coronavirus (COVID-19) pandemic?",
-                            "type": "MutuallyExclusive",
-                            "mandatory": true,
-                            "answers": [{
-                                    "id": "answer8ca3198d-60a0-45da-bc61-b7e29b55a44c",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "label": "Select all that apply",
-                                    "description": "",
-                                    "options": [{
-                                            "label": "Increased or new use of online advertising",
-                                            "value": "Increased or new use of online advertising",
-                                            "q_code": "761"
-                                        },
+            "groups": [
+                {
+                    "id": "group281e76fe-1287-43af-bfe9-e1a53be6476e",
+                    "title": "Turnover and online sales",
+                    "blocks": [
+                        {
+                            "type": "Interstitial",
+                            "id": "group281e76fe-1287-43af-bfe9-e1a53be6476e-introduction",
+                            "title": "Turnover and online sales",
+                            "description": "<p>This section asks for information about how the coronavirus (COVID-19) pandemic may have affected the business&apos;s turnover in the last two weeks, and about online sales and activity.</p>",
+                            "skip_conditions": [
+                                {
+                                    "when": [
                                         {
-                                            "label": "Increased or new use of online services to help communication with customers",
-                                            "value": "Increased or new use of online services to help communication with customers",
-                                            "q_code": "762",
-                                            "description": "For example, social media, new websites, email"
-                                        },
-                                        {
-                                            "label": "Increased or new use of video conferencing for internal communications",
-                                            "value": "Increased or new use of video conferencing for internal communications",
-                                            "q_code": "763",
-                                            "description": "For example, Zoom, Skype, Microsoft Teams, Google Hangouts"
-                                        },
-                                        {
-                                            "label": "Increased or new use of social media platforms for internal communications",
-                                            "value": "Increased or new use of social media platforms for internal communications",
-                                            "q_code": "764",
-                                            "description": "For example, WhatsApp, Slack, Trello"
-                                        },
-                                        {
-                                            "label": "Other",
-                                            "value": "Other",
-                                            "q_code": "765",
-                                            "detail_answer": {
-                                                "label": "Please describe",
-                                                "type": "TextField",
-                                                "id": "answer0a322cfd-08a6-46fc-aa15-98881479656e",
-                                                "mandatory": false
-                                            }
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
                                         }
                                     ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block9361fa44-7f22-47da-bdd0-16e104300487",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question9361fa44-7f22-47da-bdd0-16e104300487",
+                                    "title": "<em>In the last two weeks</em>, how has the coronavirus (COVID-19) pandemic affected {{ metadata['ru_name'] }}&apos;s turnover, compared with normal expectations for this time of year?",
+                                    "description": "<p>You can provide a rough estimate.</p>",
+                                    "guidance": {
+                                        "content": [
+                                            {
+                                                "description": "<strong>Exclude:</strong>"
+                                            },
+                                            {
+                                                "list": [
+                                                    "change expected due to seasonal effects",
+                                                    "change expected due to normal patterns of business activity"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer0581e398-f9ab-4597-a1a6-c67d8f96289f",
+                                            "mandatory": true,
+                                            "type": "Radio",
+                                            "label": "",
+                                            "description": "",
+                                            "q_code": "3",
+                                            "options": [
+                                                {
+                                                    "label": "Turnover has increased by more than 50%",
+                                                    "value": "Turnover has increased by more than 50%"
+                                                },
+                                                {
+                                                    "label": "Turnover has increased between 20% and 50%",
+                                                    "value": "Turnover has increased between 20% and 50%"
+                                                },
+                                                {
+                                                    "label": "Turnover has increased by up to 20%",
+                                                    "value": "Turnover has increased by up to 20%"
+                                                },
+                                                {
+                                                    "label": "Turnover has not been affected",
+                                                    "value": "Turnover has not been affected"
+                                                },
+                                                {
+                                                    "label": "Turnover has decreased by up to 20%",
+                                                    "value": "Turnover has decreased by up to 20%"
+                                                },
+                                                {
+                                                    "label": "Turnover has decreased between 20% and 50%",
+                                                    "value": "Turnover has decreased between 20% and 50%"
+                                                },
+                                                {
+                                                    "label": "Turnover has decreased by more than 50%",
+                                                    "value": "Turnover has decreased by more than 50%"
+                                                },
+                                                {
+                                                    "label": "Not sure",
+                                                    "value": "Not sure"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "block07ea7679-53f4-40e7-be6c-01e0615e3672",
+                                        "when": [
+                                            {
+                                                "id": "answer0581e398-f9ab-4597-a1a6-c67d8f96289f",
+                                                "condition": "contains any",
+                                                "values": ["Turnover has not been affected", "Not sure"]
+                                            }
+                                        ]
+                                    }
                                 },
                                 {
-                                    "id": "answer8ca3198d-60a0-45da-bc61-b7e29b55a44c-exclusive",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "description": "",
-                                    "options": [{
-                                        "label": "None of the above",
-                                        "value": "None of the above",
-                                        "q_code": "766"
-                                    }]
-                                }
-                            ]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "blockcabf3732-b3b9-4bf4-8e00-80d9cd5baff1",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questioncabf3732-b3b9-4bf4-8e00-80d9cd5baff1",
-                            "title": "Has {{ metadata['ru_name'] }} <em>diversified</em> to produce or provide new goods or services as a result of the coronavirus (COVID-19) pandemic?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer1cef2734-e2be-42ce-a724-948845ec6e5a",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "115",
-                                "options": [{
-                                        "label": "Yes",
-                                        "value": "Yes"
-                                    },
-                                    {
-                                        "label": "No",
-                                        "value": "No"
-                                    },
-                                    {
-                                        "label": "Not sure",
-                                        "value": "Not sure"
+                                    "goto": {
+                                        "block": "block0bf14da5-6919-4507-8542-5d71be2e6ac1"
                                     }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "blocka6a29cc6-f809-4ed5-9d76-cc272b66dbab",
-                                    "when": [{
-                                        "id": "answer1cef2734-e2be-42ce-a724-948845ec6e5a",
-                                        "condition": "contains any",
-                                        "values": ["Yes"]
-                                    }]
                                 }
-                            },
-                            {
-                                "goto": {
-                                    "group": "groupaf9cbebb-ec7e-4a68-b46d-2b7d081d16d7"
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
                                 }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "blocka6a29cc6-f809-4ed5-9d76-cc272b66dbab",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questiona6a29cc6-f809-4ed5-9d76-cc272b66dbab",
-                            "title": "Please give more details about how {{ metadata['ru_name'] }} has diversified to produce or provide new goods or services",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer02a69fd3-aa57-46a7-9487-cec81843a6e4",
-                                "mandatory": true,
-                                "type": "TextArea",
-                                "label": "Comments",
-                                "description": "",
-                                "q_code": "116",
-                                "max_length": 2000
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    }
-                ],
-                "skip_conditions": [{
-                        "when": [{
-                                "id": "answere866cf73-a3a4-4d61-8f0c-1a05f09e1c75",
-                                "condition": "contains any",
-                                "values": ["Not sure"]
-                            },
-                            {
-                                "id": "answere866cf73-a3a4-4d61-8f0c-1a05f09e1c75-exclusive",
-                                "condition": "contains any",
-                                "values": ["Not applicable"]
-                            },
-                            {
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "contains any",
-                                "values": [
-                                    "Paused trading but intends to restart in the next two weeks",
-                                    "Paused trading and does not intend to restart in the next two weeks"
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        "when": [{
-                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                            "condition": "contains any",
-                            "values": [
-                                "Paused trading but intends to restart in the next two weeks",
-                                "Paused trading and does not intend to restart in the next two weeks"
                             ]
-                        }]
-                    },
-                    {
-                        "when": [{
-                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                            "condition": "contains any",
-                            "values": ["Permanently ceased trading"]
-                        }]
-                    }
-                ]
-            }]
+                        },
+                        {
+                            "id": "block0bf14da5-6919-4507-8542-5d71be2e6ac1",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question0bf14da5-6919-4507-8542-5d71be2e6ac1",
+                                    "title": "Please explain in more detail how the coronavirus (COVID-19) pandemic affected {{ metadata['ru_name'] }}&apos;s turnover in the last two weeks",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answerb27dfc7c-ac12-4c9f-ba1c-29b51878d877",
+                                            "mandatory": true,
+                                            "type": "TextArea",
+                                            "label": "Comments",
+                                            "description": "",
+                                            "q_code": "5",
+                                            "max_length": 2000
+                                        }
+                                    ]
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block07ea7679-53f4-40e7-be6c-01e0615e3672",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question07ea7679-53f4-40e7-be6c-01e0615e3672",
+                                    "title": "What are your expectations about {{ metadata['ru_name'] }}&apos;s turnover in the <em>next two weeks</em>?",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer887d6dad-b184-4301-9670-89440001359b",
+                                            "mandatory": true,
+                                            "type": "Radio",
+                                            "label": "",
+                                            "description": "",
+                                            "q_code": "6",
+                                            "options": [
+                                                {
+                                                    "label": "Expect turnover to substantially increase",
+                                                    "value": "Expect turnover to substantially increase"
+                                                },
+                                                {
+                                                    "label": "Expect turnover to increase a little",
+                                                    "value": "Expect turnover to increase a little"
+                                                },
+                                                {
+                                                    "label": "Expect turnover to stay the same",
+                                                    "value": "Expect turnover to stay the same"
+                                                },
+                                                {
+                                                    "label": "Expect turnover to decrease a little",
+                                                    "value": "Expect turnover to decrease a little"
+                                                },
+                                                {
+                                                    "label": "Expect turnover to substantially decrease",
+                                                    "value": "Expect turnover to substantially decrease"
+                                                },
+                                                {
+                                                    "label": "Not sure",
+                                                    "value": "Not sure"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "blockd54d2485-7d02-4e67-90be-30c13dc1c230",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "questiond54d2485-7d02-4e67-90be-30c13dc1c230",
+                                    "title": "Prior to the coronavirus (COVID-19) pandemic, did {{ metadata['ru_name'] }} <em>sell goods or services online</em>?",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer65cee25e-1d83-4d68-8a73-6e60780d9522",
+                                            "mandatory": true,
+                                            "type": "Radio",
+                                            "label": "",
+                                            "description": "",
+                                            "q_code": "94",
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                },
+                                                {
+                                                    "label": "Not sure",
+                                                    "value": "Not sure"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "blockf2734939-baaf-4284-a007-befe2e5bf96d",
+                                        "when": [
+                                            {
+                                                "id": "answer65cee25e-1d83-4d68-8a73-6e60780d9522",
+                                                "condition": "contains any",
+                                                "values": ["Yes"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "block61e1cc56-3e05-4222-ad07-5792ddba769d"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block61e1cc56-3e05-4222-ad07-5792ddba769d",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question61e1cc56-3e05-4222-ad07-5792ddba769d",
+                                    "title": "Has {{ metadata['ru_name'] }} <em>started</em> selling goods or services online during the coronavirus (COVID-19) pandemic?",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer66776e6d-9e34-42ab-b6cf-fb8ea954c3ec",
+                                            "mandatory": true,
+                                            "type": "Radio",
+                                            "label": "",
+                                            "description": "",
+                                            "q_code": "95",
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                },
+                                                {
+                                                    "label": "Not sure",
+                                                    "value": "Not sure"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "blockf2734939-baaf-4284-a007-befe2e5bf96d",
+                                        "when": [
+                                            {
+                                                "id": "answer66776e6d-9e34-42ab-b6cf-fb8ea954c3ec",
+                                                "condition": "contains any",
+                                                "values": ["Yes"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "block0c9d4096-3307-453d-8427-e5f0fcdd9a87"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "blockf2734939-baaf-4284-a007-befe2e5bf96d",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "questionf2734939-baaf-4284-a007-befe2e5bf96d",
+                                    "title": "How have {{ metadata['ru_name'] }}&apos;s online sales of goods or services changed in the <em>last two weeks</em>?",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer8602d2d3-f3cc-417b-9a3d-0141d9f9dc39",
+                                            "mandatory": true,
+                                            "type": "Radio",
+                                            "label": "",
+                                            "description": "",
+                                            "q_code": "75",
+                                            "options": [
+                                                {
+                                                    "label": "Online sales have increased",
+                                                    "value": "Online sales have increased"
+                                                },
+                                                {
+                                                    "label": "Online sales have stayed the same",
+                                                    "value": "Online sales have stayed the same"
+                                                },
+                                                {
+                                                    "label": "Online sales have continued, but decreased",
+                                                    "value": "Online sales have continued, but decreased"
+                                                },
+                                                {
+                                                    "label": "The business stopped selling goods or services online",
+                                                    "value": "The business stopped selling goods or services online"
+                                                },
+                                                {
+                                                    "label": "Not sure",
+                                                    "value": "Not sure"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block0c9d4096-3307-453d-8427-e5f0fcdd9a87",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question0c9d4096-3307-453d-8427-e5f0fcdd9a87",
+                                    "title": "Has {{ metadata['ru_name'] }} used any of the following <em>online services</em> to support business operations during the coronavirus (COVID-19) pandemic?",
+                                    "type": "MutuallyExclusive",
+                                    "mandatory": true,
+                                    "answers": [
+                                        {
+                                            "id": "answer8ca3198d-60a0-45da-bc61-b7e29b55a44c",
+                                            "mandatory": false,
+                                            "type": "Checkbox",
+                                            "label": "Select all that apply",
+                                            "description": "",
+                                            "options": [
+                                                {
+                                                    "label": "Increased or new use of online advertising",
+                                                    "value": "Increased or new use of online advertising",
+                                                    "q_code": "761"
+                                                },
+                                                {
+                                                    "label": "Increased or new use of online services to help communication with customers",
+                                                    "value": "Increased or new use of online services to help communication with customers",
+                                                    "q_code": "762",
+                                                    "description": "For example, social media, new websites, email"
+                                                },
+                                                {
+                                                    "label": "Increased or new use of video conferencing for internal communications",
+                                                    "value": "Increased or new use of video conferencing for internal communications",
+                                                    "q_code": "763",
+                                                    "description": "For example, Zoom, Skype, Microsoft Teams, Google Hangouts"
+                                                },
+                                                {
+                                                    "label": "Increased or new use of social media platforms for internal communications",
+                                                    "value": "Increased or new use of social media platforms for internal communications",
+                                                    "q_code": "764",
+                                                    "description": "For example, WhatsApp, Slack, Trello"
+                                                },
+                                                {
+                                                    "label": "Other",
+                                                    "value": "Other",
+                                                    "q_code": "765",
+                                                    "detail_answer": {
+                                                        "label": "Please describe",
+                                                        "type": "TextField",
+                                                        "id": "answer0a322cfd-08a6-46fc-aa15-98881479656e",
+                                                        "mandatory": false
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "id": "answer8ca3198d-60a0-45da-bc61-b7e29b55a44c-exclusive",
+                                            "mandatory": false,
+                                            "type": "Checkbox",
+                                            "description": "",
+                                            "options": [
+                                                {
+                                                    "label": "None of the above",
+                                                    "value": "None of the above",
+                                                    "q_code": "766"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "blockcabf3732-b3b9-4bf4-8e00-80d9cd5baff1",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "questioncabf3732-b3b9-4bf4-8e00-80d9cd5baff1",
+                                    "title": "Has {{ metadata['ru_name'] }} <em>diversified</em> to produce or provide new goods or services as a result of the coronavirus (COVID-19) pandemic?",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer1cef2734-e2be-42ce-a724-948845ec6e5a",
+                                            "mandatory": true,
+                                            "type": "Radio",
+                                            "label": "",
+                                            "description": "",
+                                            "q_code": "115",
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                },
+                                                {
+                                                    "label": "Not sure",
+                                                    "value": "Not sure"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "blocka6a29cc6-f809-4ed5-9d76-cc272b66dbab",
+                                        "when": [
+                                            {
+                                                "id": "answer1cef2734-e2be-42ce-a724-948845ec6e5a",
+                                                "condition": "contains any",
+                                                "values": ["Yes"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "group": "groupaf9cbebb-ec7e-4a68-b46d-2b7d081d16d7"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "blocka6a29cc6-f809-4ed5-9d76-cc272b66dbab",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "questiona6a29cc6-f809-4ed5-9d76-cc272b66dbab",
+                                    "title": "Please give more details about how {{ metadata['ru_name'] }} has diversified to produce or provide new goods or services",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer02a69fd3-aa57-46a7-9487-cec81843a6e4",
+                                            "mandatory": true,
+                                            "type": "TextArea",
+                                            "label": "Comments",
+                                            "description": "",
+                                            "q_code": "125",
+                                            "max_length": 2000
+                                        }
+                                    ]
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "skip_conditions": [
+                        {
+                            "when": [
+                                {
+                                    "id": "answere866cf73-a3a4-4d61-8f0c-1a05f09e1c75",
+                                    "condition": "contains any",
+                                    "values": ["Not sure"]
+                                },
+                                {
+                                    "id": "answere866cf73-a3a4-4d61-8f0c-1a05f09e1c75-exclusive",
+                                    "condition": "contains any",
+                                    "values": ["Not applicable"]
+                                },
+                                {
+                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                    "condition": "contains any",
+                                    "values": [
+                                        "Paused trading but intends to restart in the next two weeks",
+                                        "Paused trading and does not intend to restart in the next two weeks"
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "when": [
+                                {
+                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                    "condition": "contains any",
+                                    "values": [
+                                        "Paused trading but intends to restart in the next two weeks",
+                                        "Paused trading and does not intend to restart in the next two weeks"
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "when": [
+                                {
+                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                    "condition": "contains any",
+                                    "values": ["Permanently ceased trading"]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
         },
         {
             "id": "sectionaf9cbebb-ec7e-4a68-b46d-2b7d081d16d7",
             "title": "Postponed or cancelled bookings, services and events",
-            "groups": [{
-                "id": "groupaf9cbebb-ec7e-4a68-b46d-2b7d081d16d7",
-                "title": "Postponed or cancelled bookings, services and events",
-                "blocks": [{
-                        "type": "Interstitial",
-                        "id": "groupaf9cbebb-ec7e-4a68-b46d-2b7d081d16d7-introduction",
-                        "title": "Postponed or cancelled bookings, services and events",
-                        "description": "<p>This section asks for information about how the business is managing postponed or cancelled bookings, services and events sold to customers during the coronavirus (COVID-19) pandemic.</p>",
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block36019578-5d21-43b6-a068-ebafa16c768e",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question36019578-5d21-43b6-a068-ebafa16c768e",
-                            "title": "Has {{ metadata['ru_name'] }} <em>postponed or cancelled</em> any bookings, services or events sold to customers, due to the coronavirus (COVID-19) pandemic?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer399d67d7-f59d-4ab5-ad00-d3b522fb7cd6",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "117",
-                                "options": [{
-                                        "label": "Yes",
-                                        "value": "Yes"
-                                    },
-                                    {
-                                        "label": "No",
-                                        "value": "No"
-                                    },
-                                    {
-                                        "label": "Not sure",
-                                        "value": "Not sure"
-                                    },
-                                    {
-                                        "label": "Not applicable",
-                                        "value": "Not applicable"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "group": "group139b1d35-6271-4893-8eef-e1a36f2eb3c9",
-                                    "when": [{
-                                            "id": "answer399d67d7-f59d-4ab5-ad00-d3b522fb7cd6",
-                                            "condition": "contains any",
-                                            "values": ["No", "Not sure", "Not applicable"]
-                                        },
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "contains any",
-                                            "values": [
-                                                "Currently trading and has been for more than the last two weeks",
-                                                "Started trading within the last two weeks after a pause in trading"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "group": "group8753dfce-d80c-4fe0-98ba-3cddd52a9bba",
-                                    "when": [{
-                                            "id": "answer399d67d7-f59d-4ab5-ad00-d3b522fb7cd6",
-                                            "condition": "contains any",
-                                            "values": ["No", "Not sure", "Not applicable"]
-                                        },
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "contains any",
-                                            "values": [
-                                                "Paused trading but intends to restart in the next two weeks",
-                                                "Paused trading and does not intend to restart in the next two weeks"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block935395a7-882a-45bd-860e-47c605ab1281",
-                                    "when": [{
-                                            "id": "answer399d67d7-f59d-4ab5-ad00-d3b522fb7cd6",
-                                            "condition": "contains any",
-                                            "values": ["Yes"]
-                                        },
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "contains any",
-                                            "values": [
-                                                "Currently trading and has been for more than the last two weeks",
-                                                "Started trading within the last two weeks after a pause in trading",
-                                                "Paused trading but intends to restart in the next two weeks",
-                                                "Paused trading and does not intend to restart in the next two weeks"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block935395a7-882a-45bd-860e-47c605ab1281",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question935395a7-882a-45bd-860e-47c605ab1281",
-                            "title": "How is {{ metadata['ru_name'] }} <em>managing</em> postponed or cancelled bookings, services or events sold to customers?",
-                            "type": "MutuallyExclusive",
-                            "mandatory": true,
-                            "answers": [{
-                                    "id": "answere528d417-67e6-4356-b660-107bab6c73f1",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "label": "Select all that apply",
-                                    "description": "",
-                                    "options": [{
-                                            "label": "Offering the option to re-book for future dates",
-                                            "value": "Offering the option to re-book for future dates",
-                                            "q_code": "1181"
-                                        },
-                                        {
-                                            "label": "Rescheduling for a future date",
-                                            "value": "Rescheduling for a future date",
-                                            "q_code": "1182"
-                                        },
-                                        {
-                                            "label": "Allowing customers to stop direct debits",
-                                            "value": "Allowing customers to stop direct debits",
-                                            "q_code": "1183"
-                                        },
-                                        {
-                                            "label": "Offering full refunds",
-                                            "value": "Offering full refunds",
-                                            "q_code": "1184"
-                                        },
-                                        {
-                                            "label": "Offering partial refunds",
-                                            "value": "Offering partial refunds",
-                                            "q_code": "1185"
-                                        },
-                                        {
-                                            "label": "Offering vouchers to be used on our products or services",
-                                            "value": "Offering vouchers to be used on our products or services",
-                                            "q_code": "1186"
-                                        },
-                                        {
-                                            "label": "Other",
-                                            "value": "Other",
-                                            "q_code": "1187",
-                                            "detail_answer": {
-                                                "label": "Please describe",
-                                                "type": "TextField",
-                                                "id": "answer59b22829-c22d-4c87-bc73-1028752b5818",
-                                                "mandatory": false
-                                            }
-                                        },
-                                        {
-                                            "label": "Not sure",
-                                            "value": "Not sure",
-                                            "q_code": "1188"
-                                        }
-                                    ]
-                                },
+            "groups": [
+                {
+                    "id": "groupaf9cbebb-ec7e-4a68-b46d-2b7d081d16d7",
+                    "title": "Postponed or cancelled bookings, services and events",
+                    "blocks": [
+                        {
+                            "type": "Interstitial",
+                            "id": "groupaf9cbebb-ec7e-4a68-b46d-2b7d081d16d7-introduction",
+                            "title": "Postponed or cancelled bookings, services and events",
+                            "description": "<p>This section asks for information about how the business is managing postponed or cancelled bookings, services and events sold to customers during the coronavirus (COVID-19) pandemic.</p>",
+                            "skip_conditions": [
                                 {
-                                    "id": "answere528d417-67e6-4356-b660-107bab6c73f1-exclusive",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "description": "",
-                                    "options": [{
-                                        "label": "None of the above",
-                                        "value": "None of the above",
-                                        "q_code": "1180"
-                                    }]
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
                                 }
                             ]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "group": "group139b1d35-6271-4893-8eef-e1a36f2eb3c9",
-                                    "when": [{
+                        },
+                        {
+                            "id": "block36019578-5d21-43b6-a068-ebafa16c768e",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question36019578-5d21-43b6-a068-ebafa16c768e",
+                                    "title": "Has {{ metadata['ru_name'] }} <em>postponed or cancelled</em> any bookings, services or events sold to customers, due to the coronavirus (COVID-19) pandemic?",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer399d67d7-f59d-4ab5-ad00-d3b522fb7cd6",
+                                            "mandatory": true,
+                                            "type": "Radio",
+                                            "label": "",
+                                            "description": "",
+                                            "q_code": "117",
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                },
+                                                {
+                                                    "label": "Not sure",
+                                                    "value": "Not sure"
+                                                },
+                                                {
+                                                    "label": "Not applicable",
+                                                    "value": "Not applicable"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "group": "group139b1d35-6271-4893-8eef-e1a36f2eb3c9",
+                                        "when": [
+                                            {
+                                                "id": "answer399d67d7-f59d-4ab5-ad00-d3b522fb7cd6",
+                                                "condition": "contains any",
+                                                "values": ["No", "Not sure", "Not applicable"]
+                                            },
+                                            {
+                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                                "condition": "contains any",
+                                                "values": [
+                                                    "Currently trading and has been for more than the last two weeks",
+                                                    "Started trading within the last two weeks after a pause in trading"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "group": "group8753dfce-d80c-4fe0-98ba-3cddd52a9bba",
+                                        "when": [
+                                            {
+                                                "id": "answer399d67d7-f59d-4ab5-ad00-d3b522fb7cd6",
+                                                "condition": "contains any",
+                                                "values": ["No", "Not sure", "Not applicable"]
+                                            },
+                                            {
+                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                                "condition": "contains any",
+                                                "values": [
+                                                    "Paused trading but intends to restart in the next two weeks",
+                                                    "Paused trading and does not intend to restart in the next two weeks"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "block935395a7-882a-45bd-860e-47c605ab1281",
+                                        "when": [
+                                            {
+                                                "id": "answer399d67d7-f59d-4ab5-ad00-d3b522fb7cd6",
+                                                "condition": "contains any",
+                                                "values": ["Yes"]
+                                            },
+                                            {
+                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                                "condition": "contains any",
+                                                "values": [
+                                                    "Currently trading and has been for more than the last two weeks",
+                                                    "Started trading within the last two weeks after a pause in trading",
+                                                    "Paused trading but intends to restart in the next two weeks",
+                                                    "Paused trading and does not intend to restart in the next two weeks"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block935395a7-882a-45bd-860e-47c605ab1281",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question935395a7-882a-45bd-860e-47c605ab1281",
+                                    "title": "How is {{ metadata['ru_name'] }} <em>managing</em> postponed or cancelled bookings, services or events sold to customers?",
+                                    "type": "MutuallyExclusive",
+                                    "mandatory": true,
+                                    "answers": [
+                                        {
                                             "id": "answere528d417-67e6-4356-b660-107bab6c73f1",
-                                            "condition": "contains any",
-                                            "values": ["Not sure"]
+                                            "mandatory": false,
+                                            "type": "Checkbox",
+                                            "label": "Select all that apply",
+                                            "description": "",
+                                            "options": [
+                                                {
+                                                    "label": "Offering the option to re-book for future dates",
+                                                    "value": "Offering the option to re-book for future dates",
+                                                    "q_code": "1181"
+                                                },
+                                                {
+                                                    "label": "Rescheduling for a future date",
+                                                    "value": "Rescheduling for a future date",
+                                                    "q_code": "1182"
+                                                },
+                                                {
+                                                    "label": "Allowing customers to stop direct debits",
+                                                    "value": "Allowing customers to stop direct debits",
+                                                    "q_code": "1183"
+                                                },
+                                                {
+                                                    "label": "Offering full refunds",
+                                                    "value": "Offering full refunds",
+                                                    "q_code": "1184"
+                                                },
+                                                {
+                                                    "label": "Offering partial refunds",
+                                                    "value": "Offering partial refunds",
+                                                    "q_code": "1185"
+                                                },
+                                                {
+                                                    "label": "Offering vouchers to be used on our products or services",
+                                                    "value": "Offering vouchers to be used on our products or services",
+                                                    "q_code": "1186"
+                                                },
+                                                {
+                                                    "label": "Other",
+                                                    "value": "Other",
+                                                    "q_code": "1187",
+                                                    "detail_answer": {
+                                                        "label": "Please describe",
+                                                        "type": "TextField",
+                                                        "id": "answer59b22829-c22d-4c87-bc73-1028752b5818",
+                                                        "mandatory": false
+                                                    }
+                                                },
+                                                {
+                                                    "label": "Not sure",
+                                                    "value": "Not sure",
+                                                    "q_code": "1188"
+                                                }
+                                            ]
                                         },
                                         {
                                             "id": "answere528d417-67e6-4356-b660-107bab6c73f1-exclusive",
-                                            "condition": "contains any",
-                                            "values": ["None of the above"]
-                                        },
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "contains any",
-                                            "values": [
-                                                "Currently trading and has been for more than the last two weeks",
-                                                "Started trading within the last two weeks after a pause in trading"
+                                            "mandatory": false,
+                                            "type": "Checkbox",
+                                            "description": "",
+                                            "options": [
+                                                {
+                                                    "label": "None of the above",
+                                                    "value": "None of the above",
+                                                    "q_code": "1180"
+                                                }
                                             ]
                                         }
                                     ]
                                 }
-                            },
-                            {
-                                "goto": {
-                                    "group": "group8753dfce-d80c-4fe0-98ba-3cddd52a9bba",
-                                    "when": [{
-                                            "id": "answere528d417-67e6-4356-b660-107bab6c73f1",
-                                            "condition": "contains any",
-                                            "values": ["Not sure"]
-                                        },
-                                        {
-                                            "id": "answere528d417-67e6-4356-b660-107bab6c73f1-exclusive",
-                                            "condition": "contains any",
-                                            "values": ["None of the above"]
-                                        },
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "contains any",
-                                            "values": [
-                                                "Paused trading but intends to restart in the next two weeks",
-                                                "Paused trading and does not intend to restart in the next two weeks"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block38ecd8cf-8942-4d0e-a84d-8099393acfea",
-                                    "when": [{
-                                            "id": "answere528d417-67e6-4356-b660-107bab6c73f1",
-                                            "condition": "contains any",
-                                            "values": [
-                                                "Offering the option to re-book for future dates",
-                                                "Rescheduling for a future date",
-                                                "Allowing customers to stop direct debits",
-                                                "Offering full refunds",
-                                                "Offering partial refunds",
-                                                "Offering vouchers to be used on our products or services",
-                                                "Other"
-                                            ]
-                                        },
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "contains any",
-                                            "values": [
-                                                "Currently trading and has been for more than the last two weeks",
-                                                "Started trading within the last two weeks after a pause in trading",
-                                                "Paused trading but intends to restart in the next two weeks",
-                                                "Paused trading and does not intend to restart in the next two weeks"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block38ecd8cf-8942-4d0e-a84d-8099393acfea",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question38ecd8cf-8942-4d0e-a84d-8099393acfea",
-                            "title": "Has {{ metadata['ru_name'] }} <em>changed its approach</em> for managing postponed or cancelled bookings, services or events since the start of the coronavirus (COVID-19) pandemic?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer0ebd8695-e6d4-4fe0-b24f-0a50d9ab27eb",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "119",
-                                "options": [{
-                                        "label": "Yes, approach has changed",
-                                        "value": "Yes, approach has changed"
-                                    },
-                                    {
-                                        "label": "No, approach has not changed",
-                                        "value": "No, approach has not changed"
-                                    },
-                                    {
-                                        "label": "Not sure",
-                                        "value": "Not sure"
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "group": "group139b1d35-6271-4893-8eef-e1a36f2eb3c9",
+                                        "when": [
+                                            {
+                                                "id": "answere528d417-67e6-4356-b660-107bab6c73f1",
+                                                "condition": "contains any",
+                                                "values": ["Not sure"]
+                                            },
+                                            {
+                                                "id": "answere528d417-67e6-4356-b660-107bab6c73f1-exclusive",
+                                                "condition": "contains any",
+                                                "values": ["None of the above"]
+                                            },
+                                            {
+                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                                "condition": "contains any",
+                                                "values": [
+                                                    "Currently trading and has been for more than the last two weeks",
+                                                    "Started trading within the last two weeks after a pause in trading"
+                                                ]
+                                            }
+                                        ]
                                     }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "group": "group139b1d35-6271-4893-8eef-e1a36f2eb3c9",
-                                    "when": [{
-                                            "id": "answer0ebd8695-e6d4-4fe0-b24f-0a50d9ab27eb",
-                                            "condition": "contains any",
-                                            "values": ["No, approach has not changed", "Not sure"]
-                                        },
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "contains any",
-                                            "values": [
-                                                "Currently trading and has been for more than the last two weeks",
-                                                "Started trading within the last two weeks after a pause in trading"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "group": "group8753dfce-d80c-4fe0-98ba-3cddd52a9bba",
-                                    "when": [{
-                                            "id": "answer0ebd8695-e6d4-4fe0-b24f-0a50d9ab27eb",
-                                            "condition": "contains any",
-                                            "values": ["No, approach has not changed", "Not sure"]
-                                        },
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "contains any",
-                                            "values": [
-                                                "Paused trading but intends to restart in the next two weeks",
-                                                "Paused trading and does not intend to restart in the next two weeks"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block021b3411-c28a-4eab-81b5-cdba712c2f1b",
-                                    "when": [{
-                                            "id": "answer0ebd8695-e6d4-4fe0-b24f-0a50d9ab27eb",
-                                            "condition": "contains any",
-                                            "values": ["Yes, approach has changed"]
-                                        },
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "contains any",
-                                            "values": [
-                                                "Currently trading and has been for more than the last two weeks",
-                                                "Started trading within the last two weeks after a pause in trading",
-                                                "Paused trading but intends to restart in the next two weeks",
-                                                "Paused trading and does not intend to restart in the next two weeks"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block021b3411-c28a-4eab-81b5-cdba712c2f1b",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question021b3411-c28a-4eab-81b5-cdba712c2f1b",
-                            "title": "Which of the following affected {{ metadata['ru_name'] }}&apos;s <em>decision to change its approach</em> for managing postponed or cancelled bookings, services or events?",
-                            "type": "MutuallyExclusive",
-                            "mandatory": true,
-                            "answers": [{
-                                    "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "label": "Select all that apply",
-                                    "description": "",
-                                    "options": [{
-                                            "label": "Guidance",
-                                            "value": "Guidance",
-                                            "q_code": "1201"
-                                        },
-                                        {
-                                            "label": "Requests from customers",
-                                            "value": "Requests from customers",
-                                            "q_code": "1202"
-                                        },
-                                        {
-                                            "label": "The circumstances were not covered in our existing policies",
-                                            "value": "The circumstances were not covered in our existing policies",
-                                            "q_code": "1203"
-                                        },
-                                        {
-                                            "label": "Other",
-                                            "value": "Other",
-                                            "q_code": "1204",
-                                            "detail_answer": {
-                                                "label": "Please describe",
-                                                "type": "TextField",
-                                                "id": "answerd0b7d257-7d49-48b4-93e8-be6de9c35e23",
-                                                "mandatory": false
-                                            }
-                                        }
-                                    ]
                                 },
                                 {
-                                    "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe-exclusive",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "description": "",
-                                    "options": [{
-                                        "label": "Not sure",
-                                        "value": "Not sure",
-                                        "q_code": "1205"
-                                    }]
+                                    "goto": {
+                                        "group": "group8753dfce-d80c-4fe0-98ba-3cddd52a9bba",
+                                        "when": [
+                                            {
+                                                "id": "answere528d417-67e6-4356-b660-107bab6c73f1",
+                                                "condition": "contains any",
+                                                "values": ["Not sure"]
+                                            },
+                                            {
+                                                "id": "answere528d417-67e6-4356-b660-107bab6c73f1-exclusive",
+                                                "condition": "contains any",
+                                                "values": ["None of the above"]
+                                            },
+                                            {
+                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                                "condition": "contains any",
+                                                "values": [
+                                                    "Paused trading but intends to restart in the next two weeks",
+                                                    "Paused trading and does not intend to restart in the next two weeks"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "block38ecd8cf-8942-4d0e-a84d-8099393acfea",
+                                        "when": [
+                                            {
+                                                "id": "answere528d417-67e6-4356-b660-107bab6c73f1",
+                                                "condition": "contains any",
+                                                "values": [
+                                                    "Offering the option to re-book for future dates",
+                                                    "Rescheduling for a future date",
+                                                    "Allowing customers to stop direct debits",
+                                                    "Offering full refunds",
+                                                    "Offering partial refunds",
+                                                    "Offering vouchers to be used on our products or services",
+                                                    "Other"
+                                                ]
+                                            },
+                                            {
+                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                                "condition": "contains any",
+                                                "values": [
+                                                    "Currently trading and has been for more than the last two weeks",
+                                                    "Started trading within the last two weeks after a pause in trading",
+                                                    "Paused trading but intends to restart in the next two weeks",
+                                                    "Paused trading and does not intend to restart in the next two weeks"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
                                 }
                             ]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "block7e1d161b-e606-4e72-963a-06ef3aa8d22f",
-                                    "when": [{
-                                        "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe",
-                                        "condition": "contains any",
-                                        "values": ["Guidance"]
-                                    }]
+                        },
+                        {
+                            "id": "block38ecd8cf-8942-4d0e-a84d-8099393acfea",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question38ecd8cf-8942-4d0e-a84d-8099393acfea",
+                                    "title": "Has {{ metadata['ru_name'] }} <em>changed its approach</em> for managing postponed or cancelled bookings, services or events since the start of the coronavirus (COVID-19) pandemic?",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer0ebd8695-e6d4-4fe0-b24f-0a50d9ab27eb",
+                                            "mandatory": true,
+                                            "type": "Radio",
+                                            "label": "",
+                                            "description": "",
+                                            "q_code": "119",
+                                            "options": [
+                                                {
+                                                    "label": "Yes, approach has changed",
+                                                    "value": "Yes, approach has changed"
+                                                },
+                                                {
+                                                    "label": "No, approach has not changed",
+                                                    "value": "No, approach has not changed"
+                                                },
+                                                {
+                                                    "label": "Not sure",
+                                                    "value": "Not sure"
+                                                }
+                                            ]
+                                        }
+                                    ]
                                 }
-                            },
-                            {
-                                "goto": {
-                                    "group": "group139b1d35-6271-4893-8eef-e1a36f2eb3c9",
-                                    "when": [{
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "group": "group139b1d35-6271-4893-8eef-e1a36f2eb3c9",
+                                        "when": [
+                                            {
+                                                "id": "answer0ebd8695-e6d4-4fe0-b24f-0a50d9ab27eb",
+                                                "condition": "contains any",
+                                                "values": ["No, approach has not changed", "Not sure"]
+                                            },
+                                            {
+                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                                "condition": "contains any",
+                                                "values": [
+                                                    "Currently trading and has been for more than the last two weeks",
+                                                    "Started trading within the last two weeks after a pause in trading"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "group": "group8753dfce-d80c-4fe0-98ba-3cddd52a9bba",
+                                        "when": [
+                                            {
+                                                "id": "answer0ebd8695-e6d4-4fe0-b24f-0a50d9ab27eb",
+                                                "condition": "contains any",
+                                                "values": ["No, approach has not changed", "Not sure"]
+                                            },
+                                            {
+                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                                "condition": "contains any",
+                                                "values": [
+                                                    "Paused trading but intends to restart in the next two weeks",
+                                                    "Paused trading and does not intend to restart in the next two weeks"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "block021b3411-c28a-4eab-81b5-cdba712c2f1b",
+                                        "when": [
+                                            {
+                                                "id": "answer0ebd8695-e6d4-4fe0-b24f-0a50d9ab27eb",
+                                                "condition": "contains any",
+                                                "values": ["Yes, approach has changed"]
+                                            },
+                                            {
+                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                                "condition": "contains any",
+                                                "values": [
+                                                    "Currently trading and has been for more than the last two weeks",
+                                                    "Started trading within the last two weeks after a pause in trading",
+                                                    "Paused trading but intends to restart in the next two weeks",
+                                                    "Paused trading and does not intend to restart in the next two weeks"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block021b3411-c28a-4eab-81b5-cdba712c2f1b",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question021b3411-c28a-4eab-81b5-cdba712c2f1b",
+                                    "title": "Which of the following affected {{ metadata['ru_name'] }}&apos;s <em>decision to change its approach</em> for managing postponed or cancelled bookings, services or events?",
+                                    "type": "MutuallyExclusive",
+                                    "mandatory": true,
+                                    "answers": [
+                                        {
                                             "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe",
-                                            "condition": "contains any",
-                                            "values": ["Requests from customers", "The circumstances were not covered in our existing policies", "Other"]
+                                            "mandatory": false,
+                                            "type": "Checkbox",
+                                            "label": "Select all that apply",
+                                            "description": "",
+                                            "options": [
+                                                {
+                                                    "label": "Guidance",
+                                                    "value": "Guidance",
+                                                    "q_code": "1201"
+                                                },
+                                                {
+                                                    "label": "Requests from customers",
+                                                    "value": "Requests from customers",
+                                                    "q_code": "1202"
+                                                },
+                                                {
+                                                    "label": "The circumstances were not covered in our existing policies",
+                                                    "value": "The circumstances were not covered in our existing policies",
+                                                    "q_code": "1203"
+                                                },
+                                                {
+                                                    "label": "Other",
+                                                    "value": "Other",
+                                                    "q_code": "1204",
+                                                    "detail_answer": {
+                                                        "label": "Please describe",
+                                                        "type": "TextField",
+                                                        "id": "answerd0b7d257-7d49-48b4-93e8-be6de9c35e23",
+                                                        "mandatory": false
+                                                    }
+                                                }
+                                            ]
                                         },
                                         {
                                             "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe-exclusive",
-                                            "condition": "contains any",
-                                            "values": ["Not sure"]
-                                        },
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "contains any",
-                                            "values": [
-                                                "Currently trading and has been for more than the last two weeks",
-                                                "Started trading within the last two weeks after a pause in trading"
+                                            "mandatory": false,
+                                            "type": "Checkbox",
+                                            "description": "",
+                                            "options": [
+                                                {
+                                                    "label": "Not sure",
+                                                    "value": "Not sure",
+                                                    "q_code": "1205"
+                                                }
                                             ]
                                         }
                                     ]
                                 }
-                            },
-                            {
-                                "goto": {
-                                    "group": "group8753dfce-d80c-4fe0-98ba-3cddd52a9bba",
-                                    "when": [{
-                                            "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe",
-                                            "condition": "contains any",
-                                            "values": ["Requests from customers", "The circumstances were not covered in our existing policies", "Other"]
-                                        },
-                                        {
-                                            "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe-exclusive",
-                                            "condition": "contains any",
-                                            "values": ["Not sure"]
-                                        },
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "contains any",
-                                            "values": [
-                                                "Paused trading but intends to restart in the next two weeks",
-                                                "Paused trading and does not intend to restart in the next two weeks"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block7e1d161b-e606-4e72-963a-06ef3aa8d22f",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question7e1d161b-e606-4e72-963a-06ef3aa8d22f",
-                            "title": "What did {{ metadata['ru_name'] }} use as a <em>guide</em> to change its approach?",
-                            "type": "MutuallyExclusive",
-                            "mandatory": true,
-                            "answers": [{
-                                    "id": "answerc3e789a8-f88b-4898-9d37-42e8c35dd8d2",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "label": "Select all that apply",
-                                    "description": "",
-                                    "options": [{
-                                            "label": "Government guidance",
-                                            "value": "Government guidance",
-                                            "q_code": "1211"
-                                        },
-                                        {
-                                            "label": "Guidance from the Competition and Markets Authority (CMA)",
-                                            "value": "Guidance from the Competition and Markets Authority (CMA)",
-                                            "q_code": "1212"
-                                        },
-                                        {
-                                            "label": "Guidance from the Civil Aviation Authority (CAA)",
-                                            "value": "Guidance from the Civil Aviation Authority (CAA)",
-                                            "q_code": "1213"
-                                        },
-                                        {
-                                            "label": "Guidance from the Financial Conduct Authority (FCA)",
-                                            "value": "Guidance from the Financial Conduct Authority (FCA)",
-                                            "q_code": "1214"
-                                        },
-                                        {
-                                            "label": "Guidance from Trading Standards",
-                                            "value": "Guidance from Trading Standards",
-                                            "q_code": "1215"
-                                        },
-                                        {
-                                            "label": "Other industry-specific guidance",
-                                            "value": "Other industry-specific guidance",
-                                            "q_code": "1216"
-                                        },
-                                        {
-                                            "label": "Media",
-                                            "value": "Media",
-                                            "q_code": "1217",
-                                            "description": "For example, television, radio or newspaper articles. Exclude social media."
-                                        },
-                                        {
-                                            "label": "Social media",
-                                            "value": "Social media",
-                                            "q_code": "1218",
-                                            "description": "For example, Facebook, Twitter or Instagram."
-                                        },
-                                        {
-                                            "label": "Other",
-                                            "value": "Other",
-                                            "q_code": "1219",
-                                            "detail_answer": {
-                                                "label": "Please describe",
-                                                "type": "TextField",
-                                                "id": "answer9f1ac7f9-0494-48e5-8379-50d7eef7d6a2",
-                                                "mandatory": false
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "block7e1d161b-e606-4e72-963a-06ef3aa8d22f",
+                                        "when": [
+                                            {
+                                                "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe",
+                                                "condition": "contains any",
+                                                "values": ["Guidance"]
                                             }
-                                        }
-                                    ]
+                                        ]
+                                    }
                                 },
                                 {
-                                    "id": "answerc3e789a8-f88b-4898-9d37-42e8c35dd8d2-exclusive",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "description": "",
-                                    "options": [{
-                                        "label": "Not sure",
-                                        "value": "Not sure",
-                                        "q_code": "1210"
-                                    }]
+                                    "goto": {
+                                        "group": "group139b1d35-6271-4893-8eef-e1a36f2eb3c9",
+                                        "when": [
+                                            {
+                                                "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe",
+                                                "condition": "contains any",
+                                                "values": ["Requests from customers", "The circumstances were not covered in our existing policies", "Other"]
+                                            },
+                                            {
+                                                "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe-exclusive",
+                                                "condition": "contains any",
+                                                "values": ["Not sure"]
+                                            },
+                                            {
+                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                                "condition": "contains any",
+                                                "values": [
+                                                    "Currently trading and has been for more than the last two weeks",
+                                                    "Started trading within the last two weeks after a pause in trading"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "group": "group8753dfce-d80c-4fe0-98ba-3cddd52a9bba",
+                                        "when": [
+                                            {
+                                                "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe",
+                                                "condition": "contains any",
+                                                "values": ["Requests from customers", "The circumstances were not covered in our existing policies", "Other"]
+                                            },
+                                            {
+                                                "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe-exclusive",
+                                                "condition": "contains any",
+                                                "values": ["Not sure"]
+                                            },
+                                            {
+                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                                "condition": "contains any",
+                                                "values": [
+                                                    "Paused trading but intends to restart in the next two weeks",
+                                                    "Paused trading and does not intend to restart in the next two weeks"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
                                 }
                             ]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "group": "group8753dfce-d80c-4fe0-98ba-3cddd52a9bba",
-                                    "when": [{
-                                        "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                        "condition": "contains any",
-                                        "values": [
-                                            "Paused trading but intends to restart in the next two weeks",
-                                            "Paused trading and does not intend to restart in the next two weeks"
+                        },
+                        {
+                            "id": "block7e1d161b-e606-4e72-963a-06ef3aa8d22f",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question7e1d161b-e606-4e72-963a-06ef3aa8d22f",
+                                    "title": "What did {{ metadata['ru_name'] }} use as a <em>guide</em> to change its approach?",
+                                    "type": "MutuallyExclusive",
+                                    "mandatory": true,
+                                    "answers": [
+                                        {
+                                            "id": "answerc3e789a8-f88b-4898-9d37-42e8c35dd8d2",
+                                            "mandatory": false,
+                                            "type": "Checkbox",
+                                            "label": "Select all that apply",
+                                            "description": "",
+                                            "options": [
+                                                {
+                                                    "label": "Government guidance",
+                                                    "value": "Government guidance",
+                                                    "q_code": "1211"
+                                                },
+                                                {
+                                                    "label": "Guidance from the Competition and Markets Authority (CMA)",
+                                                    "value": "Guidance from the Competition and Markets Authority (CMA)",
+                                                    "q_code": "1212"
+                                                },
+                                                {
+                                                    "label": "Guidance from the Civil Aviation Authority (CAA)",
+                                                    "value": "Guidance from the Civil Aviation Authority (CAA)",
+                                                    "q_code": "1213"
+                                                },
+                                                {
+                                                    "label": "Guidance from the Financial Conduct Authority (FCA)",
+                                                    "value": "Guidance from the Financial Conduct Authority (FCA)",
+                                                    "q_code": "1214"
+                                                },
+                                                {
+                                                    "label": "Guidance from Trading Standards",
+                                                    "value": "Guidance from Trading Standards",
+                                                    "q_code": "1215"
+                                                },
+                                                {
+                                                    "label": "Other industry-specific guidance",
+                                                    "value": "Other industry-specific guidance",
+                                                    "q_code": "1216"
+                                                },
+                                                {
+                                                    "label": "Media",
+                                                    "value": "Media",
+                                                    "q_code": "1217",
+                                                    "description": "For example, television, radio or newspaper articles. Exclude social media."
+                                                },
+                                                {
+                                                    "label": "Social media",
+                                                    "value": "Social media",
+                                                    "q_code": "1218",
+                                                    "description": "For example, Facebook, Twitter or Instagram."
+                                                },
+                                                {
+                                                    "label": "Other",
+                                                    "value": "Other",
+                                                    "q_code": "1219",
+                                                    "detail_answer": {
+                                                        "label": "Please describe",
+                                                        "type": "TextField",
+                                                        "id": "answer9f1ac7f9-0494-48e5-8379-50d7eef7d6a2",
+                                                        "mandatory": false
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "id": "answerc3e789a8-f88b-4898-9d37-42e8c35dd8d2-exclusive",
+                                            "mandatory": false,
+                                            "type": "Checkbox",
+                                            "description": "",
+                                            "options": [
+                                                {
+                                                    "label": "Not sure",
+                                                    "value": "Not sure",
+                                                    "q_code": "1210"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "group": "group8753dfce-d80c-4fe0-98ba-3cddd52a9bba",
+                                        "when": [
+                                            {
+                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                                "condition": "contains any",
+                                                "values": [
+                                                    "Paused trading but intends to restart in the next two weeks",
+                                                    "Paused trading and does not intend to restart in the next two weeks"
+                                                ]
+                                            }
                                         ]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "group": "group139b1d35-6271-4893-8eef-e1a36f2eb3c9",
-                                    "when": [{
-                                        "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                        "condition": "contains any",
-                                        "values": [
-                                            "Currently trading and has been for more than the last two weeks",
-                                            "Started trading within the last two weeks after a pause in trading"
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "group": "group139b1d35-6271-4893-8eef-e1a36f2eb3c9",
+                                        "when": [
+                                            {
+                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                                "condition": "contains any",
+                                                "values": [
+                                                    "Currently trading and has been for more than the last two weeks",
+                                                    "Started trading within the last two weeks after a pause in trading"
+                                                ]
+                                            }
                                         ]
-                                    }]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8"
+                                    }
                                 }
-                            },
-                            {
-                                "goto": {
-                                    "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8"
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
                                 }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    }
-                ],
-                "skip_conditions": [{
-                    "when": [{
-                        "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                        "condition": "contains any",
-                        "values": ["Permanently ceased trading"]
-                    }]
-                }]
-            }]
+                            ]
+                        }
+                    ],
+                    "skip_conditions": [
+                        {
+                            "when": [
+                                {
+                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                    "condition": "contains any",
+                                    "values": ["Permanently ceased trading"]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
         },
         {
             "id": "section139b1d35-6271-4893-8eef-e1a36f2eb3c9",
             "title": "Exporting and importing",
-            "groups": [{
-                "id": "group139b1d35-6271-4893-8eef-e1a36f2eb3c9",
-                "title": "Exporting and importing",
-                "blocks": [{
-                        "type": "Interstitial",
-                        "id": "group139b1d35-6271-4893-8eef-e1a36f2eb3c9-introduction",
-                        "title": "Exporting and importing",
-                        "description": "<p>This section asks for information about the business&apos;s importing and exporting activities.</p>",
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block059d51ee-2b0f-456f-8a29-23b1c97e2dac",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question059d51ee-2b0f-456f-8a29-23b1c97e2dac",
-                            "title": "Has {{ metadata['ru_name'] }} <em>exported</em> goods or services in the last 12 months?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer6e5dfc6d-189b-4d67-b64f-d40f68253cda",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "52",
-                                "options": [{
-                                        "label": "Yes",
-                                        "value": "Yes"
-                                    },
-                                    {
-                                        "label": "No",
-                                        "value": "No"
-                                    },
-                                    {
-                                        "label": "Not sure",
-                                        "value": "Not sure"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "blockf25bdbfe-14fb-4699-bf0d-29140cb007f8",
-                                    "when": [{
-                                        "id": "answer6e5dfc6d-189b-4d67-b64f-d40f68253cda",
-                                        "condition": "contains any",
-                                        "values": ["No", "Not sure"]
-                                    }]
+            "groups": [
+                {
+                    "id": "group139b1d35-6271-4893-8eef-e1a36f2eb3c9",
+                    "title": "Exporting and importing",
+                    "blocks": [
+                        {
+                            "type": "Interstitial",
+                            "id": "group139b1d35-6271-4893-8eef-e1a36f2eb3c9-introduction",
+                            "title": "Exporting and importing",
+                            "description": "<p>This section asks for information about the business&apos;s importing and exporting activities.</p>",
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
                                 }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block0af301b1-70ce-4fc7-a698-7374fb9436e4"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block0af301b1-70ce-4fc7-a698-7374fb9436e4",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question0af301b1-70ce-4fc7-a698-7374fb9436e4",
-                            "title": "Has {{ metadata['ru_name'] }} exported goods or services <em>during</em> the coronavirus (COVID-19) pandemic?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer5cd5a93e-d818-4d4e-a32f-9eeedad30a6a",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "54",
-                                "options": [{
-                                        "label": "Yes, the business has exported during the pandemic",
-                                        "value": "Yes, the business has exported during the pandemic"
-                                    },
-                                    {
-                                        "label": "No, the business has not exported during the pandemic",
-                                        "value": "No, the business has not exported during the pandemic"
-                                    },
-                                    {
-                                        "label": "Not sure",
-                                        "value": "Not sure"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "blockf25bdbfe-14fb-4699-bf0d-29140cb007f8",
-                                    "when": [{
-                                        "id": "answer5cd5a93e-d818-4d4e-a32f-9eeedad30a6a",
-                                        "condition": "contains any",
-                                        "values": ["No, the business has not exported during the pandemic", "Not sure"]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block730e686b-f62a-444a-a62d-805ced57ace8"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block730e686b-f62a-444a-a62d-805ced57ace8",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question730e686b-f62a-444a-a62d-805ced57ace8",
-                            "title": "How has {{ metadata['ru_name'] }}&apos;s exporting of goods or services been affected by the coronavirus (COVID-19) pandemic in the <em>last two weeks</em>?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer39662368-cb6b-4abb-9990-6e9eb02e3eef",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "7",
-                                "options": [{
-                                        "label": "Exporting more than normal",
-                                        "value": "Exporting more than normal"
-                                    },
-                                    {
-                                        "label": "Exporting has not been affected",
-                                        "value": "Exporting has not been affected"
-                                    },
-                                    {
-                                        "label": "Exporting, but less than normal",
-                                        "value": "Exporting, but less than normal"
-                                    },
-                                    {
-                                        "label": "Not been able to export in the last two weeks",
-                                        "value": "Not been able to export in the last two weeks"
-                                    },
-                                    {
-                                        "label": "Not sure",
-                                        "value": "Not sure"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block4728c544-95e8-4d1f-a5c7-d2fc3a95f180",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question4728c544-95e8-4d1f-a5c7-d2fc3a95f180",
-                            "title": "Let us know anything else that will help us understand {{ metadata['ru_name'] }}&#x2019;s exporting in the <em>last two weeks</em>",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer3c6cef19-ffc2-4283-9cc9-bd356713b0f2",
-                                "mandatory": false,
-                                "type": "TextArea",
-                                "label": "Comments",
-                                "description": "",
-                                "q_code": "8",
-                                "max_length": 2000
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "blockf25bdbfe-14fb-4699-bf0d-29140cb007f8",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questionf25bdbfe-14fb-4699-bf0d-29140cb007f8",
-                            "title": "Has {{ metadata['ru_name'] }} <em>imported</em> goods or services in the last 12 months?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer5ad71b6e-442c-499a-b185-e39282dd09c0",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "62",
-                                "options": [{
-                                        "label": "Yes",
-                                        "value": "Yes"
-                                    },
-                                    {
-                                        "label": "No",
-                                        "value": "No"
-                                    },
-                                    {
-                                        "label": "Not sure",
-                                        "value": "Not sure"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "group": "group5c8d0ebe-e6e2-4ff6-a2bd-99ccf4edbde6",
-                                    "when": [{
-                                        "id": "answer5ad71b6e-442c-499a-b185-e39282dd09c0",
-                                        "condition": "contains any",
-                                        "values": ["No", "Not sure"]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block4b9c0508-34e9-4b60-bde1-d803c99bed59"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block4b9c0508-34e9-4b60-bde1-d803c99bed59",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question4b9c0508-34e9-4b60-bde1-d803c99bed59",
-                            "title": "Has {{ metadata['ru_name'] }} imported goods or services <em>during</em> the coronavirus (COVID-19) pandemic?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answera7265706-a8e2-4db9-b7e9-00a4f62378d3",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "64",
-                                "options": [{
-                                        "label": "Yes, the business imported during the pandemic",
-                                        "value": "Yes, the business imported during the pandemic"
-                                    },
-                                    {
-                                        "label": "No, the business has not imported during the pandemic",
-                                        "value": "No, the business has not imported during the pandemic"
-                                    },
-                                    {
-                                        "label": "Not sure",
-                                        "value": "Not sure"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "group": "group5c8d0ebe-e6e2-4ff6-a2bd-99ccf4edbde6",
-                                    "when": [{
-                                        "id": "answera7265706-a8e2-4db9-b7e9-00a4f62378d3",
-                                        "condition": "contains any",
-                                        "values": ["No, the business has not imported during the pandemic", "Not sure"]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block41cb8d16-ed70-4442-a3e1-fac1efdea741"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block41cb8d16-ed70-4442-a3e1-fac1efdea741",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question41cb8d16-ed70-4442-a3e1-fac1efdea741",
-                            "title": "How has {{ metadata['ru_name'] }}&apos;s importing of goods or services been affected by the coronavirus (COVID-19) pandemic in the <em>last two weeks</em>?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer96cefc81-a976-46a3-a45d-429633159a3e",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "10",
-                                "options": [{
-                                        "label": "Importing more than normal",
-                                        "value": "Importing more than normal"
-                                    },
-                                    {
-                                        "label": "Importing has not been affected",
-                                        "value": "Importing has not been affected"
-                                    },
-                                    {
-                                        "label": "Importing, but less than normal",
-                                        "value": "Importing, but less than normal"
-                                    },
-                                    {
-                                        "label": "Not been able to import in the last two weeks",
-                                        "value": "Not been able to import in the last two weeks"
-                                    },
-                                    {
-                                        "label": "Not sure",
-                                        "value": "Not sure"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block4648511e-cf19-468d-9eed-14c4a92cb720",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question4648511e-cf19-468d-9eed-14c4a92cb720",
-                            "title": "Let us know anything else that will help us understand {{ metadata['ru_name'] }}&#x2019;s importing in the <em>last two weeks</em>",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer98ea4789-060e-460b-8d33-e688ceb4e947",
-                                "mandatory": false,
-                                "type": "TextArea",
-                                "label": "Comments",
-                                "description": "",
-                                "q_code": "11",
-                                "max_length": 2000
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    }
-                ],
-                "skip_conditions": [{
-                        "when": [{
-                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                            "condition": "contains any",
-                            "values": ["Permanently ceased trading"]
-                        }]
-                    },
-                    {
-                        "when": [{
-                                "id": "answer399d67d7-f59d-4ab5-ad00-d3b522fb7cd6",
-                                "condition": "contains any",
-                                "values": ["No", "Not sure", "Not applicable"]
-                            },
-                            {
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "contains any",
-                                "values": [
-                                    "Paused trading but intends to restart in the next two weeks",
-                                    "Paused trading and does not intend to restart in the next two weeks"
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        "when": [{
-                                "id": "answere528d417-67e6-4356-b660-107bab6c73f1",
-                                "condition": "contains any",
-                                "values": ["Not sure"]
-                            },
-                            {
-                                "id": "answere528d417-67e6-4356-b660-107bab6c73f1-exclusive",
-                                "condition": "contains any",
-                                "values": ["None of the above"]
-                            },
-                            {
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "contains any",
-                                "values": [
-                                    "Paused trading but intends to restart in the next two weeks",
-                                    "Paused trading and does not intend to restart in the next two weeks"
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        "when": [{
-                                "id": "answer0ebd8695-e6d4-4fe0-b24f-0a50d9ab27eb",
-                                "condition": "contains any",
-                                "values": ["No, approach has not changed", "Not sure"]
-                            },
-                            {
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "contains any",
-                                "values": [
-                                    "Paused trading but intends to restart in the next two weeks",
-                                    "Paused trading and does not intend to restart in the next two weeks"
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        "when": [{
-                                "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe",
-                                "condition": "contains any",
-                                "values": ["Requests from customers", "The circumstances were not covered in our existing policies", "Other"]
-                            },
-                            {
-                                "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe-exclusive",
-                                "condition": "contains any",
-                                "values": ["Not sure"]
-                            },
-                            {
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "contains any",
-                                "values": [
-                                    "Paused trading but intends to restart in the next two weeks",
-                                    "Paused trading and does not intend to restart in the next two weeks"
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        "when": [{
-                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                            "condition": "contains any",
-                            "values": [
-                                "Paused trading but intends to restart in the next two weeks",
-                                "Paused trading and does not intend to restart in the next two weeks"
                             ]
-                        }]
-                    }
-                ]
-            }]
+                        },
+                        {
+                            "id": "block059d51ee-2b0f-456f-8a29-23b1c97e2dac",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question059d51ee-2b0f-456f-8a29-23b1c97e2dac",
+                                    "title": "Has {{ metadata['ru_name'] }} <em>exported</em> goods or services in the last 12 months?",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer6e5dfc6d-189b-4d67-b64f-d40f68253cda",
+                                            "mandatory": true,
+                                            "type": "Radio",
+                                            "label": "",
+                                            "description": "",
+                                            "q_code": "52",
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                },
+                                                {
+                                                    "label": "Not sure",
+                                                    "value": "Not sure"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "blockf25bdbfe-14fb-4699-bf0d-29140cb007f8",
+                                        "when": [
+                                            {
+                                                "id": "answer6e5dfc6d-189b-4d67-b64f-d40f68253cda",
+                                                "condition": "contains any",
+                                                "values": ["No", "Not sure"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "block0af301b1-70ce-4fc7-a698-7374fb9436e4"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block0af301b1-70ce-4fc7-a698-7374fb9436e4",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question0af301b1-70ce-4fc7-a698-7374fb9436e4",
+                                    "title": "Has {{ metadata['ru_name'] }} exported goods or services <em>during</em> the coronavirus (COVID-19) pandemic?",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer5cd5a93e-d818-4d4e-a32f-9eeedad30a6a",
+                                            "mandatory": true,
+                                            "type": "Radio",
+                                            "label": "",
+                                            "description": "",
+                                            "q_code": "54",
+                                            "options": [
+                                                {
+                                                    "label": "Yes, the business has exported during the pandemic",
+                                                    "value": "Yes, the business has exported during the pandemic"
+                                                },
+                                                {
+                                                    "label": "No, the business has not exported during the pandemic",
+                                                    "value": "No, the business has not exported during the pandemic"
+                                                },
+                                                {
+                                                    "label": "Not sure",
+                                                    "value": "Not sure"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "blockf25bdbfe-14fb-4699-bf0d-29140cb007f8",
+                                        "when": [
+                                            {
+                                                "id": "answer5cd5a93e-d818-4d4e-a32f-9eeedad30a6a",
+                                                "condition": "contains any",
+                                                "values": ["No, the business has not exported during the pandemic", "Not sure"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "block730e686b-f62a-444a-a62d-805ced57ace8"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block730e686b-f62a-444a-a62d-805ced57ace8",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question730e686b-f62a-444a-a62d-805ced57ace8",
+                                    "title": "How has {{ metadata['ru_name'] }}&apos;s exporting of goods or services been affected by the coronavirus (COVID-19) pandemic in the <em>last two weeks</em>?",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer39662368-cb6b-4abb-9990-6e9eb02e3eef",
+                                            "mandatory": true,
+                                            "type": "Radio",
+                                            "label": "",
+                                            "description": "",
+                                            "q_code": "7",
+                                            "options": [
+                                                {
+                                                    "label": "Exporting more than normal",
+                                                    "value": "Exporting more than normal"
+                                                },
+                                                {
+                                                    "label": "Exporting has not been affected",
+                                                    "value": "Exporting has not been affected"
+                                                },
+                                                {
+                                                    "label": "Exporting, but less than normal",
+                                                    "value": "Exporting, but less than normal"
+                                                },
+                                                {
+                                                    "label": "Not been able to export in the last two weeks",
+                                                    "value": "Not been able to export in the last two weeks"
+                                                },
+                                                {
+                                                    "label": "Not sure",
+                                                    "value": "Not sure"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block4728c544-95e8-4d1f-a5c7-d2fc3a95f180",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question4728c544-95e8-4d1f-a5c7-d2fc3a95f180",
+                                    "title": "Let us know anything else that will help us understand {{ metadata['ru_name'] }}&#x2019;s exporting in the <em>last two weeks</em>",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer3c6cef19-ffc2-4283-9cc9-bd356713b0f2",
+                                            "mandatory": false,
+                                            "type": "TextArea",
+                                            "label": "Comments",
+                                            "description": "",
+                                            "q_code": "8",
+                                            "max_length": 2000
+                                        }
+                                    ]
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "blockf25bdbfe-14fb-4699-bf0d-29140cb007f8",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "questionf25bdbfe-14fb-4699-bf0d-29140cb007f8",
+                                    "title": "Has {{ metadata['ru_name'] }} <em>imported</em> goods or services in the last 12 months?",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer5ad71b6e-442c-499a-b185-e39282dd09c0",
+                                            "mandatory": true,
+                                            "type": "Radio",
+                                            "label": "",
+                                            "description": "",
+                                            "q_code": "62",
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                },
+                                                {
+                                                    "label": "Not sure",
+                                                    "value": "Not sure"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "group": "group5c8d0ebe-e6e2-4ff6-a2bd-99ccf4edbde6",
+                                        "when": [
+                                            {
+                                                "id": "answer5ad71b6e-442c-499a-b185-e39282dd09c0",
+                                                "condition": "contains any",
+                                                "values": ["No", "Not sure"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "block4b9c0508-34e9-4b60-bde1-d803c99bed59"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block4b9c0508-34e9-4b60-bde1-d803c99bed59",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question4b9c0508-34e9-4b60-bde1-d803c99bed59",
+                                    "title": "Has {{ metadata['ru_name'] }} imported goods or services <em>during</em> the coronavirus (COVID-19) pandemic?",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answera7265706-a8e2-4db9-b7e9-00a4f62378d3",
+                                            "mandatory": true,
+                                            "type": "Radio",
+                                            "label": "",
+                                            "description": "",
+                                            "q_code": "64",
+                                            "options": [
+                                                {
+                                                    "label": "Yes, the business imported during the pandemic",
+                                                    "value": "Yes, the business imported during the pandemic"
+                                                },
+                                                {
+                                                    "label": "No, the business has not imported during the pandemic",
+                                                    "value": "No, the business has not imported during the pandemic"
+                                                },
+                                                {
+                                                    "label": "Not sure",
+                                                    "value": "Not sure"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "group": "group5c8d0ebe-e6e2-4ff6-a2bd-99ccf4edbde6",
+                                        "when": [
+                                            {
+                                                "id": "answera7265706-a8e2-4db9-b7e9-00a4f62378d3",
+                                                "condition": "contains any",
+                                                "values": ["No, the business has not imported during the pandemic", "Not sure"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "block41cb8d16-ed70-4442-a3e1-fac1efdea741"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block41cb8d16-ed70-4442-a3e1-fac1efdea741",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question41cb8d16-ed70-4442-a3e1-fac1efdea741",
+                                    "title": "How has {{ metadata['ru_name'] }}&apos;s importing of goods or services been affected by the coronavirus (COVID-19) pandemic in the <em>last two weeks</em>?",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer96cefc81-a976-46a3-a45d-429633159a3e",
+                                            "mandatory": true,
+                                            "type": "Radio",
+                                            "label": "",
+                                            "description": "",
+                                            "q_code": "10",
+                                            "options": [
+                                                {
+                                                    "label": "Importing more than normal",
+                                                    "value": "Importing more than normal"
+                                                },
+                                                {
+                                                    "label": "Importing has not been affected",
+                                                    "value": "Importing has not been affected"
+                                                },
+                                                {
+                                                    "label": "Importing, but less than normal",
+                                                    "value": "Importing, but less than normal"
+                                                },
+                                                {
+                                                    "label": "Not been able to import in the last two weeks",
+                                                    "value": "Not been able to import in the last two weeks"
+                                                },
+                                                {
+                                                    "label": "Not sure",
+                                                    "value": "Not sure"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block4648511e-cf19-468d-9eed-14c4a92cb720",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question4648511e-cf19-468d-9eed-14c4a92cb720",
+                                    "title": "Let us know anything else that will help us understand {{ metadata['ru_name'] }}&#x2019;s importing in the <em>last two weeks</em>",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer98ea4789-060e-460b-8d33-e688ceb4e947",
+                                            "mandatory": false,
+                                            "type": "TextArea",
+                                            "label": "Comments",
+                                            "description": "",
+                                            "q_code": "11",
+                                            "max_length": 2000
+                                        }
+                                    ]
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "skip_conditions": [
+                        {
+                            "when": [
+                                {
+                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                    "condition": "contains any",
+                                    "values": ["Permanently ceased trading"]
+                                }
+                            ]
+                        },
+                        {
+                            "when": [
+                                {
+                                    "id": "answer399d67d7-f59d-4ab5-ad00-d3b522fb7cd6",
+                                    "condition": "contains any",
+                                    "values": ["No", "Not sure", "Not applicable"]
+                                },
+                                {
+                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                    "condition": "contains any",
+                                    "values": [
+                                        "Paused trading but intends to restart in the next two weeks",
+                                        "Paused trading and does not intend to restart in the next two weeks"
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "when": [
+                                {
+                                    "id": "answere528d417-67e6-4356-b660-107bab6c73f1",
+                                    "condition": "contains any",
+                                    "values": ["Not sure"]
+                                },
+                                {
+                                    "id": "answere528d417-67e6-4356-b660-107bab6c73f1-exclusive",
+                                    "condition": "contains any",
+                                    "values": ["None of the above"]
+                                },
+                                {
+                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                    "condition": "contains any",
+                                    "values": [
+                                        "Paused trading but intends to restart in the next two weeks",
+                                        "Paused trading and does not intend to restart in the next two weeks"
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "when": [
+                                {
+                                    "id": "answer0ebd8695-e6d4-4fe0-b24f-0a50d9ab27eb",
+                                    "condition": "contains any",
+                                    "values": ["No, approach has not changed", "Not sure"]
+                                },
+                                {
+                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                    "condition": "contains any",
+                                    "values": [
+                                        "Paused trading but intends to restart in the next two weeks",
+                                        "Paused trading and does not intend to restart in the next two weeks"
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "when": [
+                                {
+                                    "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe",
+                                    "condition": "contains any",
+                                    "values": ["Requests from customers", "The circumstances were not covered in our existing policies", "Other"]
+                                },
+                                {
+                                    "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe-exclusive",
+                                    "condition": "contains any",
+                                    "values": ["Not sure"]
+                                },
+                                {
+                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                    "condition": "contains any",
+                                    "values": [
+                                        "Paused trading but intends to restart in the next two weeks",
+                                        "Paused trading and does not intend to restart in the next two weeks"
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "when": [
+                                {
+                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                    "condition": "contains any",
+                                    "values": [
+                                        "Paused trading but intends to restart in the next two weeks",
+                                        "Paused trading and does not intend to restart in the next two weeks"
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
         },
         {
             "id": "section5c8d0ebe-e6e2-4ff6-a2bd-99ccf4edbde6",
             "title": "UK supply chain",
-            "groups": [{
-                "id": "group5c8d0ebe-e6e2-4ff6-a2bd-99ccf4edbde6",
-                "title": "UK supply chain",
-                "blocks": [{
-                        "type": "Interstitial",
-                        "id": "group5c8d0ebe-e6e2-4ff6-a2bd-99ccf4edbde6-introduction",
-                        "title": "UK supply chain",
-                        "description": "<p>This section asks for information about the availability of materials, goods and services within the UK.</p>",
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block0e1472db-36f2-4d40-b99e-510e70442636",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question0e1472db-36f2-4d40-b99e-510e70442636",
-                            "title": "Was {{ metadata['ru_name'] }} able to get the materials, goods or services it needed <em>from within the UK</em> in the <em>last two weeks</em>?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer478a7145-b712-43a1-9e1d-df39c23abddd",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "13",
-                                "options": [{
-                                        "label": "Yes, the business has been able to  get what we needed",
-                                        "value": "Yes, the business has been able to  get what we needed"
-                                    },
-                                    {
-                                        "label": "Yes, but the business had to change suppliers or find alternative solutions",
-                                        "value": "Yes, but the business had to change suppliers or find alternative solutions"
-                                    },
-                                    {
-                                        "label": "No, the business has not been able to get the materials, goods or services needed",
-                                        "value": "No, the business has not been able to get the materials, goods or services needed"
-                                    },
-                                    {
-                                        "label": "Not applicable",
-                                        "value": "Not applicable"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "blockfc873320-2213-4d19-982e-21b826833e1c",
-                                    "when": [{
-                                        "id": "answer478a7145-b712-43a1-9e1d-df39c23abddd",
-                                        "condition": "contains any",
-                                        "values": ["No, the business has not been able to get the materials, goods or services needed"]
-                                    }]
+            "groups": [
+                {
+                    "id": "group5c8d0ebe-e6e2-4ff6-a2bd-99ccf4edbde6",
+                    "title": "UK supply chain",
+                    "blocks": [
+                        {
+                            "type": "Interstitial",
+                            "id": "group5c8d0ebe-e6e2-4ff6-a2bd-99ccf4edbde6-introduction",
+                            "title": "UK supply chain",
+                            "description": "<p>This section asks for information about the availability of materials, goods and services within the UK.</p>",
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
                                 }
-                            },
-                            {
-                                "goto": {
-                                    "group": "groupff9741ed-a1da-4edf-bc6b-6bb62ddc94ec"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "blockfc873320-2213-4d19-982e-21b826833e1c",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questionfc873320-2213-4d19-982e-21b826833e1c",
-                            "title": "Please explain why {{ metadata['ru_name'] }} was not able to get the materials, goods or services needed",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer8d48af55-9228-488b-8a15-087c484266c2",
-                                "mandatory": true,
-                                "type": "TextArea",
-                                "label": "Comments",
-                                "description": "",
-                                "q_code": "14",
-                                "max_length": 2000
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    }
-                ],
-                "skip_conditions": [{
-                        "when": [{
-                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                            "condition": "contains any",
-                            "values": ["Permanently ceased trading"]
-                        }]
-                    },
-                    {
-                        "when": [{
-                                "id": "answer399d67d7-f59d-4ab5-ad00-d3b522fb7cd6",
-                                "condition": "contains any",
-                                "values": ["No", "Not sure", "Not applicable"]
-                            },
-                            {
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "contains any",
-                                "values": [
-                                    "Paused trading but intends to restart in the next two weeks",
-                                    "Paused trading and does not intend to restart in the next two weeks"
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        "when": [{
-                                "id": "answere528d417-67e6-4356-b660-107bab6c73f1",
-                                "condition": "contains any",
-                                "values": ["Not sure"]
-                            },
-                            {
-                                "id": "answere528d417-67e6-4356-b660-107bab6c73f1-exclusive",
-                                "condition": "contains any",
-                                "values": ["None of the above"]
-                            },
-                            {
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "contains any",
-                                "values": [
-                                    "Paused trading but intends to restart in the next two weeks",
-                                    "Paused trading and does not intend to restart in the next two weeks"
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        "when": [{
-                                "id": "answer0ebd8695-e6d4-4fe0-b24f-0a50d9ab27eb",
-                                "condition": "contains any",
-                                "values": ["No, approach has not changed", "Not sure"]
-                            },
-                            {
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "contains any",
-                                "values": [
-                                    "Paused trading but intends to restart in the next two weeks",
-                                    "Paused trading and does not intend to restart in the next two weeks"
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        "when": [{
-                                "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe",
-                                "condition": "contains any",
-                                "values": ["Requests from customers", "The circumstances were not covered in our existing policies", "Other"]
-                            },
-                            {
-                                "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe-exclusive",
-                                "condition": "contains any",
-                                "values": ["Not sure"]
-                            },
-                            {
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "contains any",
-                                "values": [
-                                    "Paused trading but intends to restart in the next two weeks",
-                                    "Paused trading and does not intend to restart in the next two weeks"
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        "when": [{
-                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                            "condition": "contains any",
-                            "values": [
-                                "Paused trading but intends to restart in the next two weeks",
-                                "Paused trading and does not intend to restart in the next two weeks"
                             ]
-                        }]
-                    }
-                ]
-            }]
+                        },
+                        {
+                            "id": "block0e1472db-36f2-4d40-b99e-510e70442636",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question0e1472db-36f2-4d40-b99e-510e70442636",
+                                    "title": "Was {{ metadata['ru_name'] }} able to get the materials, goods or services it needed <em>from within the UK</em> in the <em>last two weeks</em>?",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer478a7145-b712-43a1-9e1d-df39c23abddd",
+                                            "mandatory": true,
+                                            "type": "Radio",
+                                            "label": "",
+                                            "description": "",
+                                            "q_code": "13",
+                                            "options": [
+                                                {
+                                                    "label": "Yes, the business has been able to  get what we needed",
+                                                    "value": "Yes, the business has been able to  get what we needed"
+                                                },
+                                                {
+                                                    "label": "Yes, but the business had to change suppliers or find alternative solutions",
+                                                    "value": "Yes, but the business had to change suppliers or find alternative solutions"
+                                                },
+                                                {
+                                                    "label": "No, the business has not been able to get the materials, goods or services needed",
+                                                    "value": "No, the business has not been able to get the materials, goods or services needed"
+                                                },
+                                                {
+                                                    "label": "Not applicable",
+                                                    "value": "Not applicable"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "blockfc873320-2213-4d19-982e-21b826833e1c",
+                                        "when": [
+                                            {
+                                                "id": "answer478a7145-b712-43a1-9e1d-df39c23abddd",
+                                                "condition": "contains any",
+                                                "values": ["No, the business has not been able to get the materials, goods or services needed"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "group": "groupff9741ed-a1da-4edf-bc6b-6bb62ddc94ec"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "blockfc873320-2213-4d19-982e-21b826833e1c",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "questionfc873320-2213-4d19-982e-21b826833e1c",
+                                    "title": "Please explain why {{ metadata['ru_name'] }} was not able to get the materials, goods or services needed",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer8d48af55-9228-488b-8a15-087c484266c2",
+                                            "mandatory": true,
+                                            "type": "TextArea",
+                                            "label": "Comments",
+                                            "description": "",
+                                            "q_code": "14",
+                                            "max_length": 2000
+                                        }
+                                    ]
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "skip_conditions": [
+                        {
+                            "when": [
+                                {
+                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                    "condition": "contains any",
+                                    "values": ["Permanently ceased trading"]
+                                }
+                            ]
+                        },
+                        {
+                            "when": [
+                                {
+                                    "id": "answer399d67d7-f59d-4ab5-ad00-d3b522fb7cd6",
+                                    "condition": "contains any",
+                                    "values": ["No", "Not sure", "Not applicable"]
+                                },
+                                {
+                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                    "condition": "contains any",
+                                    "values": [
+                                        "Paused trading but intends to restart in the next two weeks",
+                                        "Paused trading and does not intend to restart in the next two weeks"
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "when": [
+                                {
+                                    "id": "answere528d417-67e6-4356-b660-107bab6c73f1",
+                                    "condition": "contains any",
+                                    "values": ["Not sure"]
+                                },
+                                {
+                                    "id": "answere528d417-67e6-4356-b660-107bab6c73f1-exclusive",
+                                    "condition": "contains any",
+                                    "values": ["None of the above"]
+                                },
+                                {
+                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                    "condition": "contains any",
+                                    "values": [
+                                        "Paused trading but intends to restart in the next two weeks",
+                                        "Paused trading and does not intend to restart in the next two weeks"
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "when": [
+                                {
+                                    "id": "answer0ebd8695-e6d4-4fe0-b24f-0a50d9ab27eb",
+                                    "condition": "contains any",
+                                    "values": ["No, approach has not changed", "Not sure"]
+                                },
+                                {
+                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                    "condition": "contains any",
+                                    "values": [
+                                        "Paused trading but intends to restart in the next two weeks",
+                                        "Paused trading and does not intend to restart in the next two weeks"
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "when": [
+                                {
+                                    "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe",
+                                    "condition": "contains any",
+                                    "values": ["Requests from customers", "The circumstances were not covered in our existing policies", "Other"]
+                                },
+                                {
+                                    "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe-exclusive",
+                                    "condition": "contains any",
+                                    "values": ["Not sure"]
+                                },
+                                {
+                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                    "condition": "contains any",
+                                    "values": [
+                                        "Paused trading but intends to restart in the next two weeks",
+                                        "Paused trading and does not intend to restart in the next two weeks"
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "when": [
+                                {
+                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                    "condition": "contains any",
+                                    "values": [
+                                        "Paused trading but intends to restart in the next two weeks",
+                                        "Paused trading and does not intend to restart in the next two weeks"
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
         },
         {
             "id": "sectionff9741ed-a1da-4edf-bc6b-6bb62ddc94ec",
             "title": "Prices of materials, goods and services",
-            "groups": [{
-                "id": "groupff9741ed-a1da-4edf-bc6b-6bb62ddc94ec",
-                "title": "Prices of materials, goods and services",
-                "blocks": [{
-                        "type": "Interstitial",
-                        "id": "groupff9741ed-a1da-4edf-bc6b-6bb62ddc94ec-introduction",
-                        "title": "Prices of materials, goods and services",
-                        "description": "<p>This section asks for information on any changes to the prices of goods and services <em>bought or sold</em> by the business in the last two weeks.</p>",
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "blockce542f26-a704-4dc6-a0ef-292c2739e4e6",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questionce542f26-a704-4dc6-a0ef-292c2739e4e6",
-                            "title": "How did the <em>prices</em> of materials, goods or services <em>bought</em> by {{ metadata['ru_name'] }} change in the <em>last two weeks</em>, compared with normal price fluctuations?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer27b42a40-5f79-4d32-b361-a94a454c638b",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "15",
-                                "options": [{
-                                        "label": "Prices increased more than normal",
-                                        "value": "Prices increased more than normal"
-                                    },
-                                    {
-                                        "label": "Prices did not change any more than normal",
-                                        "value": "Prices did not change any more than normal"
-                                    },
-                                    {
-                                        "label": "Prices decreased more than normal",
-                                        "value": "Prices decreased more than normal"
-                                    },
-                                    {
-                                        "label": "Some prices increased, some prices decreased",
-                                        "value": "Some prices increased, some prices decreased"
-                                    },
-                                    {
-                                        "label": "Not sure",
-                                        "value": "Not sure"
-                                    },
-                                    {
-                                        "label": "Not applicable",
-                                        "value": "Not applicable"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "block83701edb-7ee7-46b9-84f1-a9bc879f6b32",
-                                    "when": [{
-                                        "id": "answer27b42a40-5f79-4d32-b361-a94a454c638b",
-                                        "condition": "contains any",
-                                        "values": ["Not applicable"]
-                                    }]
+            "groups": [
+                {
+                    "id": "groupff9741ed-a1da-4edf-bc6b-6bb62ddc94ec",
+                    "title": "Prices of materials, goods and services",
+                    "blocks": [
+                        {
+                            "type": "Interstitial",
+                            "id": "groupff9741ed-a1da-4edf-bc6b-6bb62ddc94ec-introduction",
+                            "title": "Prices of materials, goods and services",
+                            "description": "<p>This section asks for information on any changes to the prices of goods and services <em>bought or sold</em> by the business in the last two weeks.</p>",
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
                                 }
-                            },
-                            {
-                                "goto": {
-                                    "block": "blockc09fc635-3d3d-46a0-bcca-2a04b42cd5b3",
-                                    "when": [{
-                                        "id": "answer27b42a40-5f79-4d32-b361-a94a454c638b",
-                                        "condition": "contains any",
-                                        "values": ["Prices did not change any more than normal", "Not sure"]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block89e663b4-3ff2-4e68-9d51-1ea33411a407"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block89e663b4-3ff2-4e68-9d51-1ea33411a407",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question89e663b4-3ff2-4e68-9d51-1ea33411a407",
-                            "title": "Please give more details about the prices of materials, goods or services that changed",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answera7bb01fe-3061-421f-bfee-74e02002c9ed",
-                                "mandatory": true,
-                                "type": "TextArea",
-                                "label": "Comments",
-                                "description": "",
-                                "q_code": "16",
-                                "max_length": 2000
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "blockc09fc635-3d3d-46a0-bcca-2a04b42cd5b3",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questionc09fc635-3d3d-46a0-bcca-2a04b42cd5b3",
-                            "title": "What are your expectations about changes in prices of materials, goods or services that {{ metadata['ru_name'] }} needs for the <em>next two weeks</em>?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answerdafcb524-7e33-472c-8b7e-76e77b402d92",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "17",
-                                "options": [{
-                                        "label": "Expect prices to generally increase",
-                                        "value": "Expect prices to generally increase"
-                                    },
-                                    {
-                                        "label": "Expect prices not to change",
-                                        "value": "Expect prices not to change"
-                                    },
-                                    {
-                                        "label": "Expect prices to generally decrease",
-                                        "value": "Expect prices to generally decrease"
-                                    },
-                                    {
-                                        "label": "Not sure",
-                                        "value": "Not sure"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block83701edb-7ee7-46b9-84f1-a9bc879f6b32",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question83701edb-7ee7-46b9-84f1-a9bc879f6b32",
-                            "title": "How did the prices of goods or services <em>sold</em> by {{ metadata['ru_name'] }} change in the <em>last two weeks</em>, compared with normal fluctuations?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer9274311d-e7dc-4e3b-8694-0fafc1eb4aae",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "18",
-                                "options": [{
-                                        "label": "Prices increased more than normal",
-                                        "value": "Prices increased more than normal"
-                                    },
-                                    {
-                                        "label": "Prices did not change any more than normal",
-                                        "value": "Prices did not change any more than normal"
-                                    },
-                                    {
-                                        "label": "Prices decreased more than normal",
-                                        "value": "Prices decreased more than normal"
-                                    },
-                                    {
-                                        "label": "Some prices increased, some prices decreased",
-                                        "value": "Some prices increased, some prices decreased"
-                                    },
-                                    {
-                                        "label": "Not sure",
-                                        "value": "Not sure"
-                                    },
-                                    {
-                                        "label": "Not applicable",
-                                        "value": "Not applicable"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "block13fc69db-bd9a-4996-9724-66a6a6be13c0",
-                                    "when": [{
-                                        "id": "answer9274311d-e7dc-4e3b-8694-0fafc1eb4aae",
-                                        "condition": "contains any",
-                                        "values": ["Prices did not change any more than normal", "Not sure"]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "group": "group91ec421d-5346-4b67-8d16-a8268f1c4c07",
-                                    "when": [{
-                                        "id": "answer9274311d-e7dc-4e3b-8694-0fafc1eb4aae",
-                                        "condition": "contains any",
-                                        "values": ["Not applicable"]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "blockf41e30d1-d01e-472f-9201-be7749d83557"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "blockf41e30d1-d01e-472f-9201-be7749d83557",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questionf41e30d1-d01e-472f-9201-be7749d83557",
-                            "title": "Please give more details about how prices changed",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answere3b55e00-f101-4ffe-8c5f-6a3272dfd8cc",
-                                "mandatory": true,
-                                "type": "TextArea",
-                                "label": "Comments",
-                                "description": "",
-                                "q_code": "19",
-                                "max_length": 2000
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block13fc69db-bd9a-4996-9724-66a6a6be13c0",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question13fc69db-bd9a-4996-9724-66a6a6be13c0",
-                            "title": "What are your expectations about prices of goods or services that {{ metadata['ru_name'] }} will <em>sell</em> over the <em>next two weeks</em>?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer8b015ec5-0d31-4f04-b333-b2835f5af8e2",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "20",
-                                "options": [{
-                                        "label": "Prices will generally increase",
-                                        "value": "Prices will generally increase"
-                                    },
-                                    {
-                                        "label": "Prices will stay the same",
-                                        "value": "Prices will stay the same"
-                                    },
-                                    {
-                                        "label": "Prices will generally decrease",
-                                        "value": "Prices will generally decrease"
-                                    },
-                                    {
-                                        "label": "Not sure",
-                                        "value": "Not sure"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    }
-                ],
-                "skip_conditions": [{
-                        "when": [{
-                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                            "condition": "contains any",
-                            "values": ["Permanently ceased trading"]
-                        }]
-                    },
-                    {
-                        "when": [{
-                                "id": "answer399d67d7-f59d-4ab5-ad00-d3b522fb7cd6",
-                                "condition": "contains any",
-                                "values": ["No", "Not sure", "Not applicable"]
-                            },
-                            {
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "contains any",
-                                "values": [
-                                    "Paused trading but intends to restart in the next two weeks",
-                                    "Paused trading and does not intend to restart in the next two weeks"
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        "when": [{
-                                "id": "answere528d417-67e6-4356-b660-107bab6c73f1",
-                                "condition": "contains any",
-                                "values": ["Not sure"]
-                            },
-                            {
-                                "id": "answere528d417-67e6-4356-b660-107bab6c73f1-exclusive",
-                                "condition": "contains any",
-                                "values": ["None of the above"]
-                            },
-                            {
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "contains any",
-                                "values": [
-                                    "Paused trading but intends to restart in the next two weeks",
-                                    "Paused trading and does not intend to restart in the next two weeks"
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        "when": [{
-                                "id": "answer0ebd8695-e6d4-4fe0-b24f-0a50d9ab27eb",
-                                "condition": "contains any",
-                                "values": ["No, approach has not changed", "Not sure"]
-                            },
-                            {
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "contains any",
-                                "values": [
-                                    "Paused trading but intends to restart in the next two weeks",
-                                    "Paused trading and does not intend to restart in the next two weeks"
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        "when": [{
-                                "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe",
-                                "condition": "contains any",
-                                "values": ["Requests from customers", "The circumstances were not covered in our existing policies", "Other"]
-                            },
-                            {
-                                "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe-exclusive",
-                                "condition": "contains any",
-                                "values": ["Not sure"]
-                            },
-                            {
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "contains any",
-                                "values": [
-                                    "Paused trading but intends to restart in the next two weeks",
-                                    "Paused trading and does not intend to restart in the next two weeks"
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        "when": [{
-                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                            "condition": "contains any",
-                            "values": [
-                                "Paused trading but intends to restart in the next two weeks",
-                                "Paused trading and does not intend to restart in the next two weeks"
                             ]
-                        }]
-                    }
-                ]
-            }]
+                        },
+                        {
+                            "id": "blockce542f26-a704-4dc6-a0ef-292c2739e4e6",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "questionce542f26-a704-4dc6-a0ef-292c2739e4e6",
+                                    "title": "How did the <em>prices</em> of materials, goods or services <em>bought</em> by {{ metadata['ru_name'] }} change in the <em>last two weeks</em>, compared with normal price fluctuations?",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer27b42a40-5f79-4d32-b361-a94a454c638b",
+                                            "mandatory": true,
+                                            "type": "Radio",
+                                            "label": "",
+                                            "description": "",
+                                            "q_code": "15",
+                                            "options": [
+                                                {
+                                                    "label": "Prices increased more than normal",
+                                                    "value": "Prices increased more than normal"
+                                                },
+                                                {
+                                                    "label": "Prices did not change any more than normal",
+                                                    "value": "Prices did not change any more than normal"
+                                                },
+                                                {
+                                                    "label": "Prices decreased more than normal",
+                                                    "value": "Prices decreased more than normal"
+                                                },
+                                                {
+                                                    "label": "Some prices increased, some prices decreased",
+                                                    "value": "Some prices increased, some prices decreased"
+                                                },
+                                                {
+                                                    "label": "Not sure",
+                                                    "value": "Not sure"
+                                                },
+                                                {
+                                                    "label": "Not applicable",
+                                                    "value": "Not applicable"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "block83701edb-7ee7-46b9-84f1-a9bc879f6b32",
+                                        "when": [
+                                            {
+                                                "id": "answer27b42a40-5f79-4d32-b361-a94a454c638b",
+                                                "condition": "contains any",
+                                                "values": ["Not applicable"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "blockc09fc635-3d3d-46a0-bcca-2a04b42cd5b3",
+                                        "when": [
+                                            {
+                                                "id": "answer27b42a40-5f79-4d32-b361-a94a454c638b",
+                                                "condition": "contains any",
+                                                "values": ["Prices did not change any more than normal", "Not sure"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "block89e663b4-3ff2-4e68-9d51-1ea33411a407"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block89e663b4-3ff2-4e68-9d51-1ea33411a407",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question89e663b4-3ff2-4e68-9d51-1ea33411a407",
+                                    "title": "Please give more details about the prices of materials, goods or services that changed",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answera7bb01fe-3061-421f-bfee-74e02002c9ed",
+                                            "mandatory": true,
+                                            "type": "TextArea",
+                                            "label": "Comments",
+                                            "description": "",
+                                            "q_code": "16",
+                                            "max_length": 2000
+                                        }
+                                    ]
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "blockc09fc635-3d3d-46a0-bcca-2a04b42cd5b3",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "questionc09fc635-3d3d-46a0-bcca-2a04b42cd5b3",
+                                    "title": "What are your expectations about changes in prices of materials, goods or services that {{ metadata['ru_name'] }} needs for the <em>next two weeks</em>?",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answerdafcb524-7e33-472c-8b7e-76e77b402d92",
+                                            "mandatory": true,
+                                            "type": "Radio",
+                                            "label": "",
+                                            "description": "",
+                                            "q_code": "17",
+                                            "options": [
+                                                {
+                                                    "label": "Expect prices to generally increase",
+                                                    "value": "Expect prices to generally increase"
+                                                },
+                                                {
+                                                    "label": "Expect prices not to change",
+                                                    "value": "Expect prices not to change"
+                                                },
+                                                {
+                                                    "label": "Expect prices to generally decrease",
+                                                    "value": "Expect prices to generally decrease"
+                                                },
+                                                {
+                                                    "label": "Not sure",
+                                                    "value": "Not sure"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block83701edb-7ee7-46b9-84f1-a9bc879f6b32",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question83701edb-7ee7-46b9-84f1-a9bc879f6b32",
+                                    "title": "How did the prices of goods or services <em>sold</em> by {{ metadata['ru_name'] }} change in the <em>last two weeks</em>, compared with normal fluctuations?",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer9274311d-e7dc-4e3b-8694-0fafc1eb4aae",
+                                            "mandatory": true,
+                                            "type": "Radio",
+                                            "label": "",
+                                            "description": "",
+                                            "q_code": "18",
+                                            "options": [
+                                                {
+                                                    "label": "Prices increased more than normal",
+                                                    "value": "Prices increased more than normal"
+                                                },
+                                                {
+                                                    "label": "Prices did not change any more than normal",
+                                                    "value": "Prices did not change any more than normal"
+                                                },
+                                                {
+                                                    "label": "Prices decreased more than normal",
+                                                    "value": "Prices decreased more than normal"
+                                                },
+                                                {
+                                                    "label": "Some prices increased, some prices decreased",
+                                                    "value": "Some prices increased, some prices decreased"
+                                                },
+                                                {
+                                                    "label": "Not sure",
+                                                    "value": "Not sure"
+                                                },
+                                                {
+                                                    "label": "Not applicable",
+                                                    "value": "Not applicable"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "block13fc69db-bd9a-4996-9724-66a6a6be13c0",
+                                        "when": [
+                                            {
+                                                "id": "answer9274311d-e7dc-4e3b-8694-0fafc1eb4aae",
+                                                "condition": "contains any",
+                                                "values": ["Prices did not change any more than normal", "Not sure"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "group": "group91ec421d-5346-4b67-8d16-a8268f1c4c07",
+                                        "when": [
+                                            {
+                                                "id": "answer9274311d-e7dc-4e3b-8694-0fafc1eb4aae",
+                                                "condition": "contains any",
+                                                "values": ["Not applicable"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "blockf41e30d1-d01e-472f-9201-be7749d83557"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "blockf41e30d1-d01e-472f-9201-be7749d83557",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "questionf41e30d1-d01e-472f-9201-be7749d83557",
+                                    "title": "Please give more details about how prices changed",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answere3b55e00-f101-4ffe-8c5f-6a3272dfd8cc",
+                                            "mandatory": true,
+                                            "type": "TextArea",
+                                            "label": "Comments",
+                                            "description": "",
+                                            "q_code": "19",
+                                            "max_length": 2000
+                                        }
+                                    ]
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block13fc69db-bd9a-4996-9724-66a6a6be13c0",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question13fc69db-bd9a-4996-9724-66a6a6be13c0",
+                                    "title": "What are your expectations about prices of goods or services that {{ metadata['ru_name'] }} will <em>sell</em> over the <em>next two weeks</em>?",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer8b015ec5-0d31-4f04-b333-b2835f5af8e2",
+                                            "mandatory": true,
+                                            "type": "Radio",
+                                            "label": "",
+                                            "description": "",
+                                            "q_code": "20",
+                                            "options": [
+                                                {
+                                                    "label": "Prices will generally increase",
+                                                    "value": "Prices will generally increase"
+                                                },
+                                                {
+                                                    "label": "Prices will stay the same",
+                                                    "value": "Prices will stay the same"
+                                                },
+                                                {
+                                                    "label": "Prices will generally decrease",
+                                                    "value": "Prices will generally decrease"
+                                                },
+                                                {
+                                                    "label": "Not sure",
+                                                    "value": "Not sure"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "skip_conditions": [
+                        {
+                            "when": [
+                                {
+                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                    "condition": "contains any",
+                                    "values": ["Permanently ceased trading"]
+                                }
+                            ]
+                        },
+                        {
+                            "when": [
+                                {
+                                    "id": "answer399d67d7-f59d-4ab5-ad00-d3b522fb7cd6",
+                                    "condition": "contains any",
+                                    "values": ["No", "Not sure", "Not applicable"]
+                                },
+                                {
+                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                    "condition": "contains any",
+                                    "values": [
+                                        "Paused trading but intends to restart in the next two weeks",
+                                        "Paused trading and does not intend to restart in the next two weeks"
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "when": [
+                                {
+                                    "id": "answere528d417-67e6-4356-b660-107bab6c73f1",
+                                    "condition": "contains any",
+                                    "values": ["Not sure"]
+                                },
+                                {
+                                    "id": "answere528d417-67e6-4356-b660-107bab6c73f1-exclusive",
+                                    "condition": "contains any",
+                                    "values": ["None of the above"]
+                                },
+                                {
+                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                    "condition": "contains any",
+                                    "values": [
+                                        "Paused trading but intends to restart in the next two weeks",
+                                        "Paused trading and does not intend to restart in the next two weeks"
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "when": [
+                                {
+                                    "id": "answer0ebd8695-e6d4-4fe0-b24f-0a50d9ab27eb",
+                                    "condition": "contains any",
+                                    "values": ["No, approach has not changed", "Not sure"]
+                                },
+                                {
+                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                    "condition": "contains any",
+                                    "values": [
+                                        "Paused trading but intends to restart in the next two weeks",
+                                        "Paused trading and does not intend to restart in the next two weeks"
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "when": [
+                                {
+                                    "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe",
+                                    "condition": "contains any",
+                                    "values": ["Requests from customers", "The circumstances were not covered in our existing policies", "Other"]
+                                },
+                                {
+                                    "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe-exclusive",
+                                    "condition": "contains any",
+                                    "values": ["Not sure"]
+                                },
+                                {
+                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                    "condition": "contains any",
+                                    "values": [
+                                        "Paused trading but intends to restart in the next two weeks",
+                                        "Paused trading and does not intend to restart in the next two weeks"
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "when": [
+                                {
+                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                    "condition": "contains any",
+                                    "values": [
+                                        "Paused trading but intends to restart in the next two weeks",
+                                        "Paused trading and does not intend to restart in the next two weeks"
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
         },
         {
             "id": "section91ec421d-5346-4b67-8d16-a8268f1c4c07",
             "title": "Stock and capital expenditure",
-            "groups": [{
-                "id": "group91ec421d-5346-4b67-8d16-a8268f1c4c07",
-                "title": "Stock and capital expenditure",
-                "blocks": [{
-                        "type": "Interstitial",
-                        "id": "group91ec421d-5346-4b67-8d16-a8268f1c4c07-introduction",
-                        "title": "Stock and capital expenditure",
-                        "description": "<p>This section asks for information about how the coronavirus (COVID-19) pandemic may have affected the business&apos;s stock and capital expenditure.</p>",
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block9a64bb02-fc94-4a2a-bda1-9e96f64bcd01",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question9a64bb02-fc94-4a2a-bda1-9e96f64bcd01",
-                            "title": "How has the coronavirus (COVID-19) pandemic affected {{ metadata['ru_name'] }}&#x2019;s <em>stock levels </em>in the last two weeks?",
-                            "description": "<p>Your business may use the term  &quot;inventories&quot; instead of &quot;stock&quot;.</p>",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answerc964594d-9b5b-4131-9c79-4baff0be08d1",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "110",
-                                "options": [{
-                                        "label": "Stock levels are higher than normal",
-                                        "value": "Stock levels are higher than normal"
-                                    },
-                                    {
-                                        "label": "Stock levels have not changed",
-                                        "value": "Stock levels have not changed"
-                                    },
-                                    {
-                                        "label": "Stock levels are lower than normal",
-                                        "value": "Stock levels are lower than normal"
-                                    },
-                                    {
-                                        "label": "Not sure",
-                                        "value": "Not sure"
-                                    },
-                                    {
-                                        "label": "Not applicable",
-                                        "value": "Not applicable"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "block8b3a9f71-4818-40db-a9f6-1d7ca69fe9e8",
-                                    "when": [{
-                                        "id": "answerc964594d-9b5b-4131-9c79-4baff0be08d1",
-                                        "condition": "contains any",
-                                        "values": ["Stock levels are higher than normal", "Stock levels are lower than normal"]
-                                    }]
+            "groups": [
+                {
+                    "id": "group91ec421d-5346-4b67-8d16-a8268f1c4c07",
+                    "title": "Stock and capital expenditure",
+                    "blocks": [
+                        {
+                            "type": "Interstitial",
+                            "id": "group91ec421d-5346-4b67-8d16-a8268f1c4c07-introduction",
+                            "title": "Stock and capital expenditure",
+                            "description": "<p>This section asks for information about how the coronavirus (COVID-19) pandemic may have affected the business&apos;s stock and capital expenditure.</p>",
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
                                 }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block3313b8a4-1fd6-4ab9-a874-909e86a1f86d"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block8b3a9f71-4818-40db-a9f6-1d7ca69fe9e8",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question8b3a9f71-4818-40db-a9f6-1d7ca69fe9e8",
-                            "title": "Please explain in more detail how the coronavirus (COVID-19) pandemic has affected {{ metadata['ru_name'] }}&#x2019;s stock levels in the last two weeks",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answere8a99b49-c76b-4598-925a-047596365fd1",
-                                "mandatory": true,
-                                "type": "TextArea",
-                                "label": "Comments",
-                                "description": "",
-                                "q_code": "111",
-                                "max_length": 2000
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block3313b8a4-1fd6-4ab9-a874-909e86a1f86d",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question3313b8a4-1fd6-4ab9-a874-909e86a1f86d",
-                            "title": "How has the coronavirus (COVID-19) pandemic affected {{ metadata['ru_name'] }}&apos;s <em>capital expenditure</em>?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer81b0d7f7-22b5-4fd6-a9ef-b774dbcc379f",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "122",
-                                "options": [{
-                                        "label": "Capital expenditure is higher than normal",
-                                        "value": "Capital expenditure is higher than normal"
-                                    },
-                                    {
-                                        "label": "Capital expenditure has not been affected",
-                                        "value": "Capital expenditure has not been affected"
-                                    },
-                                    {
-                                        "label": "Capital expenditure is lower than normal",
-                                        "value": "Capital expenditure is lower than normal"
-                                    },
-                                    {
-                                        "label": "Capital expenditure has stopped",
-                                        "value": "Capital expenditure has stopped"
-                                    },
-                                    {
-                                        "label": "Not sure",
-                                        "value": "Not sure"
-                                    },
-                                    {
-                                        "label": "Not applicable",
-                                        "value": "Not applicable"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "blocke4cf91f5-de29-4545-be73-519ba55ef740",
-                                    "when": [{
-                                        "id": "answer81b0d7f7-22b5-4fd6-a9ef-b774dbcc379f",
-                                        "condition": "contains any",
-                                        "values": [
-                                            "Capital expenditure is higher than normal",
-                                            "Capital expenditure is lower than normal",
-                                            "Capital expenditure has stopped"
-                                        ]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "group": "groupc4064d34-46d7-43ef-8ff1-52f12500ab4c"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "blocke4cf91f5-de29-4545-be73-519ba55ef740",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questione4cf91f5-de29-4545-be73-519ba55ef740",
-                            "title": "Please explain in more detail how the coronavirus (COVID-19) pandemic has affected {{ metadata['ru_name'] }}&#x2019;s capital expenditure",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer908cc56d-3047-40fc-a595-4d7cf639c584",
-                                "mandatory": true,
-                                "type": "TextArea",
-                                "label": "Comments",
-                                "description": "",
-                                "q_code": "123",
-                                "max_length": 2000
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    }
-                ],
-                "skip_conditions": [{
-                        "when": [{
-                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                            "condition": "contains any",
-                            "values": ["Permanently ceased trading"]
-                        }]
-                    },
-                    {
-                        "when": [{
-                                "id": "answer399d67d7-f59d-4ab5-ad00-d3b522fb7cd6",
-                                "condition": "contains any",
-                                "values": ["No", "Not sure", "Not applicable"]
-                            },
-                            {
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "contains any",
-                                "values": [
-                                    "Paused trading but intends to restart in the next two weeks",
-                                    "Paused trading and does not intend to restart in the next two weeks"
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        "when": [{
-                                "id": "answere528d417-67e6-4356-b660-107bab6c73f1",
-                                "condition": "contains any",
-                                "values": ["Not sure"]
-                            },
-                            {
-                                "id": "answere528d417-67e6-4356-b660-107bab6c73f1-exclusive",
-                                "condition": "contains any",
-                                "values": ["None of the above"]
-                            },
-                            {
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "contains any",
-                                "values": [
-                                    "Paused trading but intends to restart in the next two weeks",
-                                    "Paused trading and does not intend to restart in the next two weeks"
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        "when": [{
-                                "id": "answer0ebd8695-e6d4-4fe0-b24f-0a50d9ab27eb",
-                                "condition": "contains any",
-                                "values": ["No, approach has not changed", "Not sure"]
-                            },
-                            {
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "contains any",
-                                "values": [
-                                    "Paused trading but intends to restart in the next two weeks",
-                                    "Paused trading and does not intend to restart in the next two weeks"
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        "when": [{
-                                "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe",
-                                "condition": "contains any",
-                                "values": ["Requests from customers", "The circumstances were not covered in our existing policies", "Other"]
-                            },
-                            {
-                                "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe-exclusive",
-                                "condition": "contains any",
-                                "values": ["Not sure"]
-                            },
-                            {
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "contains any",
-                                "values": [
-                                    "Paused trading but intends to restart in the next two weeks",
-                                    "Paused trading and does not intend to restart in the next two weeks"
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        "when": [{
-                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                            "condition": "contains any",
-                            "values": [
-                                "Paused trading but intends to restart in the next two weeks",
-                                "Paused trading and does not intend to restart in the next two weeks"
                             ]
-                        }]
-                    }
-                ]
-            }]
+                        },
+                        {
+                            "id": "block9a64bb02-fc94-4a2a-bda1-9e96f64bcd01",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question9a64bb02-fc94-4a2a-bda1-9e96f64bcd01",
+                                    "title": "How has the coronavirus (COVID-19) pandemic affected {{ metadata['ru_name'] }}&#x2019;s <em>stock levels </em>in the last two weeks?",
+                                    "description": "<p>Your business may use the term  &quot;inventories&quot; instead of &quot;stock&quot;.</p>",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answerc964594d-9b5b-4131-9c79-4baff0be08d1",
+                                            "mandatory": true,
+                                            "type": "Radio",
+                                            "label": "",
+                                            "description": "",
+                                            "q_code": "110",
+                                            "options": [
+                                                {
+                                                    "label": "Stock levels are higher than normal",
+                                                    "value": "Stock levels are higher than normal"
+                                                },
+                                                {
+                                                    "label": "Stock levels have not changed",
+                                                    "value": "Stock levels have not changed"
+                                                },
+                                                {
+                                                    "label": "Stock levels are lower than normal",
+                                                    "value": "Stock levels are lower than normal"
+                                                },
+                                                {
+                                                    "label": "Not sure",
+                                                    "value": "Not sure"
+                                                },
+                                                {
+                                                    "label": "Not applicable",
+                                                    "value": "Not applicable"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "block8b3a9f71-4818-40db-a9f6-1d7ca69fe9e8",
+                                        "when": [
+                                            {
+                                                "id": "answerc964594d-9b5b-4131-9c79-4baff0be08d1",
+                                                "condition": "contains any",
+                                                "values": ["Stock levels are higher than normal", "Stock levels are lower than normal"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "block3313b8a4-1fd6-4ab9-a874-909e86a1f86d"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block8b3a9f71-4818-40db-a9f6-1d7ca69fe9e8",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question8b3a9f71-4818-40db-a9f6-1d7ca69fe9e8",
+                                    "title": "Please explain in more detail how the coronavirus (COVID-19) pandemic has affected {{ metadata['ru_name'] }}&#x2019;s stock levels in the last two weeks",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answere8a99b49-c76b-4598-925a-047596365fd1",
+                                            "mandatory": true,
+                                            "type": "TextArea",
+                                            "label": "Comments",
+                                            "description": "",
+                                            "q_code": "111",
+                                            "max_length": 2000
+                                        }
+                                    ]
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block3313b8a4-1fd6-4ab9-a874-909e86a1f86d",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question3313b8a4-1fd6-4ab9-a874-909e86a1f86d",
+                                    "title": "How has the coronavirus (COVID-19) pandemic affected {{ metadata['ru_name'] }}&apos;s <em>capital expenditure</em>?",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer81b0d7f7-22b5-4fd6-a9ef-b774dbcc379f",
+                                            "mandatory": true,
+                                            "type": "Radio",
+                                            "label": "",
+                                            "description": "",
+                                            "q_code": "122",
+                                            "options": [
+                                                {
+                                                    "label": "Capital expenditure is higher than normal",
+                                                    "value": "Capital expenditure is higher than normal"
+                                                },
+                                                {
+                                                    "label": "Capital expenditure has not been affected",
+                                                    "value": "Capital expenditure has not been affected"
+                                                },
+                                                {
+                                                    "label": "Capital expenditure is lower than normal",
+                                                    "value": "Capital expenditure is lower than normal"
+                                                },
+                                                {
+                                                    "label": "Capital expenditure has stopped",
+                                                    "value": "Capital expenditure has stopped"
+                                                },
+                                                {
+                                                    "label": "Not sure",
+                                                    "value": "Not sure"
+                                                },
+                                                {
+                                                    "label": "Not applicable",
+                                                    "value": "Not applicable"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "blocke4cf91f5-de29-4545-be73-519ba55ef740",
+                                        "when": [
+                                            {
+                                                "id": "answer81b0d7f7-22b5-4fd6-a9ef-b774dbcc379f",
+                                                "condition": "contains any",
+                                                "values": [
+                                                    "Capital expenditure is higher than normal",
+                                                    "Capital expenditure is lower than normal",
+                                                    "Capital expenditure has stopped"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "group": "groupc4064d34-46d7-43ef-8ff1-52f12500ab4c"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "blocke4cf91f5-de29-4545-be73-519ba55ef740",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "questione4cf91f5-de29-4545-be73-519ba55ef740",
+                                    "title": "Please explain in more detail how the coronavirus (COVID-19) pandemic has affected {{ metadata['ru_name'] }}&#x2019;s capital expenditure",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer908cc56d-3047-40fc-a595-4d7cf639c584",
+                                            "mandatory": true,
+                                            "type": "TextArea",
+                                            "label": "Comments",
+                                            "description": "",
+                                            "q_code": "123",
+                                            "max_length": 2000
+                                        }
+                                    ]
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "skip_conditions": [
+                        {
+                            "when": [
+                                {
+                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                    "condition": "contains any",
+                                    "values": ["Permanently ceased trading"]
+                                }
+                            ]
+                        },
+                        {
+                            "when": [
+                                {
+                                    "id": "answer399d67d7-f59d-4ab5-ad00-d3b522fb7cd6",
+                                    "condition": "contains any",
+                                    "values": ["No", "Not sure", "Not applicable"]
+                                },
+                                {
+                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                    "condition": "contains any",
+                                    "values": [
+                                        "Paused trading but intends to restart in the next two weeks",
+                                        "Paused trading and does not intend to restart in the next two weeks"
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "when": [
+                                {
+                                    "id": "answere528d417-67e6-4356-b660-107bab6c73f1",
+                                    "condition": "contains any",
+                                    "values": ["Not sure"]
+                                },
+                                {
+                                    "id": "answere528d417-67e6-4356-b660-107bab6c73f1-exclusive",
+                                    "condition": "contains any",
+                                    "values": ["None of the above"]
+                                },
+                                {
+                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                    "condition": "contains any",
+                                    "values": [
+                                        "Paused trading but intends to restart in the next two weeks",
+                                        "Paused trading and does not intend to restart in the next two weeks"
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "when": [
+                                {
+                                    "id": "answer0ebd8695-e6d4-4fe0-b24f-0a50d9ab27eb",
+                                    "condition": "contains any",
+                                    "values": ["No, approach has not changed", "Not sure"]
+                                },
+                                {
+                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                    "condition": "contains any",
+                                    "values": [
+                                        "Paused trading but intends to restart in the next two weeks",
+                                        "Paused trading and does not intend to restart in the next two weeks"
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "when": [
+                                {
+                                    "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe",
+                                    "condition": "contains any",
+                                    "values": ["Requests from customers", "The circumstances were not covered in our existing policies", "Other"]
+                                },
+                                {
+                                    "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe-exclusive",
+                                    "condition": "contains any",
+                                    "values": ["Not sure"]
+                                },
+                                {
+                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                    "condition": "contains any",
+                                    "values": [
+                                        "Paused trading but intends to restart in the next two weeks",
+                                        "Paused trading and does not intend to restart in the next two weeks"
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "when": [
+                                {
+                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                    "condition": "contains any",
+                                    "values": [
+                                        "Paused trading but intends to restart in the next two weeks",
+                                        "Paused trading and does not intend to restart in the next two weeks"
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
         },
         {
             "id": "sectionc4064d34-46d7-43ef-8ff1-52f12500ab4c",
             "title": "Innovation",
-            "groups": [{
-                "id": "groupc4064d34-46d7-43ef-8ff1-52f12500ab4c",
-                "title": "Innovation",
-                "blocks": [{
-                        "type": "Interstitial",
-                        "id": "groupc4064d34-46d7-43ef-8ff1-52f12500ab4c-introduction",
-                        "title": "Innovation",
-                        "description": "<p>This section asks for information about any new or improved innovations made by your business during the coronavirus (COVID-19) pandemic. </p>",
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block63a58106-3671-41b6-b2d1-a353092c214b",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question63a58106-3671-41b6-b2d1-a353092c214b",
-                            "title": "How has {{ metadata['ru_name'] }}&apos;s <em>level of innovation</em> been affected by the coronavirus (COVID-19) pandemic?",
-                            "definitions": [{
-                                "title": "What we mean by \"level of innovation\"",
-                                "content": [{
-                                        "description": "This refers to the level at which your business creates or significantly improves:"
-                                    },
-                                    {
-                                        "list": [
-                                            "goods, materials or services",
-                                            "processes introduced to produce or supply all goods, materials or services",
-                                            "investments for future innovation and organisational practices"
-                                        ]
-                                    }
-                                ]
-                            }],
-                            "type": "General",
-                            "answers": [{
-                                "id": "answere66540a0-a6eb-4dc2-8bb9-3cc2bf518f97",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "112",
-                                "options": [{
-                                        "label": "There has been more innovation",
-                                        "value": "There has been more innovation"
-                                    },
-                                    {
-                                        "label": "Innovation has not been affected",
-                                        "value": "Innovation has not been affected"
-                                    },
-                                    {
-                                        "label": "There has been less innovation",
-                                        "value": "There has been less innovation"
-                                    },
-                                    {
-                                        "label": "Not sure",
-                                        "value": "Not sure"
-                                    },
-                                    {
-                                        "label": "Not applicable",
-                                        "value": "Not applicable"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "block8e65201d-26a2-4a25-b00f-06eda6a70ca3",
-                                    "when": [{
-                                        "id": "answere66540a0-a6eb-4dc2-8bb9-3cc2bf518f97",
-                                        "condition": "contains any",
-                                        "values": ["Not applicable"]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "blockf1adc001-41b0-4898-b3b4-38d3abfacbe3"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "blockf1adc001-41b0-4898-b3b4-38d3abfacbe3",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questionf1adc001-41b0-4898-b3b4-38d3abfacbe3",
-                            "title": "During the coronavirus (COVID-19) pandemic, which of the following did {{ metadata['ru_name'] }} <em>innovate:</em>",
-                            "definitions": [{
-                                "title": "What we mean by \"innovate\"",
-                                "content": [{
-                                        "description": "This refers to your business creating new or significantly improved:"
-                                    },
-                                    {
-                                        "list": [
-                                            "goods, materials or services",
-                                            "processes introduced to produce or supply all goods, materials or services",
-                                            "investments for future innovation and organisational practices"
-                                        ]
-                                    }
-                                ]
-                            }],
-                            "type": "MutuallyExclusive",
-                            "mandatory": true,
-                            "answers": [{
-                                    "id": "answer733f3739-2a76-4b69-acff-6f7542b77158",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "label": "Select all that apply",
-                                    "description": "",
-                                    "options": [{
-                                            "label": "Goods and/or materials",
-                                            "value": "Goods and/or materials",
-                                            "q_code": "1131"
-                                        },
+            "groups": [
+                {
+                    "id": "groupc4064d34-46d7-43ef-8ff1-52f12500ab4c",
+                    "title": "Innovation",
+                    "blocks": [
+                        {
+                            "type": "Interstitial",
+                            "id": "groupc4064d34-46d7-43ef-8ff1-52f12500ab4c-introduction",
+                            "title": "Innovation",
+                            "description": "<p>This section asks for information about any new or improved innovations made by your business during the coronavirus (COVID-19) pandemic. </p>",
+                            "skip_conditions": [
+                                {
+                                    "when": [
                                         {
-                                            "label": "Services",
-                                            "value": "Services",
-                                            "q_code": "1132"
-                                        },
-                                        {
-                                            "label": "Methods of manufacturing  goods, materials or services",
-                                            "value": "Methods of manufacturing  goods, materials or services",
-                                            "q_code": "1133"
-                                        },
-                                        {
-                                            "label": "Methods of logistics, delivery or distribution",
-                                            "value": "Methods of logistics, delivery or distribution",
-                                            "q_code": "1134"
-                                        },
-                                        {
-                                            "label": "Supporting activities for your processes",
-                                            "value": "Supporting activities for your processes",
-                                            "q_code": "1135",
-                                            "description": "For example, maintenance systems or operations for purchasing, accounting, or computing"
-                                        },
-                                        {
-                                            "label": "Not sure",
-                                            "value": "Not sure",
-                                            "q_code": "1136"
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
                                         }
                                     ]
-                                },
-                                {
-                                    "id": "answer733f3739-2a76-4b69-acff-6f7542b77158-exclusive",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "description": "",
-                                    "options": [{
-                                        "label": "None of the above",
-                                        "value": "None of the above",
-                                        "q_code": "1130"
-                                    }]
                                 }
                             ]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block8e65201d-26a2-4a25-b00f-06eda6a70ca3",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question8e65201d-26a2-4a25-b00f-06eda6a70ca3",
-                            "title": "In the <em>next 12 months</em>, does {{ metadata['ru_name'] }} expect to use any of the following forms of intellectual property to protect its <em>innovations</em>?",
-                            "definitions": [{
-                                "title": "What we mean by \"intellectual property\"",
-                                "content": [{
-                                    "description": "This refers to creations of the mind such as inventions, names and images used in commerce, artistic works, designs, and symbols. Intellectual property is protected by law, which enables people and businesses to earn recognition or financial benefit from what they create."
-                                }]
-                            }],
-                            "type": "MutuallyExclusive",
-                            "mandatory": true,
-                            "answers": [{
-                                    "id": "answer4a8f04de-50b1-4d54-8edb-4efc8beddec9",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "label": "Select all that apply",
-                                    "description": "",
-                                    "options": [{
-                                            "label": "Copyright",
-                                            "value": "Copyright",
-                                            "q_code": "1141"
-                                        },
+                        },
+                        {
+                            "id": "block63a58106-3671-41b6-b2d1-a353092c214b",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question63a58106-3671-41b6-b2d1-a353092c214b",
+                                    "title": "How has {{ metadata['ru_name'] }}&apos;s <em>level of innovation</em> been affected by the coronavirus (COVID-19) pandemic?",
+                                    "definitions": [
                                         {
-                                            "label": "Patent",
-                                            "value": "Patent",
-                                            "q_code": "1142"
-                                        },
+                                            "title": "What we mean by \"level of innovation\"",
+                                            "content": [
+                                                {
+                                                    "description": "This refers to the level at which your business creates or significantly improves:"
+                                                },
+                                                {
+                                                    "list": [
+                                                        "goods, materials or services",
+                                                        "processes introduced to produce or supply all goods, materials or services",
+                                                        "investments for future innovation and organisational practices"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
                                         {
-                                            "label": "Registered design",
-                                            "value": "Registered design",
-                                            "q_code": "1143"
-                                        },
-                                        {
-                                            "label": "Trade mark",
-                                            "value": "Trade mark",
-                                            "q_code": "1144"
-                                        },
-                                        {
-                                            "label": "Other",
-                                            "value": "Other",
-                                            "q_code": "1145",
-                                            "detail_answer": {
-                                                "label": "Please describe",
-                                                "type": "TextField",
-                                                "id": "answer488036ea-f833-44cc-877c-19b144ae46f9",
-                                                "mandatory": false
+                                            "id": "answere66540a0-a6eb-4dc2-8bb9-3cc2bf518f97",
+                                            "mandatory": true,
+                                            "type": "Radio",
+                                            "label": "",
+                                            "description": "",
+                                            "q_code": "112",
+                                            "options": [
+                                                {
+                                                    "label": "There has been more innovation",
+                                                    "value": "There has been more innovation"
+                                                },
+                                                {
+                                                    "label": "Innovation has not been affected",
+                                                    "value": "Innovation has not been affected"
+                                                },
+                                                {
+                                                    "label": "There has been less innovation",
+                                                    "value": "There has been less innovation"
+                                                },
+                                                {
+                                                    "label": "Not sure",
+                                                    "value": "Not sure"
+                                                },
+                                                {
+                                                    "label": "Not applicable",
+                                                    "value": "Not applicable"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "block8e65201d-26a2-4a25-b00f-06eda6a70ca3",
+                                        "when": [
+                                            {
+                                                "id": "answere66540a0-a6eb-4dc2-8bb9-3cc2bf518f97",
+                                                "condition": "contains any",
+                                                "values": ["Not applicable"]
                                             }
-                                        },
-                                        {
-                                            "label": "Not sure",
-                                            "value": "Not sure",
-                                            "q_code": "1146"
-                                        }
-                                    ]
+                                        ]
+                                    }
                                 },
                                 {
-                                    "id": "answer4a8f04de-50b1-4d54-8edb-4efc8beddec9-exclusive",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "description": "",
-                                    "options": [{
-                                        "label": "None of the above",
-                                        "value": "None of the above",
-                                        "q_code": "1140"
-                                    }]
+                                    "goto": {
+                                        "block": "blockf1adc001-41b0-4898-b3b4-38d3abfacbe3"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
                                 }
                             ]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    }
-                ],
-                "skip_conditions": [{
-                        "when": [{
-                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                            "condition": "contains any",
-                            "values": ["Permanently ceased trading"]
-                        }]
-                    },
-                    {
-                        "when": [{
-                                "id": "answer399d67d7-f59d-4ab5-ad00-d3b522fb7cd6",
-                                "condition": "contains any",
-                                "values": ["No", "Not sure", "Not applicable"]
-                            },
-                            {
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "contains any",
-                                "values": [
-                                    "Paused trading but intends to restart in the next two weeks",
-                                    "Paused trading and does not intend to restart in the next two weeks"
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        "when": [{
-                                "id": "answere528d417-67e6-4356-b660-107bab6c73f1",
-                                "condition": "contains any",
-                                "values": ["Not sure"]
-                            },
-                            {
-                                "id": "answere528d417-67e6-4356-b660-107bab6c73f1-exclusive",
-                                "condition": "contains any",
-                                "values": ["None of the above"]
-                            },
-                            {
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "contains any",
-                                "values": [
-                                    "Paused trading but intends to restart in the next two weeks",
-                                    "Paused trading and does not intend to restart in the next two weeks"
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        "when": [{
-                                "id": "answer0ebd8695-e6d4-4fe0-b24f-0a50d9ab27eb",
-                                "condition": "contains any",
-                                "values": ["No, approach has not changed", "Not sure"]
-                            },
-                            {
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "contains any",
-                                "values": [
-                                    "Paused trading but intends to restart in the next two weeks",
-                                    "Paused trading and does not intend to restart in the next two weeks"
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        "when": [{
-                                "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe",
-                                "condition": "contains any",
-                                "values": ["Requests from customers", "The circumstances were not covered in our existing policies", "Other"]
-                            },
-                            {
-                                "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe-exclusive",
-                                "condition": "contains any",
-                                "values": ["Not sure"]
-                            },
-                            {
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "contains any",
-                                "values": [
-                                    "Paused trading but intends to restart in the next two weeks",
-                                    "Paused trading and does not intend to restart in the next two weeks"
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        "when": [{
-                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                            "condition": "contains any",
-                            "values": [
-                                "Paused trading but intends to restart in the next two weeks",
-                                "Paused trading and does not intend to restart in the next two weeks"
+                        },
+                        {
+                            "id": "blockf1adc001-41b0-4898-b3b4-38d3abfacbe3",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "questionf1adc001-41b0-4898-b3b4-38d3abfacbe3",
+                                    "title": "During the coronavirus (COVID-19) pandemic, which of the following did {{ metadata['ru_name'] }} <em>innovate:</em>",
+                                    "definitions": [
+                                        {
+                                            "title": "What we mean by \"innovate\"",
+                                            "content": [
+                                                {
+                                                    "description": "This refers to your business creating new or significantly improved:"
+                                                },
+                                                {
+                                                    "list": [
+                                                        "goods, materials or services",
+                                                        "processes introduced to produce or supply all goods, materials or services",
+                                                        "investments for future innovation and organisational practices"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "type": "MutuallyExclusive",
+                                    "mandatory": true,
+                                    "answers": [
+                                        {
+                                            "id": "answer733f3739-2a76-4b69-acff-6f7542b77158",
+                                            "mandatory": false,
+                                            "type": "Checkbox",
+                                            "label": "Select all that apply",
+                                            "description": "",
+                                            "options": [
+                                                {
+                                                    "label": "Goods and/or materials",
+                                                    "value": "Goods and/or materials",
+                                                    "q_code": "1131"
+                                                },
+                                                {
+                                                    "label": "Services",
+                                                    "value": "Services",
+                                                    "q_code": "1132"
+                                                },
+                                                {
+                                                    "label": "Methods of manufacturing  goods, materials or services",
+                                                    "value": "Methods of manufacturing  goods, materials or services",
+                                                    "q_code": "1133"
+                                                },
+                                                {
+                                                    "label": "Methods of logistics, delivery or distribution",
+                                                    "value": "Methods of logistics, delivery or distribution",
+                                                    "q_code": "1134"
+                                                },
+                                                {
+                                                    "label": "Supporting activities for your processes",
+                                                    "value": "Supporting activities for your processes",
+                                                    "q_code": "1135",
+                                                    "description": "For example, maintenance systems or operations for purchasing, accounting, or computing"
+                                                },
+                                                {
+                                                    "label": "Not sure",
+                                                    "value": "Not sure",
+                                                    "q_code": "1136"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "id": "answer733f3739-2a76-4b69-acff-6f7542b77158-exclusive",
+                                            "mandatory": false,
+                                            "type": "Checkbox",
+                                            "description": "",
+                                            "options": [
+                                                {
+                                                    "label": "None of the above",
+                                                    "value": "None of the above",
+                                                    "q_code": "1130"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
                             ]
-                        }]
-                    }
-                ]
-            }]
+                        },
+                        {
+                            "id": "block8e65201d-26a2-4a25-b00f-06eda6a70ca3",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question8e65201d-26a2-4a25-b00f-06eda6a70ca3",
+                                    "title": "In the <em>next 12 months</em>, does {{ metadata['ru_name'] }} expect to use any of the following forms of intellectual property to protect its <em>innovations</em>?",
+                                    "definitions": [
+                                        {
+                                            "title": "What we mean by \"intellectual property\"",
+                                            "content": [
+                                                {
+                                                    "description": "This refers to creations of the mind such as inventions, names and images used in commerce, artistic works, designs, and symbols. Intellectual property is protected by law, which enables people and businesses to earn recognition or financial benefit from what they create."
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "type": "MutuallyExclusive",
+                                    "mandatory": true,
+                                    "answers": [
+                                        {
+                                            "id": "answer4a8f04de-50b1-4d54-8edb-4efc8beddec9",
+                                            "mandatory": false,
+                                            "type": "Checkbox",
+                                            "label": "Select all that apply",
+                                            "description": "",
+                                            "options": [
+                                                {
+                                                    "label": "Copyright",
+                                                    "value": "Copyright",
+                                                    "q_code": "1141"
+                                                },
+                                                {
+                                                    "label": "Patent",
+                                                    "value": "Patent",
+                                                    "q_code": "1142"
+                                                },
+                                                {
+                                                    "label": "Registered design",
+                                                    "value": "Registered design",
+                                                    "q_code": "1143"
+                                                },
+                                                {
+                                                    "label": "Trade mark",
+                                                    "value": "Trade mark",
+                                                    "q_code": "1144"
+                                                },
+                                                {
+                                                    "label": "Other",
+                                                    "value": "Other",
+                                                    "q_code": "1145",
+                                                    "detail_answer": {
+                                                        "label": "Please describe",
+                                                        "type": "TextField",
+                                                        "id": "answer488036ea-f833-44cc-877c-19b144ae46f9",
+                                                        "mandatory": false
+                                                    }
+                                                },
+                                                {
+                                                    "label": "Not sure",
+                                                    "value": "Not sure",
+                                                    "q_code": "1146"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "id": "answer4a8f04de-50b1-4d54-8edb-4efc8beddec9-exclusive",
+                                            "mandatory": false,
+                                            "type": "Checkbox",
+                                            "description": "",
+                                            "options": [
+                                                {
+                                                    "label": "None of the above",
+                                                    "value": "None of the above",
+                                                    "q_code": "1140"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "skip_conditions": [
+                        {
+                            "when": [
+                                {
+                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                    "condition": "contains any",
+                                    "values": ["Permanently ceased trading"]
+                                }
+                            ]
+                        },
+                        {
+                            "when": [
+                                {
+                                    "id": "answer399d67d7-f59d-4ab5-ad00-d3b522fb7cd6",
+                                    "condition": "contains any",
+                                    "values": ["No", "Not sure", "Not applicable"]
+                                },
+                                {
+                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                    "condition": "contains any",
+                                    "values": [
+                                        "Paused trading but intends to restart in the next two weeks",
+                                        "Paused trading and does not intend to restart in the next two weeks"
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "when": [
+                                {
+                                    "id": "answere528d417-67e6-4356-b660-107bab6c73f1",
+                                    "condition": "contains any",
+                                    "values": ["Not sure"]
+                                },
+                                {
+                                    "id": "answere528d417-67e6-4356-b660-107bab6c73f1-exclusive",
+                                    "condition": "contains any",
+                                    "values": ["None of the above"]
+                                },
+                                {
+                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                    "condition": "contains any",
+                                    "values": [
+                                        "Paused trading but intends to restart in the next two weeks",
+                                        "Paused trading and does not intend to restart in the next two weeks"
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "when": [
+                                {
+                                    "id": "answer0ebd8695-e6d4-4fe0-b24f-0a50d9ab27eb",
+                                    "condition": "contains any",
+                                    "values": ["No, approach has not changed", "Not sure"]
+                                },
+                                {
+                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                    "condition": "contains any",
+                                    "values": [
+                                        "Paused trading but intends to restart in the next two weeks",
+                                        "Paused trading and does not intend to restart in the next two weeks"
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "when": [
+                                {
+                                    "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe",
+                                    "condition": "contains any",
+                                    "values": ["Requests from customers", "The circumstances were not covered in our existing policies", "Other"]
+                                },
+                                {
+                                    "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe-exclusive",
+                                    "condition": "contains any",
+                                    "values": ["Not sure"]
+                                },
+                                {
+                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                    "condition": "contains any",
+                                    "values": [
+                                        "Paused trading but intends to restart in the next two weeks",
+                                        "Paused trading and does not intend to restart in the next two weeks"
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "when": [
+                                {
+                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                    "condition": "contains any",
+                                    "values": [
+                                        "Paused trading but intends to restart in the next two weeks",
+                                        "Paused trading and does not intend to restart in the next two weeks"
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
         },
         {
             "id": "section8753dfce-d80c-4fe0-98ba-3cddd52a9bba",
             "title": "Access to financial support",
-            "groups": [{
-                "id": "group8753dfce-d80c-4fe0-98ba-3cddd52a9bba",
-                "title": "Access to financial support",
-                "blocks": [{
-                        "type": "Interstitial",
-                        "id": "group8753dfce-d80c-4fe0-98ba-3cddd52a9bba-introduction",
-                        "title": "Access to financial support",
-                        "description": "<p>This section asks for information on:</p><ul><li>any applications that the business made for government financial initiatives or schemes</li><li>any applications the business intends to make for government initiatives or schemes</li><li>any applications for non-government financial support</li></ul>",
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block2ea33f36-282b-40d4-a881-0d946f8d4408",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question2ea33f36-282b-40d4-a881-0d946f8d4408",
-                            "title": "Has {{ metadata['ru_name'] }} <em>applied</em> for any of the following schemes?",
-                            "type": "MutuallyExclusive",
-                            "mandatory": true,
-                            "answers": [{
-                                    "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "label": "Select all that apply",
-                                    "description": "",
-                                    "options": [{
-                                            "label": "Coronavirus Job Retention Scheme",
-                                            "value": "Coronavirus Job Retention Scheme",
-                                            "q_code": "451",
-                                            "description": "UK Government scheme that covers 80% of pay (up to £2,500 a month) for furloughed staff"
-                                        },
-                                        {
-                                            "label": "Government-backed accredited loans or finance agreements",
-                                            "value": "Government-backed accredited loans or finance agreements",
-                                            "q_code": "4526",
-                                            "description": "For example, COVID Corporate Financing Facility (CCFF), Coronavirus Business Interruption Loan Scheme (CBILS or CLBILS), Bounce Back Loan Scheme (BBLS) or loans from devolved governments"
-                                        },
-                                        {
-                                            "label": "Business grants funded by the UK and devolved governments",
-                                            "value": "Business grants funded by the UK and devolved governments",
-                                            "q_code": "4589",
-                                            "description": "Including small business grant funds and sector-specific grants in England, Wales, Scotland and Northern Ireland"
-                                        }
-                                    ]
-                                },
+            "groups": [
+                {
+                    "id": "group8753dfce-d80c-4fe0-98ba-3cddd52a9bba",
+                    "title": "Access to financial support",
+                    "blocks": [
+                        {
+                            "type": "Interstitial",
+                            "id": "group8753dfce-d80c-4fe0-98ba-3cddd52a9bba-introduction",
+                            "title": "Access to financial support",
+                            "description": "<p>This section asks for information on:</p><ul><li>any applications that the business made for government financial initiatives or schemes</li><li>any applications the business intends to make for government initiatives or schemes</li><li>any applications for non-government financial support</li></ul>",
+                            "skip_conditions": [
                                 {
-                                    "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503-exclusive",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "description": "",
-                                    "options": [{
-                                        "label": "Not applied for any of these schemes",
-                                        "value": "Not applied for any of these schemes",
-                                        "q_code": "457"
-                                    }]
-                                }
-                            ]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "blocke46ad473-b3a0-4791-b658-d3ebcd35e785",
-                                    "when": [{
-                                        "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
-                                        "condition": "contains any",
-                                        "values": ["Government-backed accredited loans or finance agreements"]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block4f715518-d276-4297-b1f5-04f4debbb713",
-                                    "when": [{
-                                        "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
-                                        "condition": "contains any",
-                                        "values": ["Business grants funded by the UK and devolved governments"]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
-                                    "when": [{
-                                        "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
-                                        "condition": "contains all",
-                                        "values": ["Coronavirus Job Retention Scheme"]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "blockd39bd617-f259-488e-baf2-a51905d69b10"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "blocke46ad473-b3a0-4791-b658-d3ebcd35e785",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questione46ad473-b3a0-4791-b658-d3ebcd35e785",
-                            "title": "Did {{ metadata['ru_name'] }} apply for the Development Bank of Wales COVID-19 Business Loan Scheme?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer845b4b07-1ed1-4937-84f1-bd7b347f1cb4",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "78",
-                                "options": [{
-                                        "label": "Yes",
-                                        "value": "Yes"
-                                    },
-                                    {
-                                        "label": "No",
-                                        "value": "No"
-                                    },
-                                    {
-                                        "label": "Not sure",
-                                        "value": "Not sure"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "block4f715518-d276-4297-b1f5-04f4debbb713",
-                                    "when": [{
-                                        "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
-                                        "condition": "contains any",
-                                        "values": ["Business grants funded by the UK and devolved governments"]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
-                                    "when": [{
-                                        "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
-                                        "condition": "contains any",
-                                        "values": ["Coronavirus Job Retention Scheme", "Government-backed accredited loans or finance agreements"]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "blockd39bd617-f259-488e-baf2-a51905d69b10"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block4f715518-d276-4297-b1f5-04f4debbb713",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question4f715518-d276-4297-b1f5-04f4debbb713",
-                            "title": "Which government offered the business <em>grants</em> that you have applied for?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer1f3f22db-c33a-4999-99d8-2333f0c1ad20",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "79",
-                                "options": [{
-                                        "label": "Northern Ireland Executive",
-                                        "value": "Northern Ireland Executive"
-                                    },
-                                    {
-                                        "label": "Scottish Government",
-                                        "value": "Scottish Government"
-                                    },
-                                    {
-                                        "label": "UK Government (England only)",
-                                        "value": "UK Government (England only)"
-                                    },
-                                    {
-                                        "label": "Welsh Government",
-                                        "value": "Welsh Government"
-                                    },
-                                    {
-                                        "label": "Not sure",
-                                        "value": "Not sure"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "block182ef910-1276-449f-9184-bb7d8234e84f",
-                                    "when": [{
-                                        "id": "answer1f3f22db-c33a-4999-99d8-2333f0c1ad20",
-                                        "condition": "contains any",
-                                        "values": ["Welsh Government"]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "blockcfdf7d4f-47d0-428c-b8e0-5ec28fd525c3",
-                                    "when": [{
-                                        "id": "answer1f3f22db-c33a-4999-99d8-2333f0c1ad20",
-                                        "condition": "contains any",
-                                        "values": ["Scottish Government"]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block5f68a3d0-365c-4247-b75e-a2ce7d5fea45",
-                                    "when": [{
-                                        "id": "answer1f3f22db-c33a-4999-99d8-2333f0c1ad20",
-                                        "condition": "contains any",
-                                        "values": ["UK Government (England only)"]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block1be2fd23-e68f-4b5f-9553-d7c8c4e43082",
-                                    "when": [{
-                                        "id": "answer1f3f22db-c33a-4999-99d8-2333f0c1ad20",
-                                        "condition": "contains any",
-                                        "values": ["Northern Ireland Executive"]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
-                                    "when": [{
-                                        "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
-                                        "condition": "contains any",
-                                        "values": ["Coronavirus Job Retention Scheme", "Government-backed accredited loans or finance agreements"]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "blockd39bd617-f259-488e-baf2-a51905d69b10"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block182ef910-1276-449f-9184-bb7d8234e84f",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question182ef910-1276-449f-9184-bb7d8234e84f",
-                            "title": "Which of the following Welsh Government grants did {{ metadata['ru_name'] }} apply for?",
-                            "type": "MutuallyExclusive",
-                            "mandatory": true,
-                            "answers": [{
-                                    "id": "answer9d2c5b50-4e17-4b31-9c3f-3188080a16b2",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "label": "Select all that apply",
-                                    "description": "",
-                                    "options": [{
-                                            "label": "COVID-19 grant for small businesses",
-                                            "value": "COVID-19 grant for small businesses",
-                                            "q_code": "801"
-                                        },
-                                        {
-                                            "label": "Economic Resilience Fund",
-                                            "value": "Economic Resilience Fund",
-                                            "q_code": "802"
-                                        },
-                                        {
-                                            "label": "Sector-specific grants",
-                                            "value": "Sector-specific grants",
-                                            "q_code": "803",
-                                            "description": "For example, retail, hospitality, leisure or fisheries grant"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "id": "answer9d2c5b50-4e17-4b31-9c3f-3188080a16b2-exclusive",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "description": "",
-                                    "options": [{
-                                        "label": "Not applied for any of these grants",
-                                        "value": "Not applied for any of these grants",
-                                        "q_code": "804"
-                                    }]
-                                }
-                            ]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "block525537e6-e6b5-401d-850d-2fe2f8da287a",
-                                    "when": [{
-                                        "id": "answer9d2c5b50-4e17-4b31-9c3f-3188080a16b2",
-                                        "condition": "contains any",
-                                        "values": ["COVID-19 grant for small businesses", "Economic Resilience Fund", "Sector-specific grants"]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
-                                    "when": [{
-                                        "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
-                                        "condition": "contains any",
-                                        "values": ["Coronavirus Job Retention Scheme", "Government-backed accredited loans or finance agreements"]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "blockf3731f81-73c0-4214-a771-3e321785afd7"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block525537e6-e6b5-401d-850d-2fe2f8da287a",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question525537e6-e6b5-401d-850d-2fe2f8da287a",
-                            "title": "Has {{ metadata['ru_name'] }} <em>received</em> funds from any of the following Welsh Government grants?",
-                            "type": "MutuallyExclusive",
-                            "mandatory": true,
-                            "answers": [{
-                                    "id": "answerc812da13-73e9-4f73-a310-c0a78ed38524",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "label": "Select all that apply",
-                                    "description": "",
-                                    "options": [{
-                                            "label": "COVID-19 grant for small businesses",
-                                            "value": "COVID-19 grant for small businesses",
-                                            "q_code": "811"
-                                        },
-                                        {
-                                            "label": "Economic Resilience Fund",
-                                            "value": "Economic Resilience Fund",
-                                            "q_code": "812"
-                                        },
-                                        {
-                                            "label": "Sector-specific grants",
-                                            "value": "Sector-specific grants",
-                                            "q_code": "813",
-                                            "description": "For example, retail, hospitality, leisure or fisheries grant"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "id": "answerc812da13-73e9-4f73-a310-c0a78ed38524-exclusive",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "description": "",
-                                    "options": [{
-                                        "label": "Not received any funds from these grants",
-                                        "value": "Not received any funds from these grants",
-                                        "q_code": "814"
-                                    }]
-                                }
-                            ]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
-                                    "when": [{
-                                        "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
-                                        "condition": "contains any",
-                                        "values": ["Coronavirus Job Retention Scheme", "Government-backed accredited loans or finance agreements"]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "blockf3731f81-73c0-4214-a771-3e321785afd7"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "blockcfdf7d4f-47d0-428c-b8e0-5ec28fd525c3",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questioncfdf7d4f-47d0-428c-b8e0-5ec28fd525c3",
-                            "title": "Which of the following Scottish Government grants did {{ metadata['ru_name'] }} apply for?",
-                            "type": "MutuallyExclusive",
-                            "mandatory": true,
-                            "answers": [{
-                                    "id": "answer9e33a258-d2be-40b8-ad4e-ae55f3d066f1",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "label": "Select all that apply",
-                                    "description": "",
-                                    "options": [{
-                                            "label": "Small Business Support grant",
-                                            "value": "Small Business Support grant",
-                                            "q_code": "821"
-                                        },
-                                        {
-                                            "label": "Pivotal Enterprise Resilience Fund",
-                                            "value": "Pivotal Enterprise Resilience Fund",
-                                            "q_code": "822"
-                                        },
-                                        {
-                                            "label": "Sector-specific grants",
-                                            "value": "Sector-specific grants",
-                                            "q_code": "823",
-                                            "description": "For example, retail, hospitality, leisure or fisheries grant"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "id": "answer9e33a258-d2be-40b8-ad4e-ae55f3d066f1-exclusive",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "description": "",
-                                    "options": [{
-                                        "label": "Not applied for any of these grants",
-                                        "value": "Not applied for any of these grants",
-                                        "q_code": "824"
-                                    }]
-                                }
-                            ]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "blockd19893fd-7edf-405d-a04a-8986f3b691fe",
-                                    "when": [{
-                                        "id": "answer9e33a258-d2be-40b8-ad4e-ae55f3d066f1",
-                                        "condition": "contains any",
-                                        "values": ["Small Business Support grant", "Pivotal Enterprise Resilience Fund", "Sector-specific grants"]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
-                                    "when": [{
-                                        "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
-                                        "condition": "contains any",
-                                        "values": ["Coronavirus Job Retention Scheme", "Government-backed accredited loans or finance agreements"]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "blockf3731f81-73c0-4214-a771-3e321785afd7"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "blockd19893fd-7edf-405d-a04a-8986f3b691fe",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questiond19893fd-7edf-405d-a04a-8986f3b691fe",
-                            "title": "Has {{ metadata['ru_name'] }} <em>received</em> funds from any of the following Scottish Government grants?",
-                            "type": "MutuallyExclusive",
-                            "mandatory": true,
-                            "answers": [{
-                                    "id": "answerb579d6b0-bc9e-4d09-bf39-aed0a1f0ef0b",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "label": "Select all that apply",
-                                    "description": "",
-                                    "options": [{
-                                            "label": "Small Business Support grant",
-                                            "value": "Small Business Support grant",
-                                            "q_code": "831"
-                                        },
-                                        {
-                                            "label": "Pivotal Enterprise Resilience Fund",
-                                            "value": "Pivotal Enterprise Resilience Fund",
-                                            "q_code": "832"
-                                        },
-                                        {
-                                            "label": "Sector-specific grants",
-                                            "value": "Sector-specific grants",
-                                            "q_code": "833",
-                                            "description": "For example, retail, hospitality, leisure or fisheries grant"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "id": "answerb579d6b0-bc9e-4d09-bf39-aed0a1f0ef0b-exclusive",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "description": "",
-                                    "options": [{
-                                        "label": "Not received any funds from these grants",
-                                        "value": "Not received any funds from these grants",
-                                        "q_code": "834"
-                                    }]
-                                }
-                            ]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
-                                    "when": [{
-                                        "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
-                                        "condition": "contains any",
-                                        "values": ["Coronavirus Job Retention Scheme", "Government-backed accredited loans or finance agreements"]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "blockf3731f81-73c0-4214-a771-3e321785afd7"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block5f68a3d0-365c-4247-b75e-a2ce7d5fea45",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question5f68a3d0-365c-4247-b75e-a2ce7d5fea45",
-                            "title": "Which of the following UK Government (England only) grants did {{ metadata['ru_name'] }} apply for?",
-                            "type": "MutuallyExclusive",
-                            "mandatory": true,
-                            "answers": [{
-                                    "id": "answer7a62b279-e8af-498b-bee4-6b861ec5d9f4",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "label": "Select all that apply",
-                                    "description": "",
-                                    "options": [{
-                                            "label": "Small Business Grant Fund (SBGF)",
-                                            "value": "Small Business Grant Fund (SBGF)",
-                                            "q_code": "841"
-                                        },
-                                        {
-                                            "label": "Sector-specific grants",
-                                            "value": "Sector-specific grants",
-                                            "q_code": "842",
-                                            "description": "For example, retail, hospitality, leisure or fisheries grant"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "id": "answer7a62b279-e8af-498b-bee4-6b861ec5d9f4-exclusive",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "description": "",
-                                    "options": [{
-                                        "label": "Not applied for any of these grants",
-                                        "value": "Not applied for any of these grants",
-                                        "q_code": "843"
-                                    }]
-                                }
-                            ]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "block77a8fcf0-6663-4372-8a78-a0eaba692e25",
-                                    "when": [{
-                                        "id": "answer7a62b279-e8af-498b-bee4-6b861ec5d9f4",
-                                        "condition": "contains any",
-                                        "values": ["Small Business Grant Fund (SBGF)", "Sector-specific grants"]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
-                                    "when": [{
-                                        "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
-                                        "condition": "contains any",
-                                        "values": ["Coronavirus Job Retention Scheme", "Government-backed accredited loans or finance agreements"]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "blockf3731f81-73c0-4214-a771-3e321785afd7"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block77a8fcf0-6663-4372-8a78-a0eaba692e25",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question77a8fcf0-6663-4372-8a78-a0eaba692e25",
-                            "title": "Has {{ metadata['ru_name'] }} <em>received</em> funds from any of the following UK Government (England only) grants?",
-                            "type": "MutuallyExclusive",
-                            "mandatory": true,
-                            "answers": [{
-                                    "id": "answer7df0f422-59af-44a2-9de5-35b06645f367",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "label": "Select all that apply",
-                                    "description": "",
-                                    "options": [{
-                                            "label": "Small Business Grant Fund (SBGF)",
-                                            "value": "Small Business Grant Fund (SBGF)",
-                                            "q_code": "851"
-                                        },
-                                        {
-                                            "label": "Sector-specific grants",
-                                            "value": "Sector-specific grants",
-                                            "q_code": "852",
-                                            "description": "For example, retail, hospitality, leisure or fisheries grant"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "id": "answer7df0f422-59af-44a2-9de5-35b06645f367-exclusive",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "description": "",
-                                    "options": [{
-                                        "label": "Not received any funds from these grants",
-                                        "value": "Not received any funds from these grants",
-                                        "q_code": "853"
-                                    }]
-                                }
-                            ]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
-                                    "when": [{
-                                        "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
-                                        "condition": "contains any",
-                                        "values": ["Coronavirus Job Retention Scheme", "Government-backed accredited loans or finance agreements"]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "blockf3731f81-73c0-4214-a771-3e321785afd7"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block1be2fd23-e68f-4b5f-9553-d7c8c4e43082",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question1be2fd23-e68f-4b5f-9553-d7c8c4e43082",
-                            "title": "Which of the following Northern Ireland Executive grants did {{ metadata['ru_name'] }} apply for?",
-                            "type": "MutuallyExclusive",
-                            "mandatory": true,
-                            "answers": [{
-                                    "id": "answer1359bc07-ae5f-452b-8abd-00cfff28b27d",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "label": "Select all that apply",
-                                    "description": "",
-                                    "options": [{
-                                            "label": "Small Business Grant Scheme",
-                                            "value": "Small Business Grant Scheme",
-                                            "q_code": "861"
-                                        },
-                                        {
-                                            "label": "Sector-specific grants",
-                                            "value": "Sector-specific grants",
-                                            "q_code": "862",
-                                            "description": "For example, retail, hospitality, leisure or fisheries grant"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "id": "answer1359bc07-ae5f-452b-8abd-00cfff28b27d-exclusive",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "description": "",
-                                    "options": [{
-                                        "label": "Not applied for any of these grants",
-                                        "value": "Not applied for any of these grants",
-                                        "q_code": "863"
-                                    }]
-                                }
-                            ]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "block08e3e6c9-a572-43c2-ba84-0b984a2ed299",
-                                    "when": [{
-                                        "id": "answer1359bc07-ae5f-452b-8abd-00cfff28b27d",
-                                        "condition": "contains any",
-                                        "values": ["Small Business Grant Scheme", "Sector-specific grants"]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
-                                    "when": [{
-                                        "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
-                                        "condition": "contains any",
-                                        "values": ["Coronavirus Job Retention Scheme", "Government-backed accredited loans or finance agreements"]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "blockf3731f81-73c0-4214-a771-3e321785afd7"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block08e3e6c9-a572-43c2-ba84-0b984a2ed299",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question08e3e6c9-a572-43c2-ba84-0b984a2ed299",
-                            "title": "Has {{ metadata['ru_name'] }} <em>received</em> funds from any of the following Northern Ireland Executive grants?",
-                            "type": "MutuallyExclusive",
-                            "mandatory": true,
-                            "answers": [{
-                                    "id": "answerb1d499f5-1ad6-469a-9ea2-9b48dea1457c",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "label": "Select all that apply",
-                                    "description": "",
-                                    "options": [{
-                                            "label": "Small Business Grant Scheme",
-                                            "value": "Small Business Grant Scheme",
-                                            "q_code": "871"
-                                        },
-                                        {
-                                            "label": "Sector-specific grants",
-                                            "value": "Sector-specific grants",
-                                            "q_code": "872",
-                                            "description": "For example, retail, hospitality, leisure or fisheries grant"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "id": "answerb1d499f5-1ad6-469a-9ea2-9b48dea1457c-exclusive",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "description": "",
-                                    "options": [{
-                                        "label": "Not received any funds from these grants",
-                                        "value": "Not received any funds from these grants",
-                                        "q_code": "873"
-                                    }]
-                                }
-                            ]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
-                                    "when": [{
-                                        "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
-                                        "condition": "contains any",
-                                        "values": ["Coronavirus Job Retention Scheme", "Government-backed accredited loans or finance agreements"]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "blockf3731f81-73c0-4214-a771-3e321785afd7"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questionb305b9d6-b021-4d5e-a92e-291381c49492",
-                            "title": "Has {{ metadata['ru_name'] }} <em>received</em> funds from any of the following schemes?",
-                            "type": "MutuallyExclusive",
-                            "mandatory": true,
-                            "answers": [{
-                                    "id": "answer30aa84e6-07cf-4887-885f-abff7788aefb",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "label": "Select all that apply",
-                                    "description": "",
-                                    "options": [{
-                                            "label": "Coronavirus Job Retention Scheme",
-                                            "value": "Coronavirus Job Retention Scheme",
-                                            "q_code": "461",
-                                            "description": "UK Government scheme that covers 80% of pay (up to £2,500 a month) for furloughed staff"
-                                        },
-                                        {
-                                            "label": "Government-backed accredited loans or finance agreements",
-                                            "value": "Government-backed accredited loans or finance agreements",
-                                            "q_code": "4629",
-                                            "description": "For example, COVID Corporate Financing Facility (CCFF), Coronavirus Business Interruption Loan Scheme (CBILS or CLBILS), Bounce Back Loan Scheme (BBLS) or loans from devolved governments"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "id": "answer30aa84e6-07cf-4887-885f-abff7788aefb-exclusive",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "description": "",
-                                    "options": [{
-                                        "label": "Not received any funds from these schemes",
-                                        "value": "Not received any funds from these schemes",
-                                        "q_code": "467"
-                                    }]
-                                }
-                            ]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "blockf3731f81-73c0-4214-a771-3e321785afd7",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questionf3731f81-73c0-4214-a771-3e321785afd7",
-                            "title": "Please describe your experience of applying for these schemes",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>For example:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "how easy or difficult it was to apply",
-                                            "how you heard about these schemes",
-                                            "if there were any barriers to you applying, such as eligibility",
-                                            "if there was enough guidance about the application process",
-                                            "if you received funding, how long it took"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer96848783-ecc7-4bcb-b8c5-bb807a118585",
-                                "mandatory": true,
-                                "type": "TextArea",
-                                "label": "Comments",
-                                "description": "",
-                                "q_code": "47",
-                                "max_length": 2000
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "blockd39bd617-f259-488e-baf2-a51905d69b10",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questiond39bd617-f259-488e-baf2-a51905d69b10",
-                            "title": "Does {{ metadata['ru_name'] }} expect to use the Coronavirus Job Retention Scheme (CJRS) in the <em>next two weeks</em>?",
-                            "description": "<p>If you have already applied once, and you plan to apply again for the next claim period, select &quot;Yes&quot;.</p>",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer36fe3ff1-cbba-46c6-a548-072c4ff1bd97",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "88",
-                                "options": [{
-                                        "label": "Yes",
-                                        "value": "Yes"
-                                    },
-                                    {
-                                        "label": "No",
-                                        "value": "No"
-                                    },
-                                    {
-                                        "label": "Not sure",
-                                        "value": "Not sure"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block7f5c1f5d-0854-4738-b801-20d9848475c2",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question7f5c1f5d-0854-4738-b801-20d9848475c2",
-                            "title": "Is {{ metadata['ru_name'] }} <em>intending</em> to apply for any of the following schemes?",
-                            "guidance": {
-                                "content": [{
-                                    "description": "Exclude any schemes that your business has already applied for"
-                                }]
-                            },
-                            "type": "MutuallyExclusive",
-                            "mandatory": true,
-                            "answers": [{
-                                    "id": "answerc05c537f-7ef0-426d-bef8-a631236e3baa",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "label": "Select all that apply",
-                                    "description": "",
-                                    "options": [{
-                                            "label": "Government-backed accredited loans or finance agreements",
-                                            "value": "Government-backed accredited loans or finance agreements",
-                                            "q_code": "4816",
-                                            "description": "For example, COVID Corporate Financing Facility (CCFF), Coronavirus Business Interruption Loan Scheme (CBILS or CLBILS), Bounce Back Loan Scheme (BBLS) or loans from devolved governments"
-                                        },
-                                        {
-                                            "label": "Business grants funded by the UK and devolved governments",
-                                            "value": "Business grants funded by the UK and devolved governments",
-                                            "q_code": "4889",
-                                            "description": "Include small business grant funds and sector-specific grants in England, Wales, Scotland and Northern Ireland"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "id": "answerc05c537f-7ef0-426d-bef8-a631236e3baa-exclusive",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "description": "",
-                                    "options": [{
-                                        "label": "Not intending to apply for any of these schemes",
-                                        "value": "Not intending to apply for any of these schemes",
-                                        "q_code": "487"
-                                    }]
-                                }
-                            ]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block707c4125-b078-4bf4-a5a7-4e98987640e0",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question707c4125-b078-4bf4-a5a7-4e98987640e0",
-                            "title": "Is {{ metadata['ru_name'] }} using any of the following <em>initiatives</em>?",
-                            "type": "MutuallyExclusive",
-                            "mandatory": true,
-                            "answers": [{
-                                    "id": "answerf6103d5e-1a15-43d7-be56-1c4dcc960b3a",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "label": "Select all that apply",
-                                    "description": "",
-                                    "options": [{
-                                            "label": "Business rates holiday",
-                                            "value": "Business rates holiday",
-                                            "q_code": "891"
-                                        },
-                                        {
-                                            "label": "Deferring VAT payments",
-                                            "value": "Deferring VAT payments",
-                                            "q_code": "892"
-                                        },
-                                        {
-                                            "label": "HMRC Time To Pay scheme",
-                                            "value": "HMRC Time To Pay scheme",
-                                            "q_code": "893"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "id": "answerf6103d5e-1a15-43d7-be56-1c4dcc960b3a-exclusive",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "description": "",
-                                    "options": [{
-                                        "label": "Not using any of these initiatives",
-                                        "value": "Not using any of these initiatives",
-                                        "q_code": "894"
-                                    }]
-                                }
-                            ]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block7a8cfd94-755c-4742-acfa-ca10a4c1cb87",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question7a8cfd94-755c-4742-acfa-ca10a4c1cb87",
-                            "title": "Is {{ metadata['ru_name'] }} <em>intending</em> to use any of the following <em>initiatives</em>?",
-                            "guidance": {
-                                "content": [{
-                                    "description": "Exclude any initiatives that your business is already using"
-                                }]
-                            },
-                            "type": "MutuallyExclusive",
-                            "mandatory": true,
-                            "answers": [{
-                                    "id": "answer6a654fac-abea-4b0d-8ca3-bf7340faa559",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "label": "Select all that apply",
-                                    "description": "",
-                                    "options": [{
-                                            "label": "Business rates holiday",
-                                            "value": "Business rates holiday",
-                                            "q_code": "901"
-                                        },
-                                        {
-                                            "label": "Deferring VAT payments",
-                                            "value": "Deferring VAT payments",
-                                            "q_code": "902"
-                                        },
-                                        {
-                                            "label": "HMRC Time To Pay scheme",
-                                            "value": "HMRC Time To Pay scheme",
-                                            "q_code": "903"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "id": "answer6a654fac-abea-4b0d-8ca3-bf7340faa559-exclusive",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "description": "",
-                                    "options": [{
-                                        "label": "Not intending to use any of these initiatives",
-                                        "value": "Not intending to use any of these initiatives",
-                                        "q_code": "904"
-                                    }]
-                                }
-                            ]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "block4fc906bb-a55c-497a-8bd0-5427d69dc055",
-                                    "when": [{
-                                        "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                        "condition": "contains any",
-                                        "values": [
-                                            "Paused trading but intends to restart in the next two weeks",
-                                            "Paused trading and does not intend to restart in the next two weeks"
-                                        ]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block35d5f073-97cd-460f-aa2e-1dd068c6f6ff",
-                                    "when": [{
-                                        "id": "answerc812da13-73e9-4f73-a310-c0a78ed38524",
-                                        "condition": "contains any",
-                                        "values": ["COVID-19 grant for small businesses", "Economic Resilience Fund", "Sector-specific grants"]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block35d5f073-97cd-460f-aa2e-1dd068c6f6ff",
-                                    "when": [{
-                                        "id": "answerb579d6b0-bc9e-4d09-bf39-aed0a1f0ef0b",
-                                        "condition": "contains any",
-                                        "values": ["Small Business Support grant", "Pivotal Enterprise Resilience Fund", "Sector-specific grants"]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block35d5f073-97cd-460f-aa2e-1dd068c6f6ff",
-                                    "when": [{
-                                        "id": "answer7df0f422-59af-44a2-9de5-35b06645f367",
-                                        "condition": "contains any",
-                                        "values": ["Small Business Grant Fund (SBGF)", "Sector-specific grants"]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block35d5f073-97cd-460f-aa2e-1dd068c6f6ff",
-                                    "when": [{
-                                        "id": "answerb1d499f5-1ad6-469a-9ea2-9b48dea1457c",
-                                        "condition": "contains any",
-                                        "values": ["Small Business Grant Scheme", "Sector-specific grants"]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block35d5f073-97cd-460f-aa2e-1dd068c6f6ff",
-                                    "when": [{
-                                        "id": "answer30aa84e6-07cf-4887-885f-abff7788aefb",
-                                        "condition": "contains any",
-                                        "values": ["Coronavirus Job Retention Scheme", "Government-backed accredited loans or finance agreements"]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block35d5f073-97cd-460f-aa2e-1dd068c6f6ff",
-                                    "when": [{
-                                        "id": "answerf6103d5e-1a15-43d7-be56-1c4dcc960b3a",
-                                        "condition": "contains any",
-                                        "values": ["Business rates holiday", "Deferring VAT payments", "HMRC Time To Pay scheme"]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block4fc906bb-a55c-497a-8bd0-5427d69dc055"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block35d5f073-97cd-460f-aa2e-1dd068c6f6ff",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question35d5f073-97cd-460f-aa2e-1dd068c6f6ff",
-                            "title": "Did the support received from these <em>initiatives</em> or <em>schemes</em> help {{ metadata['ru_name'] }} continue trading?",
-                            "guidance": {
-                                "content": [{
-                                    "description": "Include any grants or loans from government"
-                                }]
-                            },
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer147a73c6-2ec3-404a-8d63-d58dd8aae8eb",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "91",
-                                "options": [{
-                                        "label": "Yes, it helped us to continue trading",
-                                        "value": "Yes, it helped us to continue trading"
-                                    },
-                                    {
-                                        "label": "No, it did not impact our ability to continue trading",
-                                        "value": "No, it did not impact our ability to continue trading"
-                                    },
-                                    {
-                                        "label": "Not sure",
-                                        "value": "Not sure"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block4fc906bb-a55c-497a-8bd0-5427d69dc055",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question4fc906bb-a55c-497a-8bd0-5427d69dc055",
-                            "title": "Please describe any other support from government that you think could help {{ metadata['ru_name'] }}",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answere5a0ad55-8183-4fb2-8b35-29442de9c916",
-                                "mandatory": false,
-                                "type": "TextArea",
-                                "label": "Comments",
-                                "description": "",
-                                "q_code": "49",
-                                "max_length": 2000
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block1633314b-b819-4309-917a-1a5d44940027",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question1633314b-b819-4309-917a-1a5d44940027",
-                            "title": "Has {{ metadata['ru_name'] }} <em>received</em> any other financial assistance from banks or building societies?",
-                            "guidance": {
-                                "content": [{
-                                    "description": "Exclude government-backed loans"
-                                }]
-                            },
-                            "definitions": [{
-                                "title": "Examples of financial assistance from banks or building societies",
-                                "content": [{
-                                    "list": [
-                                        "Loans or emergency loans",
-                                        "Commercial mortgage payment holidays",
-                                        "Outstanding loans repayment holidays",
-                                        "Increase in business credit card and overdraft limits"
-                                    ]
-                                }]
-                            }],
-                            "type": "General",
-                            "answers": [{
-                                "id": "answere72a6e53-f48d-4cf9-ad57-a4f99f2511f5",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "92",
-                                "options": [{
-                                        "label": "Yes",
-                                        "value": "Yes"
-                                    },
-                                    {
-                                        "label": "No",
-                                        "value": "No"
-                                    },
-                                    {
-                                        "label": "Not sure",
-                                        "value": "Not sure"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "block18da18a3-82ce-4b60-a710-fe4f4b1e90f6",
-                                    "when": [{
-                                            "id": "answere72a6e53-f48d-4cf9-ad57-a4f99f2511f5",
-                                            "condition": "contains any",
-                                            "values": ["Yes"]
-                                        },
+                                    "when": [
                                         {
                                             "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "contains any",
-                                            "values": [
-                                                "Currently trading and has been for more than the last two weeks",
-                                                "Started trading within the last two weeks after a pause in trading"
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block2ea33f36-282b-40d4-a881-0d946f8d4408",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question2ea33f36-282b-40d4-a881-0d946f8d4408",
+                                    "title": "Has {{ metadata['ru_name'] }} <em>applied</em> for any of the following schemes?",
+                                    "type": "MutuallyExclusive",
+                                    "mandatory": true,
+                                    "answers": [
+                                        {
+                                            "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
+                                            "mandatory": false,
+                                            "type": "Checkbox",
+                                            "label": "Select all that apply",
+                                            "description": "",
+                                            "options": [
+                                                {
+                                                    "label": "Coronavirus Job Retention Scheme",
+                                                    "value": "Coronavirus Job Retention Scheme",
+                                                    "q_code": "451",
+                                                    "description": "UK Government scheme that covers 80% of pay (up to £2,500 a month) for furloughed staff"
+                                                },
+                                                {
+                                                    "label": "Government-backed accredited loans or finance agreements",
+                                                    "value": "Government-backed accredited loans or finance agreements",
+                                                    "q_code": "4526",
+                                                    "description": "For example, COVID Corporate Financing Facility (CCFF), Coronavirus Business Interruption Loan Scheme (CBILS or CLBILS), Bounce Back Loan Scheme (BBLS) or loans from devolved governments"
+                                                },
+                                                {
+                                                    "label": "Business grants funded by the UK and devolved governments",
+                                                    "value": "Business grants funded by the UK and devolved governments",
+                                                    "q_code": "4589",
+                                                    "description": "Including small business grant funds and sector-specific grants in England, Wales, Scotland and Northern Ireland"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503-exclusive",
+                                            "mandatory": false,
+                                            "type": "Checkbox",
+                                            "description": "",
+                                            "options": [
+                                                {
+                                                    "label": "Not applied for any of these schemes",
+                                                    "value": "Not applied for any of these schemes",
+                                                    "q_code": "457"
+                                                }
                                             ]
                                         }
                                     ]
                                 }
-                            },
-                            {
-                                "goto": {
-                                    "block": "blocka2d0a9ef-9bfc-4ead-867f-bad93d6a3bca"
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "blocke46ad473-b3a0-4791-b658-d3ebcd35e785",
+                                        "when": [
+                                            {
+                                                "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
+                                                "condition": "contains any",
+                                                "values": ["Government-backed accredited loans or finance agreements"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "block4f715518-d276-4297-b1f5-04f4debbb713",
+                                        "when": [
+                                            {
+                                                "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
+                                                "condition": "contains any",
+                                                "values": ["Business grants funded by the UK and devolved governments"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
+                                        "when": [
+                                            {
+                                                "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
+                                                "condition": "contains all",
+                                                "values": ["Coronavirus Job Retention Scheme"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "blockd39bd617-f259-488e-baf2-a51905d69b10"
+                                    }
                                 }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block18da18a3-82ce-4b60-a710-fe4f4b1e90f6",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question18da18a3-82ce-4b60-a710-fe4f4b1e90f6",
-                            "title": "Did the financial assistance received from banks or building societies help {{ metadata['ru_name'] }} continue trading?",
-                            "guidance": {
-                                "content": [{
-                                    "description": "Exclude government-backed loans"
-                                }]
-                            },
-                            "type": "General",
-                            "answers": [{
-                                "id": "answerfcef18bf-decf-4b70-a94c-c7c04c188c0b",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "93",
-                                "options": [{
-                                        "label": "Yes, it helped us to continue trading",
-                                        "value": "Yes, it helped us to continue trading"
-                                    },
-                                    {
-                                        "label": "No, it did not impact our ability to continue trading",
-                                        "value": "No, it did not impact our ability to continue trading"
-                                    },
-                                    {
-                                        "label": "Not sure",
-                                        "value": "Not sure"
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "blocke46ad473-b3a0-4791-b658-d3ebcd35e785",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "questione46ad473-b3a0-4791-b658-d3ebcd35e785",
+                                    "title": "Did {{ metadata['ru_name'] }} apply for the Development Bank of Wales COVID-19 Business Loan Scheme?",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer845b4b07-1ed1-4937-84f1-bd7b347f1cb4",
+                                            "mandatory": true,
+                                            "type": "Radio",
+                                            "label": "",
+                                            "description": "",
+                                            "q_code": "78",
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                },
+                                                {
+                                                    "label": "Not sure",
+                                                    "value": "Not sure"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "block4f715518-d276-4297-b1f5-04f4debbb713",
+                                        "when": [
+                                            {
+                                                "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
+                                                "condition": "contains any",
+                                                "values": ["Business grants funded by the UK and devolved governments"]
+                                            }
+                                        ]
                                     }
-                                ]
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "blocka2d0a9ef-9bfc-4ead-867f-bad93d6a3bca",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questiona2d0a9ef-9bfc-4ead-867f-bad93d6a3bca",
-                            "title": "How long do you think {{ metadata['ru_name'] }}&apos;s cash reserves will last?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer32a38f2a-e599-4ff7-9df9-b0419be84b96",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "73",
-                                "options": [{
-                                        "label": "No cash reserves",
-                                        "value": "No cash reserves"
-                                    },
-                                    {
-                                        "label": "Less than 1 month",
-                                        "value": "Less than 1 month"
-                                    },
-                                    {
-                                        "label": "1 to 3 months",
-                                        "value": "1 to 3 months"
-                                    },
-                                    {
-                                        "label": "4 to 6 months",
-                                        "value": "4 to 6 months"
-                                    },
-                                    {
-                                        "label": "More than 6 months",
-                                        "value": "More than 6 months"
-                                    },
-                                    {
-                                        "label": "Not sure",
-                                        "value": "Not sure"
+                                },
+                                {
+                                    "goto": {
+                                        "block": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
+                                        "when": [
+                                            {
+                                                "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
+                                                "condition": "contains any",
+                                                "values": ["Coronavirus Job Retention Scheme", "Government-backed accredited loans or finance agreements"]
+                                            }
+                                        ]
                                     }
-                                ]
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    }
-                ],
-                "skip_conditions": [{
-                    "when": [{
-                        "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                        "condition": "contains any",
-                        "values": ["Permanently ceased trading"]
-                    }]
-                }]
-            }]
+                                },
+                                {
+                                    "goto": {
+                                        "block": "blockd39bd617-f259-488e-baf2-a51905d69b10"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block4f715518-d276-4297-b1f5-04f4debbb713",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question4f715518-d276-4297-b1f5-04f4debbb713",
+                                    "title": "Which government offered the business <em>grants</em> that you have applied for?",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer1f3f22db-c33a-4999-99d8-2333f0c1ad20",
+                                            "mandatory": true,
+                                            "type": "Radio",
+                                            "label": "",
+                                            "description": "",
+                                            "q_code": "79",
+                                            "options": [
+                                                {
+                                                    "label": "Northern Ireland Executive",
+                                                    "value": "Northern Ireland Executive"
+                                                },
+                                                {
+                                                    "label": "Scottish Government",
+                                                    "value": "Scottish Government"
+                                                },
+                                                {
+                                                    "label": "UK Government (England only)",
+                                                    "value": "UK Government (England only)"
+                                                },
+                                                {
+                                                    "label": "Welsh Government",
+                                                    "value": "Welsh Government"
+                                                },
+                                                {
+                                                    "label": "Not sure",
+                                                    "value": "Not sure"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "block182ef910-1276-449f-9184-bb7d8234e84f",
+                                        "when": [
+                                            {
+                                                "id": "answer1f3f22db-c33a-4999-99d8-2333f0c1ad20",
+                                                "condition": "contains any",
+                                                "values": ["Welsh Government"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "blockcfdf7d4f-47d0-428c-b8e0-5ec28fd525c3",
+                                        "when": [
+                                            {
+                                                "id": "answer1f3f22db-c33a-4999-99d8-2333f0c1ad20",
+                                                "condition": "contains any",
+                                                "values": ["Scottish Government"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "block5f68a3d0-365c-4247-b75e-a2ce7d5fea45",
+                                        "when": [
+                                            {
+                                                "id": "answer1f3f22db-c33a-4999-99d8-2333f0c1ad20",
+                                                "condition": "contains any",
+                                                "values": ["UK Government (England only)"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "block1be2fd23-e68f-4b5f-9553-d7c8c4e43082",
+                                        "when": [
+                                            {
+                                                "id": "answer1f3f22db-c33a-4999-99d8-2333f0c1ad20",
+                                                "condition": "contains any",
+                                                "values": ["Northern Ireland Executive"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
+                                        "when": [
+                                            {
+                                                "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
+                                                "condition": "contains any",
+                                                "values": ["Coronavirus Job Retention Scheme", "Government-backed accredited loans or finance agreements"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "blockd39bd617-f259-488e-baf2-a51905d69b10"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block182ef910-1276-449f-9184-bb7d8234e84f",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question182ef910-1276-449f-9184-bb7d8234e84f",
+                                    "title": "Which of the following Welsh Government grants did {{ metadata['ru_name'] }} apply for?",
+                                    "type": "MutuallyExclusive",
+                                    "mandatory": true,
+                                    "answers": [
+                                        {
+                                            "id": "answer9d2c5b50-4e17-4b31-9c3f-3188080a16b2",
+                                            "mandatory": false,
+                                            "type": "Checkbox",
+                                            "label": "Select all that apply",
+                                            "description": "",
+                                            "options": [
+                                                {
+                                                    "label": "COVID-19 grant for small businesses",
+                                                    "value": "COVID-19 grant for small businesses",
+                                                    "q_code": "801"
+                                                },
+                                                {
+                                                    "label": "Economic Resilience Fund",
+                                                    "value": "Economic Resilience Fund",
+                                                    "q_code": "802"
+                                                },
+                                                {
+                                                    "label": "Sector-specific grants",
+                                                    "value": "Sector-specific grants",
+                                                    "q_code": "803",
+                                                    "description": "For example, retail, hospitality, leisure or fisheries grant"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "id": "answer9d2c5b50-4e17-4b31-9c3f-3188080a16b2-exclusive",
+                                            "mandatory": false,
+                                            "type": "Checkbox",
+                                            "description": "",
+                                            "options": [
+                                                {
+                                                    "label": "Not applied for any of these grants",
+                                                    "value": "Not applied for any of these grants",
+                                                    "q_code": "804"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "block525537e6-e6b5-401d-850d-2fe2f8da287a",
+                                        "when": [
+                                            {
+                                                "id": "answer9d2c5b50-4e17-4b31-9c3f-3188080a16b2",
+                                                "condition": "contains any",
+                                                "values": ["COVID-19 grant for small businesses", "Economic Resilience Fund", "Sector-specific grants"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
+                                        "when": [
+                                            {
+                                                "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
+                                                "condition": "contains any",
+                                                "values": ["Coronavirus Job Retention Scheme", "Government-backed accredited loans or finance agreements"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "blockf3731f81-73c0-4214-a771-3e321785afd7"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block525537e6-e6b5-401d-850d-2fe2f8da287a",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question525537e6-e6b5-401d-850d-2fe2f8da287a",
+                                    "title": "Has {{ metadata['ru_name'] }} <em>received</em> funds from any of the following Welsh Government grants?",
+                                    "type": "MutuallyExclusive",
+                                    "mandatory": true,
+                                    "answers": [
+                                        {
+                                            "id": "answerc812da13-73e9-4f73-a310-c0a78ed38524",
+                                            "mandatory": false,
+                                            "type": "Checkbox",
+                                            "label": "Select all that apply",
+                                            "description": "",
+                                            "options": [
+                                                {
+                                                    "label": "COVID-19 grant for small businesses",
+                                                    "value": "COVID-19 grant for small businesses",
+                                                    "q_code": "811"
+                                                },
+                                                {
+                                                    "label": "Economic Resilience Fund",
+                                                    "value": "Economic Resilience Fund",
+                                                    "q_code": "812"
+                                                },
+                                                {
+                                                    "label": "Sector-specific grants",
+                                                    "value": "Sector-specific grants",
+                                                    "q_code": "813",
+                                                    "description": "For example, retail, hospitality, leisure or fisheries grant"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "id": "answerc812da13-73e9-4f73-a310-c0a78ed38524-exclusive",
+                                            "mandatory": false,
+                                            "type": "Checkbox",
+                                            "description": "",
+                                            "options": [
+                                                {
+                                                    "label": "Not received any funds from these grants",
+                                                    "value": "Not received any funds from these grants",
+                                                    "q_code": "814"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
+                                        "when": [
+                                            {
+                                                "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
+                                                "condition": "contains any",
+                                                "values": ["Coronavirus Job Retention Scheme", "Government-backed accredited loans or finance agreements"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "blockf3731f81-73c0-4214-a771-3e321785afd7"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "blockcfdf7d4f-47d0-428c-b8e0-5ec28fd525c3",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "questioncfdf7d4f-47d0-428c-b8e0-5ec28fd525c3",
+                                    "title": "Which of the following Scottish Government grants did {{ metadata['ru_name'] }} apply for?",
+                                    "type": "MutuallyExclusive",
+                                    "mandatory": true,
+                                    "answers": [
+                                        {
+                                            "id": "answer9e33a258-d2be-40b8-ad4e-ae55f3d066f1",
+                                            "mandatory": false,
+                                            "type": "Checkbox",
+                                            "label": "Select all that apply",
+                                            "description": "",
+                                            "options": [
+                                                {
+                                                    "label": "Small Business Support grant",
+                                                    "value": "Small Business Support grant",
+                                                    "q_code": "821"
+                                                },
+                                                {
+                                                    "label": "Pivotal Enterprise Resilience Fund",
+                                                    "value": "Pivotal Enterprise Resilience Fund",
+                                                    "q_code": "822"
+                                                },
+                                                {
+                                                    "label": "Sector-specific grants",
+                                                    "value": "Sector-specific grants",
+                                                    "q_code": "823",
+                                                    "description": "For example, retail, hospitality, leisure or fisheries grant"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "id": "answer9e33a258-d2be-40b8-ad4e-ae55f3d066f1-exclusive",
+                                            "mandatory": false,
+                                            "type": "Checkbox",
+                                            "description": "",
+                                            "options": [
+                                                {
+                                                    "label": "Not applied for any of these grants",
+                                                    "value": "Not applied for any of these grants",
+                                                    "q_code": "824"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "blockd19893fd-7edf-405d-a04a-8986f3b691fe",
+                                        "when": [
+                                            {
+                                                "id": "answer9e33a258-d2be-40b8-ad4e-ae55f3d066f1",
+                                                "condition": "contains any",
+                                                "values": ["Small Business Support grant", "Pivotal Enterprise Resilience Fund", "Sector-specific grants"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
+                                        "when": [
+                                            {
+                                                "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
+                                                "condition": "contains any",
+                                                "values": ["Coronavirus Job Retention Scheme", "Government-backed accredited loans or finance agreements"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "blockf3731f81-73c0-4214-a771-3e321785afd7"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "blockd19893fd-7edf-405d-a04a-8986f3b691fe",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "questiond19893fd-7edf-405d-a04a-8986f3b691fe",
+                                    "title": "Has {{ metadata['ru_name'] }} <em>received</em> funds from any of the following Scottish Government grants?",
+                                    "type": "MutuallyExclusive",
+                                    "mandatory": true,
+                                    "answers": [
+                                        {
+                                            "id": "answerb579d6b0-bc9e-4d09-bf39-aed0a1f0ef0b",
+                                            "mandatory": false,
+                                            "type": "Checkbox",
+                                            "label": "Select all that apply",
+                                            "description": "",
+                                            "options": [
+                                                {
+                                                    "label": "Small Business Support grant",
+                                                    "value": "Small Business Support grant",
+                                                    "q_code": "831"
+                                                },
+                                                {
+                                                    "label": "Pivotal Enterprise Resilience Fund",
+                                                    "value": "Pivotal Enterprise Resilience Fund",
+                                                    "q_code": "832"
+                                                },
+                                                {
+                                                    "label": "Sector-specific grants",
+                                                    "value": "Sector-specific grants",
+                                                    "q_code": "833",
+                                                    "description": "For example, retail, hospitality, leisure or fisheries grant"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "id": "answerb579d6b0-bc9e-4d09-bf39-aed0a1f0ef0b-exclusive",
+                                            "mandatory": false,
+                                            "type": "Checkbox",
+                                            "description": "",
+                                            "options": [
+                                                {
+                                                    "label": "Not received any funds from these grants",
+                                                    "value": "Not received any funds from these grants",
+                                                    "q_code": "834"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
+                                        "when": [
+                                            {
+                                                "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
+                                                "condition": "contains any",
+                                                "values": ["Coronavirus Job Retention Scheme", "Government-backed accredited loans or finance agreements"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "blockf3731f81-73c0-4214-a771-3e321785afd7"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block5f68a3d0-365c-4247-b75e-a2ce7d5fea45",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question5f68a3d0-365c-4247-b75e-a2ce7d5fea45",
+                                    "title": "Which of the following UK Government (England only) grants did {{ metadata['ru_name'] }} apply for?",
+                                    "type": "MutuallyExclusive",
+                                    "mandatory": true,
+                                    "answers": [
+                                        {
+                                            "id": "answer7a62b279-e8af-498b-bee4-6b861ec5d9f4",
+                                            "mandatory": false,
+                                            "type": "Checkbox",
+                                            "label": "Select all that apply",
+                                            "description": "",
+                                            "options": [
+                                                {
+                                                    "label": "Small Business Grant Fund (SBGF)",
+                                                    "value": "Small Business Grant Fund (SBGF)",
+                                                    "q_code": "841"
+                                                },
+                                                {
+                                                    "label": "Sector-specific grants",
+                                                    "value": "Sector-specific grants",
+                                                    "q_code": "842",
+                                                    "description": "For example, retail, hospitality, leisure or fisheries grant"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "id": "answer7a62b279-e8af-498b-bee4-6b861ec5d9f4-exclusive",
+                                            "mandatory": false,
+                                            "type": "Checkbox",
+                                            "description": "",
+                                            "options": [
+                                                {
+                                                    "label": "Not applied for any of these grants",
+                                                    "value": "Not applied for any of these grants",
+                                                    "q_code": "843"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "block77a8fcf0-6663-4372-8a78-a0eaba692e25",
+                                        "when": [
+                                            {
+                                                "id": "answer7a62b279-e8af-498b-bee4-6b861ec5d9f4",
+                                                "condition": "contains any",
+                                                "values": ["Small Business Grant Fund (SBGF)", "Sector-specific grants"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
+                                        "when": [
+                                            {
+                                                "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
+                                                "condition": "contains any",
+                                                "values": ["Coronavirus Job Retention Scheme", "Government-backed accredited loans or finance agreements"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "blockf3731f81-73c0-4214-a771-3e321785afd7"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block77a8fcf0-6663-4372-8a78-a0eaba692e25",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question77a8fcf0-6663-4372-8a78-a0eaba692e25",
+                                    "title": "Has {{ metadata['ru_name'] }} <em>received</em> funds from any of the following UK Government (England only) grants?",
+                                    "type": "MutuallyExclusive",
+                                    "mandatory": true,
+                                    "answers": [
+                                        {
+                                            "id": "answer7df0f422-59af-44a2-9de5-35b06645f367",
+                                            "mandatory": false,
+                                            "type": "Checkbox",
+                                            "label": "Select all that apply",
+                                            "description": "",
+                                            "options": [
+                                                {
+                                                    "label": "Small Business Grant Fund (SBGF)",
+                                                    "value": "Small Business Grant Fund (SBGF)",
+                                                    "q_code": "851"
+                                                },
+                                                {
+                                                    "label": "Sector-specific grants",
+                                                    "value": "Sector-specific grants",
+                                                    "q_code": "852",
+                                                    "description": "For example, retail, hospitality, leisure or fisheries grant"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "id": "answer7df0f422-59af-44a2-9de5-35b06645f367-exclusive",
+                                            "mandatory": false,
+                                            "type": "Checkbox",
+                                            "description": "",
+                                            "options": [
+                                                {
+                                                    "label": "Not received any funds from these grants",
+                                                    "value": "Not received any funds from these grants",
+                                                    "q_code": "853"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
+                                        "when": [
+                                            {
+                                                "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
+                                                "condition": "contains any",
+                                                "values": ["Coronavirus Job Retention Scheme", "Government-backed accredited loans or finance agreements"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "blockf3731f81-73c0-4214-a771-3e321785afd7"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block1be2fd23-e68f-4b5f-9553-d7c8c4e43082",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question1be2fd23-e68f-4b5f-9553-d7c8c4e43082",
+                                    "title": "Which of the following Northern Ireland Executive grants did {{ metadata['ru_name'] }} apply for?",
+                                    "type": "MutuallyExclusive",
+                                    "mandatory": true,
+                                    "answers": [
+                                        {
+                                            "id": "answer1359bc07-ae5f-452b-8abd-00cfff28b27d",
+                                            "mandatory": false,
+                                            "type": "Checkbox",
+                                            "label": "Select all that apply",
+                                            "description": "",
+                                            "options": [
+                                                {
+                                                    "label": "Small Business Grant Scheme",
+                                                    "value": "Small Business Grant Scheme",
+                                                    "q_code": "861"
+                                                },
+                                                {
+                                                    "label": "Sector-specific grants",
+                                                    "value": "Sector-specific grants",
+                                                    "q_code": "862",
+                                                    "description": "For example, retail, hospitality, leisure or fisheries grant"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "id": "answer1359bc07-ae5f-452b-8abd-00cfff28b27d-exclusive",
+                                            "mandatory": false,
+                                            "type": "Checkbox",
+                                            "description": "",
+                                            "options": [
+                                                {
+                                                    "label": "Not applied for any of these grants",
+                                                    "value": "Not applied for any of these grants",
+                                                    "q_code": "863"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "block08e3e6c9-a572-43c2-ba84-0b984a2ed299",
+                                        "when": [
+                                            {
+                                                "id": "answer1359bc07-ae5f-452b-8abd-00cfff28b27d",
+                                                "condition": "contains any",
+                                                "values": ["Small Business Grant Scheme", "Sector-specific grants"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
+                                        "when": [
+                                            {
+                                                "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
+                                                "condition": "contains any",
+                                                "values": ["Coronavirus Job Retention Scheme", "Government-backed accredited loans or finance agreements"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "blockf3731f81-73c0-4214-a771-3e321785afd7"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block08e3e6c9-a572-43c2-ba84-0b984a2ed299",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question08e3e6c9-a572-43c2-ba84-0b984a2ed299",
+                                    "title": "Has {{ metadata['ru_name'] }} <em>received</em> funds from any of the following Northern Ireland Executive grants?",
+                                    "type": "MutuallyExclusive",
+                                    "mandatory": true,
+                                    "answers": [
+                                        {
+                                            "id": "answerb1d499f5-1ad6-469a-9ea2-9b48dea1457c",
+                                            "mandatory": false,
+                                            "type": "Checkbox",
+                                            "label": "Select all that apply",
+                                            "description": "",
+                                            "options": [
+                                                {
+                                                    "label": "Small Business Grant Scheme",
+                                                    "value": "Small Business Grant Scheme",
+                                                    "q_code": "871"
+                                                },
+                                                {
+                                                    "label": "Sector-specific grants",
+                                                    "value": "Sector-specific grants",
+                                                    "q_code": "872",
+                                                    "description": "For example, retail, hospitality, leisure or fisheries grant"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "id": "answerb1d499f5-1ad6-469a-9ea2-9b48dea1457c-exclusive",
+                                            "mandatory": false,
+                                            "type": "Checkbox",
+                                            "description": "",
+                                            "options": [
+                                                {
+                                                    "label": "Not received any funds from these grants",
+                                                    "value": "Not received any funds from these grants",
+                                                    "q_code": "873"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
+                                        "when": [
+                                            {
+                                                "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
+                                                "condition": "contains any",
+                                                "values": ["Coronavirus Job Retention Scheme", "Government-backed accredited loans or finance agreements"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "blockf3731f81-73c0-4214-a771-3e321785afd7"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "questionb305b9d6-b021-4d5e-a92e-291381c49492",
+                                    "title": "Has {{ metadata['ru_name'] }} <em>received</em> funds from any of the following schemes?",
+                                    "type": "MutuallyExclusive",
+                                    "mandatory": true,
+                                    "answers": [
+                                        {
+                                            "id": "answer30aa84e6-07cf-4887-885f-abff7788aefb",
+                                            "mandatory": false,
+                                            "type": "Checkbox",
+                                            "label": "Select all that apply",
+                                            "description": "",
+                                            "options": [
+                                                {
+                                                    "label": "Coronavirus Job Retention Scheme",
+                                                    "value": "Coronavirus Job Retention Scheme",
+                                                    "q_code": "461",
+                                                    "description": "UK Government scheme that covers 80% of pay (up to £2,500 a month) for furloughed staff"
+                                                },
+                                                {
+                                                    "label": "Government-backed accredited loans or finance agreements",
+                                                    "value": "Government-backed accredited loans or finance agreements",
+                                                    "q_code": "4629",
+                                                    "description": "For example, COVID Corporate Financing Facility (CCFF), Coronavirus Business Interruption Loan Scheme (CBILS or CLBILS), Bounce Back Loan Scheme (BBLS) or loans from devolved governments"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "id": "answer30aa84e6-07cf-4887-885f-abff7788aefb-exclusive",
+                                            "mandatory": false,
+                                            "type": "Checkbox",
+                                            "description": "",
+                                            "options": [
+                                                {
+                                                    "label": "Not received any funds from these schemes",
+                                                    "value": "Not received any funds from these schemes",
+                                                    "q_code": "467"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "blockf3731f81-73c0-4214-a771-3e321785afd7",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "questionf3731f81-73c0-4214-a771-3e321785afd7",
+                                    "title": "Please describe your experience of applying for these schemes",
+                                    "guidance": {
+                                        "content": [
+                                            {
+                                                "description": "<strong>For example:</strong>"
+                                            },
+                                            {
+                                                "list": [
+                                                    "how easy or difficult it was to apply",
+                                                    "how you heard about these schemes",
+                                                    "if there were any barriers to you applying, such as eligibility",
+                                                    "if there was enough guidance about the application process",
+                                                    "if you received funding, how long it took"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer96848783-ecc7-4bcb-b8c5-bb807a118585",
+                                            "mandatory": true,
+                                            "type": "TextArea",
+                                            "label": "Comments",
+                                            "description": "",
+                                            "q_code": "47",
+                                            "max_length": 2000
+                                        }
+                                    ]
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "blockd39bd617-f259-488e-baf2-a51905d69b10",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "questiond39bd617-f259-488e-baf2-a51905d69b10",
+                                    "title": "Does {{ metadata['ru_name'] }} expect to use the Coronavirus Job Retention Scheme (CJRS) in the <em>next two weeks</em>?",
+                                    "description": "<p>If you have already applied once, and you plan to apply again for the next claim period, select &quot;Yes&quot;.</p>",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer36fe3ff1-cbba-46c6-a548-072c4ff1bd97",
+                                            "mandatory": true,
+                                            "type": "Radio",
+                                            "label": "",
+                                            "description": "",
+                                            "q_code": "88",
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                },
+                                                {
+                                                    "label": "Not sure",
+                                                    "value": "Not sure"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block7f5c1f5d-0854-4738-b801-20d9848475c2",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question7f5c1f5d-0854-4738-b801-20d9848475c2",
+                                    "title": "Is {{ metadata['ru_name'] }} <em>intending</em> to apply for any of the following schemes?",
+                                    "guidance": {
+                                        "content": [
+                                            {
+                                                "description": "Exclude any schemes that your business has already applied for"
+                                            }
+                                        ]
+                                    },
+                                    "type": "MutuallyExclusive",
+                                    "mandatory": true,
+                                    "answers": [
+                                        {
+                                            "id": "answerc05c537f-7ef0-426d-bef8-a631236e3baa",
+                                            "mandatory": false,
+                                            "type": "Checkbox",
+                                            "label": "Select all that apply",
+                                            "description": "",
+                                            "options": [
+                                                {
+                                                    "label": "Government-backed accredited loans or finance agreements",
+                                                    "value": "Government-backed accredited loans or finance agreements",
+                                                    "q_code": "4816",
+                                                    "description": "For example, COVID Corporate Financing Facility (CCFF), Coronavirus Business Interruption Loan Scheme (CBILS or CLBILS), Bounce Back Loan Scheme (BBLS) or loans from devolved governments"
+                                                },
+                                                {
+                                                    "label": "Business grants funded by the UK and devolved governments",
+                                                    "value": "Business grants funded by the UK and devolved governments",
+                                                    "q_code": "4889",
+                                                    "description": "Include small business grant funds and sector-specific grants in England, Wales, Scotland and Northern Ireland"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "id": "answerc05c537f-7ef0-426d-bef8-a631236e3baa-exclusive",
+                                            "mandatory": false,
+                                            "type": "Checkbox",
+                                            "description": "",
+                                            "options": [
+                                                {
+                                                    "label": "Not intending to apply for any of these schemes",
+                                                    "value": "Not intending to apply for any of these schemes",
+                                                    "q_code": "487"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block707c4125-b078-4bf4-a5a7-4e98987640e0",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question707c4125-b078-4bf4-a5a7-4e98987640e0",
+                                    "title": "Is {{ metadata['ru_name'] }} using any of the following <em>initiatives</em>?",
+                                    "type": "MutuallyExclusive",
+                                    "mandatory": true,
+                                    "answers": [
+                                        {
+                                            "id": "answerf6103d5e-1a15-43d7-be56-1c4dcc960b3a",
+                                            "mandatory": false,
+                                            "type": "Checkbox",
+                                            "label": "Select all that apply",
+                                            "description": "",
+                                            "options": [
+                                                {
+                                                    "label": "Business rates holiday",
+                                                    "value": "Business rates holiday",
+                                                    "q_code": "891"
+                                                },
+                                                {
+                                                    "label": "Deferring VAT payments",
+                                                    "value": "Deferring VAT payments",
+                                                    "q_code": "892"
+                                                },
+                                                {
+                                                    "label": "HMRC Time To Pay scheme",
+                                                    "value": "HMRC Time To Pay scheme",
+                                                    "q_code": "893"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "id": "answerf6103d5e-1a15-43d7-be56-1c4dcc960b3a-exclusive",
+                                            "mandatory": false,
+                                            "type": "Checkbox",
+                                            "description": "",
+                                            "options": [
+                                                {
+                                                    "label": "Not using any of these initiatives",
+                                                    "value": "Not using any of these initiatives",
+                                                    "q_code": "894"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block7a8cfd94-755c-4742-acfa-ca10a4c1cb87",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question7a8cfd94-755c-4742-acfa-ca10a4c1cb87",
+                                    "title": "Is {{ metadata['ru_name'] }} <em>intending</em> to use any of the following <em>initiatives</em>?",
+                                    "guidance": {
+                                        "content": [
+                                            {
+                                                "description": "Exclude any initiatives that your business is already using"
+                                            }
+                                        ]
+                                    },
+                                    "type": "MutuallyExclusive",
+                                    "mandatory": true,
+                                    "answers": [
+                                        {
+                                            "id": "answer6a654fac-abea-4b0d-8ca3-bf7340faa559",
+                                            "mandatory": false,
+                                            "type": "Checkbox",
+                                            "label": "Select all that apply",
+                                            "description": "",
+                                            "options": [
+                                                {
+                                                    "label": "Business rates holiday",
+                                                    "value": "Business rates holiday",
+                                                    "q_code": "901"
+                                                },
+                                                {
+                                                    "label": "Deferring VAT payments",
+                                                    "value": "Deferring VAT payments",
+                                                    "q_code": "902"
+                                                },
+                                                {
+                                                    "label": "HMRC Time To Pay scheme",
+                                                    "value": "HMRC Time To Pay scheme",
+                                                    "q_code": "903"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "id": "answer6a654fac-abea-4b0d-8ca3-bf7340faa559-exclusive",
+                                            "mandatory": false,
+                                            "type": "Checkbox",
+                                            "description": "",
+                                            "options": [
+                                                {
+                                                    "label": "Not intending to use any of these initiatives",
+                                                    "value": "Not intending to use any of these initiatives",
+                                                    "q_code": "904"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "block4fc906bb-a55c-497a-8bd0-5427d69dc055",
+                                        "when": [
+                                            {
+                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                                "condition": "contains any",
+                                                "values": [
+                                                    "Paused trading but intends to restart in the next two weeks",
+                                                    "Paused trading and does not intend to restart in the next two weeks"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "block35d5f073-97cd-460f-aa2e-1dd068c6f6ff",
+                                        "when": [
+                                            {
+                                                "id": "answerc812da13-73e9-4f73-a310-c0a78ed38524",
+                                                "condition": "contains any",
+                                                "values": ["COVID-19 grant for small businesses", "Economic Resilience Fund", "Sector-specific grants"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "block35d5f073-97cd-460f-aa2e-1dd068c6f6ff",
+                                        "when": [
+                                            {
+                                                "id": "answerb579d6b0-bc9e-4d09-bf39-aed0a1f0ef0b",
+                                                "condition": "contains any",
+                                                "values": ["Small Business Support grant", "Pivotal Enterprise Resilience Fund", "Sector-specific grants"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "block35d5f073-97cd-460f-aa2e-1dd068c6f6ff",
+                                        "when": [
+                                            {
+                                                "id": "answer7df0f422-59af-44a2-9de5-35b06645f367",
+                                                "condition": "contains any",
+                                                "values": ["Small Business Grant Fund (SBGF)", "Sector-specific grants"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "block35d5f073-97cd-460f-aa2e-1dd068c6f6ff",
+                                        "when": [
+                                            {
+                                                "id": "answerb1d499f5-1ad6-469a-9ea2-9b48dea1457c",
+                                                "condition": "contains any",
+                                                "values": ["Small Business Grant Scheme", "Sector-specific grants"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "block35d5f073-97cd-460f-aa2e-1dd068c6f6ff",
+                                        "when": [
+                                            {
+                                                "id": "answer30aa84e6-07cf-4887-885f-abff7788aefb",
+                                                "condition": "contains any",
+                                                "values": ["Coronavirus Job Retention Scheme", "Government-backed accredited loans or finance agreements"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "block35d5f073-97cd-460f-aa2e-1dd068c6f6ff",
+                                        "when": [
+                                            {
+                                                "id": "answerf6103d5e-1a15-43d7-be56-1c4dcc960b3a",
+                                                "condition": "contains any",
+                                                "values": ["Business rates holiday", "Deferring VAT payments", "HMRC Time To Pay scheme"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "block4fc906bb-a55c-497a-8bd0-5427d69dc055"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block35d5f073-97cd-460f-aa2e-1dd068c6f6ff",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question35d5f073-97cd-460f-aa2e-1dd068c6f6ff",
+                                    "title": "Did the support received from these <em>initiatives</em> or <em>schemes</em> help {{ metadata['ru_name'] }} continue trading?",
+                                    "guidance": {
+                                        "content": [
+                                            {
+                                                "description": "Include any grants or loans from government"
+                                            }
+                                        ]
+                                    },
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer147a73c6-2ec3-404a-8d63-d58dd8aae8eb",
+                                            "mandatory": true,
+                                            "type": "Radio",
+                                            "label": "",
+                                            "description": "",
+                                            "q_code": "91",
+                                            "options": [
+                                                {
+                                                    "label": "Yes, it helped us to continue trading",
+                                                    "value": "Yes, it helped us to continue trading"
+                                                },
+                                                {
+                                                    "label": "No, it did not impact our ability to continue trading",
+                                                    "value": "No, it did not impact our ability to continue trading"
+                                                },
+                                                {
+                                                    "label": "Not sure",
+                                                    "value": "Not sure"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block4fc906bb-a55c-497a-8bd0-5427d69dc055",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question4fc906bb-a55c-497a-8bd0-5427d69dc055",
+                                    "title": "Please describe any other support from government that you think could help {{ metadata['ru_name'] }}",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answere5a0ad55-8183-4fb2-8b35-29442de9c916",
+                                            "mandatory": false,
+                                            "type": "TextArea",
+                                            "label": "Comments",
+                                            "description": "",
+                                            "q_code": "49",
+                                            "max_length": 2000
+                                        }
+                                    ]
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block1633314b-b819-4309-917a-1a5d44940027",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question1633314b-b819-4309-917a-1a5d44940027",
+                                    "title": "Has {{ metadata['ru_name'] }} <em>received</em> any other financial assistance from banks or building societies?",
+                                    "guidance": {
+                                        "content": [
+                                            {
+                                                "description": "Exclude government-backed loans"
+                                            }
+                                        ]
+                                    },
+                                    "definitions": [
+                                        {
+                                            "title": "Examples of financial assistance from banks or building societies",
+                                            "content": [
+                                                {
+                                                    "list": [
+                                                        "Loans or emergency loans",
+                                                        "Commercial mortgage payment holidays",
+                                                        "Outstanding loans repayment holidays",
+                                                        "Increase in business credit card and overdraft limits"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answere72a6e53-f48d-4cf9-ad57-a4f99f2511f5",
+                                            "mandatory": true,
+                                            "type": "Radio",
+                                            "label": "",
+                                            "description": "",
+                                            "q_code": "92",
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                },
+                                                {
+                                                    "label": "Not sure",
+                                                    "value": "Not sure"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "block18da18a3-82ce-4b60-a710-fe4f4b1e90f6",
+                                        "when": [
+                                            {
+                                                "id": "answere72a6e53-f48d-4cf9-ad57-a4f99f2511f5",
+                                                "condition": "contains any",
+                                                "values": ["Yes"]
+                                            },
+                                            {
+                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                                "condition": "contains any",
+                                                "values": [
+                                                    "Currently trading and has been for more than the last two weeks",
+                                                    "Started trading within the last two weeks after a pause in trading"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "blocka2d0a9ef-9bfc-4ead-867f-bad93d6a3bca"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block18da18a3-82ce-4b60-a710-fe4f4b1e90f6",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question18da18a3-82ce-4b60-a710-fe4f4b1e90f6",
+                                    "title": "Did the financial assistance received from banks or building societies help {{ metadata['ru_name'] }} continue trading?",
+                                    "guidance": {
+                                        "content": [
+                                            {
+                                                "description": "Exclude government-backed loans"
+                                            }
+                                        ]
+                                    },
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answerfcef18bf-decf-4b70-a94c-c7c04c188c0b",
+                                            "mandatory": true,
+                                            "type": "Radio",
+                                            "label": "",
+                                            "description": "",
+                                            "q_code": "93",
+                                            "options": [
+                                                {
+                                                    "label": "Yes, it helped us to continue trading",
+                                                    "value": "Yes, it helped us to continue trading"
+                                                },
+                                                {
+                                                    "label": "No, it did not impact our ability to continue trading",
+                                                    "value": "No, it did not impact our ability to continue trading"
+                                                },
+                                                {
+                                                    "label": "Not sure",
+                                                    "value": "Not sure"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "blocka2d0a9ef-9bfc-4ead-867f-bad93d6a3bca",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "questiona2d0a9ef-9bfc-4ead-867f-bad93d6a3bca",
+                                    "title": "How long do you think {{ metadata['ru_name'] }}&apos;s cash reserves will last?",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer32a38f2a-e599-4ff7-9df9-b0419be84b96",
+                                            "mandatory": true,
+                                            "type": "Radio",
+                                            "label": "",
+                                            "description": "",
+                                            "q_code": "73",
+                                            "options": [
+                                                {
+                                                    "label": "No cash reserves",
+                                                    "value": "No cash reserves"
+                                                },
+                                                {
+                                                    "label": "Less than 1 month",
+                                                    "value": "Less than 1 month"
+                                                },
+                                                {
+                                                    "label": "1 to 3 months",
+                                                    "value": "1 to 3 months"
+                                                },
+                                                {
+                                                    "label": "4 to 6 months",
+                                                    "value": "4 to 6 months"
+                                                },
+                                                {
+                                                    "label": "More than 6 months",
+                                                    "value": "More than 6 months"
+                                                },
+                                                {
+                                                    "label": "Not sure",
+                                                    "value": "Not sure"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "skip_conditions": [
+                        {
+                            "when": [
+                                {
+                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                    "condition": "contains any",
+                                    "values": ["Permanently ceased trading"]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
         },
         {
             "id": "section1760a554-060f-4e6a-bf64-970f98d84ac7",
             "title": "Operational performance",
-            "groups": [{
-                "id": "group1760a554-060f-4e6a-bf64-970f98d84ac7",
-                "title": "Operational performance",
-                "blocks": [{
-                        "type": "Interstitial",
-                        "id": "group1760a554-060f-4e6a-bf64-970f98d84ac7-introduction",
-                        "title": "Operational performance",
-                        "description": "<p>This section asks for information about your workforce such as the: </p><ul><li>percentage , for example, on furlough leave or working remotely </li><li>percentage returning from furlough or remote working </li><li>percentage of furloughed staff receiving top-ups in addition to the Coronavirus Job Retention Scheme (CJRS) payments</li><li>number of vacancies</li></ul><p>It also asks about safety measures in the workplace.</p>",
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block90beb26c-59f1-4f7f-9dee-e9a822e871be",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question90beb26c-59f1-4f7f-9dee-e9a822e871be",
-                            "title": "In the <em>last two weeks</em>, approximately what percentage of {{ metadata['ru_name'] }}&apos;s workforce were:",
-                            "description": "<p>Your answers should <em>add up to 100%</em>. If your workforce did not fall into one of the categories, enter &apos;0&apos;. </p>",
-                            "type": "Calculated",
-                            "answers": [{
-                                    "id": "answer92e4004a-ceef-424e-b5fa-d93520bc4780",
-                                    "mandatory": true,
-                                    "type": "Percentage",
-                                    "label": "On furlough leave",
-                                    "description": "Under the terms of the UK Government's Coronavirus Job Retention Scheme",
-                                    "q_code": "371",
-                                    "min_value": {
-                                        "value": 0,
-                                        "exclusive": false
-                                    },
-                                    "max_value": {
-                                        "value": 100,
-                                        "exclusive": false
-                                    },
-                                    "decimal_places": 0
-                                },
+            "groups": [
+                {
+                    "id": "group1760a554-060f-4e6a-bf64-970f98d84ac7",
+                    "title": "Operational performance",
+                    "blocks": [
+                        {
+                            "type": "Interstitial",
+                            "id": "group1760a554-060f-4e6a-bf64-970f98d84ac7-introduction",
+                            "title": "Operational performance",
+                            "description": "<p>This section asks for information about your workforce such as the: </p><ul><li>percentage , for example, on furlough leave or working remotely </li><li>percentage returning from furlough or remote working </li><li>percentage of furloughed staff receiving top-ups in addition to the Coronavirus Job Retention Scheme (CJRS) payments</li><li>number of vacancies</li></ul><p>It also asks about safety measures in the workplace.</p>",
+                            "skip_conditions": [
                                 {
-                                    "id": "answerbc9d0665-2c42-4e04-988b-34423d020920",
-                                    "mandatory": true,
-                                    "type": "Percentage",
-                                    "label": "Working at their normal place of work",
-                                    "description": "Include those who are normally remote workers",
-                                    "q_code": "3741",
-                                    "min_value": {
-                                        "value": 0,
-                                        "exclusive": false
-                                    },
-                                    "max_value": {
-                                        "value": 100,
-                                        "exclusive": false
-                                    },
-                                    "decimal_places": 0
-                                },
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block90beb26c-59f1-4f7f-9dee-e9a822e871be",
+                            "type": "Question",
+                            "questions": [
                                 {
-                                    "id": "answerbec1b9cb-9f1f-471e-a874-f25ceaeef160",
-                                    "mandatory": true,
-                                    "type": "Percentage",
-                                    "label": "Working remotely instead of at their normal place of work",
-                                    "description": "Exclude those who are normally remote workers",
-                                    "q_code": "3742",
-                                    "min_value": {
-                                        "value": 0,
-                                        "exclusive": false
-                                    },
-                                    "max_value": {
-                                        "value": 100,
-                                        "exclusive": false
-                                    },
-                                    "decimal_places": 0
-                                },
-                                {
-                                    "id": "answerb6a74106-d408-491a-898c-42534143e246",
-                                    "mandatory": true,
-                                    "type": "Percentage",
-                                    "label": "On sick leave or in self-isolation due to coronavirus (COVID-19)",
-                                    "description": "With statutory or company pay",
-                                    "q_code": "372",
-                                    "min_value": {
-                                        "value": 0,
-                                        "exclusive": false
-                                    },
-                                    "max_value": {
-                                        "value": 100,
-                                        "exclusive": false
-                                    },
-                                    "decimal_places": 0
-                                },
-                                {
-                                    "id": "answer5319de32-f061-4988-88a4-95637cca3873",
-                                    "mandatory": true,
-                                    "type": "Percentage",
-                                    "label": "Made permanently redundant",
-                                    "description": "",
-                                    "q_code": "373",
-                                    "min_value": {
-                                        "value": 0,
-                                        "exclusive": false
-                                    },
-                                    "max_value": {
-                                        "value": 100,
-                                        "exclusive": false
-                                    },
-                                    "decimal_places": 0
-                                },
-                                {
-                                    "id": "answer2218d478-9b02-4806-babb-f6dc3a92cb55",
-                                    "mandatory": true,
-                                    "type": "Percentage",
-                                    "label": "Other",
-                                    "description": "",
-                                    "q_code": "375",
-                                    "min_value": {
-                                        "value": 0,
-                                        "exclusive": false
-                                    },
-                                    "max_value": {
-                                        "value": 100,
-                                        "exclusive": false
-                                    },
-                                    "decimal_places": 0
+                                    "id": "question90beb26c-59f1-4f7f-9dee-e9a822e871be",
+                                    "title": "In the <em>last two weeks</em>, approximately what percentage of {{ metadata['ru_name'] }}&apos;s workforce were:",
+                                    "description": "<p>Your answers should <em>add up to 100%</em>. If your workforce did not fall into one of the categories, enter &apos;0&apos;. </p>",
+                                    "type": "Calculated",
+                                    "answers": [
+                                        {
+                                            "id": "answer92e4004a-ceef-424e-b5fa-d93520bc4780",
+                                            "mandatory": true,
+                                            "type": "Percentage",
+                                            "label": "On furlough leave",
+                                            "description": "Under the terms of the UK Government's Coronavirus Job Retention Scheme",
+                                            "q_code": "371",
+                                            "min_value": {
+                                                "value": 0,
+                                                "exclusive": false
+                                            },
+                                            "max_value": {
+                                                "value": 100,
+                                                "exclusive": false
+                                            },
+                                            "decimal_places": 0
+                                        },
+                                        {
+                                            "id": "answerbc9d0665-2c42-4e04-988b-34423d020920",
+                                            "mandatory": true,
+                                            "type": "Percentage",
+                                            "label": "Working at their normal place of work",
+                                            "description": "Include those who are normally remote workers",
+                                            "q_code": "3741",
+                                            "min_value": {
+                                                "value": 0,
+                                                "exclusive": false
+                                            },
+                                            "max_value": {
+                                                "value": 100,
+                                                "exclusive": false
+                                            },
+                                            "decimal_places": 0
+                                        },
+                                        {
+                                            "id": "answerbec1b9cb-9f1f-471e-a874-f25ceaeef160",
+                                            "mandatory": true,
+                                            "type": "Percentage",
+                                            "label": "Working remotely instead of at their normal place of work",
+                                            "description": "Exclude those who are normally remote workers",
+                                            "q_code": "3742",
+                                            "min_value": {
+                                                "value": 0,
+                                                "exclusive": false
+                                            },
+                                            "max_value": {
+                                                "value": 100,
+                                                "exclusive": false
+                                            },
+                                            "decimal_places": 0
+                                        },
+                                        {
+                                            "id": "answerb6a74106-d408-491a-898c-42534143e246",
+                                            "mandatory": true,
+                                            "type": "Percentage",
+                                            "label": "On sick leave or in self-isolation due to coronavirus (COVID-19)",
+                                            "description": "With statutory or company pay",
+                                            "q_code": "372",
+                                            "min_value": {
+                                                "value": 0,
+                                                "exclusive": false
+                                            },
+                                            "max_value": {
+                                                "value": 100,
+                                                "exclusive": false
+                                            },
+                                            "decimal_places": 0
+                                        },
+                                        {
+                                            "id": "answer5319de32-f061-4988-88a4-95637cca3873",
+                                            "mandatory": true,
+                                            "type": "Percentage",
+                                            "label": "Made permanently redundant",
+                                            "description": "",
+                                            "q_code": "373",
+                                            "min_value": {
+                                                "value": 0,
+                                                "exclusive": false
+                                            },
+                                            "max_value": {
+                                                "value": 100,
+                                                "exclusive": false
+                                            },
+                                            "decimal_places": 0
+                                        },
+                                        {
+                                            "id": "answer2218d478-9b02-4806-babb-f6dc3a92cb55",
+                                            "mandatory": true,
+                                            "type": "Percentage",
+                                            "label": "Other",
+                                            "description": "",
+                                            "q_code": "375",
+                                            "min_value": {
+                                                "value": 0,
+                                                "exclusive": false
+                                            },
+                                            "max_value": {
+                                                "value": 100,
+                                                "exclusive": false
+                                            },
+                                            "decimal_places": 0
+                                        }
+                                    ],
+                                    "calculations": [
+                                        {
+                                            "calculation_type": "sum",
+                                            "answers_to_calculate": [
+                                                "answer92e4004a-ceef-424e-b5fa-d93520bc4780",
+                                                "answerbc9d0665-2c42-4e04-988b-34423d020920",
+                                                "answerbec1b9cb-9f1f-471e-a874-f25ceaeef160",
+                                                "answerb6a74106-d408-491a-898c-42534143e246",
+                                                "answer5319de32-f061-4988-88a4-95637cca3873",
+                                                "answer2218d478-9b02-4806-babb-f6dc3a92cb55"
+                                            ],
+                                            "conditions": ["equals"],
+                                            "value": 100
+                                        }
+                                    ]
                                 }
                             ],
-                            "calculations": [{
-                                "calculation_type": "sum",
-                                "answers_to_calculate": [
-                                    "answer92e4004a-ceef-424e-b5fa-d93520bc4780",
-                                    "answerbc9d0665-2c42-4e04-988b-34423d020920",
-                                    "answerbec1b9cb-9f1f-471e-a874-f25ceaeef160",
-                                    "answerb6a74106-d408-491a-898c-42534143e246",
-                                    "answer5319de32-f061-4988-88a4-95637cca3873",
-                                    "answer2218d478-9b02-4806-babb-f6dc3a92cb55"
-                                ],
-                                "conditions": ["equals"],
-                                "value": 100
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "blockb12b5e7d-c421-4252-a174-42a2a0210c6b",
-                                    "when": [{
-                                        "id": "answer2218d478-9b02-4806-babb-f6dc3a92cb55",
-                                        "condition": "greater than",
-                                        "value": 0
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "blockb646b254-98b4-4d42-ab91-c13b5fec21b0",
-                                    "when": [{
-                                        "id": "answer92e4004a-ceef-424e-b5fa-d93520bc4780",
-                                        "condition": "greater than",
-                                        "value": 0
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block66bef12d-2546-4df7-9e64-15e48bdf99c4",
-                                    "when": [{
-                                        "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                        "condition": "contains any",
-                                        "values": [
-                                            "Currently trading and has been for more than the last two weeks",
-                                            "Started trading within the last two weeks after a pause in trading"
-                                        ]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block66bdbc42-37a9-4134-9f22-235e40594178",
-                                    "when": [{
-                                        "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                        "condition": "contains any",
-                                        "values": [
-                                            "Paused trading but intends to restart in the next two weeks",
-                                            "Paused trading and does not intend to restart in the next two weeks"
-                                        ]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "blocke94a866c-fda4-469d-ba7d-e858307138cb"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "blockb12b5e7d-c421-4252-a174-42a2a0210c6b",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questionb12b5e7d-c421-4252-a174-42a2a0210c6b",
-                            "title": "You said that {{ answers['answer2218d478-9b02-4806-babb-f6dc3a92cb55'] }}% of your workforce were classified as &quot;other&quot;. Please describe what this includes",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer4c92cb9c-0ac7-43ef-a57f-e44350703379",
-                                "mandatory": true,
-                                "type": "TextArea",
-                                "label": "Comments",
-                                "description": "",
-                                "q_code": "96",
-                                "max_length": 2000
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "blockb646b254-98b4-4d42-ab91-c13b5fec21b0",
-                                    "when": [{
-                                        "id": "answer92e4004a-ceef-424e-b5fa-d93520bc4780",
-                                        "condition": "greater than",
-                                        "value": 0
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block66bef12d-2546-4df7-9e64-15e48bdf99c4",
-                                    "when": [{
-                                        "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                        "condition": "contains any",
-                                        "values": [
-                                            "Currently trading and has been for more than the last two weeks",
-                                            "Started trading within the last two weeks after a pause in trading"
-                                        ]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block66bdbc42-37a9-4134-9f22-235e40594178",
-                                    "when": [{
-                                        "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                        "condition": "contains any",
-                                        "values": [
-                                            "Paused trading but intends to restart in the next two weeks",
-                                            "Paused trading and does not intend to restart in the next two weeks"
-                                        ]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "blocke94a866c-fda4-469d-ba7d-e858307138cb"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "blockb646b254-98b4-4d42-ab91-c13b5fec21b0",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questionb646b254-98b4-4d42-ab91-c13b5fec21b0",
-                            "title": "Is {{ metadata['ru_name'] }} providing top-ups to any <em>furloughed workers&apos;</em> pay, on top of the Coronavirus Job Retention Scheme (CJRS) payments?",
-                            "description": "<p>The Coronavirus Job Retention Scheme (CJRS) covers 80% of pay (up to &#xA3;2,500 a month) for furloughed staff</p>",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer3b3c0791-e310-4279-9116-92f1040606b4",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "97",
-                                "options": [{
-                                        "label": "Yes, the business is providing a top-up",
-                                        "value": "Yes, the business is providing a top-up"
-                                    },
-                                    {
-                                        "label": "No, the business is not providing a top-up",
-                                        "value": "No, the business is not providing a top-up"
-                                    },
-                                    {
-                                        "label": "Not sure",
-                                        "value": "Not sure"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "block4f6d1ad5-2f37-4135-92fc-339b1943fc0e",
-                                    "when": [{
-                                        "id": "answer3b3c0791-e310-4279-9116-92f1040606b4",
-                                        "condition": "contains any",
-                                        "values": ["Yes, the business is providing a top-up"]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block66bef12d-2546-4df7-9e64-15e48bdf99c4",
-                                    "when": [{
-                                            "id": "answer3b3c0791-e310-4279-9116-92f1040606b4",
-                                            "condition": "contains any",
-                                            "values": ["No, the business is not providing a top-up", "Not sure"]
-                                        },
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "contains any",
-                                            "values": [
-                                                "Currently trading and has been for more than the last two weeks",
-                                                "Started trading within the last two weeks after a pause in trading"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block66bdbc42-37a9-4134-9f22-235e40594178",
-                                    "when": [{
-                                            "id": "answer3b3c0791-e310-4279-9116-92f1040606b4",
-                                            "condition": "contains any",
-                                            "values": ["No, the business is not providing a top-up", "Not sure"]
-                                        },
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "contains any",
-                                            "values": [
-                                                "Paused trading but intends to restart in the next two weeks",
-                                                "Paused trading and does not intend to restart in the next two weeks"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "blocke94a866c-fda4-469d-ba7d-e858307138cb"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block4f6d1ad5-2f37-4135-92fc-339b1943fc0e",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question4f6d1ad5-2f37-4135-92fc-339b1943fc0e",
-                            "title": "Of those on <em>furlough leave</em>, approximately what <em>percentage of workers</em> have had their pay topped up?",
-                            "description": "<p>Your answer should be out of 100%. </p>",
-                            "definitions": [{
-                                "title": "How you might answer this question",
-                                "content": [{
-                                    "description": "If 50% of your workforce have been furloughed, but you are topping up the pay for <strong>all</strong> of those furloughed workers, the answer would be 100%. If you are topping up the pay for <strong>half</strong> of those furloughed workers, the answer would be 50%."
-                                }]
-                            }],
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer4300ee07-0122-4efc-81e2-02cec3abcb32",
-                                "mandatory": true,
-                                "type": "Percentage",
-                                "label": "Percentage of furloughed workers with top-up pay",
-                                "description": "",
-                                "q_code": "98",
-                                "min_value": {
-                                    "value": 0,
-                                    "exclusive": false
-                                },
-                                "max_value": {
-                                    "value": 100,
-                                    "exclusive": false
-                                },
-                                "decimal_places": 0
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "block66bdbc42-37a9-4134-9f22-235e40594178",
-                                    "when": [{
-                                        "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                        "condition": "contains any",
-                                        "values": [
-                                            "Paused trading but intends to restart in the next two weeks",
-                                            "Paused trading and does not intend to restart in the next two weeks"
-                                        ]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block66bef12d-2546-4df7-9e64-15e48bdf99c4"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block66bef12d-2546-4df7-9e64-15e48bdf99c4",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question66bef12d-2546-4df7-9e64-15e48bdf99c4",
-                            "title": "In the <em>last two weeks</em>, approximately what percentage of {{ metadata['ru_name'] }}&apos;s workforce have:",
-                            "type": "General",
-                            "answers": [{
-                                    "id": "answer647b4d64-5529-44ae-8412-903ff0250f71",
-                                    "mandatory": true,
-                                    "type": "Percentage",
-                                    "label": "Returned from furlough leave",
-                                    "description": "",
-                                    "q_code": "991",
-                                    "min_value": {
-                                        "value": 0,
-                                        "exclusive": false
-                                    },
-                                    "max_value": {
-                                        "value": 100,
-                                        "exclusive": false
-                                    },
-                                    "decimal_places": 0
-                                },
+                            "routing_rules": [
                                 {
-                                    "id": "answer8256ff1c-5839-4b89-8d1d-9f76e6280683",
-                                    "mandatory": true,
-                                    "type": "Percentage",
-                                    "label": "Moved from remote working  to the normal workplace",
-                                    "description": "Exclude those who would normally work remotely prior to the pandemic",
-                                    "q_code": "992",
-                                    "min_value": {
-                                        "value": 0,
-                                        "exclusive": false
-                                    },
-                                    "max_value": {
-                                        "value": 100,
-                                        "exclusive": false
-                                    },
-                                    "decimal_places": 0
-                                }
-                            ]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block66bdbc42-37a9-4134-9f22-235e40594178",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question66bdbc42-37a9-4134-9f22-235e40594178",
-                            "title": "In the <em>next two weeks</em>, approximately what percentage of {{ metadata['ru_name'] }}&apos;s workforce will:",
-                            "type": "General",
-                            "answers": [{
-                                    "id": "answerf99be2e6-938d-4adf-99b5-942b78122fda",
-                                    "mandatory": true,
-                                    "type": "Percentage",
-                                    "label": "Return to work from furlough",
-                                    "description": "Include those returning from furlough to remote working",
-                                    "q_code": "1001",
-                                    "min_value": {
-                                        "value": 0,
-                                        "exclusive": false
-                                    },
-                                    "max_value": {
-                                        "value": 100,
-                                        "exclusive": false
-                                    },
-                                    "decimal_places": 0
-                                },
-                                {
-                                    "id": "answer00c0324e-6deb-404a-b425-563ebaf3829d",
-                                    "mandatory": true,
-                                    "type": "Percentage",
-                                    "label": "Return to the workplace from remote working",
-                                    "description": "Exclude those who would normally work remotely prior to the pandemic",
-                                    "q_code": "1002",
-                                    "min_value": {
-                                        "value": 0,
-                                        "exclusive": false
-                                    },
-                                    "max_value": {
-                                        "value": 100,
-                                        "exclusive": false
-                                    },
-                                    "decimal_places": 0
-                                },
-                                {
-                                    "id": "answer325edc5e-846a-4c17-870d-fce3c9b4c9fb",
-                                    "mandatory": true,
-                                    "type": "Percentage",
-                                    "label": "Be made permanently redundant",
-                                    "description": "",
-                                    "q_code": "1003",
-                                    "decimal_places": 0
-                                }
-                            ]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "blocke94a866c-fda4-469d-ba7d-e858307138cb",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questione94a866c-fda4-469d-ba7d-e858307138cb",
-                            "title": "How many <em>external job vacancies</em> is  {{ metadata['ru_name'] }} actively recruiting for?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer6fc41202-89c7-48f2-b65a-7801cd5086e4",
-                                "mandatory": true,
-                                "type": "Number",
-                                "label": "Number of external job vacancies",
-                                "description": "",
-                                "q_code": "101",
-                                "min_value": {
-                                    "value": 0,
-                                    "exclusive": false
-                                },
-                                "decimal_places": 0
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "block29eac987-68af-41fc-adaf-53c45511d4da",
-                                    "when": [{
-                                        "id": "answer6fc41202-89c7-48f2-b65a-7801cd5086e4",
-                                        "condition": "equals",
-                                        "value": 0
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block653770e8-e13b-440e-8146-30b8e2c5fdf9"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block653770e8-e13b-440e-8146-30b8e2c5fdf9",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question653770e8-e13b-440e-8146-30b8e2c5fdf9",
-                            "title": "Of the {{ answers['answer6fc41202-89c7-48f2-b65a-7801cd5086e4'] | format_number }} external job vacancies, how many were <em>new</em> in the <em>last two weeks</em>?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answerb8942943-ba5d-4772-ae72-38b84abaeec0",
-                                "mandatory": true,
-                                "type": "Number",
-                                "label": "Number of new external job vacancies",
-                                "description": "",
-                                "q_code": "102",
-                                "max_value": {
-                                    "answer_id": "answer6fc41202-89c7-48f2-b65a-7801cd5086e4",
-                                    "exclusive": false
-                                },
-                                "decimal_places": 0
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block29eac987-68af-41fc-adaf-53c45511d4da",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question29eac987-68af-41fc-adaf-53c45511d4da",
-                            "title": "Is {{ metadata['ru_name'] }} using, or intending to use, any of the following <em>safety measures</em> in the workplace?",
-                            "type": "MutuallyExclusive",
-                            "mandatory": true,
-                            "answers": [{
-                                    "id": "answerc46ba0d2-68da-4098-af49-b6c5981c4e8f",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "label": "Select all that apply",
-                                    "description": "",
-                                    "options": [{
-                                            "label": "Personal Protective Equipment (PPE)",
-                                            "value": "Personal Protective Equipment (PPE)",
-                                            "q_code": "951",
-                                            "description": "For example, masks, gloves, etc."
-                                        },
-                                        {
-                                            "label": "Temperature checks",
-                                            "value": "Temperature checks",
-                                            "q_code": "959"
-                                        },
-                                        {
-                                            "label": "Routine COVID-19 testing",
-                                            "value": "Routine COVID-19 testing",
-                                            "q_code": "9510"
-                                        },
-                                        {
-                                            "label": "Social distancing",
-                                            "value": "Social distancing",
-                                            "q_code": "952"
-                                        },
-                                        {
-                                            "label": "Shift working",
-                                            "value": "Shift working",
-                                            "q_code": "953"
-                                        },
-                                        {
-                                            "label": "Working in fixed teams",
-                                            "value": "Working in fixed teams",
-                                            "q_code": "955"
-                                        },
-                                        {
-                                            "label": "Staggered breaks",
-                                            "value": "Staggered breaks",
-                                            "q_code": "954"
-                                        },
-                                        {
-                                            "label": "Hygiene measures",
-                                            "value": "Hygiene measures",
-                                            "q_code": "9511",
-                                            "description": "For example, increased cleaning of work areas and equipment"
-                                        },
-                                        {
-                                            "label": "Other",
-                                            "value": "Other",
-                                            "q_code": "956",
-                                            "detail_answer": {
-                                                "label": "Please describe",
-                                                "type": "TextField",
-                                                "id": "answer36243886-6609-4cf4-af4b-111c29e9cc4f",
-                                                "mandatory": false
+                                    "goto": {
+                                        "block": "blockb12b5e7d-c421-4252-a174-42a2a0210c6b",
+                                        "when": [
+                                            {
+                                                "id": "answer2218d478-9b02-4806-babb-f6dc3a92cb55",
+                                                "condition": "greater than",
+                                                "value": 0
                                             }
-                                        },
-                                        {
-                                            "label": "None of these",
-                                            "value": "None of these",
-                                            "q_code": "957"
-                                        }
-                                    ]
+                                        ]
+                                    }
                                 },
                                 {
-                                    "id": "answerc46ba0d2-68da-4098-af49-b6c5981c4e8f-exclusive",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "description": "",
-                                    "options": [{
-                                        "label": "Not sure",
-                                        "value": "Not sure",
-                                        "q_code": "958"
-                                    }]
+                                    "goto": {
+                                        "block": "blockb646b254-98b4-4d42-ab91-c13b5fec21b0",
+                                        "when": [
+                                            {
+                                                "id": "answer92e4004a-ceef-424e-b5fa-d93520bc4780",
+                                                "condition": "greater than",
+                                                "value": 0
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "block66bef12d-2546-4df7-9e64-15e48bdf99c4",
+                                        "when": [
+                                            {
+                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                                "condition": "contains any",
+                                                "values": [
+                                                    "Currently trading and has been for more than the last two weeks",
+                                                    "Started trading within the last two weeks after a pause in trading"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "block66bdbc42-37a9-4134-9f22-235e40594178",
+                                        "when": [
+                                            {
+                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                                "condition": "contains any",
+                                                "values": [
+                                                    "Paused trading but intends to restart in the next two weeks",
+                                                    "Paused trading and does not intend to restart in the next two weeks"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "blocke94a866c-fda4-469d-ba7d-e858307138cb"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
                                 }
                             ]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "blockb8481e29-f74a-4b32-8b95-2720c2842e0c",
-                                    "when": [{
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "contains any",
-                                            "values": [
-                                                "Currently trading and has been for more than the last two weeks",
-                                                "Started trading within the last two weeks after a pause in trading"
-                                            ]
-                                        },
+                        },
+                        {
+                            "id": "blockb12b5e7d-c421-4252-a174-42a2a0210c6b",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "questionb12b5e7d-c421-4252-a174-42a2a0210c6b",
+                                    "title": "You said that {{ answers['answer2218d478-9b02-4806-babb-f6dc3a92cb55'] }}% of your workforce were classified as &quot;other&quot;. Please describe what this includes",
+                                    "type": "General",
+                                    "answers": [
                                         {
-                                            "id": "answerc46ba0d2-68da-4098-af49-b6c5981c4e8f",
-                                            "condition": "contains any",
-                                            "values": [
-                                                "Personal Protective Equipment (PPE)",
-                                                "Temperature checks",
-                                                "Routine COVID-19 testing",
-                                                "Social distancing",
-                                                "Shift working",
-                                                "Working in fixed teams",
-                                                "Staggered breaks",
-                                                "Hygiene measures",
-                                                "Other"
-                                            ]
+                                            "id": "answer4c92cb9c-0ac7-43ef-a57f-e44350703379",
+                                            "mandatory": true,
+                                            "type": "TextArea",
+                                            "label": "Comments",
+                                            "description": "",
+                                            "q_code": "96",
+                                            "max_length": 2000
                                         }
                                     ]
                                 }
-                            },
-                            {
-                                "goto": {
-                                    "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8",
-                                    "when": [{
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "contains any",
-                                            "values": [
-                                                "Currently trading and has been for more than the last two weeks",
-                                                "Started trading within the last two weeks after a pause in trading"
-                                            ]
-                                        },
-                                        {
-                                            "id": "answerc46ba0d2-68da-4098-af49-b6c5981c4e8f",
-                                            "condition": "contains any",
-                                            "values": ["None of these"]
-                                        },
-                                        {
-                                            "id": "answerc46ba0d2-68da-4098-af49-b6c5981c4e8f-exclusive",
-                                            "condition": "contains any",
-                                            "values": ["Not sure"]
-                                        }
-                                    ]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block7ff4579e-ede4-4d33-804e-54df3c02d837",
-                                    "when": [{
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "contains any",
-                                            "values": [
-                                                "Paused trading but intends to restart in the next two weeks",
-                                                "Paused trading and does not intend to restart in the next two weeks"
-                                            ]
-                                        },
-                                        {
-                                            "id": "answerc46ba0d2-68da-4098-af49-b6c5981c4e8f",
-                                            "condition": "contains any",
-                                            "values": [
-                                                "Personal Protective Equipment (PPE)",
-                                                "Temperature checks",
-                                                "Routine COVID-19 testing",
-                                                "Social distancing",
-                                                "Shift working",
-                                                "Working in fixed teams",
-                                                "Staggered breaks",
-                                                "Hygiene measures",
-                                                "Other"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8",
-                                    "when": [{
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "contains any",
-                                            "values": [
-                                                "Paused trading but intends to restart in the next two weeks",
-                                                "Paused trading and does not intend to restart in the next two weeks"
-                                            ]
-                                        },
-                                        {
-                                            "id": "answerc46ba0d2-68da-4098-af49-b6c5981c4e8f",
-                                            "condition": "contains any",
-                                            "values": ["None of these"]
-                                        },
-                                        {
-                                            "id": "answerc46ba0d2-68da-4098-af49-b6c5981c4e8f-exclusive",
-                                            "condition": "contains any",
-                                            "values": ["Not sure"]
-                                        }
-                                    ]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "blockb8481e29-f74a-4b32-8b95-2720c2842e0c",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questionb8481e29-f74a-4b32-8b95-2720c2842e0c",
-                            "title": "How has the implementation of these safety measures affected {{ metadata['ru_name'] }}&apos;s <em>operating costs</em>?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer740ce2f4-18bd-48b9-a01d-47854e1e1796",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "116",
-                                "options": [{
-                                        "label": "Operating costs have substantially increased",
-                                        "value": "Operating costs have substantially increased"
-                                    },
-                                    {
-                                        "label": "Operating costs have increased a little",
-                                        "value": "Operating costs have increased a little"
-                                    },
-                                    {
-                                        "label": "Operating costs have stayed the same",
-                                        "value": "Operating costs have stayed the same"
-                                    },
-                                    {
-                                        "label": "Operating costs have decreased a little",
-                                        "value": "Operating costs have decreased a little"
-                                    },
-                                    {
-                                        "label": "Operating costs have substantially decreased",
-                                        "value": "Operating costs have substantially decreased"
-                                    },
-                                    {
-                                        "label": "Not sure",
-                                        "value": "Not sure"
-                                    },
-                                    {
-                                        "label": "Not applicable",
-                                        "value": "Not applicable"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8",
-                                    "when": [{
-                                        "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                        "condition": "contains any",
-                                        "values": [
-                                            "Currently trading and has been for more than the last two weeks",
-                                            "Started trading within the last two weeks after a pause in trading"
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "blockb646b254-98b4-4d42-ab91-c13b5fec21b0",
+                                        "when": [
+                                            {
+                                                "id": "answer92e4004a-ceef-424e-b5fa-d93520bc4780",
+                                                "condition": "greater than",
+                                                "value": 0
+                                            }
                                         ]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block7ff4579e-ede4-4d33-804e-54df3c02d837"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block7ff4579e-ede4-4d33-804e-54df3c02d837",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question7ff4579e-ede4-4d33-804e-54df3c02d837",
-                            "title": "How do you expect the implementation of these safety measures to affect {{ metadata['ru_name'] }}&apos;s <em>operating costs</em>?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer000984b9-561c-40ba-b529-6faa4d95fc1b",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "117",
-                                "options": [{
-                                        "label": "Operating costs will substantially increase",
-                                        "value": "Operating costs will substantially increase"
-                                    },
-                                    {
-                                        "label": "Operating costs will increase a little",
-                                        "value": "Operating costs will increase a little"
-                                    },
-                                    {
-                                        "label": "Operating costs will stay the same",
-                                        "value": "Operating costs will stay the same"
-                                    },
-                                    {
-                                        "label": "Operating costs will decrease a little",
-                                        "value": "Operating costs will decrease a little"
-                                    },
-                                    {
-                                        "label": "Operating costs will substantially decrease",
-                                        "value": "Operating costs will substantially decrease"
-                                    },
-                                    {
-                                        "label": "Not sure",
-                                        "value": "Not sure"
-                                    },
-                                    {
-                                        "label": "Not applicable",
-                                        "value": "Not applicable"
                                     }
-                                ]
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                "condition": "not set"
-                            }]
-                        }]
-                    }
-                ],
-                "skip_conditions": [{
-                    "when": [{
-                        "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                        "condition": "contains any",
-                        "values": ["Permanently ceased trading"]
-                    }]
-                }]
-            }]
+                                },
+                                {
+                                    "goto": {
+                                        "block": "block66bef12d-2546-4df7-9e64-15e48bdf99c4",
+                                        "when": [
+                                            {
+                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                                "condition": "contains any",
+                                                "values": [
+                                                    "Currently trading and has been for more than the last two weeks",
+                                                    "Started trading within the last two weeks after a pause in trading"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "block66bdbc42-37a9-4134-9f22-235e40594178",
+                                        "when": [
+                                            {
+                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                                "condition": "contains any",
+                                                "values": [
+                                                    "Paused trading but intends to restart in the next two weeks",
+                                                    "Paused trading and does not intend to restart in the next two weeks"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "blocke94a866c-fda4-469d-ba7d-e858307138cb"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "blockb646b254-98b4-4d42-ab91-c13b5fec21b0",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "questionb646b254-98b4-4d42-ab91-c13b5fec21b0",
+                                    "title": "Is {{ metadata['ru_name'] }} providing top-ups to any <em>furloughed workers&apos;</em> pay, on top of the Coronavirus Job Retention Scheme (CJRS) payments?",
+                                    "description": "<p>The Coronavirus Job Retention Scheme (CJRS) covers 80% of pay (up to &#xA3;2,500 a month) for furloughed staff</p>",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer3b3c0791-e310-4279-9116-92f1040606b4",
+                                            "mandatory": true,
+                                            "type": "Radio",
+                                            "label": "",
+                                            "description": "",
+                                            "q_code": "97",
+                                            "options": [
+                                                {
+                                                    "label": "Yes, the business is providing a top-up",
+                                                    "value": "Yes, the business is providing a top-up"
+                                                },
+                                                {
+                                                    "label": "No, the business is not providing a top-up",
+                                                    "value": "No, the business is not providing a top-up"
+                                                },
+                                                {
+                                                    "label": "Not sure",
+                                                    "value": "Not sure"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "block4f6d1ad5-2f37-4135-92fc-339b1943fc0e",
+                                        "when": [
+                                            {
+                                                "id": "answer3b3c0791-e310-4279-9116-92f1040606b4",
+                                                "condition": "contains any",
+                                                "values": ["Yes, the business is providing a top-up"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "block66bef12d-2546-4df7-9e64-15e48bdf99c4",
+                                        "when": [
+                                            {
+                                                "id": "answer3b3c0791-e310-4279-9116-92f1040606b4",
+                                                "condition": "contains any",
+                                                "values": ["No, the business is not providing a top-up", "Not sure"]
+                                            },
+                                            {
+                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                                "condition": "contains any",
+                                                "values": [
+                                                    "Currently trading and has been for more than the last two weeks",
+                                                    "Started trading within the last two weeks after a pause in trading"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "block66bdbc42-37a9-4134-9f22-235e40594178",
+                                        "when": [
+                                            {
+                                                "id": "answer3b3c0791-e310-4279-9116-92f1040606b4",
+                                                "condition": "contains any",
+                                                "values": ["No, the business is not providing a top-up", "Not sure"]
+                                            },
+                                            {
+                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                                "condition": "contains any",
+                                                "values": [
+                                                    "Paused trading but intends to restart in the next two weeks",
+                                                    "Paused trading and does not intend to restart in the next two weeks"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "blocke94a866c-fda4-469d-ba7d-e858307138cb"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block4f6d1ad5-2f37-4135-92fc-339b1943fc0e",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question4f6d1ad5-2f37-4135-92fc-339b1943fc0e",
+                                    "title": "Of those on <em>furlough leave</em>, approximately what <em>percentage of workers</em> have had their pay topped up?",
+                                    "description": "<p>Your answer should be out of 100%. </p>",
+                                    "definitions": [
+                                        {
+                                            "title": "How you might answer this question",
+                                            "content": [
+                                                {
+                                                    "description": "If 50% of your workforce have been furloughed, but you are topping up the pay for <strong>all</strong> of those furloughed workers, the answer would be 100%. If you are topping up the pay for <strong>half</strong> of those furloughed workers, the answer would be 50%."
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer4300ee07-0122-4efc-81e2-02cec3abcb32",
+                                            "mandatory": true,
+                                            "type": "Percentage",
+                                            "label": "Percentage of furloughed workers with top-up pay",
+                                            "description": "",
+                                            "q_code": "98",
+                                            "min_value": {
+                                                "value": 0,
+                                                "exclusive": false
+                                            },
+                                            "max_value": {
+                                                "value": 100,
+                                                "exclusive": false
+                                            },
+                                            "decimal_places": 0
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "block66bdbc42-37a9-4134-9f22-235e40594178",
+                                        "when": [
+                                            {
+                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                                "condition": "contains any",
+                                                "values": [
+                                                    "Paused trading but intends to restart in the next two weeks",
+                                                    "Paused trading and does not intend to restart in the next two weeks"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "block66bef12d-2546-4df7-9e64-15e48bdf99c4"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block66bef12d-2546-4df7-9e64-15e48bdf99c4",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question66bef12d-2546-4df7-9e64-15e48bdf99c4",
+                                    "title": "In the <em>last two weeks</em>, approximately what percentage of {{ metadata['ru_name'] }}&apos;s workforce have:",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer647b4d64-5529-44ae-8412-903ff0250f71",
+                                            "mandatory": true,
+                                            "type": "Percentage",
+                                            "label": "Returned from furlough leave",
+                                            "description": "",
+                                            "q_code": "991",
+                                            "min_value": {
+                                                "value": 0,
+                                                "exclusive": false
+                                            },
+                                            "max_value": {
+                                                "value": 100,
+                                                "exclusive": false
+                                            },
+                                            "decimal_places": 0
+                                        },
+                                        {
+                                            "id": "answer8256ff1c-5839-4b89-8d1d-9f76e6280683",
+                                            "mandatory": true,
+                                            "type": "Percentage",
+                                            "label": "Moved from remote working  to the normal workplace",
+                                            "description": "Exclude those who would normally work remotely prior to the pandemic",
+                                            "q_code": "992",
+                                            "min_value": {
+                                                "value": 0,
+                                                "exclusive": false
+                                            },
+                                            "max_value": {
+                                                "value": 100,
+                                                "exclusive": false
+                                            },
+                                            "decimal_places": 0
+                                        }
+                                    ]
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block66bdbc42-37a9-4134-9f22-235e40594178",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question66bdbc42-37a9-4134-9f22-235e40594178",
+                                    "title": "In the <em>next two weeks</em>, approximately what percentage of {{ metadata['ru_name'] }}&apos;s workforce will:",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answerf99be2e6-938d-4adf-99b5-942b78122fda",
+                                            "mandatory": true,
+                                            "type": "Percentage",
+                                            "label": "Return to work from furlough",
+                                            "description": "Include those returning from furlough to remote working",
+                                            "q_code": "1001",
+                                            "min_value": {
+                                                "value": 0,
+                                                "exclusive": false
+                                            },
+                                            "max_value": {
+                                                "value": 100,
+                                                "exclusive": false
+                                            },
+                                            "decimal_places": 0
+                                        },
+                                        {
+                                            "id": "answer00c0324e-6deb-404a-b425-563ebaf3829d",
+                                            "mandatory": true,
+                                            "type": "Percentage",
+                                            "label": "Return to the workplace from remote working",
+                                            "description": "Exclude those who would normally work remotely prior to the pandemic",
+                                            "q_code": "1002",
+                                            "min_value": {
+                                                "value": 0,
+                                                "exclusive": false
+                                            },
+                                            "max_value": {
+                                                "value": 100,
+                                                "exclusive": false
+                                            },
+                                            "decimal_places": 0
+                                        },
+                                        {
+                                            "id": "answer325edc5e-846a-4c17-870d-fce3c9b4c9fb",
+                                            "mandatory": true,
+                                            "type": "Percentage",
+                                            "label": "Be made permanently redundant",
+                                            "description": "",
+                                            "q_code": "1003",
+                                            "decimal_places": 0
+                                        }
+                                    ]
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "blocke94a866c-fda4-469d-ba7d-e858307138cb",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "questione94a866c-fda4-469d-ba7d-e858307138cb",
+                                    "title": "How many <em>external job vacancies</em> is  {{ metadata['ru_name'] }} actively recruiting for?",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer6fc41202-89c7-48f2-b65a-7801cd5086e4",
+                                            "mandatory": true,
+                                            "type": "Number",
+                                            "label": "Number of external job vacancies",
+                                            "description": "",
+                                            "q_code": "101",
+                                            "min_value": {
+                                                "value": 0,
+                                                "exclusive": false
+                                            },
+                                            "decimal_places": 0
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "block29eac987-68af-41fc-adaf-53c45511d4da",
+                                        "when": [
+                                            {
+                                                "id": "answer6fc41202-89c7-48f2-b65a-7801cd5086e4",
+                                                "condition": "equals",
+                                                "value": 0
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "block653770e8-e13b-440e-8146-30b8e2c5fdf9"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block653770e8-e13b-440e-8146-30b8e2c5fdf9",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question653770e8-e13b-440e-8146-30b8e2c5fdf9",
+                                    "title": "Of the {{ answers['answer6fc41202-89c7-48f2-b65a-7801cd5086e4'] | format_number }} external job vacancies, how many were <em>new</em> in the <em>last two weeks</em>?",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answerb8942943-ba5d-4772-ae72-38b84abaeec0",
+                                            "mandatory": true,
+                                            "type": "Number",
+                                            "label": "Number of new external job vacancies",
+                                            "description": "",
+                                            "q_code": "102",
+                                            "max_value": {
+                                                "answer_id": "answer6fc41202-89c7-48f2-b65a-7801cd5086e4",
+                                                "exclusive": false
+                                            },
+                                            "decimal_places": 0
+                                        }
+                                    ]
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block29eac987-68af-41fc-adaf-53c45511d4da",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question29eac987-68af-41fc-adaf-53c45511d4da",
+                                    "title": "Is {{ metadata['ru_name'] }} using, or intending to use, any of the following <em>safety measures</em> in the workplace?",
+                                    "type": "MutuallyExclusive",
+                                    "mandatory": true,
+                                    "answers": [
+                                        {
+                                            "id": "answerc46ba0d2-68da-4098-af49-b6c5981c4e8f",
+                                            "mandatory": false,
+                                            "type": "Checkbox",
+                                            "label": "Select all that apply",
+                                            "description": "",
+                                            "options": [
+                                                {
+                                                    "label": "Personal Protective Equipment (PPE)",
+                                                    "value": "Personal Protective Equipment (PPE)",
+                                                    "q_code": "951",
+                                                    "description": "For example, masks, gloves, etc."
+                                                },
+                                                {
+                                                    "label": "Temperature checks",
+                                                    "value": "Temperature checks",
+                                                    "q_code": "959"
+                                                },
+                                                {
+                                                    "label": "Routine COVID-19 testing",
+                                                    "value": "Routine COVID-19 testing",
+                                                    "q_code": "9510"
+                                                },
+                                                {
+                                                    "label": "Social distancing",
+                                                    "value": "Social distancing",
+                                                    "q_code": "952"
+                                                },
+                                                {
+                                                    "label": "Shift working",
+                                                    "value": "Shift working",
+                                                    "q_code": "953"
+                                                },
+                                                {
+                                                    "label": "Working in fixed teams",
+                                                    "value": "Working in fixed teams",
+                                                    "q_code": "955"
+                                                },
+                                                {
+                                                    "label": "Staggered breaks",
+                                                    "value": "Staggered breaks",
+                                                    "q_code": "954"
+                                                },
+                                                {
+                                                    "label": "Hygiene measures",
+                                                    "value": "Hygiene measures",
+                                                    "q_code": "9511",
+                                                    "description": "For example, increased cleaning of work areas and equipment"
+                                                },
+                                                {
+                                                    "label": "Other",
+                                                    "value": "Other",
+                                                    "q_code": "956",
+                                                    "detail_answer": {
+                                                        "label": "Please describe",
+                                                        "type": "TextField",
+                                                        "id": "answer36243886-6609-4cf4-af4b-111c29e9cc4f",
+                                                        "mandatory": false
+                                                    }
+                                                },
+                                                {
+                                                    "label": "None of these",
+                                                    "value": "None of these",
+                                                    "q_code": "957"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "id": "answerc46ba0d2-68da-4098-af49-b6c5981c4e8f-exclusive",
+                                            "mandatory": false,
+                                            "type": "Checkbox",
+                                            "description": "",
+                                            "options": [
+                                                {
+                                                    "label": "Not sure",
+                                                    "value": "Not sure",
+                                                    "q_code": "958"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "block": "blockb8481e29-f74a-4b32-8b95-2720c2842e0c",
+                                        "when": [
+                                            {
+                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                                "condition": "contains any",
+                                                "values": [
+                                                    "Currently trading and has been for more than the last two weeks",
+                                                    "Started trading within the last two weeks after a pause in trading"
+                                                ]
+                                            },
+                                            {
+                                                "id": "answerc46ba0d2-68da-4098-af49-b6c5981c4e8f",
+                                                "condition": "contains any",
+                                                "values": [
+                                                    "Personal Protective Equipment (PPE)",
+                                                    "Temperature checks",
+                                                    "Routine COVID-19 testing",
+                                                    "Social distancing",
+                                                    "Shift working",
+                                                    "Working in fixed teams",
+                                                    "Staggered breaks",
+                                                    "Hygiene measures",
+                                                    "Other"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8",
+                                        "when": [
+                                            {
+                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                                "condition": "contains any",
+                                                "values": [
+                                                    "Currently trading and has been for more than the last two weeks",
+                                                    "Started trading within the last two weeks after a pause in trading"
+                                                ]
+                                            },
+                                            {
+                                                "id": "answerc46ba0d2-68da-4098-af49-b6c5981c4e8f",
+                                                "condition": "contains any",
+                                                "values": ["None of these"]
+                                            },
+                                            {
+                                                "id": "answerc46ba0d2-68da-4098-af49-b6c5981c4e8f-exclusive",
+                                                "condition": "contains any",
+                                                "values": ["Not sure"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "block7ff4579e-ede4-4d33-804e-54df3c02d837",
+                                        "when": [
+                                            {
+                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                                "condition": "contains any",
+                                                "values": [
+                                                    "Paused trading but intends to restart in the next two weeks",
+                                                    "Paused trading and does not intend to restart in the next two weeks"
+                                                ]
+                                            },
+                                            {
+                                                "id": "answerc46ba0d2-68da-4098-af49-b6c5981c4e8f",
+                                                "condition": "contains any",
+                                                "values": [
+                                                    "Personal Protective Equipment (PPE)",
+                                                    "Temperature checks",
+                                                    "Routine COVID-19 testing",
+                                                    "Social distancing",
+                                                    "Shift working",
+                                                    "Working in fixed teams",
+                                                    "Staggered breaks",
+                                                    "Hygiene measures",
+                                                    "Other"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8",
+                                        "when": [
+                                            {
+                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                                "condition": "contains any",
+                                                "values": [
+                                                    "Paused trading but intends to restart in the next two weeks",
+                                                    "Paused trading and does not intend to restart in the next two weeks"
+                                                ]
+                                            },
+                                            {
+                                                "id": "answerc46ba0d2-68da-4098-af49-b6c5981c4e8f",
+                                                "condition": "contains any",
+                                                "values": ["None of these"]
+                                            },
+                                            {
+                                                "id": "answerc46ba0d2-68da-4098-af49-b6c5981c4e8f-exclusive",
+                                                "condition": "contains any",
+                                                "values": ["Not sure"]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "blockb8481e29-f74a-4b32-8b95-2720c2842e0c",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "questionb8481e29-f74a-4b32-8b95-2720c2842e0c",
+                                    "title": "How has the implementation of these safety measures affected {{ metadata['ru_name'] }}&apos;s <em>operating costs</em>?",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer740ce2f4-18bd-48b9-a01d-47854e1e1796",
+                                            "mandatory": true,
+                                            "type": "Radio",
+                                            "label": "",
+                                            "description": "",
+                                            "q_code": "116",
+                                            "options": [
+                                                {
+                                                    "label": "Operating costs have substantially increased",
+                                                    "value": "Operating costs have substantially increased"
+                                                },
+                                                {
+                                                    "label": "Operating costs have increased a little",
+                                                    "value": "Operating costs have increased a little"
+                                                },
+                                                {
+                                                    "label": "Operating costs have stayed the same",
+                                                    "value": "Operating costs have stayed the same"
+                                                },
+                                                {
+                                                    "label": "Operating costs have decreased a little",
+                                                    "value": "Operating costs have decreased a little"
+                                                },
+                                                {
+                                                    "label": "Operating costs have substantially decreased",
+                                                    "value": "Operating costs have substantially decreased"
+                                                },
+                                                {
+                                                    "label": "Not sure",
+                                                    "value": "Not sure"
+                                                },
+                                                {
+                                                    "label": "Not applicable",
+                                                    "value": "Not applicable"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8",
+                                        "when": [
+                                            {
+                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                                "condition": "contains any",
+                                                "values": [
+                                                    "Currently trading and has been for more than the last two weeks",
+                                                    "Started trading within the last two weeks after a pause in trading"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "block7ff4579e-ede4-4d33-804e-54df3c02d837"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "block7ff4579e-ede4-4d33-804e-54df3c02d837",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question7ff4579e-ede4-4d33-804e-54df3c02d837",
+                                    "title": "How do you expect the implementation of these safety measures to affect {{ metadata['ru_name'] }}&apos;s <em>operating costs</em>?",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answer000984b9-561c-40ba-b529-6faa4d95fc1b",
+                                            "mandatory": true,
+                                            "type": "Radio",
+                                            "label": "",
+                                            "description": "",
+                                            "q_code": "117",
+                                            "options": [
+                                                {
+                                                    "label": "Operating costs will substantially increase",
+                                                    "value": "Operating costs will substantially increase"
+                                                },
+                                                {
+                                                    "label": "Operating costs will increase a little",
+                                                    "value": "Operating costs will increase a little"
+                                                },
+                                                {
+                                                    "label": "Operating costs will stay the same",
+                                                    "value": "Operating costs will stay the same"
+                                                },
+                                                {
+                                                    "label": "Operating costs will decrease a little",
+                                                    "value": "Operating costs will decrease a little"
+                                                },
+                                                {
+                                                    "label": "Operating costs will substantially decrease",
+                                                    "value": "Operating costs will substantially decrease"
+                                                },
+                                                {
+                                                    "label": "Not sure",
+                                                    "value": "Not sure"
+                                                },
+                                                {
+                                                    "label": "Not applicable",
+                                                    "value": "Not applicable"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "not set"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "skip_conditions": [
+                        {
+                            "when": [
+                                {
+                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                    "condition": "contains any",
+                                    "values": ["Permanently ceased trading"]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
         },
         {
             "id": "section19187b42-33f0-4bf8-92c3-aa13bc8628f8",
             "title": "Comments",
-            "groups": [{
+            "groups": [
+                {
                     "id": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8",
                     "title": "Comments",
-                    "blocks": [{
-                        "id": "block840d9b9e-842b-4307-9006-9d93de8466ce",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question840d9b9e-842b-4307-9006-9d93de8466ce",
-                            "title": "Let us know anything else that you think may help us understand {{ metadata['ru_name'] }}&apos;s current situation",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answerf2cd92db-8721-45eb-be99-848705657b88",
-                                "mandatory": false,
-                                "type": "TextArea",
-                                "label": "Comments",
-                                "description": "",
-                                "q_code": "146",
-                                "max_length": 2000
-                            }]
-                        }]
-                    }]
+                    "blocks": [
+                        {
+                            "id": "block840d9b9e-842b-4307-9006-9d93de8466ce",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "question840d9b9e-842b-4307-9006-9d93de8466ce",
+                                    "title": "Let us know anything else that you think may help us understand {{ metadata['ru_name'] }}&apos;s current situation",
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "id": "answerf2cd92db-8721-45eb-be99-848705657b88",
+                                            "mandatory": false,
+                                            "type": "TextArea",
+                                            "label": "Comments",
+                                            "description": "",
+                                            "q_code": "146",
+                                            "max_length": 2000
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
                 },
                 {
                     "id": "summary-group",
                     "title": "Summary",
-                    "blocks": [{
-                        "type": "Summary",
-                        "id": "summary-block"
-                    }]
+                    "blocks": [
+                        {
+                            "type": "Summary",
+                            "id": "summary-block"
+                        }
+                    ]
                 }
             ]
         }
@@ -5763,7 +6801,8 @@
     "navigation": {
         "visible": true
     },
-    "metadata": [{
+    "metadata": [
+        {
             "name": "user_id",
             "validator": "string"
         },

--- a/data/en/covid_0001.json
+++ b/data/en/covid_0001.json
@@ -6,6793 +6,5755 @@
     "data_version": "0.0.1",
     "survey_id": "283",
     "title": "Business Impact of Coronavirus (COVID-19) Survey",
-    "sections": [
-        {
+    "sections": [{
             "id": "section07aa7033-76e4-41b4-81e4-a957831a5a42",
             "title": "Trading status of your business",
-            "groups": [
-                {
-                    "id": "group07aa7033-76e4-41b4-81e4-a957831a5a42",
-                    "title": "Trading status of your business",
-                    "blocks": [
-                        {
-                            "type": "Introduction",
-                            "id": "introduction-block",
-                            "primary_content": [
+            "groups": [{
+                "id": "group07aa7033-76e4-41b4-81e4-a957831a5a42",
+                "title": "Trading status of your business",
+                "blocks": [{
+                        "type": "Introduction",
+                        "id": "introduction-block",
+                        "primary_content": [{
+                            "type": "Basic",
+                            "id": "primary",
+                            "content": [{
+                                    "list": [
+                                        "Your response helps us to provide real-time information during the coronavirus (COVID-19) pandemic.",
+                                        "This is so the government has the information it needs to manage the UK&#x2019;s response."
+                                    ]
+                                },
                                 {
-                                    "type": "Basic",
-                                    "id": "primary",
-                                    "content": [
+                                    "description": "<strong>Thank you for completing this survey at this challenging time.</strong>"
+                                }
+                            ]
+                        }],
+                        "preview_content": {
+                            "id": "preview",
+                            "title": "Information you need",
+                            "content": [{
+                                "description": "<a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/surveys/informationforbusinesses/businesssurveys/thequestionsonthebusinessimpactofcoronaviruscovid19survey'>View the questions before you start the survey (external link)</a>",
+                                "list": [
+                                    "Information should relate to the UK.",
+                                    "We will treat your information securely and confidentially.",
+                                    "This survey is refreshed every two weeks. To avoid losing data, please submit by the return date and before the next fortnightly survey is published."
+                                ]
+                            }],
+                            "questions": [{
+                                    "question": "Trading status of your business",
+                                    "content": [{
+                                        "description": "This section asks for general information on the business&apos;s trading status."
+                                    }]
+                                },
+                                {
+                                    "question": "Turnover and online sales",
+                                    "content": [{
+                                        "description": "This section asks for information on any changes to the business&apos;s turnover in the last two weeks and any changes to its online sales and activities."
+                                    }]
+                                },
+                                {
+                                    "question": "Postponed or cancelled bookings, services and events",
+                                    "content": [{
+                                        "description": "This section asks for information about how the business is managing postponed or cancelled bookings, services and events sold to customers during the coronavirus (COVID-19) pandemic."
+                                    }]
+                                },
+                                {
+                                    "question": "Exporting, importing and UK trade",
+                                    "content": [{
+                                        "description": "This section asks for information about the business&apos;s importing and exporting activities."
+                                    }]
+                                },
+                                {
+                                    "question": "UK supply chain",
+                                    "content": [{
+                                        "description": "This section asks for information about the availability of materials, goods and services within the UK."
+                                    }]
+                                },
+                                {
+                                    "question": "Prices of materials, goods and services",
+                                    "content": [{
+                                        "description": "This section asks for information on any changes to the prices of goods and services bought or sold by the business in the last two weeks."
+                                    }]
+                                },
+                                {
+                                    "question": "Stock and capital expenditure",
+                                    "content": [{
+                                        "description": "This section asks for information about how the coronavirus (COVID-19) pandemic may have affected the business&apos;s stock and capital expenditure."
+                                    }]
+                                },
+                                {
+                                    "question": "Innovation",
+                                    "content": [{
+                                        "description": "This section asks for information about any new or improved innovations made by the business during the coronavirus (COVID-19) pandemic."
+                                    }]
+                                },
+                                {
+                                    "question": "Access to financial support",
+                                    "content": [{
+                                            "description": "This section asks for information on:"
+                                        },
                                         {
                                             "list": [
-                                                "Your response helps us to provide real-time information during the coronavirus (COVID-19) pandemic.",
-                                                "This is so the government has the information it needs to manage the UK&#x2019;s response."
+                                                "any applications that the business made for government financial initiatives or schemes",
+                                                "any applications the business intends to make for government initiatives or schemes",
+                                                "any applications for non-government financial support"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": "Operational performance",
+                                    "content": [{
+                                            "description": "This section asks for information about the business&apos;s workforce such as the:"
+                                        },
+                                        {
+                                            "list": [
+                                                "percentage on, for example, furlough leave or working remotely",
+                                                "percentage returning from furlough or remote working, or would be made permanently redundant",
+                                                "percentage of furloughed staff receiving top-ups in addition to the Coronavirus Job Retention Scheme (CJRS) payment",
+                                                "number of vacancies"
                                             ]
                                         },
                                         {
-                                            "description": "<strong>Thank you for completing this survey at this challenging time.</strong>"
+                                            "description": "It also asks about safety measures in the workplace."
                                         }
                                     ]
                                 }
-                            ],
-                            "preview_content": {
-                                "id": "preview",
-                                "title": "Information you need",
-                                "content": [
-                                    {
-                                        "description": "<a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/surveys/informationforbusinesses/businesssurveys/thequestionsonthebusinessimpactofcoronaviruscovid19survey'>View the questions before you start the survey (external link)</a>",
-                                        "list": [
-                                            "Information should relate to the UK.",
-                                            "We will treat your information securely and confidentially.",
-                                            "This survey is refreshed every two weeks. To avoid losing data, please submit by the return date and before the next fortnightly survey is published."
-                                        ]
-                                    }
-                                ],
-                                "questions": [
-                                    {
-                                        "question": "Trading status of your business",
-                                        "content": [
-                                            {
-                                                "description": "This section asks for general information on the business&apos;s trading status."
-                                            }
-                                        ]
+                            ]
+                        },
+                        "secondary_content": [{
+                            "id": "secondary-content",
+                            "title": ""
+                        }]
+                    },
+                    {
+                        "type": "Interstitial",
+                        "id": "group07aa7033-76e4-41b4-81e4-a957831a5a42-introduction",
+                        "title": "Trading status of your business",
+                        "description": "<p>This section asks for general information on the business&apos;s trading status.</p>"
+                    },
+                    {
+                        "id": "blockbe7effcb-8832-4733-90b4-b699fcffa38a",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "questionbe7effcb-8832-4733-90b4-b699fcffa38a",
+                            "title": "Which of the following statements best describes {{ metadata['ru_name'] }}&apos;s trading status?",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "label": "",
+                                "description": "",
+                                "q_code": "32",
+                                "options": [{
+                                        "label": "Currently trading and has been for more than the last two weeks",
+                                        "value": "Currently trading and has been for more than the last two weeks"
                                     },
                                     {
-                                        "question": "Turnover and online sales",
-                                        "content": [
-                                            {
-                                                "description": "This section asks for information on any changes to the business&apos;s turnover in the last two weeks and any changes to its online sales and activities."
-                                            }
-                                        ]
+                                        "label": "Started trading within the last two weeks after a pause in trading",
+                                        "value": "Started trading within the last two weeks after a pause in trading"
                                     },
                                     {
-                                        "question": "Postponed or cancelled bookings, services and events",
-                                        "content": [
-                                            {
-                                                "description": "This section asks for information about how the business is managing postponed or cancelled bookings, services and events sold to customers during the coronavirus (COVID-19) pandemic."
-                                            }
-                                        ]
+                                        "label": "Paused trading but intends to restart in the next two weeks",
+                                        "value": "Paused trading but intends to restart in the next two weeks"
                                     },
                                     {
-                                        "question": "Exporting, importing and UK trade",
-                                        "content": [
-                                            {
-                                                "description": "This section asks for information about the business&apos;s importing and exporting activities."
-                                            }
-                                        ]
+                                        "label": "Paused trading and does not intend to restart in the next two weeks",
+                                        "value": "Paused trading and does not intend to restart in the next two weeks"
                                     },
                                     {
-                                        "question": "UK supply chain",
-                                        "content": [
-                                            {
-                                                "description": "This section asks for information about the availability of materials, goods and services within the UK."
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "question": "Prices of materials, goods and services",
-                                        "content": [
-                                            {
-                                                "description": "This section asks for information on any changes to the prices of goods and services bought or sold by the business in the last two weeks."
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "question": "Stock and capital expenditure",
-                                        "content": [
-                                            {
-                                                "description": "This section asks for information about how the coronavirus (COVID-19) pandemic may have affected the business&apos;s stock and capital expenditure."
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "question": "Innovation",
-                                        "content": [
-                                            {
-                                                "description": "This section asks for information about any new or improved innovations made by the business during the coronavirus (COVID-19) pandemic."
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "question": "Access to financial support",
-                                        "content": [
-                                            {
-                                                "description": "This section asks for information on:"
-                                            },
-                                            {
-                                                "list": [
-                                                    "any applications that the business made for government financial initiatives or schemes",
-                                                    "any applications the business intends to make for government initiatives or schemes",
-                                                    "any applications for non-government financial support"
-                                                ]
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "question": "Operational performance",
-                                        "content": [
-                                            {
-                                                "description": "This section asks for information about the business&apos;s workforce such as the:"
-                                            },
-                                            {
-                                                "list": [
-                                                    "percentage on, for example, furlough leave or working remotely",
-                                                    "percentage returning from furlough or remote working, or would be made permanently redundant",
-                                                    "percentage of furloughed staff receiving top-ups in addition to the Coronavirus Job Retention Scheme (CJRS) payment",
-                                                    "number of vacancies"
-                                                ]
-                                            },
-                                            {
-                                                "description": "It also asks about safety measures in the workplace."
-                                            }
-                                        ]
+                                        "label": "Permanently ceased trading",
+                                        "value": "Permanently ceased trading"
                                     }
                                 ]
-                            },
-                            "secondary_content": [
-                                {
-                                    "id": "secondary-content",
-                                    "title": ""
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "block2bf9c26a-511c-466b-b889-f936535bef7f",
+                                    "when": [{
+                                        "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                        "condition": "contains any",
+                                        "values": [
+                                            "Currently trading and has been for more than the last two weeks",
+                                            "Started trading within the last two weeks after a pause in trading",
+                                            "Paused trading but intends to restart in the next two weeks",
+                                            "Paused trading and does not intend to restart in the next two weeks"
+                                        ]
+                                    }]
                                 }
-                            ]
-                        },
-                        {
-                            "type": "Interstitial",
-                            "id": "group07aa7033-76e4-41b4-81e4-a957831a5a42-introduction",
-                            "title": "Trading status of your business",
-                            "description": "<p>This section asks for general information on the business&apos;s trading status.</p>"
-                        },
-                        {
-                            "id": "blockbe7effcb-8832-4733-90b4-b699fcffa38a",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "questionbe7effcb-8832-4733-90b4-b699fcffa38a",
-                                    "title": "Which of the following statements best describes {{ metadata['ru_name'] }}&apos;s trading status?",
-                                    "type": "General",
-                                    "answers": [
+                            },
+                            {
+                                "goto": {
+                                    "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "block2bf9c26a-511c-466b-b889-f936535bef7f",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question2bf9c26a-511c-466b-b889-f936535bef7f",
+                            "title": "<em>Where in the UK</em> are {{ metadata['ru_name'] }}&apos;s sites located?",
+                            "description": "<p>The UK consists of England, Northern Ireland, Scotland and Wales. </p>",
+                            "type": "MutuallyExclusive",
+                            "mandatory": true,
+                            "answers": [{
+                                    "id": "answere866cf73-a3a4-4d61-8f0c-1a05f09e1c75",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "label": "Select all that apply",
+                                    "description": "",
+                                    "options": [{
+                                            "label": "Northern Ireland",
+                                            "value": "Northern Ireland",
+                                            "q_code": "1241"
+                                        },
                                         {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "mandatory": true,
-                                            "type": "Radio",
-                                            "label": "",
-                                            "description": "",
-                                            "q_code": "32",
-                                            "options": [
-                                                {
-                                                    "label": "Currently trading and has been for more than the last two weeks",
-                                                    "value": "Currently trading and has been for more than the last two weeks"
-                                                },
-                                                {
-                                                    "label": "Started trading within the last two weeks after a pause in trading",
-                                                    "value": "Started trading within the last two weeks after a pause in trading"
-                                                },
-                                                {
-                                                    "label": "Paused trading but intends to restart in the next two weeks",
-                                                    "value": "Paused trading but intends to restart in the next two weeks"
-                                                },
-                                                {
-                                                    "label": "Paused trading and does not intend to restart in the next two weeks",
-                                                    "value": "Paused trading and does not intend to restart in the next two weeks"
-                                                },
-                                                {
-                                                    "label": "Permanently ceased trading",
-                                                    "value": "Permanently ceased trading"
-                                                }
-                                            ]
+                                            "label": "Scotland",
+                                            "value": "Scotland",
+                                            "q_code": "1242"
+                                        },
+                                        {
+                                            "label": "Wales",
+                                            "value": "Wales",
+                                            "q_code": "1243"
+                                        },
+                                        {
+                                            "label": "East of England",
+                                            "value": "East of England",
+                                            "q_code": "1244"
+                                        },
+                                        {
+                                            "label": "East Midlands",
+                                            "value": "East Midlands",
+                                            "q_code": "1245"
+                                        },
+                                        {
+                                            "label": "Greater London",
+                                            "value": "Greater London",
+                                            "q_code": "1246"
+                                        },
+                                        {
+                                            "label": "North East of England",
+                                            "value": "North East of England",
+                                            "q_code": "1247"
+                                        },
+                                        {
+                                            "label": "North West of England",
+                                            "value": "North West of England",
+                                            "q_code": "1248"
+                                        },
+                                        {
+                                            "label": "South East of England",
+                                            "value": "South East of England",
+                                            "q_code": "1249"
+                                        },
+                                        {
+                                            "label": "South West of England",
+                                            "value": "South West of England",
+                                            "q_code": "12410"
+                                        },
+                                        {
+                                            "label": "West Midlands",
+                                            "value": "West Midlands",
+                                            "q_code": "12411"
+                                        },
+                                        {
+                                            "label": "Yorkshire and The Humber",
+                                            "value": "Yorkshire and The Humber",
+                                            "q_code": "12412"
+                                        },
+                                        {
+                                            "label": "Not sure",
+                                            "value": "Not sure",
+                                            "q_code": "12413"
                                         }
                                     ]
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "block": "block2bf9c26a-511c-466b-b889-f936535bef7f",
-                                        "when": [
-                                            {
-                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                                "condition": "contains any",
-                                                "values": [
-                                                    "Currently trading and has been for more than the last two weeks",
-                                                    "Started trading within the last two weeks after a pause in trading",
-                                                    "Paused trading but intends to restart in the next two weeks",
-                                                    "Paused trading and does not intend to restart in the next two weeks"
-                                                ]
-                                            }
-                                        ]
-                                    }
                                 },
                                 {
-                                    "goto": {
-                                        "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8"
-                                    }
+                                    "id": "answere866cf73-a3a4-4d61-8f0c-1a05f09e1c75-exclusive",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "description": "",
+                                    "options": [{
+                                        "label": "Not applicable",
+                                        "value": "Not applicable",
+                                        "q_code": "1240"
+                                    }]
                                 }
                             ]
-                        },
-                        {
-                            "id": "block2bf9c26a-511c-466b-b889-f936535bef7f",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question2bf9c26a-511c-466b-b889-f936535bef7f",
-                                    "title": "<em>Where in the UK</em> are {{ metadata['ru_name'] }}&apos;s sites located?",
-                                    "description": "<p>The UK consists of England, Northern Ireland, Scotland and Wales. </p>",
-                                    "type": "MutuallyExclusive",
-                                    "mandatory": true,
-                                    "answers": [
-                                        {
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "group": "groupaf9cbebb-ec7e-4a68-b46d-2b7d081d16d7",
+                                    "when": [{
                                             "id": "answere866cf73-a3a4-4d61-8f0c-1a05f09e1c75",
-                                            "mandatory": false,
-                                            "type": "Checkbox",
-                                            "label": "Select all that apply",
-                                            "description": "",
-                                            "options": [
-                                                {
-                                                    "label": "Northern Ireland",
-                                                    "value": "Northern Ireland",
-                                                    "q_code": "1241"
-                                                },
-                                                {
-                                                    "label": "Scotland",
-                                                    "value": "Scotland",
-                                                    "q_code": "1242"
-                                                },
-                                                {
-                                                    "label": "Wales",
-                                                    "value": "Wales",
-                                                    "q_code": "1243"
-                                                },
-                                                {
-                                                    "label": "East of England",
-                                                    "value": "East of England",
-                                                    "q_code": "1244"
-                                                },
-                                                {
-                                                    "label": "East Midlands",
-                                                    "value": "East Midlands",
-                                                    "q_code": "1245"
-                                                },
-                                                {
-                                                    "label": "Greater London",
-                                                    "value": "Greater London",
-                                                    "q_code": "1246"
-                                                },
-                                                {
-                                                    "label": "North East of England",
-                                                    "value": "North East of England",
-                                                    "q_code": "1247"
-                                                },
-                                                {
-                                                    "label": "North West of England",
-                                                    "value": "North West of England",
-                                                    "q_code": "1248"
-                                                },
-                                                {
-                                                    "label": "South East of England",
-                                                    "value": "South East of England",
-                                                    "q_code": "1249"
-                                                },
-                                                {
-                                                    "label": "South West of England",
-                                                    "value": "South West of England",
-                                                    "q_code": "12410"
-                                                },
-                                                {
-                                                    "label": "West Midlands",
-                                                    "value": "West Midlands",
-                                                    "q_code": "12411"
-                                                },
-                                                {
-                                                    "label": "Yorkshire and The Humber",
-                                                    "value": "Yorkshire and The Humber",
-                                                    "q_code": "12412"
-                                                },
-                                                {
-                                                    "label": "Not sure",
-                                                    "value": "Not sure",
-                                                    "q_code": "12413"
-                                                }
-                                            ]
+                                            "condition": "contains any",
+                                            "values": ["Not sure"]
                                         },
                                         {
                                             "id": "answere866cf73-a3a4-4d61-8f0c-1a05f09e1c75-exclusive",
-                                            "mandatory": false,
-                                            "type": "Checkbox",
-                                            "description": "",
-                                            "options": [
-                                                {
-                                                    "label": "Not applicable",
-                                                    "value": "Not applicable",
-                                                    "q_code": "1240"
-                                                }
+                                            "condition": "contains any",
+                                            "values": ["Not applicable"]
+                                        },
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "contains any",
+                                            "values": [
+                                                "Paused trading but intends to restart in the next two weeks",
+                                                "Paused trading and does not intend to restart in the next two weeks"
                                             ]
                                         }
                                     ]
                                 }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "group": "groupaf9cbebb-ec7e-4a68-b46d-2b7d081d16d7",
-                                        "when": [
-                                            {
-                                                "id": "answere866cf73-a3a4-4d61-8f0c-1a05f09e1c75",
-                                                "condition": "contains any",
-                                                "values": ["Not sure"]
-                                            },
-                                            {
-                                                "id": "answere866cf73-a3a4-4d61-8f0c-1a05f09e1c75-exclusive",
-                                                "condition": "contains any",
-                                                "values": ["Not applicable"]
-                                            },
-                                            {
-                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                                "condition": "contains any",
-                                                "values": [
-                                                    "Paused trading but intends to restart in the next two weeks",
-                                                    "Paused trading and does not intend to restart in the next two weeks"
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "group": "group281e76fe-1287-43af-bfe9-e1a53be6476e",
-                                        "when": [
-                                            {
-                                                "id": "answere866cf73-a3a4-4d61-8f0c-1a05f09e1c75",
-                                                "condition": "contains any",
-                                                "values": ["Not sure"]
-                                            },
-                                            {
-                                                "id": "answere866cf73-a3a4-4d61-8f0c-1a05f09e1c75-exclusive",
-                                                "condition": "contains any",
-                                                "values": ["Not applicable"]
-                                            },
-                                            {
-                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                                "condition": "contains any",
-                                                "values": [
-                                                    "Currently trading and has been for more than the last two weeks",
-                                                    "Started trading within the last two weeks after a pause in trading"
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "blockae8d1838-da63-4805-b596-6b55fdb86447",
-                                        "when": [
-                                            {
-                                                "id": "answere866cf73-a3a4-4d61-8f0c-1a05f09e1c75",
-                                                "condition": "contains any",
-                                                "values": [
-                                                    "Northern Ireland",
-                                                    "Scotland",
-                                                    "Wales",
-                                                    "East of England",
-                                                    "East Midlands",
-                                                    "Greater London",
-                                                    "North East of England",
-                                                    "North West of England",
-                                                    "South East of England",
-                                                    "South West of England",
-                                                    "West Midlands",
-                                                    "Yorkshire and The Humber"
-                                                ]
-                                            },
-                                            {
-                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                                "condition": "contains any",
-                                                "values": [
-                                                    "Currently trading and has been for more than the last two weeks",
-                                                    "Started trading within the last two weeks after a pause in trading",
-                                                    "Paused trading but intends to restart in the next two weeks",
-                                                    "Paused trading and does not intend to restart in the next two weeks"
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8"
-                                    }
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
+                            },
+                            {
+                                "goto": {
+                                    "group": "group281e76fe-1287-43af-bfe9-e1a53be6476e",
+                                    "when": [{
+                                            "id": "answere866cf73-a3a4-4d61-8f0c-1a05f09e1c75",
+                                            "condition": "contains any",
+                                            "values": ["Not sure"]
+                                        },
+                                        {
+                                            "id": "answere866cf73-a3a4-4d61-8f0c-1a05f09e1c75-exclusive",
+                                            "condition": "contains any",
+                                            "values": ["Not applicable"]
+                                        },
                                         {
                                             "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
+                                            "condition": "contains any",
+                                            "values": [
+                                                "Currently trading and has been for more than the last two weeks",
+                                                "Started trading within the last two weeks after a pause in trading"
+                                            ]
                                         }
                                     ]
                                 }
-                            ]
-                        },
-                        {
-                            "id": "blockae8d1838-da63-4805-b596-6b55fdb86447",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "questionae8d1838-da63-4805-b596-6b55fdb86447",
-                                    "title": "Where in the UK are {{ metadata['ru_name'] }}&apos;s <em>sites currently paused or ceased trading</em>?",
-                                    "description": "<p>Select all the regions where the majority of the business&apos;s sites are paused or ceased trading.</p>",
-                                    "type": "MutuallyExclusive",
-                                    "mandatory": true,
-                                    "answers": [
-                                        {
-                                            "id": "answer59821270-1fd0-4719-b72b-46923591d46a",
-                                            "mandatory": false,
-                                            "type": "Checkbox",
-                                            "label": "Select all that apply",
-                                            "description": "",
-                                            "options": [
-                                                {
-                                                    "label": "Northern Ireland",
-                                                    "value": "Northern Ireland",
-                                                    "q_code": "1141"
-                                                },
-                                                {
-                                                    "label": "Scotland",
-                                                    "value": "Scotland",
-                                                    "q_code": "1142"
-                                                },
-                                                {
-                                                    "label": "Wales",
-                                                    "value": "Wales",
-                                                    "q_code": "1143"
-                                                },
-                                                {
-                                                    "label": "East of England",
-                                                    "value": "East of England",
-                                                    "q_code": "1144"
-                                                },
-                                                {
-                                                    "label": "East Midlands",
-                                                    "value": "East Midlands",
-                                                    "q_code": "1145"
-                                                },
-                                                {
-                                                    "label": "Greater London",
-                                                    "value": "Greater London",
-                                                    "q_code": "1146"
-                                                },
-                                                {
-                                                    "label": "North East of England",
-                                                    "value": "North East of England",
-                                                    "q_code": "1147"
-                                                },
-                                                {
-                                                    "label": "North West of England",
-                                                    "value": "North West of England",
-                                                    "q_code": "1148"
-                                                },
-                                                {
-                                                    "label": "South East of England",
-                                                    "value": "South East of England",
-                                                    "q_code": "1149"
-                                                },
-                                                {
-                                                    "label": "South West of England",
-                                                    "value": "South West of England",
-                                                    "q_code": "11410"
-                                                },
-                                                {
-                                                    "label": "West Midlands",
-                                                    "value": "West Midlands",
-                                                    "q_code": "11411"
-                                                },
-                                                {
-                                                    "label": "Yorkshire and The Humber",
-                                                    "value": "Yorkshire and The Humber",
-                                                    "q_code": "11412"
-                                                },
-                                                {
-                                                    "label": "Not sure",
-                                                    "value": "Not sure",
-                                                    "q_code": "11413"
-                                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "blockae8d1838-da63-4805-b596-6b55fdb86447",
+                                    "when": [{
+                                            "id": "answere866cf73-a3a4-4d61-8f0c-1a05f09e1c75",
+                                            "condition": "contains any",
+                                            "values": [
+                                                "Northern Ireland",
+                                                "Scotland",
+                                                "Wales",
+                                                "East of England",
+                                                "East Midlands",
+                                                "Greater London",
+                                                "North East of England",
+                                                "North West of England",
+                                                "South East of England",
+                                                "South West of England",
+                                                "West Midlands",
+                                                "Yorkshire and The Humber"
                                             ]
                                         },
                                         {
-                                            "id": "answer59821270-1fd0-4719-b72b-46923591d46a-exclusive",
-                                            "mandatory": false,
-                                            "type": "Checkbox",
-                                            "description": "",
-                                            "options": [
-                                                {
-                                                    "label": "None of our sites are currently paused or ceased trading",
-                                                    "value": "None of our sites are currently paused or ceased trading",
-                                                    "q_code": "1140"
-                                                }
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "contains any",
+                                            "values": [
+                                                "Currently trading and has been for more than the last two weeks",
+                                                "Started trading within the last two weeks after a pause in trading",
+                                                "Paused trading but intends to restart in the next two weeks",
+                                                "Paused trading and does not intend to restart in the next two weeks"
                                             ]
                                         }
                                     ]
                                 }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "group": "groupaf9cbebb-ec7e-4a68-b46d-2b7d081d16d7",
-                                        "when": [
-                                            {
-                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                                "condition": "contains any",
-                                                "values": [
-                                                    "Paused trading but intends to restart in the next two weeks",
-                                                    "Paused trading and does not intend to restart in the next two weeks"
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8",
-                                        "when": [
-                                            {
-                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                                "condition": "contains any",
-                                                "values": ["Permanently ceased trading"]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "group": "group281e76fe-1287-43af-bfe9-e1a53be6476e"
-                                    }
+                            },
+                            {
+                                "goto": {
+                                    "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8"
                                 }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
+                            }
+                        ],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "blockae8d1838-da63-4805-b596-6b55fdb86447",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "questionae8d1838-da63-4805-b596-6b55fdb86447",
+                            "title": "Where in the UK are {{ metadata['ru_name'] }}&apos;s <em>sites currently paused or ceased trading</em>?",
+                            "description": "<p>Select all the regions where the majority of the business&apos;s sites are paused or ceased trading.</p>",
+                            "type": "MutuallyExclusive",
+                            "mandatory": true,
+                            "answers": [{
+                                    "id": "answer59821270-1fd0-4719-b72b-46923591d46a",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "label": "Select all that apply",
+                                    "description": "",
+                                    "options": [{
+                                            "label": "Northern Ireland",
+                                            "value": "Northern Ireland",
+                                            "q_code": "1141"
+                                        },
                                         {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
+                                            "label": "Scotland",
+                                            "value": "Scotland",
+                                            "q_code": "1142"
+                                        },
+                                        {
+                                            "label": "Wales",
+                                            "value": "Wales",
+                                            "q_code": "1143"
+                                        },
+                                        {
+                                            "label": "East of England",
+                                            "value": "East of England",
+                                            "q_code": "1144"
+                                        },
+                                        {
+                                            "label": "East Midlands",
+                                            "value": "East Midlands",
+                                            "q_code": "1145"
+                                        },
+                                        {
+                                            "label": "Greater London",
+                                            "value": "Greater London",
+                                            "q_code": "1146"
+                                        },
+                                        {
+                                            "label": "North East of England",
+                                            "value": "North East of England",
+                                            "q_code": "1147"
+                                        },
+                                        {
+                                            "label": "North West of England",
+                                            "value": "North West of England",
+                                            "q_code": "1148"
+                                        },
+                                        {
+                                            "label": "South East of England",
+                                            "value": "South East of England",
+                                            "q_code": "1149"
+                                        },
+                                        {
+                                            "label": "South West of England",
+                                            "value": "South West of England",
+                                            "q_code": "11410"
+                                        },
+                                        {
+                                            "label": "West Midlands",
+                                            "value": "West Midlands",
+                                            "q_code": "11411"
+                                        },
+                                        {
+                                            "label": "Yorkshire and The Humber",
+                                            "value": "Yorkshire and The Humber",
+                                            "q_code": "11412"
+                                        },
+                                        {
+                                            "label": "Not sure",
+                                            "value": "Not sure",
+                                            "q_code": "11413"
                                         }
                                     ]
+                                },
+                                {
+                                    "id": "answer59821270-1fd0-4719-b72b-46923591d46a-exclusive",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "description": "",
+                                    "options": [{
+                                        "label": "None of our sites are currently paused or ceased trading",
+                                        "value": "None of our sites are currently paused or ceased trading",
+                                        "q_code": "1140"
+                                    }]
                                 }
                             ]
-                        }
-                    ]
-                }
-            ]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "group": "groupaf9cbebb-ec7e-4a68-b46d-2b7d081d16d7",
+                                    "when": [{
+                                        "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                        "condition": "contains any",
+                                        "values": [
+                                            "Paused trading but intends to restart in the next two weeks",
+                                            "Paused trading and does not intend to restart in the next two weeks"
+                                        ]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8",
+                                    "when": [{
+                                        "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                        "condition": "contains any",
+                                        "values": ["Permanently ceased trading"]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "group": "group281e76fe-1287-43af-bfe9-e1a53be6476e"
+                                }
+                            }
+                        ],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    }
+                ]
+            }]
         },
         {
             "id": "section281e76fe-1287-43af-bfe9-e1a53be6476e",
             "title": "Turnover and online sales",
-            "groups": [
-                {
-                    "id": "group281e76fe-1287-43af-bfe9-e1a53be6476e",
-                    "title": "Turnover and online sales",
-                    "blocks": [
-                        {
-                            "type": "Interstitial",
-                            "id": "group281e76fe-1287-43af-bfe9-e1a53be6476e-introduction",
-                            "title": "Turnover and online sales",
-                            "description": "<p>This section asks for information about how the coronavirus (COVID-19) pandemic may have affected the business&apos;s turnover in the last two weeks, and about online sales and activity.</p>",
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block9361fa44-7f22-47da-bdd0-16e104300487",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question9361fa44-7f22-47da-bdd0-16e104300487",
-                                    "title": "<em>In the last two weeks</em>, how has the coronavirus (COVID-19) pandemic affected {{ metadata['ru_name'] }}&apos;s turnover, compared with normal expectations for this time of year?",
-                                    "description": "<p>You can provide a rough estimate.</p>",
-                                    "guidance": {
-                                        "content": [
-                                            {
-                                                "description": "<strong>Exclude:</strong>"
-                                            },
-                                            {
-                                                "list": [
-                                                    "change expected due to seasonal effects",
-                                                    "change expected due to normal patterns of business activity"
-                                                ]
-                                            }
-                                        ]
+            "groups": [{
+                "id": "group281e76fe-1287-43af-bfe9-e1a53be6476e",
+                "title": "Turnover and online sales",
+                "blocks": [{
+                        "type": "Interstitial",
+                        "id": "group281e76fe-1287-43af-bfe9-e1a53be6476e-introduction",
+                        "title": "Turnover and online sales",
+                        "description": "<p>This section asks for information about how the coronavirus (COVID-19) pandemic may have affected the business&apos;s turnover in the last two weeks, and about online sales and activity.</p>",
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block9361fa44-7f22-47da-bdd0-16e104300487",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question9361fa44-7f22-47da-bdd0-16e104300487",
+                            "title": "<em>In the last two weeks</em>, how has the coronavirus (COVID-19) pandemic affected {{ metadata['ru_name'] }}&apos;s turnover, compared with normal expectations for this time of year?",
+                            "description": "<p>You can provide a rough estimate.</p>",
+                            "guidance": {
+                                "content": [{
+                                        "description": "<strong>Exclude:</strong>"
                                     },
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer0581e398-f9ab-4597-a1a6-c67d8f96289f",
-                                            "mandatory": true,
-                                            "type": "Radio",
-                                            "label": "",
-                                            "description": "",
-                                            "q_code": "3",
-                                            "options": [
-                                                {
-                                                    "label": "Turnover has increased by more than 50%",
-                                                    "value": "Turnover has increased by more than 50%"
-                                                },
-                                                {
-                                                    "label": "Turnover has increased between 20% and 50%",
-                                                    "value": "Turnover has increased between 20% and 50%"
-                                                },
-                                                {
-                                                    "label": "Turnover has increased by up to 20%",
-                                                    "value": "Turnover has increased by up to 20%"
-                                                },
-                                                {
-                                                    "label": "Turnover has not been affected",
-                                                    "value": "Turnover has not been affected"
-                                                },
-                                                {
-                                                    "label": "Turnover has decreased by up to 20%",
-                                                    "value": "Turnover has decreased by up to 20%"
-                                                },
-                                                {
-                                                    "label": "Turnover has decreased between 20% and 50%",
-                                                    "value": "Turnover has decreased between 20% and 50%"
-                                                },
-                                                {
-                                                    "label": "Turnover has decreased by more than 50%",
-                                                    "value": "Turnover has decreased by more than 50%"
-                                                },
-                                                {
-                                                    "label": "Not sure",
-                                                    "value": "Not sure"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "block": "block07ea7679-53f4-40e7-be6c-01e0615e3672",
-                                        "when": [
-                                            {
-                                                "id": "answer0581e398-f9ab-4597-a1a6-c67d8f96289f",
-                                                "condition": "contains any",
-                                                "values": ["Turnover has not been affected", "Not sure"]
-                                            }
+                                    {
+                                        "list": [
+                                            "change expected due to seasonal effects",
+                                            "change expected due to normal patterns of business activity"
                                         ]
                                     }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "block0bf14da5-6919-4507-8542-5d71be2e6ac1"
+                                ]
+                            },
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer0581e398-f9ab-4597-a1a6-c67d8f96289f",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "label": "",
+                                "description": "",
+                                "q_code": "3",
+                                "options": [{
+                                        "label": "Turnover has increased by more than 50%",
+                                        "value": "Turnover has increased by more than 50%"
+                                    },
+                                    {
+                                        "label": "Turnover has increased between 20% and 50%",
+                                        "value": "Turnover has increased between 20% and 50%"
+                                    },
+                                    {
+                                        "label": "Turnover has increased by up to 20%",
+                                        "value": "Turnover has increased by up to 20%"
+                                    },
+                                    {
+                                        "label": "Turnover has not been affected",
+                                        "value": "Turnover has not been affected"
+                                    },
+                                    {
+                                        "label": "Turnover has decreased by up to 20%",
+                                        "value": "Turnover has decreased by up to 20%"
+                                    },
+                                    {
+                                        "label": "Turnover has decreased between 20% and 50%",
+                                        "value": "Turnover has decreased between 20% and 50%"
+                                    },
+                                    {
+                                        "label": "Turnover has decreased by more than 50%",
+                                        "value": "Turnover has decreased by more than 50%"
+                                    },
+                                    {
+                                        "label": "Not sure",
+                                        "value": "Not sure"
                                     }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "block07ea7679-53f4-40e7-be6c-01e0615e3672",
+                                    "when": [{
+                                        "id": "answer0581e398-f9ab-4597-a1a6-c67d8f96289f",
+                                        "condition": "contains any",
+                                        "values": ["Turnover has not been affected", "Not sure"]
+                                    }]
                                 }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
+                            },
+                            {
+                                "goto": {
+                                    "block": "block0bf14da5-6919-4507-8542-5d71be2e6ac1"
                                 }
-                            ]
-                        },
-                        {
-                            "id": "block0bf14da5-6919-4507-8542-5d71be2e6ac1",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question0bf14da5-6919-4507-8542-5d71be2e6ac1",
-                                    "title": "Please explain in more detail how the coronavirus (COVID-19) pandemic affected {{ metadata['ru_name'] }}&apos;s turnover in the last two weeks",
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answerb27dfc7c-ac12-4c9f-ba1c-29b51878d877",
-                                            "mandatory": true,
-                                            "type": "TextArea",
-                                            "label": "Comments",
-                                            "description": "",
-                                            "q_code": "5",
-                                            "max_length": 2000
-                                        }
-                                    ]
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block07ea7679-53f4-40e7-be6c-01e0615e3672",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question07ea7679-53f4-40e7-be6c-01e0615e3672",
-                                    "title": "What are your expectations about {{ metadata['ru_name'] }}&apos;s turnover in the <em>next two weeks</em>?",
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer887d6dad-b184-4301-9670-89440001359b",
-                                            "mandatory": true,
-                                            "type": "Radio",
-                                            "label": "",
-                                            "description": "",
-                                            "q_code": "6",
-                                            "options": [
-                                                {
-                                                    "label": "Expect turnover to substantially increase",
-                                                    "value": "Expect turnover to substantially increase"
-                                                },
-                                                {
-                                                    "label": "Expect turnover to increase a little",
-                                                    "value": "Expect turnover to increase a little"
-                                                },
-                                                {
-                                                    "label": "Expect turnover to stay the same",
-                                                    "value": "Expect turnover to stay the same"
-                                                },
-                                                {
-                                                    "label": "Expect turnover to decrease a little",
-                                                    "value": "Expect turnover to decrease a little"
-                                                },
-                                                {
-                                                    "label": "Expect turnover to substantially decrease",
-                                                    "value": "Expect turnover to substantially decrease"
-                                                },
-                                                {
-                                                    "label": "Not sure",
-                                                    "value": "Not sure"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "blockd54d2485-7d02-4e67-90be-30c13dc1c230",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "questiond54d2485-7d02-4e67-90be-30c13dc1c230",
-                                    "title": "Prior to the coronavirus (COVID-19) pandemic, did {{ metadata['ru_name'] }} <em>sell goods or services online</em>?",
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer65cee25e-1d83-4d68-8a73-6e60780d9522",
-                                            "mandatory": true,
-                                            "type": "Radio",
-                                            "label": "",
-                                            "description": "",
-                                            "q_code": "94",
-                                            "options": [
-                                                {
-                                                    "label": "Yes",
-                                                    "value": "Yes"
-                                                },
-                                                {
-                                                    "label": "No",
-                                                    "value": "No"
-                                                },
-                                                {
-                                                    "label": "Not sure",
-                                                    "value": "Not sure"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "block": "blockf2734939-baaf-4284-a007-befe2e5bf96d",
-                                        "when": [
-                                            {
-                                                "id": "answer65cee25e-1d83-4d68-8a73-6e60780d9522",
-                                                "condition": "contains any",
-                                                "values": ["Yes"]
-                                            }
-                                        ]
+                            }
+                        ],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block0bf14da5-6919-4507-8542-5d71be2e6ac1",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question0bf14da5-6919-4507-8542-5d71be2e6ac1",
+                            "title": "Please explain in more detail how the coronavirus (COVID-19) pandemic affected {{ metadata['ru_name'] }}&apos;s turnover in the last two weeks",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answerb27dfc7c-ac12-4c9f-ba1c-29b51878d877",
+                                "mandatory": true,
+                                "type": "TextArea",
+                                "label": "Comments",
+                                "description": "",
+                                "q_code": "5",
+                                "max_length": 2000
+                            }]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block07ea7679-53f4-40e7-be6c-01e0615e3672",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question07ea7679-53f4-40e7-be6c-01e0615e3672",
+                            "title": "What are your expectations about {{ metadata['ru_name'] }}&apos;s turnover in the <em>next two weeks</em>?",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer887d6dad-b184-4301-9670-89440001359b",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "label": "",
+                                "description": "",
+                                "q_code": "6",
+                                "options": [{
+                                        "label": "Expect turnover to substantially increase",
+                                        "value": "Expect turnover to substantially increase"
+                                    },
+                                    {
+                                        "label": "Expect turnover to increase a little",
+                                        "value": "Expect turnover to increase a little"
+                                    },
+                                    {
+                                        "label": "Expect turnover to stay the same",
+                                        "value": "Expect turnover to stay the same"
+                                    },
+                                    {
+                                        "label": "Expect turnover to decrease a little",
+                                        "value": "Expect turnover to decrease a little"
+                                    },
+                                    {
+                                        "label": "Expect turnover to substantially decrease",
+                                        "value": "Expect turnover to substantially decrease"
+                                    },
+                                    {
+                                        "label": "Not sure",
+                                        "value": "Not sure"
                                     }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "block61e1cc56-3e05-4222-ad07-5792ddba769d"
+                                ]
+                            }]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "blockd54d2485-7d02-4e67-90be-30c13dc1c230",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "questiond54d2485-7d02-4e67-90be-30c13dc1c230",
+                            "title": "Prior to the coronavirus (COVID-19) pandemic, did {{ metadata['ru_name'] }} <em>sell goods or services online</em>?",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer65cee25e-1d83-4d68-8a73-6e60780d9522",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "label": "",
+                                "description": "",
+                                "q_code": "94",
+                                "options": [{
+                                        "label": "Yes",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No",
+                                        "value": "No"
+                                    },
+                                    {
+                                        "label": "Not sure",
+                                        "value": "Not sure"
                                     }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "blockf2734939-baaf-4284-a007-befe2e5bf96d",
+                                    "when": [{
+                                        "id": "answer65cee25e-1d83-4d68-8a73-6e60780d9522",
+                                        "condition": "contains any",
+                                        "values": ["Yes"]
+                                    }]
                                 }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
+                            },
+                            {
+                                "goto": {
+                                    "block": "block61e1cc56-3e05-4222-ad07-5792ddba769d"
                                 }
-                            ]
-                        },
-                        {
-                            "id": "block61e1cc56-3e05-4222-ad07-5792ddba769d",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question61e1cc56-3e05-4222-ad07-5792ddba769d",
-                                    "title": "Has {{ metadata['ru_name'] }} <em>started</em> selling goods or services online during the coronavirus (COVID-19) pandemic?",
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer66776e6d-9e34-42ab-b6cf-fb8ea954c3ec",
-                                            "mandatory": true,
-                                            "type": "Radio",
-                                            "label": "",
-                                            "description": "",
-                                            "q_code": "95",
-                                            "options": [
-                                                {
-                                                    "label": "Yes",
-                                                    "value": "Yes"
-                                                },
-                                                {
-                                                    "label": "No",
-                                                    "value": "No"
-                                                },
-                                                {
-                                                    "label": "Not sure",
-                                                    "value": "Not sure"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "block": "blockf2734939-baaf-4284-a007-befe2e5bf96d",
-                                        "when": [
-                                            {
-                                                "id": "answer66776e6d-9e34-42ab-b6cf-fb8ea954c3ec",
-                                                "condition": "contains any",
-                                                "values": ["Yes"]
-                                            }
-                                        ]
+                            }
+                        ],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block61e1cc56-3e05-4222-ad07-5792ddba769d",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question61e1cc56-3e05-4222-ad07-5792ddba769d",
+                            "title": "Has {{ metadata['ru_name'] }} <em>started</em> selling goods or services online during the coronavirus (COVID-19) pandemic?",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer66776e6d-9e34-42ab-b6cf-fb8ea954c3ec",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "label": "",
+                                "description": "",
+                                "q_code": "95",
+                                "options": [{
+                                        "label": "Yes",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No",
+                                        "value": "No"
+                                    },
+                                    {
+                                        "label": "Not sure",
+                                        "value": "Not sure"
                                     }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "block0c9d4096-3307-453d-8427-e5f0fcdd9a87"
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "blockf2734939-baaf-4284-a007-befe2e5bf96d",
+                                    "when": [{
+                                        "id": "answer66776e6d-9e34-42ab-b6cf-fb8ea954c3ec",
+                                        "condition": "contains any",
+                                        "values": ["Yes"]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "block0c9d4096-3307-453d-8427-e5f0fcdd9a87"
+                                }
+                            }
+                        ],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "blockf2734939-baaf-4284-a007-befe2e5bf96d",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "questionf2734939-baaf-4284-a007-befe2e5bf96d",
+                            "title": "How have {{ metadata['ru_name'] }}&apos;s online sales of goods or services changed in the <em>last two weeks</em>?",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer8602d2d3-f3cc-417b-9a3d-0141d9f9dc39",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "label": "",
+                                "description": "",
+                                "q_code": "75",
+                                "options": [{
+                                        "label": "Online sales have increased",
+                                        "value": "Online sales have increased"
+                                    },
+                                    {
+                                        "label": "Online sales have stayed the same",
+                                        "value": "Online sales have stayed the same"
+                                    },
+                                    {
+                                        "label": "Online sales have continued, but decreased",
+                                        "value": "Online sales have continued, but decreased"
+                                    },
+                                    {
+                                        "label": "The business stopped selling goods or services online",
+                                        "value": "The business stopped selling goods or services online"
+                                    },
+                                    {
+                                        "label": "Not sure",
+                                        "value": "Not sure"
                                     }
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "blockf2734939-baaf-4284-a007-befe2e5bf96d",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "questionf2734939-baaf-4284-a007-befe2e5bf96d",
-                                    "title": "How have {{ metadata['ru_name'] }}&apos;s online sales of goods or services changed in the <em>last two weeks</em>?",
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer8602d2d3-f3cc-417b-9a3d-0141d9f9dc39",
-                                            "mandatory": true,
-                                            "type": "Radio",
-                                            "label": "",
-                                            "description": "",
-                                            "q_code": "75",
-                                            "options": [
-                                                {
-                                                    "label": "Online sales have increased",
-                                                    "value": "Online sales have increased"
-                                                },
-                                                {
-                                                    "label": "Online sales have stayed the same",
-                                                    "value": "Online sales have stayed the same"
-                                                },
-                                                {
-                                                    "label": "Online sales have continued, but decreased",
-                                                    "value": "Online sales have continued, but decreased"
-                                                },
-                                                {
-                                                    "label": "The business stopped selling goods or services online",
-                                                    "value": "The business stopped selling goods or services online"
-                                                },
-                                                {
-                                                    "label": "Not sure",
-                                                    "value": "Not sure"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block0c9d4096-3307-453d-8427-e5f0fcdd9a87",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question0c9d4096-3307-453d-8427-e5f0fcdd9a87",
-                                    "title": "Has {{ metadata['ru_name'] }} used any of the following <em>online services</em> to support business operations during the coronavirus (COVID-19) pandemic?",
-                                    "type": "MutuallyExclusive",
-                                    "mandatory": true,
-                                    "answers": [
-                                        {
-                                            "id": "answer8ca3198d-60a0-45da-bc61-b7e29b55a44c",
-                                            "mandatory": false,
-                                            "type": "Checkbox",
-                                            "label": "Select all that apply",
-                                            "description": "",
-                                            "options": [
-                                                {
-                                                    "label": "Increased or new use of online advertising",
-                                                    "value": "Increased or new use of online advertising",
-                                                    "q_code": "761"
-                                                },
-                                                {
-                                                    "label": "Increased or new use of online services to help communication with customers",
-                                                    "value": "Increased or new use of online services to help communication with customers",
-                                                    "q_code": "762",
-                                                    "description": "For example, social media, new websites, email"
-                                                },
-                                                {
-                                                    "label": "Increased or new use of video conferencing for internal communications",
-                                                    "value": "Increased or new use of video conferencing for internal communications",
-                                                    "q_code": "763",
-                                                    "description": "For example, Zoom, Skype, Microsoft Teams, Google Hangouts"
-                                                },
-                                                {
-                                                    "label": "Increased or new use of social media platforms for internal communications",
-                                                    "value": "Increased or new use of social media platforms for internal communications",
-                                                    "q_code": "764",
-                                                    "description": "For example, WhatsApp, Slack, Trello"
-                                                },
-                                                {
-                                                    "label": "Other",
-                                                    "value": "Other",
-                                                    "q_code": "765",
-                                                    "detail_answer": {
-                                                        "label": "Please describe",
-                                                        "type": "TextField",
-                                                        "id": "answer0a322cfd-08a6-46fc-aa15-98881479656e",
-                                                        "mandatory": false
-                                                    }
-                                                }
-                                            ]
+                                ]
+                            }]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block0c9d4096-3307-453d-8427-e5f0fcdd9a87",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question0c9d4096-3307-453d-8427-e5f0fcdd9a87",
+                            "title": "Has {{ metadata['ru_name'] }} used any of the following <em>online services</em> to support business operations during the coronavirus (COVID-19) pandemic?",
+                            "type": "MutuallyExclusive",
+                            "mandatory": true,
+                            "answers": [{
+                                    "id": "answer8ca3198d-60a0-45da-bc61-b7e29b55a44c",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "label": "Select all that apply",
+                                    "description": "",
+                                    "options": [{
+                                            "label": "Increased or new use of online advertising",
+                                            "value": "Increased or new use of online advertising",
+                                            "q_code": "761"
                                         },
                                         {
-                                            "id": "answer8ca3198d-60a0-45da-bc61-b7e29b55a44c-exclusive",
-                                            "mandatory": false,
-                                            "type": "Checkbox",
-                                            "description": "",
-                                            "options": [
-                                                {
-                                                    "label": "None of the above",
-                                                    "value": "None of the above",
-                                                    "q_code": "766"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
+                                            "label": "Increased or new use of online services to help communication with customers",
+                                            "value": "Increased or new use of online services to help communication with customers",
+                                            "q_code": "762",
+                                            "description": "For example, social media, new websites, email"
+                                        },
                                         {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "blockcabf3732-b3b9-4bf4-8e00-80d9cd5baff1",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "questioncabf3732-b3b9-4bf4-8e00-80d9cd5baff1",
-                                    "title": "Has {{ metadata['ru_name'] }} <em>diversified</em> to produce or provide new goods or services as a result of the coronavirus (COVID-19) pandemic?",
-                                    "type": "General",
-                                    "answers": [
+                                            "label": "Increased or new use of video conferencing for internal communications",
+                                            "value": "Increased or new use of video conferencing for internal communications",
+                                            "q_code": "763",
+                                            "description": "For example, Zoom, Skype, Microsoft Teams, Google Hangouts"
+                                        },
                                         {
-                                            "id": "answer1cef2734-e2be-42ce-a724-948845ec6e5a",
-                                            "mandatory": true,
-                                            "type": "Radio",
-                                            "label": "",
-                                            "description": "",
-                                            "q_code": "115",
-                                            "options": [
-                                                {
-                                                    "label": "Yes",
-                                                    "value": "Yes"
-                                                },
-                                                {
-                                                    "label": "No",
-                                                    "value": "No"
-                                                },
-                                                {
-                                                    "label": "Not sure",
-                                                    "value": "Not sure"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "block": "blocka6a29cc6-f809-4ed5-9d76-cc272b66dbab",
-                                        "when": [
-                                            {
-                                                "id": "answer1cef2734-e2be-42ce-a724-948845ec6e5a",
-                                                "condition": "contains any",
-                                                "values": ["Yes"]
+                                            "label": "Increased or new use of social media platforms for internal communications",
+                                            "value": "Increased or new use of social media platforms for internal communications",
+                                            "q_code": "764",
+                                            "description": "For example, WhatsApp, Slack, Trello"
+                                        },
+                                        {
+                                            "label": "Other",
+                                            "value": "Other",
+                                            "q_code": "765",
+                                            "detail_answer": {
+                                                "label": "Please describe",
+                                                "type": "TextField",
+                                                "id": "answer0a322cfd-08a6-46fc-aa15-98881479656e",
+                                                "mandatory": false
                                             }
-                                        ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "answer8ca3198d-60a0-45da-bc61-b7e29b55a44c-exclusive",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "description": "",
+                                    "options": [{
+                                        "label": "None of the above",
+                                        "value": "None of the above",
+                                        "q_code": "766"
+                                    }]
+                                }
+                            ]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "blockcabf3732-b3b9-4bf4-8e00-80d9cd5baff1",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "questioncabf3732-b3b9-4bf4-8e00-80d9cd5baff1",
+                            "title": "Has {{ metadata['ru_name'] }} <em>diversified</em> to produce or provide new goods or services as a result of the coronavirus (COVID-19) pandemic?",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer1cef2734-e2be-42ce-a724-948845ec6e5a",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "label": "",
+                                "description": "",
+                                "q_code": "115",
+                                "options": [{
+                                        "label": "Yes",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No",
+                                        "value": "No"
+                                    },
+                                    {
+                                        "label": "Not sure",
+                                        "value": "Not sure"
                                     }
-                                },
-                                {
-                                    "goto": {
-                                        "group": "groupaf9cbebb-ec7e-4a68-b46d-2b7d081d16d7"
-                                    }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "blocka6a29cc6-f809-4ed5-9d76-cc272b66dbab",
+                                    "when": [{
+                                        "id": "answer1cef2734-e2be-42ce-a724-948845ec6e5a",
+                                        "condition": "contains any",
+                                        "values": ["Yes"]
+                                    }]
                                 }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
+                            },
+                            {
+                                "goto": {
+                                    "group": "groupaf9cbebb-ec7e-4a68-b46d-2b7d081d16d7"
                                 }
+                            }
+                        ],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "blocka6a29cc6-f809-4ed5-9d76-cc272b66dbab",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "questiona6a29cc6-f809-4ed5-9d76-cc272b66dbab",
+                            "title": "Please give more details about how {{ metadata['ru_name'] }} has diversified to produce or provide new goods or services",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer02a69fd3-aa57-46a7-9487-cec81843a6e4",
+                                "mandatory": true,
+                                "type": "TextArea",
+                                "label": "Comments",
+                                "description": "",
+                                "q_code": "125",
+                                "max_length": 2000
+                            }]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    }
+                ],
+                "skip_conditions": [{
+                        "when": [{
+                                "id": "answere866cf73-a3a4-4d61-8f0c-1a05f09e1c75",
+                                "condition": "contains any",
+                                "values": ["Not sure"]
+                            },
+                            {
+                                "id": "answere866cf73-a3a4-4d61-8f0c-1a05f09e1c75-exclusive",
+                                "condition": "contains any",
+                                "values": ["Not applicable"]
+                            },
+                            {
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "contains any",
+                                "values": [
+                                    "Paused trading but intends to restart in the next two weeks",
+                                    "Paused trading and does not intend to restart in the next two weeks"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "when": [{
+                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                            "condition": "contains any",
+                            "values": [
+                                "Paused trading but intends to restart in the next two weeks",
+                                "Paused trading and does not intend to restart in the next two weeks"
                             ]
-                        },
-                        {
-                            "id": "blocka6a29cc6-f809-4ed5-9d76-cc272b66dbab",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "questiona6a29cc6-f809-4ed5-9d76-cc272b66dbab",
-                                    "title": "Please give more details about how {{ metadata['ru_name'] }} has diversified to produce or provide new goods or services",
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer02a69fd3-aa57-46a7-9487-cec81843a6e4",
-                                            "mandatory": true,
-                                            "type": "TextArea",
-                                            "label": "Comments",
-                                            "description": "",
-                                            "q_code": "125",
-                                            "max_length": 2000
-                                        }
-                                    ]
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
-                    ],
-                    "skip_conditions": [
-                        {
-                            "when": [
-                                {
-                                    "id": "answere866cf73-a3a4-4d61-8f0c-1a05f09e1c75",
-                                    "condition": "contains any",
-                                    "values": ["Not sure"]
-                                },
-                                {
-                                    "id": "answere866cf73-a3a4-4d61-8f0c-1a05f09e1c75-exclusive",
-                                    "condition": "contains any",
-                                    "values": ["Not applicable"]
-                                },
-                                {
-                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                    "condition": "contains any",
-                                    "values": [
-                                        "Paused trading but intends to restart in the next two weeks",
-                                        "Paused trading and does not intend to restart in the next two weeks"
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "when": [
-                                {
-                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                    "condition": "contains any",
-                                    "values": [
-                                        "Paused trading but intends to restart in the next two weeks",
-                                        "Paused trading and does not intend to restart in the next two weeks"
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "when": [
-                                {
-                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                    "condition": "contains any",
-                                    "values": ["Permanently ceased trading"]
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ]
+                        }]
+                    },
+                    {
+                        "when": [{
+                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                            "condition": "contains any",
+                            "values": ["Permanently ceased trading"]
+                        }]
+                    }
+                ]
+            }]
         },
         {
             "id": "sectionaf9cbebb-ec7e-4a68-b46d-2b7d081d16d7",
             "title": "Postponed or cancelled bookings, services and events",
-            "groups": [
-                {
-                    "id": "groupaf9cbebb-ec7e-4a68-b46d-2b7d081d16d7",
-                    "title": "Postponed or cancelled bookings, services and events",
-                    "blocks": [
-                        {
-                            "type": "Interstitial",
-                            "id": "groupaf9cbebb-ec7e-4a68-b46d-2b7d081d16d7-introduction",
-                            "title": "Postponed or cancelled bookings, services and events",
-                            "description": "<p>This section asks for information about how the business is managing postponed or cancelled bookings, services and events sold to customers during the coronavirus (COVID-19) pandemic.</p>",
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block36019578-5d21-43b6-a068-ebafa16c768e",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question36019578-5d21-43b6-a068-ebafa16c768e",
-                                    "title": "Has {{ metadata['ru_name'] }} <em>postponed or cancelled</em> any bookings, services or events sold to customers, due to the coronavirus (COVID-19) pandemic?",
-                                    "type": "General",
-                                    "answers": [
-                                        {
+            "groups": [{
+                "id": "groupaf9cbebb-ec7e-4a68-b46d-2b7d081d16d7",
+                "title": "Postponed or cancelled bookings, services and events",
+                "blocks": [{
+                        "type": "Interstitial",
+                        "id": "groupaf9cbebb-ec7e-4a68-b46d-2b7d081d16d7-introduction",
+                        "title": "Postponed or cancelled bookings, services and events",
+                        "description": "<p>This section asks for information about how the business is managing postponed or cancelled bookings, services and events sold to customers during the coronavirus (COVID-19) pandemic.</p>",
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block36019578-5d21-43b6-a068-ebafa16c768e",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question36019578-5d21-43b6-a068-ebafa16c768e",
+                            "title": "Has {{ metadata['ru_name'] }} <em>postponed or cancelled</em> any bookings, services or events sold to customers, due to the coronavirus (COVID-19) pandemic?",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer399d67d7-f59d-4ab5-ad00-d3b522fb7cd6",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "label": "",
+                                "description": "",
+                                "q_code": "117",
+                                "options": [{
+                                        "label": "Yes",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No",
+                                        "value": "No"
+                                    },
+                                    {
+                                        "label": "Not sure",
+                                        "value": "Not sure"
+                                    },
+                                    {
+                                        "label": "Not applicable",
+                                        "value": "Not applicable"
+                                    }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "group": "group139b1d35-6271-4893-8eef-e1a36f2eb3c9",
+                                    "when": [{
                                             "id": "answer399d67d7-f59d-4ab5-ad00-d3b522fb7cd6",
-                                            "mandatory": true,
-                                            "type": "Radio",
-                                            "label": "",
-                                            "description": "",
-                                            "q_code": "117",
-                                            "options": [
-                                                {
-                                                    "label": "Yes",
-                                                    "value": "Yes"
-                                                },
-                                                {
-                                                    "label": "No",
-                                                    "value": "No"
-                                                },
-                                                {
-                                                    "label": "Not sure",
-                                                    "value": "Not sure"
-                                                },
-                                                {
-                                                    "label": "Not applicable",
-                                                    "value": "Not applicable"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "group": "group139b1d35-6271-4893-8eef-e1a36f2eb3c9",
-                                        "when": [
-                                            {
-                                                "id": "answer399d67d7-f59d-4ab5-ad00-d3b522fb7cd6",
-                                                "condition": "contains any",
-                                                "values": ["No", "Not sure", "Not applicable"]
-                                            },
-                                            {
-                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                                "condition": "contains any",
-                                                "values": [
-                                                    "Currently trading and has been for more than the last two weeks",
-                                                    "Started trading within the last two weeks after a pause in trading"
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "group": "group8753dfce-d80c-4fe0-98ba-3cddd52a9bba",
-                                        "when": [
-                                            {
-                                                "id": "answer399d67d7-f59d-4ab5-ad00-d3b522fb7cd6",
-                                                "condition": "contains any",
-                                                "values": ["No", "Not sure", "Not applicable"]
-                                            },
-                                            {
-                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                                "condition": "contains any",
-                                                "values": [
-                                                    "Paused trading but intends to restart in the next two weeks",
-                                                    "Paused trading and does not intend to restart in the next two weeks"
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "block935395a7-882a-45bd-860e-47c605ab1281",
-                                        "when": [
-                                            {
-                                                "id": "answer399d67d7-f59d-4ab5-ad00-d3b522fb7cd6",
-                                                "condition": "contains any",
-                                                "values": ["Yes"]
-                                            },
-                                            {
-                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                                "condition": "contains any",
-                                                "values": [
-                                                    "Currently trading and has been for more than the last two weeks",
-                                                    "Started trading within the last two weeks after a pause in trading",
-                                                    "Paused trading but intends to restart in the next two weeks",
-                                                    "Paused trading and does not intend to restart in the next two weeks"
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8"
-                                    }
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
+                                            "condition": "contains any",
+                                            "values": ["No", "Not sure", "Not applicable"]
+                                        },
                                         {
                                             "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
+                                            "condition": "contains any",
+                                            "values": [
+                                                "Currently trading and has been for more than the last two weeks",
+                                                "Started trading within the last two weeks after a pause in trading"
+                                            ]
                                         }
                                     ]
                                 }
-                            ]
-                        },
-                        {
-                            "id": "block935395a7-882a-45bd-860e-47c605ab1281",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question935395a7-882a-45bd-860e-47c605ab1281",
-                                    "title": "How is {{ metadata['ru_name'] }} <em>managing</em> postponed or cancelled bookings, services or events sold to customers?",
-                                    "type": "MutuallyExclusive",
-                                    "mandatory": true,
-                                    "answers": [
+                            },
+                            {
+                                "goto": {
+                                    "group": "group8753dfce-d80c-4fe0-98ba-3cddd52a9bba",
+                                    "when": [{
+                                            "id": "answer399d67d7-f59d-4ab5-ad00-d3b522fb7cd6",
+                                            "condition": "contains any",
+                                            "values": ["No", "Not sure", "Not applicable"]
+                                        },
                                         {
-                                            "id": "answere528d417-67e6-4356-b660-107bab6c73f1",
-                                            "mandatory": false,
-                                            "type": "Checkbox",
-                                            "label": "Select all that apply",
-                                            "description": "",
-                                            "options": [
-                                                {
-                                                    "label": "Offering the option to re-book for future dates",
-                                                    "value": "Offering the option to re-book for future dates",
-                                                    "q_code": "1181"
-                                                },
-                                                {
-                                                    "label": "Rescheduling for a future date",
-                                                    "value": "Rescheduling for a future date",
-                                                    "q_code": "1182"
-                                                },
-                                                {
-                                                    "label": "Allowing customers to stop direct debits",
-                                                    "value": "Allowing customers to stop direct debits",
-                                                    "q_code": "1183"
-                                                },
-                                                {
-                                                    "label": "Offering full refunds",
-                                                    "value": "Offering full refunds",
-                                                    "q_code": "1184"
-                                                },
-                                                {
-                                                    "label": "Offering partial refunds",
-                                                    "value": "Offering partial refunds",
-                                                    "q_code": "1185"
-                                                },
-                                                {
-                                                    "label": "Offering vouchers to be used on our products or services",
-                                                    "value": "Offering vouchers to be used on our products or services",
-                                                    "q_code": "1186"
-                                                },
-                                                {
-                                                    "label": "Other",
-                                                    "value": "Other",
-                                                    "q_code": "1187",
-                                                    "detail_answer": {
-                                                        "label": "Please describe",
-                                                        "type": "TextField",
-                                                        "id": "answer59b22829-c22d-4c87-bc73-1028752b5818",
-                                                        "mandatory": false
-                                                    }
-                                                },
-                                                {
-                                                    "label": "Not sure",
-                                                    "value": "Not sure",
-                                                    "q_code": "1188"
-                                                }
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "contains any",
+                                            "values": [
+                                                "Paused trading but intends to restart in the next two weeks",
+                                                "Paused trading and does not intend to restart in the next two weeks"
                                             ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "block935395a7-882a-45bd-860e-47c605ab1281",
+                                    "when": [{
+                                            "id": "answer399d67d7-f59d-4ab5-ad00-d3b522fb7cd6",
+                                            "condition": "contains any",
+                                            "values": ["Yes"]
+                                        },
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "contains any",
+                                            "values": [
+                                                "Currently trading and has been for more than the last two weeks",
+                                                "Started trading within the last two weeks after a pause in trading",
+                                                "Paused trading but intends to restart in the next two weeks",
+                                                "Paused trading and does not intend to restart in the next two weeks"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8"
+                                }
+                            }
+                        ],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block935395a7-882a-45bd-860e-47c605ab1281",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question935395a7-882a-45bd-860e-47c605ab1281",
+                            "title": "How is {{ metadata['ru_name'] }} <em>managing</em> postponed or cancelled bookings, services or events sold to customers?",
+                            "type": "MutuallyExclusive",
+                            "mandatory": true,
+                            "answers": [{
+                                    "id": "answere528d417-67e6-4356-b660-107bab6c73f1",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "label": "Select all that apply",
+                                    "description": "",
+                                    "options": [{
+                                            "label": "Offering the option to re-book for future dates",
+                                            "value": "Offering the option to re-book for future dates",
+                                            "q_code": "1181"
+                                        },
+                                        {
+                                            "label": "Rescheduling for a future date",
+                                            "value": "Rescheduling for a future date",
+                                            "q_code": "1182"
+                                        },
+                                        {
+                                            "label": "Allowing customers to stop direct debits",
+                                            "value": "Allowing customers to stop direct debits",
+                                            "q_code": "1183"
+                                        },
+                                        {
+                                            "label": "Offering full refunds",
+                                            "value": "Offering full refunds",
+                                            "q_code": "1184"
+                                        },
+                                        {
+                                            "label": "Offering partial refunds",
+                                            "value": "Offering partial refunds",
+                                            "q_code": "1185"
+                                        },
+                                        {
+                                            "label": "Offering vouchers to be used on our products or services",
+                                            "value": "Offering vouchers to be used on our products or services",
+                                            "q_code": "1186"
+                                        },
+                                        {
+                                            "label": "Other",
+                                            "value": "Other",
+                                            "q_code": "1187",
+                                            "detail_answer": {
+                                                "label": "Please describe",
+                                                "type": "TextField",
+                                                "id": "answer59b22829-c22d-4c87-bc73-1028752b5818",
+                                                "mandatory": false
+                                            }
+                                        },
+                                        {
+                                            "label": "Not sure",
+                                            "value": "Not sure",
+                                            "q_code": "1188"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "answere528d417-67e6-4356-b660-107bab6c73f1-exclusive",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "description": "",
+                                    "options": [{
+                                        "label": "None of the above",
+                                        "value": "None of the above",
+                                        "q_code": "1180"
+                                    }]
+                                }
+                            ]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "group": "group139b1d35-6271-4893-8eef-e1a36f2eb3c9",
+                                    "when": [{
+                                            "id": "answere528d417-67e6-4356-b660-107bab6c73f1",
+                                            "condition": "contains any",
+                                            "values": ["Not sure"]
                                         },
                                         {
                                             "id": "answere528d417-67e6-4356-b660-107bab6c73f1-exclusive",
-                                            "mandatory": false,
-                                            "type": "Checkbox",
-                                            "description": "",
-                                            "options": [
-                                                {
-                                                    "label": "None of the above",
-                                                    "value": "None of the above",
-                                                    "q_code": "1180"
-                                                }
+                                            "condition": "contains any",
+                                            "values": ["None of the above"]
+                                        },
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "contains any",
+                                            "values": [
+                                                "Currently trading and has been for more than the last two weeks",
+                                                "Started trading within the last two weeks after a pause in trading"
                                             ]
                                         }
                                     ]
                                 }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "group": "group139b1d35-6271-4893-8eef-e1a36f2eb3c9",
-                                        "when": [
-                                            {
-                                                "id": "answere528d417-67e6-4356-b660-107bab6c73f1",
-                                                "condition": "contains any",
-                                                "values": ["Not sure"]
-                                            },
-                                            {
-                                                "id": "answere528d417-67e6-4356-b660-107bab6c73f1-exclusive",
-                                                "condition": "contains any",
-                                                "values": ["None of the above"]
-                                            },
-                                            {
-                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                                "condition": "contains any",
-                                                "values": [
-                                                    "Currently trading and has been for more than the last two weeks",
-                                                    "Started trading within the last two weeks after a pause in trading"
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "group": "group8753dfce-d80c-4fe0-98ba-3cddd52a9bba",
-                                        "when": [
-                                            {
-                                                "id": "answere528d417-67e6-4356-b660-107bab6c73f1",
-                                                "condition": "contains any",
-                                                "values": ["Not sure"]
-                                            },
-                                            {
-                                                "id": "answere528d417-67e6-4356-b660-107bab6c73f1-exclusive",
-                                                "condition": "contains any",
-                                                "values": ["None of the above"]
-                                            },
-                                            {
-                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                                "condition": "contains any",
-                                                "values": [
-                                                    "Paused trading but intends to restart in the next two weeks",
-                                                    "Paused trading and does not intend to restart in the next two weeks"
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "block38ecd8cf-8942-4d0e-a84d-8099393acfea",
-                                        "when": [
-                                            {
-                                                "id": "answere528d417-67e6-4356-b660-107bab6c73f1",
-                                                "condition": "contains any",
-                                                "values": [
-                                                    "Offering the option to re-book for future dates",
-                                                    "Rescheduling for a future date",
-                                                    "Allowing customers to stop direct debits",
-                                                    "Offering full refunds",
-                                                    "Offering partial refunds",
-                                                    "Offering vouchers to be used on our products or services",
-                                                    "Other"
-                                                ]
-                                            },
-                                            {
-                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                                "condition": "contains any",
-                                                "values": [
-                                                    "Currently trading and has been for more than the last two weeks",
-                                                    "Started trading within the last two weeks after a pause in trading",
-                                                    "Paused trading but intends to restart in the next two weeks",
-                                                    "Paused trading and does not intend to restart in the next two weeks"
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8"
-                                    }
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
+                            },
+                            {
+                                "goto": {
+                                    "group": "group8753dfce-d80c-4fe0-98ba-3cddd52a9bba",
+                                    "when": [{
+                                            "id": "answere528d417-67e6-4356-b660-107bab6c73f1",
+                                            "condition": "contains any",
+                                            "values": ["Not sure"]
+                                        },
+                                        {
+                                            "id": "answere528d417-67e6-4356-b660-107bab6c73f1-exclusive",
+                                            "condition": "contains any",
+                                            "values": ["None of the above"]
+                                        },
                                         {
                                             "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
+                                            "condition": "contains any",
+                                            "values": [
+                                                "Paused trading but intends to restart in the next two weeks",
+                                                "Paused trading and does not intend to restart in the next two weeks"
+                                            ]
                                         }
                                     ]
                                 }
-                            ]
-                        },
-                        {
-                            "id": "block38ecd8cf-8942-4d0e-a84d-8099393acfea",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question38ecd8cf-8942-4d0e-a84d-8099393acfea",
-                                    "title": "Has {{ metadata['ru_name'] }} <em>changed its approach</em> for managing postponed or cancelled bookings, services or events since the start of the coronavirus (COVID-19) pandemic?",
-                                    "type": "General",
-                                    "answers": [
+                            },
+                            {
+                                "goto": {
+                                    "block": "block38ecd8cf-8942-4d0e-a84d-8099393acfea",
+                                    "when": [{
+                                            "id": "answere528d417-67e6-4356-b660-107bab6c73f1",
+                                            "condition": "contains any",
+                                            "values": [
+                                                "Offering the option to re-book for future dates",
+                                                "Rescheduling for a future date",
+                                                "Allowing customers to stop direct debits",
+                                                "Offering full refunds",
+                                                "Offering partial refunds",
+                                                "Offering vouchers to be used on our products or services",
+                                                "Other"
+                                            ]
+                                        },
                                         {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "contains any",
+                                            "values": [
+                                                "Currently trading and has been for more than the last two weeks",
+                                                "Started trading within the last two weeks after a pause in trading",
+                                                "Paused trading but intends to restart in the next two weeks",
+                                                "Paused trading and does not intend to restart in the next two weeks"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8"
+                                }
+                            }
+                        ],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block38ecd8cf-8942-4d0e-a84d-8099393acfea",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question38ecd8cf-8942-4d0e-a84d-8099393acfea",
+                            "title": "Has {{ metadata['ru_name'] }} <em>changed its approach</em> for managing postponed or cancelled bookings, services or events since the start of the coronavirus (COVID-19) pandemic?",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer0ebd8695-e6d4-4fe0-b24f-0a50d9ab27eb",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "label": "",
+                                "description": "",
+                                "q_code": "119",
+                                "options": [{
+                                        "label": "Yes, approach has changed",
+                                        "value": "Yes, approach has changed"
+                                    },
+                                    {
+                                        "label": "No, approach has not changed",
+                                        "value": "No, approach has not changed"
+                                    },
+                                    {
+                                        "label": "Not sure",
+                                        "value": "Not sure"
+                                    }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "group": "group139b1d35-6271-4893-8eef-e1a36f2eb3c9",
+                                    "when": [{
                                             "id": "answer0ebd8695-e6d4-4fe0-b24f-0a50d9ab27eb",
-                                            "mandatory": true,
-                                            "type": "Radio",
-                                            "label": "",
-                                            "description": "",
-                                            "q_code": "119",
-                                            "options": [
-                                                {
-                                                    "label": "Yes, approach has changed",
-                                                    "value": "Yes, approach has changed"
-                                                },
-                                                {
-                                                    "label": "No, approach has not changed",
-                                                    "value": "No, approach has not changed"
-                                                },
-                                                {
-                                                    "label": "Not sure",
-                                                    "value": "Not sure"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "group": "group139b1d35-6271-4893-8eef-e1a36f2eb3c9",
-                                        "when": [
-                                            {
-                                                "id": "answer0ebd8695-e6d4-4fe0-b24f-0a50d9ab27eb",
-                                                "condition": "contains any",
-                                                "values": ["No, approach has not changed", "Not sure"]
-                                            },
-                                            {
-                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                                "condition": "contains any",
-                                                "values": [
-                                                    "Currently trading and has been for more than the last two weeks",
-                                                    "Started trading within the last two weeks after a pause in trading"
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "group": "group8753dfce-d80c-4fe0-98ba-3cddd52a9bba",
-                                        "when": [
-                                            {
-                                                "id": "answer0ebd8695-e6d4-4fe0-b24f-0a50d9ab27eb",
-                                                "condition": "contains any",
-                                                "values": ["No, approach has not changed", "Not sure"]
-                                            },
-                                            {
-                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                                "condition": "contains any",
-                                                "values": [
-                                                    "Paused trading but intends to restart in the next two weeks",
-                                                    "Paused trading and does not intend to restart in the next two weeks"
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "block021b3411-c28a-4eab-81b5-cdba712c2f1b",
-                                        "when": [
-                                            {
-                                                "id": "answer0ebd8695-e6d4-4fe0-b24f-0a50d9ab27eb",
-                                                "condition": "contains any",
-                                                "values": ["Yes, approach has changed"]
-                                            },
-                                            {
-                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                                "condition": "contains any",
-                                                "values": [
-                                                    "Currently trading and has been for more than the last two weeks",
-                                                    "Started trading within the last two weeks after a pause in trading",
-                                                    "Paused trading but intends to restart in the next two weeks",
-                                                    "Paused trading and does not intend to restart in the next two weeks"
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8"
-                                    }
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
+                                            "condition": "contains any",
+                                            "values": ["No, approach has not changed", "Not sure"]
+                                        },
                                         {
                                             "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
+                                            "condition": "contains any",
+                                            "values": [
+                                                "Currently trading and has been for more than the last two weeks",
+                                                "Started trading within the last two weeks after a pause in trading"
+                                            ]
                                         }
                                     ]
                                 }
-                            ]
-                        },
-                        {
-                            "id": "block021b3411-c28a-4eab-81b5-cdba712c2f1b",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question021b3411-c28a-4eab-81b5-cdba712c2f1b",
-                                    "title": "Which of the following affected {{ metadata['ru_name'] }}&apos;s <em>decision to change its approach</em> for managing postponed or cancelled bookings, services or events?",
-                                    "type": "MutuallyExclusive",
-                                    "mandatory": true,
-                                    "answers": [
+                            },
+                            {
+                                "goto": {
+                                    "group": "group8753dfce-d80c-4fe0-98ba-3cddd52a9bba",
+                                    "when": [{
+                                            "id": "answer0ebd8695-e6d4-4fe0-b24f-0a50d9ab27eb",
+                                            "condition": "contains any",
+                                            "values": ["No, approach has not changed", "Not sure"]
+                                        },
                                         {
-                                            "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe",
-                                            "mandatory": false,
-                                            "type": "Checkbox",
-                                            "label": "Select all that apply",
-                                            "description": "",
-                                            "options": [
-                                                {
-                                                    "label": "Guidance",
-                                                    "value": "Guidance",
-                                                    "q_code": "1201"
-                                                },
-                                                {
-                                                    "label": "Requests from customers",
-                                                    "value": "Requests from customers",
-                                                    "q_code": "1202"
-                                                },
-                                                {
-                                                    "label": "The circumstances were not covered in our existing policies",
-                                                    "value": "The circumstances were not covered in our existing policies",
-                                                    "q_code": "1203"
-                                                },
-                                                {
-                                                    "label": "Other",
-                                                    "value": "Other",
-                                                    "q_code": "1204",
-                                                    "detail_answer": {
-                                                        "label": "Please describe",
-                                                        "type": "TextField",
-                                                        "id": "answerd0b7d257-7d49-48b4-93e8-be6de9c35e23",
-                                                        "mandatory": false
-                                                    }
-                                                }
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "contains any",
+                                            "values": [
+                                                "Paused trading but intends to restart in the next two weeks",
+                                                "Paused trading and does not intend to restart in the next two weeks"
                                             ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "block021b3411-c28a-4eab-81b5-cdba712c2f1b",
+                                    "when": [{
+                                            "id": "answer0ebd8695-e6d4-4fe0-b24f-0a50d9ab27eb",
+                                            "condition": "contains any",
+                                            "values": ["Yes, approach has changed"]
+                                        },
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "contains any",
+                                            "values": [
+                                                "Currently trading and has been for more than the last two weeks",
+                                                "Started trading within the last two weeks after a pause in trading",
+                                                "Paused trading but intends to restart in the next two weeks",
+                                                "Paused trading and does not intend to restart in the next two weeks"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8"
+                                }
+                            }
+                        ],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block021b3411-c28a-4eab-81b5-cdba712c2f1b",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question021b3411-c28a-4eab-81b5-cdba712c2f1b",
+                            "title": "Which of the following affected {{ metadata['ru_name'] }}&apos;s <em>decision to change its approach</em> for managing postponed or cancelled bookings, services or events?",
+                            "type": "MutuallyExclusive",
+                            "mandatory": true,
+                            "answers": [{
+                                    "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "label": "Select all that apply",
+                                    "description": "",
+                                    "options": [{
+                                            "label": "Guidance",
+                                            "value": "Guidance",
+                                            "q_code": "1201"
+                                        },
+                                        {
+                                            "label": "Requests from customers",
+                                            "value": "Requests from customers",
+                                            "q_code": "1202"
+                                        },
+                                        {
+                                            "label": "The circumstances were not covered in our existing policies",
+                                            "value": "The circumstances were not covered in our existing policies",
+                                            "q_code": "1203"
+                                        },
+                                        {
+                                            "label": "Other",
+                                            "value": "Other",
+                                            "q_code": "1204",
+                                            "detail_answer": {
+                                                "label": "Please describe",
+                                                "type": "TextField",
+                                                "id": "answerd0b7d257-7d49-48b4-93e8-be6de9c35e23",
+                                                "mandatory": false
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe-exclusive",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "description": "",
+                                    "options": [{
+                                        "label": "Not sure",
+                                        "value": "Not sure",
+                                        "q_code": "1205"
+                                    }]
+                                }
+                            ]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "block7e1d161b-e606-4e72-963a-06ef3aa8d22f",
+                                    "when": [{
+                                        "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe",
+                                        "condition": "contains any",
+                                        "values": ["Guidance"]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "group": "group139b1d35-6271-4893-8eef-e1a36f2eb3c9",
+                                    "when": [{
+                                            "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe",
+                                            "condition": "contains any",
+                                            "values": ["Requests from customers", "The circumstances were not covered in our existing policies", "Other"]
                                         },
                                         {
                                             "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe-exclusive",
-                                            "mandatory": false,
-                                            "type": "Checkbox",
-                                            "description": "",
-                                            "options": [
-                                                {
-                                                    "label": "Not sure",
-                                                    "value": "Not sure",
-                                                    "q_code": "1205"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "block": "block7e1d161b-e606-4e72-963a-06ef3aa8d22f",
-                                        "when": [
-                                            {
-                                                "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe",
-                                                "condition": "contains any",
-                                                "values": ["Guidance"]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "group": "group139b1d35-6271-4893-8eef-e1a36f2eb3c9",
-                                        "when": [
-                                            {
-                                                "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe",
-                                                "condition": "contains any",
-                                                "values": ["Requests from customers", "The circumstances were not covered in our existing policies", "Other"]
-                                            },
-                                            {
-                                                "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe-exclusive",
-                                                "condition": "contains any",
-                                                "values": ["Not sure"]
-                                            },
-                                            {
-                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                                "condition": "contains any",
-                                                "values": [
-                                                    "Currently trading and has been for more than the last two weeks",
-                                                    "Started trading within the last two weeks after a pause in trading"
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "group": "group8753dfce-d80c-4fe0-98ba-3cddd52a9bba",
-                                        "when": [
-                                            {
-                                                "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe",
-                                                "condition": "contains any",
-                                                "values": ["Requests from customers", "The circumstances were not covered in our existing policies", "Other"]
-                                            },
-                                            {
-                                                "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe-exclusive",
-                                                "condition": "contains any",
-                                                "values": ["Not sure"]
-                                            },
-                                            {
-                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                                "condition": "contains any",
-                                                "values": [
-                                                    "Paused trading but intends to restart in the next two weeks",
-                                                    "Paused trading and does not intend to restart in the next two weeks"
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8"
-                                    }
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block7e1d161b-e606-4e72-963a-06ef3aa8d22f",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question7e1d161b-e606-4e72-963a-06ef3aa8d22f",
-                                    "title": "What did {{ metadata['ru_name'] }} use as a <em>guide</em> to change its approach?",
-                                    "type": "MutuallyExclusive",
-                                    "mandatory": true,
-                                    "answers": [
-                                        {
-                                            "id": "answerc3e789a8-f88b-4898-9d37-42e8c35dd8d2",
-                                            "mandatory": false,
-                                            "type": "Checkbox",
-                                            "label": "Select all that apply",
-                                            "description": "",
-                                            "options": [
-                                                {
-                                                    "label": "Government guidance",
-                                                    "value": "Government guidance",
-                                                    "q_code": "1211"
-                                                },
-                                                {
-                                                    "label": "Guidance from the Competition and Markets Authority (CMA)",
-                                                    "value": "Guidance from the Competition and Markets Authority (CMA)",
-                                                    "q_code": "1212"
-                                                },
-                                                {
-                                                    "label": "Guidance from the Civil Aviation Authority (CAA)",
-                                                    "value": "Guidance from the Civil Aviation Authority (CAA)",
-                                                    "q_code": "1213"
-                                                },
-                                                {
-                                                    "label": "Guidance from the Financial Conduct Authority (FCA)",
-                                                    "value": "Guidance from the Financial Conduct Authority (FCA)",
-                                                    "q_code": "1214"
-                                                },
-                                                {
-                                                    "label": "Guidance from Trading Standards",
-                                                    "value": "Guidance from Trading Standards",
-                                                    "q_code": "1215"
-                                                },
-                                                {
-                                                    "label": "Other industry-specific guidance",
-                                                    "value": "Other industry-specific guidance",
-                                                    "q_code": "1216"
-                                                },
-                                                {
-                                                    "label": "Media",
-                                                    "value": "Media",
-                                                    "q_code": "1217",
-                                                    "description": "For example, television, radio or newspaper articles. Exclude social media."
-                                                },
-                                                {
-                                                    "label": "Social media",
-                                                    "value": "Social media",
-                                                    "q_code": "1218",
-                                                    "description": "For example, Facebook, Twitter or Instagram."
-                                                },
-                                                {
-                                                    "label": "Other",
-                                                    "value": "Other",
-                                                    "q_code": "1219",
-                                                    "detail_answer": {
-                                                        "label": "Please describe",
-                                                        "type": "TextField",
-                                                        "id": "answer9f1ac7f9-0494-48e5-8379-50d7eef7d6a2",
-                                                        "mandatory": false
-                                                    }
-                                                }
-                                            ]
+                                            "condition": "contains any",
+                                            "values": ["Not sure"]
                                         },
                                         {
-                                            "id": "answerc3e789a8-f88b-4898-9d37-42e8c35dd8d2-exclusive",
-                                            "mandatory": false,
-                                            "type": "Checkbox",
-                                            "description": "",
-                                            "options": [
-                                                {
-                                                    "label": "Not sure",
-                                                    "value": "Not sure",
-                                                    "q_code": "1210"
-                                                }
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "contains any",
+                                            "values": [
+                                                "Currently trading and has been for more than the last two weeks",
+                                                "Started trading within the last two weeks after a pause in trading"
                                             ]
                                         }
                                     ]
                                 }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "group": "group8753dfce-d80c-4fe0-98ba-3cddd52a9bba",
-                                        "when": [
-                                            {
-                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                                "condition": "contains any",
-                                                "values": [
-                                                    "Paused trading but intends to restart in the next two weeks",
-                                                    "Paused trading and does not intend to restart in the next two weeks"
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "group": "group139b1d35-6271-4893-8eef-e1a36f2eb3c9",
-                                        "when": [
-                                            {
-                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                                "condition": "contains any",
-                                                "values": [
-                                                    "Currently trading and has been for more than the last two weeks",
-                                                    "Started trading within the last two weeks after a pause in trading"
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8"
-                                    }
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
+                            },
+                            {
+                                "goto": {
+                                    "group": "group8753dfce-d80c-4fe0-98ba-3cddd52a9bba",
+                                    "when": [{
+                                            "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe",
+                                            "condition": "contains any",
+                                            "values": ["Requests from customers", "The circumstances were not covered in our existing policies", "Other"]
+                                        },
+                                        {
+                                            "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe-exclusive",
+                                            "condition": "contains any",
+                                            "values": ["Not sure"]
+                                        },
                                         {
                                             "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
+                                            "condition": "contains any",
+                                            "values": [
+                                                "Paused trading but intends to restart in the next two weeks",
+                                                "Paused trading and does not intend to restart in the next two weeks"
+                                            ]
                                         }
                                     ]
                                 }
-                            ]
-                        }
-                    ],
-                    "skip_conditions": [
-                        {
-                            "when": [
+                            },
+                            {
+                                "goto": {
+                                    "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8"
+                                }
+                            }
+                        ],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block7e1d161b-e606-4e72-963a-06ef3aa8d22f",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question7e1d161b-e606-4e72-963a-06ef3aa8d22f",
+                            "title": "What did {{ metadata['ru_name'] }} use as a <em>guide</em> to change its approach?",
+                            "type": "MutuallyExclusive",
+                            "mandatory": true,
+                            "answers": [{
+                                    "id": "answerc3e789a8-f88b-4898-9d37-42e8c35dd8d2",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "label": "Select all that apply",
+                                    "description": "",
+                                    "options": [{
+                                            "label": "Government guidance",
+                                            "value": "Government guidance",
+                                            "q_code": "1211"
+                                        },
+                                        {
+                                            "label": "Guidance from the Competition and Markets Authority (CMA)",
+                                            "value": "Guidance from the Competition and Markets Authority (CMA)",
+                                            "q_code": "1212"
+                                        },
+                                        {
+                                            "label": "Guidance from the Civil Aviation Authority (CAA)",
+                                            "value": "Guidance from the Civil Aviation Authority (CAA)",
+                                            "q_code": "1213"
+                                        },
+                                        {
+                                            "label": "Guidance from the Financial Conduct Authority (FCA)",
+                                            "value": "Guidance from the Financial Conduct Authority (FCA)",
+                                            "q_code": "1214"
+                                        },
+                                        {
+                                            "label": "Guidance from Trading Standards",
+                                            "value": "Guidance from Trading Standards",
+                                            "q_code": "1215"
+                                        },
+                                        {
+                                            "label": "Other industry-specific guidance",
+                                            "value": "Other industry-specific guidance",
+                                            "q_code": "1216"
+                                        },
+                                        {
+                                            "label": "Media",
+                                            "value": "Media",
+                                            "q_code": "1217",
+                                            "description": "For example, television, radio or newspaper articles. Exclude social media."
+                                        },
+                                        {
+                                            "label": "Social media",
+                                            "value": "Social media",
+                                            "q_code": "1218",
+                                            "description": "For example, Facebook, Twitter or Instagram."
+                                        },
+                                        {
+                                            "label": "Other",
+                                            "value": "Other",
+                                            "q_code": "1219",
+                                            "detail_answer": {
+                                                "label": "Please describe",
+                                                "type": "TextField",
+                                                "id": "answer9f1ac7f9-0494-48e5-8379-50d7eef7d6a2",
+                                                "mandatory": false
+                                            }
+                                        }
+                                    ]
+                                },
                                 {
-                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                    "condition": "contains any",
-                                    "values": ["Permanently ceased trading"]
+                                    "id": "answerc3e789a8-f88b-4898-9d37-42e8c35dd8d2-exclusive",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "description": "",
+                                    "options": [{
+                                        "label": "Not sure",
+                                        "value": "Not sure",
+                                        "q_code": "1210"
+                                    }]
                                 }
                             ]
-                        }
-                    ]
-                }
-            ]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "group": "group8753dfce-d80c-4fe0-98ba-3cddd52a9bba",
+                                    "when": [{
+                                        "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                        "condition": "contains any",
+                                        "values": [
+                                            "Paused trading but intends to restart in the next two weeks",
+                                            "Paused trading and does not intend to restart in the next two weeks"
+                                        ]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "group": "group139b1d35-6271-4893-8eef-e1a36f2eb3c9",
+                                    "when": [{
+                                        "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                        "condition": "contains any",
+                                        "values": [
+                                            "Currently trading and has been for more than the last two weeks",
+                                            "Started trading within the last two weeks after a pause in trading"
+                                        ]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8"
+                                }
+                            }
+                        ],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    }
+                ],
+                "skip_conditions": [{
+                    "when": [{
+                        "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                        "condition": "contains any",
+                        "values": ["Permanently ceased trading"]
+                    }]
+                }]
+            }]
         },
         {
             "id": "section139b1d35-6271-4893-8eef-e1a36f2eb3c9",
             "title": "Exporting and importing",
-            "groups": [
-                {
-                    "id": "group139b1d35-6271-4893-8eef-e1a36f2eb3c9",
-                    "title": "Exporting and importing",
-                    "blocks": [
-                        {
-                            "type": "Interstitial",
-                            "id": "group139b1d35-6271-4893-8eef-e1a36f2eb3c9-introduction",
-                            "title": "Exporting and importing",
-                            "description": "<p>This section asks for information about the business&apos;s importing and exporting activities.</p>",
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block059d51ee-2b0f-456f-8a29-23b1c97e2dac",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question059d51ee-2b0f-456f-8a29-23b1c97e2dac",
-                                    "title": "Has {{ metadata['ru_name'] }} <em>exported</em> goods or services in the last 12 months?",
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer6e5dfc6d-189b-4d67-b64f-d40f68253cda",
-                                            "mandatory": true,
-                                            "type": "Radio",
-                                            "label": "",
-                                            "description": "",
-                                            "q_code": "52",
-                                            "options": [
-                                                {
-                                                    "label": "Yes",
-                                                    "value": "Yes"
-                                                },
-                                                {
-                                                    "label": "No",
-                                                    "value": "No"
-                                                },
-                                                {
-                                                    "label": "Not sure",
-                                                    "value": "Not sure"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "block": "blockf25bdbfe-14fb-4699-bf0d-29140cb007f8",
-                                        "when": [
-                                            {
-                                                "id": "answer6e5dfc6d-189b-4d67-b64f-d40f68253cda",
-                                                "condition": "contains any",
-                                                "values": ["No", "Not sure"]
-                                            }
-                                        ]
+            "groups": [{
+                "id": "group139b1d35-6271-4893-8eef-e1a36f2eb3c9",
+                "title": "Exporting and importing",
+                "blocks": [{
+                        "type": "Interstitial",
+                        "id": "group139b1d35-6271-4893-8eef-e1a36f2eb3c9-introduction",
+                        "title": "Exporting and importing",
+                        "description": "<p>This section asks for information about the business&apos;s importing and exporting activities.</p>",
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block059d51ee-2b0f-456f-8a29-23b1c97e2dac",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question059d51ee-2b0f-456f-8a29-23b1c97e2dac",
+                            "title": "Has {{ metadata['ru_name'] }} <em>exported</em> goods or services in the last 12 months?",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer6e5dfc6d-189b-4d67-b64f-d40f68253cda",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "label": "",
+                                "description": "",
+                                "q_code": "52",
+                                "options": [{
+                                        "label": "Yes",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No",
+                                        "value": "No"
+                                    },
+                                    {
+                                        "label": "Not sure",
+                                        "value": "Not sure"
                                     }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "block0af301b1-70ce-4fc7-a698-7374fb9436e4"
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "blockf25bdbfe-14fb-4699-bf0d-29140cb007f8",
+                                    "when": [{
+                                        "id": "answer6e5dfc6d-189b-4d67-b64f-d40f68253cda",
+                                        "condition": "contains any",
+                                        "values": ["No", "Not sure"]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "block0af301b1-70ce-4fc7-a698-7374fb9436e4"
+                                }
+                            }
+                        ],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block0af301b1-70ce-4fc7-a698-7374fb9436e4",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question0af301b1-70ce-4fc7-a698-7374fb9436e4",
+                            "title": "Has {{ metadata['ru_name'] }} exported goods or services <em>during</em> the coronavirus (COVID-19) pandemic?",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer5cd5a93e-d818-4d4e-a32f-9eeedad30a6a",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "label": "",
+                                "description": "",
+                                "q_code": "54",
+                                "options": [{
+                                        "label": "Yes, the business has exported during the pandemic",
+                                        "value": "Yes, the business has exported during the pandemic"
+                                    },
+                                    {
+                                        "label": "No, the business has not exported during the pandemic",
+                                        "value": "No, the business has not exported during the pandemic"
+                                    },
+                                    {
+                                        "label": "Not sure",
+                                        "value": "Not sure"
                                     }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "blockf25bdbfe-14fb-4699-bf0d-29140cb007f8",
+                                    "when": [{
+                                        "id": "answer5cd5a93e-d818-4d4e-a32f-9eeedad30a6a",
+                                        "condition": "contains any",
+                                        "values": ["No, the business has not exported during the pandemic", "Not sure"]
+                                    }]
                                 }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
+                            },
+                            {
+                                "goto": {
+                                    "block": "block730e686b-f62a-444a-a62d-805ced57ace8"
                                 }
-                            ]
-                        },
-                        {
-                            "id": "block0af301b1-70ce-4fc7-a698-7374fb9436e4",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question0af301b1-70ce-4fc7-a698-7374fb9436e4",
-                                    "title": "Has {{ metadata['ru_name'] }} exported goods or services <em>during</em> the coronavirus (COVID-19) pandemic?",
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer5cd5a93e-d818-4d4e-a32f-9eeedad30a6a",
-                                            "mandatory": true,
-                                            "type": "Radio",
-                                            "label": "",
-                                            "description": "",
-                                            "q_code": "54",
-                                            "options": [
-                                                {
-                                                    "label": "Yes, the business has exported during the pandemic",
-                                                    "value": "Yes, the business has exported during the pandemic"
-                                                },
-                                                {
-                                                    "label": "No, the business has not exported during the pandemic",
-                                                    "value": "No, the business has not exported during the pandemic"
-                                                },
-                                                {
-                                                    "label": "Not sure",
-                                                    "value": "Not sure"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "block": "blockf25bdbfe-14fb-4699-bf0d-29140cb007f8",
-                                        "when": [
-                                            {
-                                                "id": "answer5cd5a93e-d818-4d4e-a32f-9eeedad30a6a",
-                                                "condition": "contains any",
-                                                "values": ["No, the business has not exported during the pandemic", "Not sure"]
-                                            }
-                                        ]
+                            }
+                        ],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block730e686b-f62a-444a-a62d-805ced57ace8",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question730e686b-f62a-444a-a62d-805ced57ace8",
+                            "title": "How has {{ metadata['ru_name'] }}&apos;s exporting of goods or services been affected by the coronavirus (COVID-19) pandemic in the <em>last two weeks</em>?",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer39662368-cb6b-4abb-9990-6e9eb02e3eef",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "label": "",
+                                "description": "",
+                                "q_code": "7",
+                                "options": [{
+                                        "label": "Exporting more than normal",
+                                        "value": "Exporting more than normal"
+                                    },
+                                    {
+                                        "label": "Exporting has not been affected",
+                                        "value": "Exporting has not been affected"
+                                    },
+                                    {
+                                        "label": "Exporting, but less than normal",
+                                        "value": "Exporting, but less than normal"
+                                    },
+                                    {
+                                        "label": "Not been able to export in the last two weeks",
+                                        "value": "Not been able to export in the last two weeks"
+                                    },
+                                    {
+                                        "label": "Not sure",
+                                        "value": "Not sure"
                                     }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "block730e686b-f62a-444a-a62d-805ced57ace8"
+                                ]
+                            }]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block4728c544-95e8-4d1f-a5c7-d2fc3a95f180",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question4728c544-95e8-4d1f-a5c7-d2fc3a95f180",
+                            "title": "Let us know anything else that will help us understand {{ metadata['ru_name'] }}&#x2019;s exporting in the <em>last two weeks</em>",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer3c6cef19-ffc2-4283-9cc9-bd356713b0f2",
+                                "mandatory": false,
+                                "type": "TextArea",
+                                "label": "Comments",
+                                "description": "",
+                                "q_code": "8",
+                                "max_length": 2000
+                            }]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "blockf25bdbfe-14fb-4699-bf0d-29140cb007f8",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "questionf25bdbfe-14fb-4699-bf0d-29140cb007f8",
+                            "title": "Has {{ metadata['ru_name'] }} <em>imported</em> goods or services in the last 12 months?",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer5ad71b6e-442c-499a-b185-e39282dd09c0",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "label": "",
+                                "description": "",
+                                "q_code": "62",
+                                "options": [{
+                                        "label": "Yes",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No",
+                                        "value": "No"
+                                    },
+                                    {
+                                        "label": "Not sure",
+                                        "value": "Not sure"
                                     }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "group": "group5c8d0ebe-e6e2-4ff6-a2bd-99ccf4edbde6",
+                                    "when": [{
+                                        "id": "answer5ad71b6e-442c-499a-b185-e39282dd09c0",
+                                        "condition": "contains any",
+                                        "values": ["No", "Not sure"]
+                                    }]
                                 }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
+                            },
+                            {
+                                "goto": {
+                                    "block": "block4b9c0508-34e9-4b60-bde1-d803c99bed59"
                                 }
-                            ]
-                        },
-                        {
-                            "id": "block730e686b-f62a-444a-a62d-805ced57ace8",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question730e686b-f62a-444a-a62d-805ced57ace8",
-                                    "title": "How has {{ metadata['ru_name'] }}&apos;s exporting of goods or services been affected by the coronavirus (COVID-19) pandemic in the <em>last two weeks</em>?",
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer39662368-cb6b-4abb-9990-6e9eb02e3eef",
-                                            "mandatory": true,
-                                            "type": "Radio",
-                                            "label": "",
-                                            "description": "",
-                                            "q_code": "7",
-                                            "options": [
-                                                {
-                                                    "label": "Exporting more than normal",
-                                                    "value": "Exporting more than normal"
-                                                },
-                                                {
-                                                    "label": "Exporting has not been affected",
-                                                    "value": "Exporting has not been affected"
-                                                },
-                                                {
-                                                    "label": "Exporting, but less than normal",
-                                                    "value": "Exporting, but less than normal"
-                                                },
-                                                {
-                                                    "label": "Not been able to export in the last two weeks",
-                                                    "value": "Not been able to export in the last two weeks"
-                                                },
-                                                {
-                                                    "label": "Not sure",
-                                                    "value": "Not sure"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block4728c544-95e8-4d1f-a5c7-d2fc3a95f180",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question4728c544-95e8-4d1f-a5c7-d2fc3a95f180",
-                                    "title": "Let us know anything else that will help us understand {{ metadata['ru_name'] }}&#x2019;s exporting in the <em>last two weeks</em>",
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer3c6cef19-ffc2-4283-9cc9-bd356713b0f2",
-                                            "mandatory": false,
-                                            "type": "TextArea",
-                                            "label": "Comments",
-                                            "description": "",
-                                            "q_code": "8",
-                                            "max_length": 2000
-                                        }
-                                    ]
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "blockf25bdbfe-14fb-4699-bf0d-29140cb007f8",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "questionf25bdbfe-14fb-4699-bf0d-29140cb007f8",
-                                    "title": "Has {{ metadata['ru_name'] }} <em>imported</em> goods or services in the last 12 months?",
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer5ad71b6e-442c-499a-b185-e39282dd09c0",
-                                            "mandatory": true,
-                                            "type": "Radio",
-                                            "label": "",
-                                            "description": "",
-                                            "q_code": "62",
-                                            "options": [
-                                                {
-                                                    "label": "Yes",
-                                                    "value": "Yes"
-                                                },
-                                                {
-                                                    "label": "No",
-                                                    "value": "No"
-                                                },
-                                                {
-                                                    "label": "Not sure",
-                                                    "value": "Not sure"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "group": "group5c8d0ebe-e6e2-4ff6-a2bd-99ccf4edbde6",
-                                        "when": [
-                                            {
-                                                "id": "answer5ad71b6e-442c-499a-b185-e39282dd09c0",
-                                                "condition": "contains any",
-                                                "values": ["No", "Not sure"]
-                                            }
-                                        ]
+                            }
+                        ],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block4b9c0508-34e9-4b60-bde1-d803c99bed59",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question4b9c0508-34e9-4b60-bde1-d803c99bed59",
+                            "title": "Has {{ metadata['ru_name'] }} imported goods or services <em>during</em> the coronavirus (COVID-19) pandemic?",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answera7265706-a8e2-4db9-b7e9-00a4f62378d3",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "label": "",
+                                "description": "",
+                                "q_code": "64",
+                                "options": [{
+                                        "label": "Yes, the business imported during the pandemic",
+                                        "value": "Yes, the business imported during the pandemic"
+                                    },
+                                    {
+                                        "label": "No, the business has not imported during the pandemic",
+                                        "value": "No, the business has not imported during the pandemic"
+                                    },
+                                    {
+                                        "label": "Not sure",
+                                        "value": "Not sure"
                                     }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "block4b9c0508-34e9-4b60-bde1-d803c99bed59"
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "group": "group5c8d0ebe-e6e2-4ff6-a2bd-99ccf4edbde6",
+                                    "when": [{
+                                        "id": "answera7265706-a8e2-4db9-b7e9-00a4f62378d3",
+                                        "condition": "contains any",
+                                        "values": ["No, the business has not imported during the pandemic", "Not sure"]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "block41cb8d16-ed70-4442-a3e1-fac1efdea741"
+                                }
+                            }
+                        ],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block41cb8d16-ed70-4442-a3e1-fac1efdea741",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question41cb8d16-ed70-4442-a3e1-fac1efdea741",
+                            "title": "How has {{ metadata['ru_name'] }}&apos;s importing of goods or services been affected by the coronavirus (COVID-19) pandemic in the <em>last two weeks</em>?",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer96cefc81-a976-46a3-a45d-429633159a3e",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "label": "",
+                                "description": "",
+                                "q_code": "10",
+                                "options": [{
+                                        "label": "Importing more than normal",
+                                        "value": "Importing more than normal"
+                                    },
+                                    {
+                                        "label": "Importing has not been affected",
+                                        "value": "Importing has not been affected"
+                                    },
+                                    {
+                                        "label": "Importing, but less than normal",
+                                        "value": "Importing, but less than normal"
+                                    },
+                                    {
+                                        "label": "Not been able to import in the last two weeks",
+                                        "value": "Not been able to import in the last two weeks"
+                                    },
+                                    {
+                                        "label": "Not sure",
+                                        "value": "Not sure"
                                     }
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
+                                ]
+                            }]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block4648511e-cf19-468d-9eed-14c4a92cb720",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question4648511e-cf19-468d-9eed-14c4a92cb720",
+                            "title": "Let us know anything else that will help us understand {{ metadata['ru_name'] }}&#x2019;s importing in the <em>last two weeks</em>",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer98ea4789-060e-460b-8d33-e688ceb4e947",
+                                "mandatory": false,
+                                "type": "TextArea",
+                                "label": "Comments",
+                                "description": "",
+                                "q_code": "11",
+                                "max_length": 2000
+                            }]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    }
+                ],
+                "skip_conditions": [{
+                        "when": [{
+                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                            "condition": "contains any",
+                            "values": ["Permanently ceased trading"]
+                        }]
+                    },
+                    {
+                        "when": [{
+                                "id": "answer399d67d7-f59d-4ab5-ad00-d3b522fb7cd6",
+                                "condition": "contains any",
+                                "values": ["No", "Not sure", "Not applicable"]
+                            },
+                            {
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "contains any",
+                                "values": [
+                                    "Paused trading but intends to restart in the next two weeks",
+                                    "Paused trading and does not intend to restart in the next two weeks"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "when": [{
+                                "id": "answere528d417-67e6-4356-b660-107bab6c73f1",
+                                "condition": "contains any",
+                                "values": ["Not sure"]
+                            },
+                            {
+                                "id": "answere528d417-67e6-4356-b660-107bab6c73f1-exclusive",
+                                "condition": "contains any",
+                                "values": ["None of the above"]
+                            },
+                            {
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "contains any",
+                                "values": [
+                                    "Paused trading but intends to restart in the next two weeks",
+                                    "Paused trading and does not intend to restart in the next two weeks"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "when": [{
+                                "id": "answer0ebd8695-e6d4-4fe0-b24f-0a50d9ab27eb",
+                                "condition": "contains any",
+                                "values": ["No, approach has not changed", "Not sure"]
+                            },
+                            {
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "contains any",
+                                "values": [
+                                    "Paused trading but intends to restart in the next two weeks",
+                                    "Paused trading and does not intend to restart in the next two weeks"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "when": [{
+                                "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe",
+                                "condition": "contains any",
+                                "values": ["Requests from customers", "The circumstances were not covered in our existing policies", "Other"]
+                            },
+                            {
+                                "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe-exclusive",
+                                "condition": "contains any",
+                                "values": ["Not sure"]
+                            },
+                            {
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "contains any",
+                                "values": [
+                                    "Paused trading but intends to restart in the next two weeks",
+                                    "Paused trading and does not intend to restart in the next two weeks"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "when": [{
+                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                            "condition": "contains any",
+                            "values": [
+                                "Paused trading but intends to restart in the next two weeks",
+                                "Paused trading and does not intend to restart in the next two weeks"
                             ]
-                        },
-                        {
-                            "id": "block4b9c0508-34e9-4b60-bde1-d803c99bed59",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question4b9c0508-34e9-4b60-bde1-d803c99bed59",
-                                    "title": "Has {{ metadata['ru_name'] }} imported goods or services <em>during</em> the coronavirus (COVID-19) pandemic?",
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answera7265706-a8e2-4db9-b7e9-00a4f62378d3",
-                                            "mandatory": true,
-                                            "type": "Radio",
-                                            "label": "",
-                                            "description": "",
-                                            "q_code": "64",
-                                            "options": [
-                                                {
-                                                    "label": "Yes, the business imported during the pandemic",
-                                                    "value": "Yes, the business imported during the pandemic"
-                                                },
-                                                {
-                                                    "label": "No, the business has not imported during the pandemic",
-                                                    "value": "No, the business has not imported during the pandemic"
-                                                },
-                                                {
-                                                    "label": "Not sure",
-                                                    "value": "Not sure"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "group": "group5c8d0ebe-e6e2-4ff6-a2bd-99ccf4edbde6",
-                                        "when": [
-                                            {
-                                                "id": "answera7265706-a8e2-4db9-b7e9-00a4f62378d3",
-                                                "condition": "contains any",
-                                                "values": ["No, the business has not imported during the pandemic", "Not sure"]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "block41cb8d16-ed70-4442-a3e1-fac1efdea741"
-                                    }
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block41cb8d16-ed70-4442-a3e1-fac1efdea741",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question41cb8d16-ed70-4442-a3e1-fac1efdea741",
-                                    "title": "How has {{ metadata['ru_name'] }}&apos;s importing of goods or services been affected by the coronavirus (COVID-19) pandemic in the <em>last two weeks</em>?",
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer96cefc81-a976-46a3-a45d-429633159a3e",
-                                            "mandatory": true,
-                                            "type": "Radio",
-                                            "label": "",
-                                            "description": "",
-                                            "q_code": "10",
-                                            "options": [
-                                                {
-                                                    "label": "Importing more than normal",
-                                                    "value": "Importing more than normal"
-                                                },
-                                                {
-                                                    "label": "Importing has not been affected",
-                                                    "value": "Importing has not been affected"
-                                                },
-                                                {
-                                                    "label": "Importing, but less than normal",
-                                                    "value": "Importing, but less than normal"
-                                                },
-                                                {
-                                                    "label": "Not been able to import in the last two weeks",
-                                                    "value": "Not been able to import in the last two weeks"
-                                                },
-                                                {
-                                                    "label": "Not sure",
-                                                    "value": "Not sure"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block4648511e-cf19-468d-9eed-14c4a92cb720",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question4648511e-cf19-468d-9eed-14c4a92cb720",
-                                    "title": "Let us know anything else that will help us understand {{ metadata['ru_name'] }}&#x2019;s importing in the <em>last two weeks</em>",
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer98ea4789-060e-460b-8d33-e688ceb4e947",
-                                            "mandatory": false,
-                                            "type": "TextArea",
-                                            "label": "Comments",
-                                            "description": "",
-                                            "q_code": "11",
-                                            "max_length": 2000
-                                        }
-                                    ]
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
-                    ],
-                    "skip_conditions": [
-                        {
-                            "when": [
-                                {
-                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                    "condition": "contains any",
-                                    "values": ["Permanently ceased trading"]
-                                }
-                            ]
-                        },
-                        {
-                            "when": [
-                                {
-                                    "id": "answer399d67d7-f59d-4ab5-ad00-d3b522fb7cd6",
-                                    "condition": "contains any",
-                                    "values": ["No", "Not sure", "Not applicable"]
-                                },
-                                {
-                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                    "condition": "contains any",
-                                    "values": [
-                                        "Paused trading but intends to restart in the next two weeks",
-                                        "Paused trading and does not intend to restart in the next two weeks"
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "when": [
-                                {
-                                    "id": "answere528d417-67e6-4356-b660-107bab6c73f1",
-                                    "condition": "contains any",
-                                    "values": ["Not sure"]
-                                },
-                                {
-                                    "id": "answere528d417-67e6-4356-b660-107bab6c73f1-exclusive",
-                                    "condition": "contains any",
-                                    "values": ["None of the above"]
-                                },
-                                {
-                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                    "condition": "contains any",
-                                    "values": [
-                                        "Paused trading but intends to restart in the next two weeks",
-                                        "Paused trading and does not intend to restart in the next two weeks"
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "when": [
-                                {
-                                    "id": "answer0ebd8695-e6d4-4fe0-b24f-0a50d9ab27eb",
-                                    "condition": "contains any",
-                                    "values": ["No, approach has not changed", "Not sure"]
-                                },
-                                {
-                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                    "condition": "contains any",
-                                    "values": [
-                                        "Paused trading but intends to restart in the next two weeks",
-                                        "Paused trading and does not intend to restart in the next two weeks"
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "when": [
-                                {
-                                    "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe",
-                                    "condition": "contains any",
-                                    "values": ["Requests from customers", "The circumstances were not covered in our existing policies", "Other"]
-                                },
-                                {
-                                    "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe-exclusive",
-                                    "condition": "contains any",
-                                    "values": ["Not sure"]
-                                },
-                                {
-                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                    "condition": "contains any",
-                                    "values": [
-                                        "Paused trading but intends to restart in the next two weeks",
-                                        "Paused trading and does not intend to restart in the next two weeks"
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "when": [
-                                {
-                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                    "condition": "contains any",
-                                    "values": [
-                                        "Paused trading but intends to restart in the next two weeks",
-                                        "Paused trading and does not intend to restart in the next two weeks"
-                                    ]
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ]
+                        }]
+                    }
+                ]
+            }]
         },
         {
             "id": "section5c8d0ebe-e6e2-4ff6-a2bd-99ccf4edbde6",
             "title": "UK supply chain",
-            "groups": [
-                {
-                    "id": "group5c8d0ebe-e6e2-4ff6-a2bd-99ccf4edbde6",
-                    "title": "UK supply chain",
-                    "blocks": [
-                        {
-                            "type": "Interstitial",
-                            "id": "group5c8d0ebe-e6e2-4ff6-a2bd-99ccf4edbde6-introduction",
-                            "title": "UK supply chain",
-                            "description": "<p>This section asks for information about the availability of materials, goods and services within the UK.</p>",
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block0e1472db-36f2-4d40-b99e-510e70442636",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question0e1472db-36f2-4d40-b99e-510e70442636",
-                                    "title": "Was {{ metadata['ru_name'] }} able to get the materials, goods or services it needed <em>from within the UK</em> in the <em>last two weeks</em>?",
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer478a7145-b712-43a1-9e1d-df39c23abddd",
-                                            "mandatory": true,
-                                            "type": "Radio",
-                                            "label": "",
-                                            "description": "",
-                                            "q_code": "13",
-                                            "options": [
-                                                {
-                                                    "label": "Yes, the business has been able to  get what we needed",
-                                                    "value": "Yes, the business has been able to  get what we needed"
-                                                },
-                                                {
-                                                    "label": "Yes, but the business had to change suppliers or find alternative solutions",
-                                                    "value": "Yes, but the business had to change suppliers or find alternative solutions"
-                                                },
-                                                {
-                                                    "label": "No, the business has not been able to get the materials, goods or services needed",
-                                                    "value": "No, the business has not been able to get the materials, goods or services needed"
-                                                },
-                                                {
-                                                    "label": "Not applicable",
-                                                    "value": "Not applicable"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "block": "blockfc873320-2213-4d19-982e-21b826833e1c",
-                                        "when": [
-                                            {
-                                                "id": "answer478a7145-b712-43a1-9e1d-df39c23abddd",
-                                                "condition": "contains any",
-                                                "values": ["No, the business has not been able to get the materials, goods or services needed"]
-                                            }
-                                        ]
+            "groups": [{
+                "id": "group5c8d0ebe-e6e2-4ff6-a2bd-99ccf4edbde6",
+                "title": "UK supply chain",
+                "blocks": [{
+                        "type": "Interstitial",
+                        "id": "group5c8d0ebe-e6e2-4ff6-a2bd-99ccf4edbde6-introduction",
+                        "title": "UK supply chain",
+                        "description": "<p>This section asks for information about the availability of materials, goods and services within the UK.</p>",
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block0e1472db-36f2-4d40-b99e-510e70442636",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question0e1472db-36f2-4d40-b99e-510e70442636",
+                            "title": "Was {{ metadata['ru_name'] }} able to get the materials, goods or services it needed <em>from within the UK</em> in the <em>last two weeks</em>?",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer478a7145-b712-43a1-9e1d-df39c23abddd",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "label": "",
+                                "description": "",
+                                "q_code": "13",
+                                "options": [{
+                                        "label": "Yes, the business has been able to  get what we needed",
+                                        "value": "Yes, the business has been able to  get what we needed"
+                                    },
+                                    {
+                                        "label": "Yes, but the business had to change suppliers or find alternative solutions",
+                                        "value": "Yes, but the business had to change suppliers or find alternative solutions"
+                                    },
+                                    {
+                                        "label": "No, the business has not been able to get the materials, goods or services needed",
+                                        "value": "No, the business has not been able to get the materials, goods or services needed"
+                                    },
+                                    {
+                                        "label": "Not applicable",
+                                        "value": "Not applicable"
                                     }
-                                },
-                                {
-                                    "goto": {
-                                        "group": "groupff9741ed-a1da-4edf-bc6b-6bb62ddc94ec"
-                                    }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "blockfc873320-2213-4d19-982e-21b826833e1c",
+                                    "when": [{
+                                        "id": "answer478a7145-b712-43a1-9e1d-df39c23abddd",
+                                        "condition": "contains any",
+                                        "values": ["No, the business has not been able to get the materials, goods or services needed"]
+                                    }]
                                 }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
+                            },
+                            {
+                                "goto": {
+                                    "group": "groupff9741ed-a1da-4edf-bc6b-6bb62ddc94ec"
                                 }
+                            }
+                        ],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "blockfc873320-2213-4d19-982e-21b826833e1c",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "questionfc873320-2213-4d19-982e-21b826833e1c",
+                            "title": "Please explain why {{ metadata['ru_name'] }} was not able to get the materials, goods or services needed",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer8d48af55-9228-488b-8a15-087c484266c2",
+                                "mandatory": true,
+                                "type": "TextArea",
+                                "label": "Comments",
+                                "description": "",
+                                "q_code": "14",
+                                "max_length": 2000
+                            }]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    }
+                ],
+                "skip_conditions": [{
+                        "when": [{
+                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                            "condition": "contains any",
+                            "values": ["Permanently ceased trading"]
+                        }]
+                    },
+                    {
+                        "when": [{
+                                "id": "answer399d67d7-f59d-4ab5-ad00-d3b522fb7cd6",
+                                "condition": "contains any",
+                                "values": ["No", "Not sure", "Not applicable"]
+                            },
+                            {
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "contains any",
+                                "values": [
+                                    "Paused trading but intends to restart in the next two weeks",
+                                    "Paused trading and does not intend to restart in the next two weeks"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "when": [{
+                                "id": "answere528d417-67e6-4356-b660-107bab6c73f1",
+                                "condition": "contains any",
+                                "values": ["Not sure"]
+                            },
+                            {
+                                "id": "answere528d417-67e6-4356-b660-107bab6c73f1-exclusive",
+                                "condition": "contains any",
+                                "values": ["None of the above"]
+                            },
+                            {
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "contains any",
+                                "values": [
+                                    "Paused trading but intends to restart in the next two weeks",
+                                    "Paused trading and does not intend to restart in the next two weeks"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "when": [{
+                                "id": "answer0ebd8695-e6d4-4fe0-b24f-0a50d9ab27eb",
+                                "condition": "contains any",
+                                "values": ["No, approach has not changed", "Not sure"]
+                            },
+                            {
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "contains any",
+                                "values": [
+                                    "Paused trading but intends to restart in the next two weeks",
+                                    "Paused trading and does not intend to restart in the next two weeks"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "when": [{
+                                "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe",
+                                "condition": "contains any",
+                                "values": ["Requests from customers", "The circumstances were not covered in our existing policies", "Other"]
+                            },
+                            {
+                                "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe-exclusive",
+                                "condition": "contains any",
+                                "values": ["Not sure"]
+                            },
+                            {
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "contains any",
+                                "values": [
+                                    "Paused trading but intends to restart in the next two weeks",
+                                    "Paused trading and does not intend to restart in the next two weeks"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "when": [{
+                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                            "condition": "contains any",
+                            "values": [
+                                "Paused trading but intends to restart in the next two weeks",
+                                "Paused trading and does not intend to restart in the next two weeks"
                             ]
-                        },
-                        {
-                            "id": "blockfc873320-2213-4d19-982e-21b826833e1c",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "questionfc873320-2213-4d19-982e-21b826833e1c",
-                                    "title": "Please explain why {{ metadata['ru_name'] }} was not able to get the materials, goods or services needed",
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer8d48af55-9228-488b-8a15-087c484266c2",
-                                            "mandatory": true,
-                                            "type": "TextArea",
-                                            "label": "Comments",
-                                            "description": "",
-                                            "q_code": "14",
-                                            "max_length": 2000
-                                        }
-                                    ]
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
-                    ],
-                    "skip_conditions": [
-                        {
-                            "when": [
-                                {
-                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                    "condition": "contains any",
-                                    "values": ["Permanently ceased trading"]
-                                }
-                            ]
-                        },
-                        {
-                            "when": [
-                                {
-                                    "id": "answer399d67d7-f59d-4ab5-ad00-d3b522fb7cd6",
-                                    "condition": "contains any",
-                                    "values": ["No", "Not sure", "Not applicable"]
-                                },
-                                {
-                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                    "condition": "contains any",
-                                    "values": [
-                                        "Paused trading but intends to restart in the next two weeks",
-                                        "Paused trading and does not intend to restart in the next two weeks"
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "when": [
-                                {
-                                    "id": "answere528d417-67e6-4356-b660-107bab6c73f1",
-                                    "condition": "contains any",
-                                    "values": ["Not sure"]
-                                },
-                                {
-                                    "id": "answere528d417-67e6-4356-b660-107bab6c73f1-exclusive",
-                                    "condition": "contains any",
-                                    "values": ["None of the above"]
-                                },
-                                {
-                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                    "condition": "contains any",
-                                    "values": [
-                                        "Paused trading but intends to restart in the next two weeks",
-                                        "Paused trading and does not intend to restart in the next two weeks"
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "when": [
-                                {
-                                    "id": "answer0ebd8695-e6d4-4fe0-b24f-0a50d9ab27eb",
-                                    "condition": "contains any",
-                                    "values": ["No, approach has not changed", "Not sure"]
-                                },
-                                {
-                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                    "condition": "contains any",
-                                    "values": [
-                                        "Paused trading but intends to restart in the next two weeks",
-                                        "Paused trading and does not intend to restart in the next two weeks"
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "when": [
-                                {
-                                    "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe",
-                                    "condition": "contains any",
-                                    "values": ["Requests from customers", "The circumstances were not covered in our existing policies", "Other"]
-                                },
-                                {
-                                    "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe-exclusive",
-                                    "condition": "contains any",
-                                    "values": ["Not sure"]
-                                },
-                                {
-                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                    "condition": "contains any",
-                                    "values": [
-                                        "Paused trading but intends to restart in the next two weeks",
-                                        "Paused trading and does not intend to restart in the next two weeks"
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "when": [
-                                {
-                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                    "condition": "contains any",
-                                    "values": [
-                                        "Paused trading but intends to restart in the next two weeks",
-                                        "Paused trading and does not intend to restart in the next two weeks"
-                                    ]
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ]
+                        }]
+                    }
+                ]
+            }]
         },
         {
             "id": "sectionff9741ed-a1da-4edf-bc6b-6bb62ddc94ec",
             "title": "Prices of materials, goods and services",
-            "groups": [
-                {
-                    "id": "groupff9741ed-a1da-4edf-bc6b-6bb62ddc94ec",
-                    "title": "Prices of materials, goods and services",
-                    "blocks": [
-                        {
-                            "type": "Interstitial",
-                            "id": "groupff9741ed-a1da-4edf-bc6b-6bb62ddc94ec-introduction",
-                            "title": "Prices of materials, goods and services",
-                            "description": "<p>This section asks for information on any changes to the prices of goods and services <em>bought or sold</em> by the business in the last two weeks.</p>",
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "blockce542f26-a704-4dc6-a0ef-292c2739e4e6",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "questionce542f26-a704-4dc6-a0ef-292c2739e4e6",
-                                    "title": "How did the <em>prices</em> of materials, goods or services <em>bought</em> by {{ metadata['ru_name'] }} change in the <em>last two weeks</em>, compared with normal price fluctuations?",
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer27b42a40-5f79-4d32-b361-a94a454c638b",
-                                            "mandatory": true,
-                                            "type": "Radio",
-                                            "label": "",
-                                            "description": "",
-                                            "q_code": "15",
-                                            "options": [
-                                                {
-                                                    "label": "Prices increased more than normal",
-                                                    "value": "Prices increased more than normal"
-                                                },
-                                                {
-                                                    "label": "Prices did not change any more than normal",
-                                                    "value": "Prices did not change any more than normal"
-                                                },
-                                                {
-                                                    "label": "Prices decreased more than normal",
-                                                    "value": "Prices decreased more than normal"
-                                                },
-                                                {
-                                                    "label": "Some prices increased, some prices decreased",
-                                                    "value": "Some prices increased, some prices decreased"
-                                                },
-                                                {
-                                                    "label": "Not sure",
-                                                    "value": "Not sure"
-                                                },
-                                                {
-                                                    "label": "Not applicable",
-                                                    "value": "Not applicable"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "block": "block83701edb-7ee7-46b9-84f1-a9bc879f6b32",
-                                        "when": [
-                                            {
-                                                "id": "answer27b42a40-5f79-4d32-b361-a94a454c638b",
-                                                "condition": "contains any",
-                                                "values": ["Not applicable"]
-                                            }
-                                        ]
+            "groups": [{
+                "id": "groupff9741ed-a1da-4edf-bc6b-6bb62ddc94ec",
+                "title": "Prices of materials, goods and services",
+                "blocks": [{
+                        "type": "Interstitial",
+                        "id": "groupff9741ed-a1da-4edf-bc6b-6bb62ddc94ec-introduction",
+                        "title": "Prices of materials, goods and services",
+                        "description": "<p>This section asks for information on any changes to the prices of goods and services <em>bought or sold</em> by the business in the last two weeks.</p>",
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "blockce542f26-a704-4dc6-a0ef-292c2739e4e6",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "questionce542f26-a704-4dc6-a0ef-292c2739e4e6",
+                            "title": "How did the <em>prices</em> of materials, goods or services <em>bought</em> by {{ metadata['ru_name'] }} change in the <em>last two weeks</em>, compared with normal price fluctuations?",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer27b42a40-5f79-4d32-b361-a94a454c638b",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "label": "",
+                                "description": "",
+                                "q_code": "15",
+                                "options": [{
+                                        "label": "Prices increased more than normal",
+                                        "value": "Prices increased more than normal"
+                                    },
+                                    {
+                                        "label": "Prices did not change any more than normal",
+                                        "value": "Prices did not change any more than normal"
+                                    },
+                                    {
+                                        "label": "Prices decreased more than normal",
+                                        "value": "Prices decreased more than normal"
+                                    },
+                                    {
+                                        "label": "Some prices increased, some prices decreased",
+                                        "value": "Some prices increased, some prices decreased"
+                                    },
+                                    {
+                                        "label": "Not sure",
+                                        "value": "Not sure"
+                                    },
+                                    {
+                                        "label": "Not applicable",
+                                        "value": "Not applicable"
                                     }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "blockc09fc635-3d3d-46a0-bcca-2a04b42cd5b3",
-                                        "when": [
-                                            {
-                                                "id": "answer27b42a40-5f79-4d32-b361-a94a454c638b",
-                                                "condition": "contains any",
-                                                "values": ["Prices did not change any more than normal", "Not sure"]
-                                            }
-                                        ]
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "block83701edb-7ee7-46b9-84f1-a9bc879f6b32",
+                                    "when": [{
+                                        "id": "answer27b42a40-5f79-4d32-b361-a94a454c638b",
+                                        "condition": "contains any",
+                                        "values": ["Not applicable"]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "blockc09fc635-3d3d-46a0-bcca-2a04b42cd5b3",
+                                    "when": [{
+                                        "id": "answer27b42a40-5f79-4d32-b361-a94a454c638b",
+                                        "condition": "contains any",
+                                        "values": ["Prices did not change any more than normal", "Not sure"]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "block89e663b4-3ff2-4e68-9d51-1ea33411a407"
+                                }
+                            }
+                        ],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block89e663b4-3ff2-4e68-9d51-1ea33411a407",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question89e663b4-3ff2-4e68-9d51-1ea33411a407",
+                            "title": "Please give more details about the prices of materials, goods or services that changed",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answera7bb01fe-3061-421f-bfee-74e02002c9ed",
+                                "mandatory": true,
+                                "type": "TextArea",
+                                "label": "Comments",
+                                "description": "",
+                                "q_code": "16",
+                                "max_length": 2000
+                            }]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "blockc09fc635-3d3d-46a0-bcca-2a04b42cd5b3",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "questionc09fc635-3d3d-46a0-bcca-2a04b42cd5b3",
+                            "title": "What are your expectations about changes in prices of materials, goods or services that {{ metadata['ru_name'] }} needs for the <em>next two weeks</em>?",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answerdafcb524-7e33-472c-8b7e-76e77b402d92",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "label": "",
+                                "description": "",
+                                "q_code": "17",
+                                "options": [{
+                                        "label": "Expect prices to generally increase",
+                                        "value": "Expect prices to generally increase"
+                                    },
+                                    {
+                                        "label": "Expect prices not to change",
+                                        "value": "Expect prices not to change"
+                                    },
+                                    {
+                                        "label": "Expect prices to generally decrease",
+                                        "value": "Expect prices to generally decrease"
+                                    },
+                                    {
+                                        "label": "Not sure",
+                                        "value": "Not sure"
                                     }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "block89e663b4-3ff2-4e68-9d51-1ea33411a407"
+                                ]
+                            }]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block83701edb-7ee7-46b9-84f1-a9bc879f6b32",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question83701edb-7ee7-46b9-84f1-a9bc879f6b32",
+                            "title": "How did the prices of goods or services <em>sold</em> by {{ metadata['ru_name'] }} change in the <em>last two weeks</em>, compared with normal fluctuations?",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer9274311d-e7dc-4e3b-8694-0fafc1eb4aae",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "label": "",
+                                "description": "",
+                                "q_code": "18",
+                                "options": [{
+                                        "label": "Prices increased more than normal",
+                                        "value": "Prices increased more than normal"
+                                    },
+                                    {
+                                        "label": "Prices did not change any more than normal",
+                                        "value": "Prices did not change any more than normal"
+                                    },
+                                    {
+                                        "label": "Prices decreased more than normal",
+                                        "value": "Prices decreased more than normal"
+                                    },
+                                    {
+                                        "label": "Some prices increased, some prices decreased",
+                                        "value": "Some prices increased, some prices decreased"
+                                    },
+                                    {
+                                        "label": "Not sure",
+                                        "value": "Not sure"
+                                    },
+                                    {
+                                        "label": "Not applicable",
+                                        "value": "Not applicable"
                                     }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "block13fc69db-bd9a-4996-9724-66a6a6be13c0",
+                                    "when": [{
+                                        "id": "answer9274311d-e7dc-4e3b-8694-0fafc1eb4aae",
+                                        "condition": "contains any",
+                                        "values": ["Prices did not change any more than normal", "Not sure"]
+                                    }]
                                 }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
+                            },
+                            {
+                                "goto": {
+                                    "group": "group91ec421d-5346-4b67-8d16-a8268f1c4c07",
+                                    "when": [{
+                                        "id": "answer9274311d-e7dc-4e3b-8694-0fafc1eb4aae",
+                                        "condition": "contains any",
+                                        "values": ["Not applicable"]
+                                    }]
                                 }
-                            ]
-                        },
-                        {
-                            "id": "block89e663b4-3ff2-4e68-9d51-1ea33411a407",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question89e663b4-3ff2-4e68-9d51-1ea33411a407",
-                                    "title": "Please give more details about the prices of materials, goods or services that changed",
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answera7bb01fe-3061-421f-bfee-74e02002c9ed",
-                                            "mandatory": true,
-                                            "type": "TextArea",
-                                            "label": "Comments",
-                                            "description": "",
-                                            "q_code": "16",
-                                            "max_length": 2000
-                                        }
-                                    ]
+                            },
+                            {
+                                "goto": {
+                                    "block": "blockf41e30d1-d01e-472f-9201-be7749d83557"
                                 }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "blockc09fc635-3d3d-46a0-bcca-2a04b42cd5b3",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "questionc09fc635-3d3d-46a0-bcca-2a04b42cd5b3",
-                                    "title": "What are your expectations about changes in prices of materials, goods or services that {{ metadata['ru_name'] }} needs for the <em>next two weeks</em>?",
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answerdafcb524-7e33-472c-8b7e-76e77b402d92",
-                                            "mandatory": true,
-                                            "type": "Radio",
-                                            "label": "",
-                                            "description": "",
-                                            "q_code": "17",
-                                            "options": [
-                                                {
-                                                    "label": "Expect prices to generally increase",
-                                                    "value": "Expect prices to generally increase"
-                                                },
-                                                {
-                                                    "label": "Expect prices not to change",
-                                                    "value": "Expect prices not to change"
-                                                },
-                                                {
-                                                    "label": "Expect prices to generally decrease",
-                                                    "value": "Expect prices to generally decrease"
-                                                },
-                                                {
-                                                    "label": "Not sure",
-                                                    "value": "Not sure"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block83701edb-7ee7-46b9-84f1-a9bc879f6b32",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question83701edb-7ee7-46b9-84f1-a9bc879f6b32",
-                                    "title": "How did the prices of goods or services <em>sold</em> by {{ metadata['ru_name'] }} change in the <em>last two weeks</em>, compared with normal fluctuations?",
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer9274311d-e7dc-4e3b-8694-0fafc1eb4aae",
-                                            "mandatory": true,
-                                            "type": "Radio",
-                                            "label": "",
-                                            "description": "",
-                                            "q_code": "18",
-                                            "options": [
-                                                {
-                                                    "label": "Prices increased more than normal",
-                                                    "value": "Prices increased more than normal"
-                                                },
-                                                {
-                                                    "label": "Prices did not change any more than normal",
-                                                    "value": "Prices did not change any more than normal"
-                                                },
-                                                {
-                                                    "label": "Prices decreased more than normal",
-                                                    "value": "Prices decreased more than normal"
-                                                },
-                                                {
-                                                    "label": "Some prices increased, some prices decreased",
-                                                    "value": "Some prices increased, some prices decreased"
-                                                },
-                                                {
-                                                    "label": "Not sure",
-                                                    "value": "Not sure"
-                                                },
-                                                {
-                                                    "label": "Not applicable",
-                                                    "value": "Not applicable"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "block": "block13fc69db-bd9a-4996-9724-66a6a6be13c0",
-                                        "when": [
-                                            {
-                                                "id": "answer9274311d-e7dc-4e3b-8694-0fafc1eb4aae",
-                                                "condition": "contains any",
-                                                "values": ["Prices did not change any more than normal", "Not sure"]
-                                            }
-                                        ]
+                            }
+                        ],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "blockf41e30d1-d01e-472f-9201-be7749d83557",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "questionf41e30d1-d01e-472f-9201-be7749d83557",
+                            "title": "Please give more details about how prices changed",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answere3b55e00-f101-4ffe-8c5f-6a3272dfd8cc",
+                                "mandatory": true,
+                                "type": "TextArea",
+                                "label": "Comments",
+                                "description": "",
+                                "q_code": "19",
+                                "max_length": 2000
+                            }]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block13fc69db-bd9a-4996-9724-66a6a6be13c0",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question13fc69db-bd9a-4996-9724-66a6a6be13c0",
+                            "title": "What are your expectations about prices of goods or services that {{ metadata['ru_name'] }} will <em>sell</em> over the <em>next two weeks</em>?",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer8b015ec5-0d31-4f04-b333-b2835f5af8e2",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "label": "",
+                                "description": "",
+                                "q_code": "20",
+                                "options": [{
+                                        "label": "Prices will generally increase",
+                                        "value": "Prices will generally increase"
+                                    },
+                                    {
+                                        "label": "Prices will stay the same",
+                                        "value": "Prices will stay the same"
+                                    },
+                                    {
+                                        "label": "Prices will generally decrease",
+                                        "value": "Prices will generally decrease"
+                                    },
+                                    {
+                                        "label": "Not sure",
+                                        "value": "Not sure"
                                     }
-                                },
-                                {
-                                    "goto": {
-                                        "group": "group91ec421d-5346-4b67-8d16-a8268f1c4c07",
-                                        "when": [
-                                            {
-                                                "id": "answer9274311d-e7dc-4e3b-8694-0fafc1eb4aae",
-                                                "condition": "contains any",
-                                                "values": ["Not applicable"]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "blockf41e30d1-d01e-472f-9201-be7749d83557"
-                                    }
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
+                                ]
+                            }]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    }
+                ],
+                "skip_conditions": [{
+                        "when": [{
+                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                            "condition": "contains any",
+                            "values": ["Permanently ceased trading"]
+                        }]
+                    },
+                    {
+                        "when": [{
+                                "id": "answer399d67d7-f59d-4ab5-ad00-d3b522fb7cd6",
+                                "condition": "contains any",
+                                "values": ["No", "Not sure", "Not applicable"]
+                            },
+                            {
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "contains any",
+                                "values": [
+                                    "Paused trading but intends to restart in the next two weeks",
+                                    "Paused trading and does not intend to restart in the next two weeks"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "when": [{
+                                "id": "answere528d417-67e6-4356-b660-107bab6c73f1",
+                                "condition": "contains any",
+                                "values": ["Not sure"]
+                            },
+                            {
+                                "id": "answere528d417-67e6-4356-b660-107bab6c73f1-exclusive",
+                                "condition": "contains any",
+                                "values": ["None of the above"]
+                            },
+                            {
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "contains any",
+                                "values": [
+                                    "Paused trading but intends to restart in the next two weeks",
+                                    "Paused trading and does not intend to restart in the next two weeks"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "when": [{
+                                "id": "answer0ebd8695-e6d4-4fe0-b24f-0a50d9ab27eb",
+                                "condition": "contains any",
+                                "values": ["No, approach has not changed", "Not sure"]
+                            },
+                            {
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "contains any",
+                                "values": [
+                                    "Paused trading but intends to restart in the next two weeks",
+                                    "Paused trading and does not intend to restart in the next two weeks"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "when": [{
+                                "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe",
+                                "condition": "contains any",
+                                "values": ["Requests from customers", "The circumstances were not covered in our existing policies", "Other"]
+                            },
+                            {
+                                "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe-exclusive",
+                                "condition": "contains any",
+                                "values": ["Not sure"]
+                            },
+                            {
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "contains any",
+                                "values": [
+                                    "Paused trading but intends to restart in the next two weeks",
+                                    "Paused trading and does not intend to restart in the next two weeks"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "when": [{
+                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                            "condition": "contains any",
+                            "values": [
+                                "Paused trading but intends to restart in the next two weeks",
+                                "Paused trading and does not intend to restart in the next two weeks"
                             ]
-                        },
-                        {
-                            "id": "blockf41e30d1-d01e-472f-9201-be7749d83557",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "questionf41e30d1-d01e-472f-9201-be7749d83557",
-                                    "title": "Please give more details about how prices changed",
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answere3b55e00-f101-4ffe-8c5f-6a3272dfd8cc",
-                                            "mandatory": true,
-                                            "type": "TextArea",
-                                            "label": "Comments",
-                                            "description": "",
-                                            "q_code": "19",
-                                            "max_length": 2000
-                                        }
-                                    ]
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block13fc69db-bd9a-4996-9724-66a6a6be13c0",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question13fc69db-bd9a-4996-9724-66a6a6be13c0",
-                                    "title": "What are your expectations about prices of goods or services that {{ metadata['ru_name'] }} will <em>sell</em> over the <em>next two weeks</em>?",
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer8b015ec5-0d31-4f04-b333-b2835f5af8e2",
-                                            "mandatory": true,
-                                            "type": "Radio",
-                                            "label": "",
-                                            "description": "",
-                                            "q_code": "20",
-                                            "options": [
-                                                {
-                                                    "label": "Prices will generally increase",
-                                                    "value": "Prices will generally increase"
-                                                },
-                                                {
-                                                    "label": "Prices will stay the same",
-                                                    "value": "Prices will stay the same"
-                                                },
-                                                {
-                                                    "label": "Prices will generally decrease",
-                                                    "value": "Prices will generally decrease"
-                                                },
-                                                {
-                                                    "label": "Not sure",
-                                                    "value": "Not sure"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
-                    ],
-                    "skip_conditions": [
-                        {
-                            "when": [
-                                {
-                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                    "condition": "contains any",
-                                    "values": ["Permanently ceased trading"]
-                                }
-                            ]
-                        },
-                        {
-                            "when": [
-                                {
-                                    "id": "answer399d67d7-f59d-4ab5-ad00-d3b522fb7cd6",
-                                    "condition": "contains any",
-                                    "values": ["No", "Not sure", "Not applicable"]
-                                },
-                                {
-                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                    "condition": "contains any",
-                                    "values": [
-                                        "Paused trading but intends to restart in the next two weeks",
-                                        "Paused trading and does not intend to restart in the next two weeks"
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "when": [
-                                {
-                                    "id": "answere528d417-67e6-4356-b660-107bab6c73f1",
-                                    "condition": "contains any",
-                                    "values": ["Not sure"]
-                                },
-                                {
-                                    "id": "answere528d417-67e6-4356-b660-107bab6c73f1-exclusive",
-                                    "condition": "contains any",
-                                    "values": ["None of the above"]
-                                },
-                                {
-                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                    "condition": "contains any",
-                                    "values": [
-                                        "Paused trading but intends to restart in the next two weeks",
-                                        "Paused trading and does not intend to restart in the next two weeks"
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "when": [
-                                {
-                                    "id": "answer0ebd8695-e6d4-4fe0-b24f-0a50d9ab27eb",
-                                    "condition": "contains any",
-                                    "values": ["No, approach has not changed", "Not sure"]
-                                },
-                                {
-                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                    "condition": "contains any",
-                                    "values": [
-                                        "Paused trading but intends to restart in the next two weeks",
-                                        "Paused trading and does not intend to restart in the next two weeks"
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "when": [
-                                {
-                                    "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe",
-                                    "condition": "contains any",
-                                    "values": ["Requests from customers", "The circumstances were not covered in our existing policies", "Other"]
-                                },
-                                {
-                                    "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe-exclusive",
-                                    "condition": "contains any",
-                                    "values": ["Not sure"]
-                                },
-                                {
-                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                    "condition": "contains any",
-                                    "values": [
-                                        "Paused trading but intends to restart in the next two weeks",
-                                        "Paused trading and does not intend to restart in the next two weeks"
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "when": [
-                                {
-                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                    "condition": "contains any",
-                                    "values": [
-                                        "Paused trading but intends to restart in the next two weeks",
-                                        "Paused trading and does not intend to restart in the next two weeks"
-                                    ]
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ]
+                        }]
+                    }
+                ]
+            }]
         },
         {
             "id": "section91ec421d-5346-4b67-8d16-a8268f1c4c07",
             "title": "Stock and capital expenditure",
-            "groups": [
-                {
-                    "id": "group91ec421d-5346-4b67-8d16-a8268f1c4c07",
-                    "title": "Stock and capital expenditure",
-                    "blocks": [
-                        {
-                            "type": "Interstitial",
-                            "id": "group91ec421d-5346-4b67-8d16-a8268f1c4c07-introduction",
-                            "title": "Stock and capital expenditure",
-                            "description": "<p>This section asks for information about how the coronavirus (COVID-19) pandemic may have affected the business&apos;s stock and capital expenditure.</p>",
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
+            "groups": [{
+                "id": "group91ec421d-5346-4b67-8d16-a8268f1c4c07",
+                "title": "Stock and capital expenditure",
+                "blocks": [{
+                        "type": "Interstitial",
+                        "id": "group91ec421d-5346-4b67-8d16-a8268f1c4c07-introduction",
+                        "title": "Stock and capital expenditure",
+                        "description": "<p>This section asks for information about how the coronavirus (COVID-19) pandemic may have affected the business&apos;s stock and capital expenditure.</p>",
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block9a64bb02-fc94-4a2a-bda1-9e96f64bcd01",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question9a64bb02-fc94-4a2a-bda1-9e96f64bcd01",
+                            "title": "How has the coronavirus (COVID-19) pandemic affected {{ metadata['ru_name'] }}&#x2019;s <em>stock levels </em>in the last two weeks?",
+                            "description": "<p>Your business may use the term  &quot;inventories&quot; instead of &quot;stock&quot;.</p>",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answerc964594d-9b5b-4131-9c79-4baff0be08d1",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "label": "",
+                                "description": "",
+                                "q_code": "110",
+                                "options": [{
+                                        "label": "Stock levels are higher than normal",
+                                        "value": "Stock levels are higher than normal"
+                                    },
+                                    {
+                                        "label": "Stock levels have not changed",
+                                        "value": "Stock levels have not changed"
+                                    },
+                                    {
+                                        "label": "Stock levels are lower than normal",
+                                        "value": "Stock levels are lower than normal"
+                                    },
+                                    {
+                                        "label": "Not sure",
+                                        "value": "Not sure"
+                                    },
+                                    {
+                                        "label": "Not applicable",
+                                        "value": "Not applicable"
+                                    }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "block8b3a9f71-4818-40db-a9f6-1d7ca69fe9e8",
+                                    "when": [{
+                                        "id": "answerc964594d-9b5b-4131-9c79-4baff0be08d1",
+                                        "condition": "contains any",
+                                        "values": ["Stock levels are higher than normal", "Stock levels are lower than normal"]
+                                    }]
                                 }
-                            ]
-                        },
-                        {
-                            "id": "block9a64bb02-fc94-4a2a-bda1-9e96f64bcd01",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question9a64bb02-fc94-4a2a-bda1-9e96f64bcd01",
-                                    "title": "How has the coronavirus (COVID-19) pandemic affected {{ metadata['ru_name'] }}&#x2019;s <em>stock levels </em>in the last two weeks?",
-                                    "description": "<p>Your business may use the term  &quot;inventories&quot; instead of &quot;stock&quot;.</p>",
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answerc964594d-9b5b-4131-9c79-4baff0be08d1",
-                                            "mandatory": true,
-                                            "type": "Radio",
-                                            "label": "",
-                                            "description": "",
-                                            "q_code": "110",
-                                            "options": [
-                                                {
-                                                    "label": "Stock levels are higher than normal",
-                                                    "value": "Stock levels are higher than normal"
-                                                },
-                                                {
-                                                    "label": "Stock levels have not changed",
-                                                    "value": "Stock levels have not changed"
-                                                },
-                                                {
-                                                    "label": "Stock levels are lower than normal",
-                                                    "value": "Stock levels are lower than normal"
-                                                },
-                                                {
-                                                    "label": "Not sure",
-                                                    "value": "Not sure"
-                                                },
-                                                {
-                                                    "label": "Not applicable",
-                                                    "value": "Not applicable"
-                                                }
-                                            ]
-                                        }
-                                    ]
+                            },
+                            {
+                                "goto": {
+                                    "block": "block3313b8a4-1fd6-4ab9-a874-909e86a1f86d"
                                 }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "block": "block8b3a9f71-4818-40db-a9f6-1d7ca69fe9e8",
-                                        "when": [
-                                            {
-                                                "id": "answerc964594d-9b5b-4131-9c79-4baff0be08d1",
-                                                "condition": "contains any",
-                                                "values": ["Stock levels are higher than normal", "Stock levels are lower than normal"]
-                                            }
+                            }
+                        ],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block8b3a9f71-4818-40db-a9f6-1d7ca69fe9e8",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question8b3a9f71-4818-40db-a9f6-1d7ca69fe9e8",
+                            "title": "Please explain in more detail how the coronavirus (COVID-19) pandemic has affected {{ metadata['ru_name'] }}&#x2019;s stock levels in the last two weeks",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answere8a99b49-c76b-4598-925a-047596365fd1",
+                                "mandatory": true,
+                                "type": "TextArea",
+                                "label": "Comments",
+                                "description": "",
+                                "q_code": "111",
+                                "max_length": 2000
+                            }]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block3313b8a4-1fd6-4ab9-a874-909e86a1f86d",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question3313b8a4-1fd6-4ab9-a874-909e86a1f86d",
+                            "title": "How has the coronavirus (COVID-19) pandemic affected {{ metadata['ru_name'] }}&apos;s <em>capital expenditure</em>?",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer81b0d7f7-22b5-4fd6-a9ef-b774dbcc379f",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "label": "",
+                                "description": "",
+                                "q_code": "122",
+                                "options": [{
+                                        "label": "Capital expenditure is higher than normal",
+                                        "value": "Capital expenditure is higher than normal"
+                                    },
+                                    {
+                                        "label": "Capital expenditure has not been affected",
+                                        "value": "Capital expenditure has not been affected"
+                                    },
+                                    {
+                                        "label": "Capital expenditure is lower than normal",
+                                        "value": "Capital expenditure is lower than normal"
+                                    },
+                                    {
+                                        "label": "Capital expenditure has stopped",
+                                        "value": "Capital expenditure has stopped"
+                                    },
+                                    {
+                                        "label": "Not sure",
+                                        "value": "Not sure"
+                                    },
+                                    {
+                                        "label": "Not applicable",
+                                        "value": "Not applicable"
+                                    }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "blocke4cf91f5-de29-4545-be73-519ba55ef740",
+                                    "when": [{
+                                        "id": "answer81b0d7f7-22b5-4fd6-a9ef-b774dbcc379f",
+                                        "condition": "contains any",
+                                        "values": [
+                                            "Capital expenditure is higher than normal",
+                                            "Capital expenditure is lower than normal",
+                                            "Capital expenditure has stopped"
                                         ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "block3313b8a4-1fd6-4ab9-a874-909e86a1f86d"
-                                    }
+                                    }]
                                 }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
+                            },
+                            {
+                                "goto": {
+                                    "group": "groupc4064d34-46d7-43ef-8ff1-52f12500ab4c"
                                 }
+                            }
+                        ],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "blocke4cf91f5-de29-4545-be73-519ba55ef740",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "questione4cf91f5-de29-4545-be73-519ba55ef740",
+                            "title": "Please explain in more detail how the coronavirus (COVID-19) pandemic has affected {{ metadata['ru_name'] }}&#x2019;s capital expenditure",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer908cc56d-3047-40fc-a595-4d7cf639c584",
+                                "mandatory": true,
+                                "type": "TextArea",
+                                "label": "Comments",
+                                "description": "",
+                                "q_code": "123",
+                                "max_length": 2000
+                            }]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    }
+                ],
+                "skip_conditions": [{
+                        "when": [{
+                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                            "condition": "contains any",
+                            "values": ["Permanently ceased trading"]
+                        }]
+                    },
+                    {
+                        "when": [{
+                                "id": "answer399d67d7-f59d-4ab5-ad00-d3b522fb7cd6",
+                                "condition": "contains any",
+                                "values": ["No", "Not sure", "Not applicable"]
+                            },
+                            {
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "contains any",
+                                "values": [
+                                    "Paused trading but intends to restart in the next two weeks",
+                                    "Paused trading and does not intend to restart in the next two weeks"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "when": [{
+                                "id": "answere528d417-67e6-4356-b660-107bab6c73f1",
+                                "condition": "contains any",
+                                "values": ["Not sure"]
+                            },
+                            {
+                                "id": "answere528d417-67e6-4356-b660-107bab6c73f1-exclusive",
+                                "condition": "contains any",
+                                "values": ["None of the above"]
+                            },
+                            {
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "contains any",
+                                "values": [
+                                    "Paused trading but intends to restart in the next two weeks",
+                                    "Paused trading and does not intend to restart in the next two weeks"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "when": [{
+                                "id": "answer0ebd8695-e6d4-4fe0-b24f-0a50d9ab27eb",
+                                "condition": "contains any",
+                                "values": ["No, approach has not changed", "Not sure"]
+                            },
+                            {
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "contains any",
+                                "values": [
+                                    "Paused trading but intends to restart in the next two weeks",
+                                    "Paused trading and does not intend to restart in the next two weeks"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "when": [{
+                                "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe",
+                                "condition": "contains any",
+                                "values": ["Requests from customers", "The circumstances were not covered in our existing policies", "Other"]
+                            },
+                            {
+                                "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe-exclusive",
+                                "condition": "contains any",
+                                "values": ["Not sure"]
+                            },
+                            {
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "contains any",
+                                "values": [
+                                    "Paused trading but intends to restart in the next two weeks",
+                                    "Paused trading and does not intend to restart in the next two weeks"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "when": [{
+                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                            "condition": "contains any",
+                            "values": [
+                                "Paused trading but intends to restart in the next two weeks",
+                                "Paused trading and does not intend to restart in the next two weeks"
                             ]
-                        },
-                        {
-                            "id": "block8b3a9f71-4818-40db-a9f6-1d7ca69fe9e8",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question8b3a9f71-4818-40db-a9f6-1d7ca69fe9e8",
-                                    "title": "Please explain in more detail how the coronavirus (COVID-19) pandemic has affected {{ metadata['ru_name'] }}&#x2019;s stock levels in the last two weeks",
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answere8a99b49-c76b-4598-925a-047596365fd1",
-                                            "mandatory": true,
-                                            "type": "TextArea",
-                                            "label": "Comments",
-                                            "description": "",
-                                            "q_code": "111",
-                                            "max_length": 2000
-                                        }
-                                    ]
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block3313b8a4-1fd6-4ab9-a874-909e86a1f86d",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question3313b8a4-1fd6-4ab9-a874-909e86a1f86d",
-                                    "title": "How has the coronavirus (COVID-19) pandemic affected {{ metadata['ru_name'] }}&apos;s <em>capital expenditure</em>?",
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer81b0d7f7-22b5-4fd6-a9ef-b774dbcc379f",
-                                            "mandatory": true,
-                                            "type": "Radio",
-                                            "label": "",
-                                            "description": "",
-                                            "q_code": "122",
-                                            "options": [
-                                                {
-                                                    "label": "Capital expenditure is higher than normal",
-                                                    "value": "Capital expenditure is higher than normal"
-                                                },
-                                                {
-                                                    "label": "Capital expenditure has not been affected",
-                                                    "value": "Capital expenditure has not been affected"
-                                                },
-                                                {
-                                                    "label": "Capital expenditure is lower than normal",
-                                                    "value": "Capital expenditure is lower than normal"
-                                                },
-                                                {
-                                                    "label": "Capital expenditure has stopped",
-                                                    "value": "Capital expenditure has stopped"
-                                                },
-                                                {
-                                                    "label": "Not sure",
-                                                    "value": "Not sure"
-                                                },
-                                                {
-                                                    "label": "Not applicable",
-                                                    "value": "Not applicable"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "block": "blocke4cf91f5-de29-4545-be73-519ba55ef740",
-                                        "when": [
-                                            {
-                                                "id": "answer81b0d7f7-22b5-4fd6-a9ef-b774dbcc379f",
-                                                "condition": "contains any",
-                                                "values": [
-                                                    "Capital expenditure is higher than normal",
-                                                    "Capital expenditure is lower than normal",
-                                                    "Capital expenditure has stopped"
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "group": "groupc4064d34-46d7-43ef-8ff1-52f12500ab4c"
-                                    }
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "blocke4cf91f5-de29-4545-be73-519ba55ef740",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "questione4cf91f5-de29-4545-be73-519ba55ef740",
-                                    "title": "Please explain in more detail how the coronavirus (COVID-19) pandemic has affected {{ metadata['ru_name'] }}&#x2019;s capital expenditure",
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer908cc56d-3047-40fc-a595-4d7cf639c584",
-                                            "mandatory": true,
-                                            "type": "TextArea",
-                                            "label": "Comments",
-                                            "description": "",
-                                            "q_code": "123",
-                                            "max_length": 2000
-                                        }
-                                    ]
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
-                    ],
-                    "skip_conditions": [
-                        {
-                            "when": [
-                                {
-                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                    "condition": "contains any",
-                                    "values": ["Permanently ceased trading"]
-                                }
-                            ]
-                        },
-                        {
-                            "when": [
-                                {
-                                    "id": "answer399d67d7-f59d-4ab5-ad00-d3b522fb7cd6",
-                                    "condition": "contains any",
-                                    "values": ["No", "Not sure", "Not applicable"]
-                                },
-                                {
-                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                    "condition": "contains any",
-                                    "values": [
-                                        "Paused trading but intends to restart in the next two weeks",
-                                        "Paused trading and does not intend to restart in the next two weeks"
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "when": [
-                                {
-                                    "id": "answere528d417-67e6-4356-b660-107bab6c73f1",
-                                    "condition": "contains any",
-                                    "values": ["Not sure"]
-                                },
-                                {
-                                    "id": "answere528d417-67e6-4356-b660-107bab6c73f1-exclusive",
-                                    "condition": "contains any",
-                                    "values": ["None of the above"]
-                                },
-                                {
-                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                    "condition": "contains any",
-                                    "values": [
-                                        "Paused trading but intends to restart in the next two weeks",
-                                        "Paused trading and does not intend to restart in the next two weeks"
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "when": [
-                                {
-                                    "id": "answer0ebd8695-e6d4-4fe0-b24f-0a50d9ab27eb",
-                                    "condition": "contains any",
-                                    "values": ["No, approach has not changed", "Not sure"]
-                                },
-                                {
-                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                    "condition": "contains any",
-                                    "values": [
-                                        "Paused trading but intends to restart in the next two weeks",
-                                        "Paused trading and does not intend to restart in the next two weeks"
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "when": [
-                                {
-                                    "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe",
-                                    "condition": "contains any",
-                                    "values": ["Requests from customers", "The circumstances were not covered in our existing policies", "Other"]
-                                },
-                                {
-                                    "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe-exclusive",
-                                    "condition": "contains any",
-                                    "values": ["Not sure"]
-                                },
-                                {
-                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                    "condition": "contains any",
-                                    "values": [
-                                        "Paused trading but intends to restart in the next two weeks",
-                                        "Paused trading and does not intend to restart in the next two weeks"
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "when": [
-                                {
-                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                    "condition": "contains any",
-                                    "values": [
-                                        "Paused trading but intends to restart in the next two weeks",
-                                        "Paused trading and does not intend to restart in the next two weeks"
-                                    ]
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ]
+                        }]
+                    }
+                ]
+            }]
         },
         {
             "id": "sectionc4064d34-46d7-43ef-8ff1-52f12500ab4c",
             "title": "Innovation",
-            "groups": [
-                {
-                    "id": "groupc4064d34-46d7-43ef-8ff1-52f12500ab4c",
-                    "title": "Innovation",
-                    "blocks": [
-                        {
-                            "type": "Interstitial",
-                            "id": "groupc4064d34-46d7-43ef-8ff1-52f12500ab4c-introduction",
-                            "title": "Innovation",
-                            "description": "<p>This section asks for information about any new or improved innovations made by your business during the coronavirus (COVID-19) pandemic. </p>",
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block63a58106-3671-41b6-b2d1-a353092c214b",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question63a58106-3671-41b6-b2d1-a353092c214b",
-                                    "title": "How has {{ metadata['ru_name'] }}&apos;s <em>level of innovation</em> been affected by the coronavirus (COVID-19) pandemic?",
-                                    "definitions": [
-                                        {
-                                            "title": "What we mean by \"level of innovation\"",
-                                            "content": [
-                                                {
-                                                    "description": "This refers to the level at which your business creates or significantly improves:"
-                                                },
-                                                {
-                                                    "list": [
-                                                        "goods, materials or services",
-                                                        "processes introduced to produce or supply all goods, materials or services",
-                                                        "investments for future innovation and organisational practices"
-                                                    ]
-                                                }
-                                            ]
-                                        }
-                                    ],
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answere66540a0-a6eb-4dc2-8bb9-3cc2bf518f97",
-                                            "mandatory": true,
-                                            "type": "Radio",
-                                            "label": "",
-                                            "description": "",
-                                            "q_code": "112",
-                                            "options": [
-                                                {
-                                                    "label": "There has been more innovation",
-                                                    "value": "There has been more innovation"
-                                                },
-                                                {
-                                                    "label": "Innovation has not been affected",
-                                                    "value": "Innovation has not been affected"
-                                                },
-                                                {
-                                                    "label": "There has been less innovation",
-                                                    "value": "There has been less innovation"
-                                                },
-                                                {
-                                                    "label": "Not sure",
-                                                    "value": "Not sure"
-                                                },
-                                                {
-                                                    "label": "Not applicable",
-                                                    "value": "Not applicable"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "block": "block8e65201d-26a2-4a25-b00f-06eda6a70ca3",
-                                        "when": [
-                                            {
-                                                "id": "answere66540a0-a6eb-4dc2-8bb9-3cc2bf518f97",
-                                                "condition": "contains any",
-                                                "values": ["Not applicable"]
-                                            }
+            "groups": [{
+                "id": "groupc4064d34-46d7-43ef-8ff1-52f12500ab4c",
+                "title": "Innovation",
+                "blocks": [{
+                        "type": "Interstitial",
+                        "id": "groupc4064d34-46d7-43ef-8ff1-52f12500ab4c-introduction",
+                        "title": "Innovation",
+                        "description": "<p>This section asks for information about any new or improved innovations made by your business during the coronavirus (COVID-19) pandemic. </p>",
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block63a58106-3671-41b6-b2d1-a353092c214b",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question63a58106-3671-41b6-b2d1-a353092c214b",
+                            "title": "How has {{ metadata['ru_name'] }}&apos;s <em>level of innovation</em> been affected by the coronavirus (COVID-19) pandemic?",
+                            "definitions": [{
+                                "title": "What we mean by \"level of innovation\"",
+                                "content": [{
+                                        "description": "This refers to the level at which your business creates or significantly improves:"
+                                    },
+                                    {
+                                        "list": [
+                                            "goods, materials or services",
+                                            "processes introduced to produce or supply all goods, materials or services",
+                                            "investments for future innovation and organisational practices"
                                         ]
                                     }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "blockf1adc001-41b0-4898-b3b4-38d3abfacbe3"
+                                ]
+                            }],
+                            "type": "General",
+                            "answers": [{
+                                "id": "answere66540a0-a6eb-4dc2-8bb9-3cc2bf518f97",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "label": "",
+                                "description": "",
+                                "q_code": "112",
+                                "options": [{
+                                        "label": "There has been more innovation",
+                                        "value": "There has been more innovation"
+                                    },
+                                    {
+                                        "label": "Innovation has not been affected",
+                                        "value": "Innovation has not been affected"
+                                    },
+                                    {
+                                        "label": "There has been less innovation",
+                                        "value": "There has been less innovation"
+                                    },
+                                    {
+                                        "label": "Not sure",
+                                        "value": "Not sure"
+                                    },
+                                    {
+                                        "label": "Not applicable",
+                                        "value": "Not applicable"
                                     }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "block8e65201d-26a2-4a25-b00f-06eda6a70ca3",
+                                    "when": [{
+                                        "id": "answere66540a0-a6eb-4dc2-8bb9-3cc2bf518f97",
+                                        "condition": "contains any",
+                                        "values": ["Not applicable"]
+                                    }]
                                 }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
+                            },
+                            {
+                                "goto": {
+                                    "block": "blockf1adc001-41b0-4898-b3b4-38d3abfacbe3"
                                 }
-                            ]
-                        },
-                        {
-                            "id": "blockf1adc001-41b0-4898-b3b4-38d3abfacbe3",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "questionf1adc001-41b0-4898-b3b4-38d3abfacbe3",
-                                    "title": "During the coronavirus (COVID-19) pandemic, which of the following did {{ metadata['ru_name'] }} <em>innovate:</em>",
-                                    "definitions": [
-                                        {
-                                            "title": "What we mean by \"innovate\"",
-                                            "content": [
-                                                {
-                                                    "description": "This refers to your business creating new or significantly improved:"
-                                                },
-                                                {
-                                                    "list": [
-                                                        "goods, materials or services",
-                                                        "processes introduced to produce or supply all goods, materials or services",
-                                                        "investments for future innovation and organisational practices"
-                                                    ]
-                                                }
-                                            ]
-                                        }
-                                    ],
-                                    "type": "MutuallyExclusive",
-                                    "mandatory": true,
-                                    "answers": [
-                                        {
-                                            "id": "answer733f3739-2a76-4b69-acff-6f7542b77158",
-                                            "mandatory": false,
-                                            "type": "Checkbox",
-                                            "label": "Select all that apply",
-                                            "description": "",
-                                            "options": [
-                                                {
-                                                    "label": "Goods and/or materials",
-                                                    "value": "Goods and/or materials",
-                                                    "q_code": "1131"
-                                                },
-                                                {
-                                                    "label": "Services",
-                                                    "value": "Services",
-                                                    "q_code": "1132"
-                                                },
-                                                {
-                                                    "label": "Methods of manufacturing  goods, materials or services",
-                                                    "value": "Methods of manufacturing  goods, materials or services",
-                                                    "q_code": "1133"
-                                                },
-                                                {
-                                                    "label": "Methods of logistics, delivery or distribution",
-                                                    "value": "Methods of logistics, delivery or distribution",
-                                                    "q_code": "1134"
-                                                },
-                                                {
-                                                    "label": "Supporting activities for your processes",
-                                                    "value": "Supporting activities for your processes",
-                                                    "q_code": "1135",
-                                                    "description": "For example, maintenance systems or operations for purchasing, accounting, or computing"
-                                                },
-                                                {
-                                                    "label": "Not sure",
-                                                    "value": "Not sure",
-                                                    "q_code": "1136"
-                                                }
-                                            ]
+                            }
+                        ],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "blockf1adc001-41b0-4898-b3b4-38d3abfacbe3",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "questionf1adc001-41b0-4898-b3b4-38d3abfacbe3",
+                            "title": "During the coronavirus (COVID-19) pandemic, which of the following did {{ metadata['ru_name'] }} <em>innovate:</em>",
+                            "definitions": [{
+                                "title": "What we mean by \"innovate\"",
+                                "content": [{
+                                        "description": "This refers to your business creating new or significantly improved:"
+                                    },
+                                    {
+                                        "list": [
+                                            "goods, materials or services",
+                                            "processes introduced to produce or supply all goods, materials or services",
+                                            "investments for future innovation and organisational practices"
+                                        ]
+                                    }
+                                ]
+                            }],
+                            "type": "MutuallyExclusive",
+                            "mandatory": true,
+                            "answers": [{
+                                    "id": "answer733f3739-2a76-4b69-acff-6f7542b77158",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "label": "Select all that apply",
+                                    "description": "",
+                                    "options": [{
+                                            "label": "Goods and/or materials",
+                                            "value": "Goods and/or materials",
+                                            "q_code": "1131"
                                         },
                                         {
-                                            "id": "answer733f3739-2a76-4b69-acff-6f7542b77158-exclusive",
-                                            "mandatory": false,
-                                            "type": "Checkbox",
-                                            "description": "",
-                                            "options": [
-                                                {
-                                                    "label": "None of the above",
-                                                    "value": "None of the above",
-                                                    "q_code": "1130"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block8e65201d-26a2-4a25-b00f-06eda6a70ca3",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question8e65201d-26a2-4a25-b00f-06eda6a70ca3",
-                                    "title": "In the <em>next 12 months</em>, does {{ metadata['ru_name'] }} expect to use any of the following forms of intellectual property to protect its <em>innovations</em>?",
-                                    "definitions": [
-                                        {
-                                            "title": "What we mean by \"intellectual property\"",
-                                            "content": [
-                                                {
-                                                    "description": "This refers to creations of the mind such as inventions, names and images used in commerce, artistic works, designs, and symbols. Intellectual property is protected by law, which enables people and businesses to earn recognition or financial benefit from what they create."
-                                                }
-                                            ]
-                                        }
-                                    ],
-                                    "type": "MutuallyExclusive",
-                                    "mandatory": true,
-                                    "answers": [
-                                        {
-                                            "id": "answer4a8f04de-50b1-4d54-8edb-4efc8beddec9",
-                                            "mandatory": false,
-                                            "type": "Checkbox",
-                                            "label": "Select all that apply",
-                                            "description": "",
-                                            "options": [
-                                                {
-                                                    "label": "Copyright",
-                                                    "value": "Copyright",
-                                                    "q_code": "1141"
-                                                },
-                                                {
-                                                    "label": "Patent",
-                                                    "value": "Patent",
-                                                    "q_code": "1142"
-                                                },
-                                                {
-                                                    "label": "Registered design",
-                                                    "value": "Registered design",
-                                                    "q_code": "1143"
-                                                },
-                                                {
-                                                    "label": "Trade mark",
-                                                    "value": "Trade mark",
-                                                    "q_code": "1144"
-                                                },
-                                                {
-                                                    "label": "Other",
-                                                    "value": "Other",
-                                                    "q_code": "1145",
-                                                    "detail_answer": {
-                                                        "label": "Please describe",
-                                                        "type": "TextField",
-                                                        "id": "answer488036ea-f833-44cc-877c-19b144ae46f9",
-                                                        "mandatory": false
-                                                    }
-                                                },
-                                                {
-                                                    "label": "Not sure",
-                                                    "value": "Not sure",
-                                                    "q_code": "1146"
-                                                }
-                                            ]
+                                            "label": "Services",
+                                            "value": "Services",
+                                            "q_code": "1132"
                                         },
                                         {
-                                            "id": "answer4a8f04de-50b1-4d54-8edb-4efc8beddec9-exclusive",
-                                            "mandatory": false,
-                                            "type": "Checkbox",
-                                            "description": "",
-                                            "options": [
-                                                {
-                                                    "label": "None of the above",
-                                                    "value": "None of the above",
-                                                    "q_code": "1140"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
+                                            "label": "Methods of manufacturing  goods, materials or services",
+                                            "value": "Methods of manufacturing  goods, materials or services",
+                                            "q_code": "1133"
+                                        },
                                         {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
+                                            "label": "Methods of logistics, delivery or distribution",
+                                            "value": "Methods of logistics, delivery or distribution",
+                                            "q_code": "1134"
+                                        },
+                                        {
+                                            "label": "Supporting activities for your processes",
+                                            "value": "Supporting activities for your processes",
+                                            "q_code": "1135",
+                                            "description": "For example, maintenance systems or operations for purchasing, accounting, or computing"
+                                        },
+                                        {
+                                            "label": "Not sure",
+                                            "value": "Not sure",
+                                            "q_code": "1136"
                                         }
                                     ]
-                                }
-                            ]
-                        }
-                    ],
-                    "skip_conditions": [
-                        {
-                            "when": [
-                                {
-                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                    "condition": "contains any",
-                                    "values": ["Permanently ceased trading"]
-                                }
-                            ]
-                        },
-                        {
-                            "when": [
-                                {
-                                    "id": "answer399d67d7-f59d-4ab5-ad00-d3b522fb7cd6",
-                                    "condition": "contains any",
-                                    "values": ["No", "Not sure", "Not applicable"]
                                 },
                                 {
-                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                    "condition": "contains any",
-                                    "values": [
-                                        "Paused trading but intends to restart in the next two weeks",
-                                        "Paused trading and does not intend to restart in the next two weeks"
+                                    "id": "answer733f3739-2a76-4b69-acff-6f7542b77158-exclusive",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "description": "",
+                                    "options": [{
+                                        "label": "None of the above",
+                                        "value": "None of the above",
+                                        "q_code": "1130"
+                                    }]
+                                }
+                            ]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block8e65201d-26a2-4a25-b00f-06eda6a70ca3",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question8e65201d-26a2-4a25-b00f-06eda6a70ca3",
+                            "title": "In the <em>next 12 months</em>, does {{ metadata['ru_name'] }} expect to use any of the following forms of intellectual property to protect its <em>innovations</em>?",
+                            "definitions": [{
+                                "title": "What we mean by \"intellectual property\"",
+                                "content": [{
+                                    "description": "This refers to creations of the mind such as inventions, names and images used in commerce, artistic works, designs, and symbols. Intellectual property is protected by law, which enables people and businesses to earn recognition or financial benefit from what they create."
+                                }]
+                            }],
+                            "type": "MutuallyExclusive",
+                            "mandatory": true,
+                            "answers": [{
+                                    "id": "answer4a8f04de-50b1-4d54-8edb-4efc8beddec9",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "label": "Select all that apply",
+                                    "description": "",
+                                    "options": [{
+                                            "label": "Copyright",
+                                            "value": "Copyright",
+                                            "q_code": "1141"
+                                        },
+                                        {
+                                            "label": "Patent",
+                                            "value": "Patent",
+                                            "q_code": "1142"
+                                        },
+                                        {
+                                            "label": "Registered design",
+                                            "value": "Registered design",
+                                            "q_code": "1143"
+                                        },
+                                        {
+                                            "label": "Trade mark",
+                                            "value": "Trade mark",
+                                            "q_code": "1144"
+                                        },
+                                        {
+                                            "label": "Other",
+                                            "value": "Other",
+                                            "q_code": "1145",
+                                            "detail_answer": {
+                                                "label": "Please describe",
+                                                "type": "TextField",
+                                                "id": "answer488036ea-f833-44cc-877c-19b144ae46f9",
+                                                "mandatory": false
+                                            }
+                                        },
+                                        {
+                                            "label": "Not sure",
+                                            "value": "Not sure",
+                                            "q_code": "1146"
+                                        }
                                     ]
-                                }
-                            ]
-                        },
-                        {
-                            "when": [
-                                {
-                                    "id": "answere528d417-67e6-4356-b660-107bab6c73f1",
-                                    "condition": "contains any",
-                                    "values": ["Not sure"]
                                 },
                                 {
-                                    "id": "answere528d417-67e6-4356-b660-107bab6c73f1-exclusive",
-                                    "condition": "contains any",
-                                    "values": ["None of the above"]
-                                },
-                                {
-                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                    "condition": "contains any",
-                                    "values": [
-                                        "Paused trading but intends to restart in the next two weeks",
-                                        "Paused trading and does not intend to restart in the next two weeks"
-                                    ]
+                                    "id": "answer4a8f04de-50b1-4d54-8edb-4efc8beddec9-exclusive",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "description": "",
+                                    "options": [{
+                                        "label": "None of the above",
+                                        "value": "None of the above",
+                                        "q_code": "1140"
+                                    }]
                                 }
                             ]
-                        },
-                        {
-                            "when": [
-                                {
-                                    "id": "answer0ebd8695-e6d4-4fe0-b24f-0a50d9ab27eb",
-                                    "condition": "contains any",
-                                    "values": ["No, approach has not changed", "Not sure"]
-                                },
-                                {
-                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                    "condition": "contains any",
-                                    "values": [
-                                        "Paused trading but intends to restart in the next two weeks",
-                                        "Paused trading and does not intend to restart in the next two weeks"
-                                    ]
-                                }
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    }
+                ],
+                "skip_conditions": [{
+                        "when": [{
+                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                            "condition": "contains any",
+                            "values": ["Permanently ceased trading"]
+                        }]
+                    },
+                    {
+                        "when": [{
+                                "id": "answer399d67d7-f59d-4ab5-ad00-d3b522fb7cd6",
+                                "condition": "contains any",
+                                "values": ["No", "Not sure", "Not applicable"]
+                            },
+                            {
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "contains any",
+                                "values": [
+                                    "Paused trading but intends to restart in the next two weeks",
+                                    "Paused trading and does not intend to restart in the next two weeks"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "when": [{
+                                "id": "answere528d417-67e6-4356-b660-107bab6c73f1",
+                                "condition": "contains any",
+                                "values": ["Not sure"]
+                            },
+                            {
+                                "id": "answere528d417-67e6-4356-b660-107bab6c73f1-exclusive",
+                                "condition": "contains any",
+                                "values": ["None of the above"]
+                            },
+                            {
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "contains any",
+                                "values": [
+                                    "Paused trading but intends to restart in the next two weeks",
+                                    "Paused trading and does not intend to restart in the next two weeks"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "when": [{
+                                "id": "answer0ebd8695-e6d4-4fe0-b24f-0a50d9ab27eb",
+                                "condition": "contains any",
+                                "values": ["No, approach has not changed", "Not sure"]
+                            },
+                            {
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "contains any",
+                                "values": [
+                                    "Paused trading but intends to restart in the next two weeks",
+                                    "Paused trading and does not intend to restart in the next two weeks"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "when": [{
+                                "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe",
+                                "condition": "contains any",
+                                "values": ["Requests from customers", "The circumstances were not covered in our existing policies", "Other"]
+                            },
+                            {
+                                "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe-exclusive",
+                                "condition": "contains any",
+                                "values": ["Not sure"]
+                            },
+                            {
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "contains any",
+                                "values": [
+                                    "Paused trading but intends to restart in the next two weeks",
+                                    "Paused trading and does not intend to restart in the next two weeks"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "when": [{
+                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                            "condition": "contains any",
+                            "values": [
+                                "Paused trading but intends to restart in the next two weeks",
+                                "Paused trading and does not intend to restart in the next two weeks"
                             ]
-                        },
-                        {
-                            "when": [
-                                {
-                                    "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe",
-                                    "condition": "contains any",
-                                    "values": ["Requests from customers", "The circumstances were not covered in our existing policies", "Other"]
-                                },
-                                {
-                                    "id": "answer35b1899b-c9b4-489e-9390-113d37cdebfe-exclusive",
-                                    "condition": "contains any",
-                                    "values": ["Not sure"]
-                                },
-                                {
-                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                    "condition": "contains any",
-                                    "values": [
-                                        "Paused trading but intends to restart in the next two weeks",
-                                        "Paused trading and does not intend to restart in the next two weeks"
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "when": [
-                                {
-                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                    "condition": "contains any",
-                                    "values": [
-                                        "Paused trading but intends to restart in the next two weeks",
-                                        "Paused trading and does not intend to restart in the next two weeks"
-                                    ]
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ]
+                        }]
+                    }
+                ]
+            }]
         },
         {
             "id": "section8753dfce-d80c-4fe0-98ba-3cddd52a9bba",
             "title": "Access to financial support",
-            "groups": [
-                {
-                    "id": "group8753dfce-d80c-4fe0-98ba-3cddd52a9bba",
-                    "title": "Access to financial support",
-                    "blocks": [
-                        {
-                            "type": "Interstitial",
-                            "id": "group8753dfce-d80c-4fe0-98ba-3cddd52a9bba-introduction",
-                            "title": "Access to financial support",
-                            "description": "<p>This section asks for information on:</p><ul><li>any applications that the business made for government financial initiatives or schemes</li><li>any applications the business intends to make for government initiatives or schemes</li><li>any applications for non-government financial support</li></ul>",
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block2ea33f36-282b-40d4-a881-0d946f8d4408",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question2ea33f36-282b-40d4-a881-0d946f8d4408",
-                                    "title": "Has {{ metadata['ru_name'] }} <em>applied</em> for any of the following schemes?",
-                                    "type": "MutuallyExclusive",
-                                    "mandatory": true,
-                                    "answers": [
-                                        {
-                                            "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
-                                            "mandatory": false,
-                                            "type": "Checkbox",
-                                            "label": "Select all that apply",
-                                            "description": "",
-                                            "options": [
-                                                {
-                                                    "label": "Coronavirus Job Retention Scheme",
-                                                    "value": "Coronavirus Job Retention Scheme",
-                                                    "q_code": "451",
-                                                    "description": "UK Government scheme that covers 80% of pay (up to £2,500 a month) for furloughed staff"
-                                                },
-                                                {
-                                                    "label": "Government-backed accredited loans or finance agreements",
-                                                    "value": "Government-backed accredited loans or finance agreements",
-                                                    "q_code": "4526",
-                                                    "description": "For example, COVID Corporate Financing Facility (CCFF), Coronavirus Business Interruption Loan Scheme (CBILS or CLBILS), Bounce Back Loan Scheme (BBLS) or loans from devolved governments"
-                                                },
-                                                {
-                                                    "label": "Business grants funded by the UK and devolved governments",
-                                                    "value": "Business grants funded by the UK and devolved governments",
-                                                    "q_code": "4589",
-                                                    "description": "Including small business grant funds and sector-specific grants in England, Wales, Scotland and Northern Ireland"
-                                                }
-                                            ]
+            "groups": [{
+                "id": "group8753dfce-d80c-4fe0-98ba-3cddd52a9bba",
+                "title": "Access to financial support",
+                "blocks": [{
+                        "type": "Interstitial",
+                        "id": "group8753dfce-d80c-4fe0-98ba-3cddd52a9bba-introduction",
+                        "title": "Access to financial support",
+                        "description": "<p>This section asks for information on:</p><ul><li>any applications that the business made for government financial initiatives or schemes</li><li>any applications the business intends to make for government initiatives or schemes</li><li>any applications for non-government financial support</li></ul>",
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block2ea33f36-282b-40d4-a881-0d946f8d4408",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question2ea33f36-282b-40d4-a881-0d946f8d4408",
+                            "title": "Has {{ metadata['ru_name'] }} <em>applied</em> for any of the following schemes?",
+                            "type": "MutuallyExclusive",
+                            "mandatory": true,
+                            "answers": [{
+                                    "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "label": "Select all that apply",
+                                    "description": "",
+                                    "options": [{
+                                            "label": "Coronavirus Job Retention Scheme",
+                                            "value": "Coronavirus Job Retention Scheme",
+                                            "q_code": "451",
+                                            "description": "UK Government scheme that covers 80% of pay (up to £2,500 a month) for furloughed staff"
                                         },
                                         {
-                                            "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503-exclusive",
-                                            "mandatory": false,
-                                            "type": "Checkbox",
-                                            "description": "",
-                                            "options": [
-                                                {
-                                                    "label": "Not applied for any of these schemes",
-                                                    "value": "Not applied for any of these schemes",
-                                                    "q_code": "457"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "block": "blocke46ad473-b3a0-4791-b658-d3ebcd35e785",
-                                        "when": [
-                                            {
-                                                "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
-                                                "condition": "contains any",
-                                                "values": ["Government-backed accredited loans or finance agreements"]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "block4f715518-d276-4297-b1f5-04f4debbb713",
-                                        "when": [
-                                            {
-                                                "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
-                                                "condition": "contains any",
-                                                "values": ["Business grants funded by the UK and devolved governments"]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
-                                        "when": [
-                                            {
-                                                "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
-                                                "condition": "contains all",
-                                                "values": ["Coronavirus Job Retention Scheme"]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "blockd39bd617-f259-488e-baf2-a51905d69b10"
-                                    }
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "blocke46ad473-b3a0-4791-b658-d3ebcd35e785",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "questione46ad473-b3a0-4791-b658-d3ebcd35e785",
-                                    "title": "Did {{ metadata['ru_name'] }} apply for the Development Bank of Wales COVID-19 Business Loan Scheme?",
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer845b4b07-1ed1-4937-84f1-bd7b347f1cb4",
-                                            "mandatory": true,
-                                            "type": "Radio",
-                                            "label": "",
-                                            "description": "",
-                                            "q_code": "78",
-                                            "options": [
-                                                {
-                                                    "label": "Yes",
-                                                    "value": "Yes"
-                                                },
-                                                {
-                                                    "label": "No",
-                                                    "value": "No"
-                                                },
-                                                {
-                                                    "label": "Not sure",
-                                                    "value": "Not sure"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "block": "block4f715518-d276-4297-b1f5-04f4debbb713",
-                                        "when": [
-                                            {
-                                                "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
-                                                "condition": "contains any",
-                                                "values": ["Business grants funded by the UK and devolved governments"]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
-                                        "when": [
-                                            {
-                                                "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
-                                                "condition": "contains any",
-                                                "values": ["Coronavirus Job Retention Scheme", "Government-backed accredited loans or finance agreements"]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "blockd39bd617-f259-488e-baf2-a51905d69b10"
-                                    }
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block4f715518-d276-4297-b1f5-04f4debbb713",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question4f715518-d276-4297-b1f5-04f4debbb713",
-                                    "title": "Which government offered the business <em>grants</em> that you have applied for?",
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer1f3f22db-c33a-4999-99d8-2333f0c1ad20",
-                                            "mandatory": true,
-                                            "type": "Radio",
-                                            "label": "",
-                                            "description": "",
-                                            "q_code": "79",
-                                            "options": [
-                                                {
-                                                    "label": "Northern Ireland Executive",
-                                                    "value": "Northern Ireland Executive"
-                                                },
-                                                {
-                                                    "label": "Scottish Government",
-                                                    "value": "Scottish Government"
-                                                },
-                                                {
-                                                    "label": "UK Government (England only)",
-                                                    "value": "UK Government (England only)"
-                                                },
-                                                {
-                                                    "label": "Welsh Government",
-                                                    "value": "Welsh Government"
-                                                },
-                                                {
-                                                    "label": "Not sure",
-                                                    "value": "Not sure"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "block": "block182ef910-1276-449f-9184-bb7d8234e84f",
-                                        "when": [
-                                            {
-                                                "id": "answer1f3f22db-c33a-4999-99d8-2333f0c1ad20",
-                                                "condition": "contains any",
-                                                "values": ["Welsh Government"]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "blockcfdf7d4f-47d0-428c-b8e0-5ec28fd525c3",
-                                        "when": [
-                                            {
-                                                "id": "answer1f3f22db-c33a-4999-99d8-2333f0c1ad20",
-                                                "condition": "contains any",
-                                                "values": ["Scottish Government"]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "block5f68a3d0-365c-4247-b75e-a2ce7d5fea45",
-                                        "when": [
-                                            {
-                                                "id": "answer1f3f22db-c33a-4999-99d8-2333f0c1ad20",
-                                                "condition": "contains any",
-                                                "values": ["UK Government (England only)"]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "block1be2fd23-e68f-4b5f-9553-d7c8c4e43082",
-                                        "when": [
-                                            {
-                                                "id": "answer1f3f22db-c33a-4999-99d8-2333f0c1ad20",
-                                                "condition": "contains any",
-                                                "values": ["Northern Ireland Executive"]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
-                                        "when": [
-                                            {
-                                                "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
-                                                "condition": "contains any",
-                                                "values": ["Coronavirus Job Retention Scheme", "Government-backed accredited loans or finance agreements"]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "blockd39bd617-f259-488e-baf2-a51905d69b10"
-                                    }
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block182ef910-1276-449f-9184-bb7d8234e84f",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question182ef910-1276-449f-9184-bb7d8234e84f",
-                                    "title": "Which of the following Welsh Government grants did {{ metadata['ru_name'] }} apply for?",
-                                    "type": "MutuallyExclusive",
-                                    "mandatory": true,
-                                    "answers": [
-                                        {
-                                            "id": "answer9d2c5b50-4e17-4b31-9c3f-3188080a16b2",
-                                            "mandatory": false,
-                                            "type": "Checkbox",
-                                            "label": "Select all that apply",
-                                            "description": "",
-                                            "options": [
-                                                {
-                                                    "label": "COVID-19 grant for small businesses",
-                                                    "value": "COVID-19 grant for small businesses",
-                                                    "q_code": "801"
-                                                },
-                                                {
-                                                    "label": "Economic Resilience Fund",
-                                                    "value": "Economic Resilience Fund",
-                                                    "q_code": "802"
-                                                },
-                                                {
-                                                    "label": "Sector-specific grants",
-                                                    "value": "Sector-specific grants",
-                                                    "q_code": "803",
-                                                    "description": "For example, retail, hospitality, leisure or fisheries grant"
-                                                }
-                                            ]
+                                            "label": "Government-backed accredited loans or finance agreements",
+                                            "value": "Government-backed accredited loans or finance agreements",
+                                            "q_code": "4526",
+                                            "description": "For example, COVID Corporate Financing Facility (CCFF), Coronavirus Business Interruption Loan Scheme (CBILS or CLBILS), Bounce Back Loan Scheme (BBLS) or loans from devolved governments"
                                         },
                                         {
-                                            "id": "answer9d2c5b50-4e17-4b31-9c3f-3188080a16b2-exclusive",
-                                            "mandatory": false,
-                                            "type": "Checkbox",
-                                            "description": "",
-                                            "options": [
-                                                {
-                                                    "label": "Not applied for any of these grants",
-                                                    "value": "Not applied for any of these grants",
-                                                    "q_code": "804"
-                                                }
-                                            ]
+                                            "label": "Business grants funded by the UK and devolved governments",
+                                            "value": "Business grants funded by the UK and devolved governments",
+                                            "q_code": "4589",
+                                            "description": "Including small business grant funds and sector-specific grants in England, Wales, Scotland and Northern Ireland"
                                         }
                                     ]
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "block": "block525537e6-e6b5-401d-850d-2fe2f8da287a",
-                                        "when": [
-                                            {
-                                                "id": "answer9d2c5b50-4e17-4b31-9c3f-3188080a16b2",
-                                                "condition": "contains any",
-                                                "values": ["COVID-19 grant for small businesses", "Economic Resilience Fund", "Sector-specific grants"]
-                                            }
-                                        ]
-                                    }
                                 },
                                 {
-                                    "goto": {
-                                        "block": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
-                                        "when": [
-                                            {
-                                                "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
-                                                "condition": "contains any",
-                                                "values": ["Coronavirus Job Retention Scheme", "Government-backed accredited loans or finance agreements"]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "blockf3731f81-73c0-4214-a771-3e321785afd7"
-                                    }
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
+                                    "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503-exclusive",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "description": "",
+                                    "options": [{
+                                        "label": "Not applied for any of these schemes",
+                                        "value": "Not applied for any of these schemes",
+                                        "q_code": "457"
+                                    }]
                                 }
                             ]
-                        },
-                        {
-                            "id": "block525537e6-e6b5-401d-850d-2fe2f8da287a",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question525537e6-e6b5-401d-850d-2fe2f8da287a",
-                                    "title": "Has {{ metadata['ru_name'] }} <em>received</em> funds from any of the following Welsh Government grants?",
-                                    "type": "MutuallyExclusive",
-                                    "mandatory": true,
-                                    "answers": [
-                                        {
-                                            "id": "answerc812da13-73e9-4f73-a310-c0a78ed38524",
-                                            "mandatory": false,
-                                            "type": "Checkbox",
-                                            "label": "Select all that apply",
-                                            "description": "",
-                                            "options": [
-                                                {
-                                                    "label": "COVID-19 grant for small businesses",
-                                                    "value": "COVID-19 grant for small businesses",
-                                                    "q_code": "811"
-                                                },
-                                                {
-                                                    "label": "Economic Resilience Fund",
-                                                    "value": "Economic Resilience Fund",
-                                                    "q_code": "812"
-                                                },
-                                                {
-                                                    "label": "Sector-specific grants",
-                                                    "value": "Sector-specific grants",
-                                                    "q_code": "813",
-                                                    "description": "For example, retail, hospitality, leisure or fisheries grant"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "id": "answerc812da13-73e9-4f73-a310-c0a78ed38524-exclusive",
-                                            "mandatory": false,
-                                            "type": "Checkbox",
-                                            "description": "",
-                                            "options": [
-                                                {
-                                                    "label": "Not received any funds from these grants",
-                                                    "value": "Not received any funds from these grants",
-                                                    "q_code": "814"
-                                                }
-                                            ]
-                                        }
-                                    ]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "blocke46ad473-b3a0-4791-b658-d3ebcd35e785",
+                                    "when": [{
+                                        "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
+                                        "condition": "contains any",
+                                        "values": ["Government-backed accredited loans or finance agreements"]
+                                    }]
                                 }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "block": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
-                                        "when": [
-                                            {
-                                                "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
-                                                "condition": "contains any",
-                                                "values": ["Coronavirus Job Retention Scheme", "Government-backed accredited loans or finance agreements"]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "blockf3731f81-73c0-4214-a771-3e321785afd7"
-                                    }
+                            },
+                            {
+                                "goto": {
+                                    "block": "block4f715518-d276-4297-b1f5-04f4debbb713",
+                                    "when": [{
+                                        "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
+                                        "condition": "contains any",
+                                        "values": ["Business grants funded by the UK and devolved governments"]
+                                    }]
                                 }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
+                            },
+                            {
+                                "goto": {
+                                    "block": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
+                                    "when": [{
+                                        "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
+                                        "condition": "contains all",
+                                        "values": ["Coronavirus Job Retention Scheme"]
+                                    }]
                                 }
-                            ]
-                        },
-                        {
-                            "id": "blockcfdf7d4f-47d0-428c-b8e0-5ec28fd525c3",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "questioncfdf7d4f-47d0-428c-b8e0-5ec28fd525c3",
-                                    "title": "Which of the following Scottish Government grants did {{ metadata['ru_name'] }} apply for?",
-                                    "type": "MutuallyExclusive",
-                                    "mandatory": true,
-                                    "answers": [
-                                        {
-                                            "id": "answer9e33a258-d2be-40b8-ad4e-ae55f3d066f1",
-                                            "mandatory": false,
-                                            "type": "Checkbox",
-                                            "label": "Select all that apply",
-                                            "description": "",
-                                            "options": [
-                                                {
-                                                    "label": "Small Business Support grant",
-                                                    "value": "Small Business Support grant",
-                                                    "q_code": "821"
-                                                },
-                                                {
-                                                    "label": "Pivotal Enterprise Resilience Fund",
-                                                    "value": "Pivotal Enterprise Resilience Fund",
-                                                    "q_code": "822"
-                                                },
-                                                {
-                                                    "label": "Sector-specific grants",
-                                                    "value": "Sector-specific grants",
-                                                    "q_code": "823",
-                                                    "description": "For example, retail, hospitality, leisure or fisheries grant"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "id": "answer9e33a258-d2be-40b8-ad4e-ae55f3d066f1-exclusive",
-                                            "mandatory": false,
-                                            "type": "Checkbox",
-                                            "description": "",
-                                            "options": [
-                                                {
-                                                    "label": "Not applied for any of these grants",
-                                                    "value": "Not applied for any of these grants",
-                                                    "q_code": "824"
-                                                }
-                                            ]
-                                        }
-                                    ]
+                            },
+                            {
+                                "goto": {
+                                    "block": "blockd39bd617-f259-488e-baf2-a51905d69b10"
                                 }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "block": "blockd19893fd-7edf-405d-a04a-8986f3b691fe",
-                                        "when": [
-                                            {
-                                                "id": "answer9e33a258-d2be-40b8-ad4e-ae55f3d066f1",
-                                                "condition": "contains any",
-                                                "values": ["Small Business Support grant", "Pivotal Enterprise Resilience Fund", "Sector-specific grants"]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
-                                        "when": [
-                                            {
-                                                "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
-                                                "condition": "contains any",
-                                                "values": ["Coronavirus Job Retention Scheme", "Government-backed accredited loans or finance agreements"]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "blockf3731f81-73c0-4214-a771-3e321785afd7"
-                                    }
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "blockd19893fd-7edf-405d-a04a-8986f3b691fe",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "questiond19893fd-7edf-405d-a04a-8986f3b691fe",
-                                    "title": "Has {{ metadata['ru_name'] }} <em>received</em> funds from any of the following Scottish Government grants?",
-                                    "type": "MutuallyExclusive",
-                                    "mandatory": true,
-                                    "answers": [
-                                        {
-                                            "id": "answerb579d6b0-bc9e-4d09-bf39-aed0a1f0ef0b",
-                                            "mandatory": false,
-                                            "type": "Checkbox",
-                                            "label": "Select all that apply",
-                                            "description": "",
-                                            "options": [
-                                                {
-                                                    "label": "Small Business Support grant",
-                                                    "value": "Small Business Support grant",
-                                                    "q_code": "831"
-                                                },
-                                                {
-                                                    "label": "Pivotal Enterprise Resilience Fund",
-                                                    "value": "Pivotal Enterprise Resilience Fund",
-                                                    "q_code": "832"
-                                                },
-                                                {
-                                                    "label": "Sector-specific grants",
-                                                    "value": "Sector-specific grants",
-                                                    "q_code": "833",
-                                                    "description": "For example, retail, hospitality, leisure or fisheries grant"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "id": "answerb579d6b0-bc9e-4d09-bf39-aed0a1f0ef0b-exclusive",
-                                            "mandatory": false,
-                                            "type": "Checkbox",
-                                            "description": "",
-                                            "options": [
-                                                {
-                                                    "label": "Not received any funds from these grants",
-                                                    "value": "Not received any funds from these grants",
-                                                    "q_code": "834"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "block": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
-                                        "when": [
-                                            {
-                                                "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
-                                                "condition": "contains any",
-                                                "values": ["Coronavirus Job Retention Scheme", "Government-backed accredited loans or finance agreements"]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "blockf3731f81-73c0-4214-a771-3e321785afd7"
-                                    }
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block5f68a3d0-365c-4247-b75e-a2ce7d5fea45",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question5f68a3d0-365c-4247-b75e-a2ce7d5fea45",
-                                    "title": "Which of the following UK Government (England only) grants did {{ metadata['ru_name'] }} apply for?",
-                                    "type": "MutuallyExclusive",
-                                    "mandatory": true,
-                                    "answers": [
-                                        {
-                                            "id": "answer7a62b279-e8af-498b-bee4-6b861ec5d9f4",
-                                            "mandatory": false,
-                                            "type": "Checkbox",
-                                            "label": "Select all that apply",
-                                            "description": "",
-                                            "options": [
-                                                {
-                                                    "label": "Small Business Grant Fund (SBGF)",
-                                                    "value": "Small Business Grant Fund (SBGF)",
-                                                    "q_code": "841"
-                                                },
-                                                {
-                                                    "label": "Sector-specific grants",
-                                                    "value": "Sector-specific grants",
-                                                    "q_code": "842",
-                                                    "description": "For example, retail, hospitality, leisure or fisheries grant"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "id": "answer7a62b279-e8af-498b-bee4-6b861ec5d9f4-exclusive",
-                                            "mandatory": false,
-                                            "type": "Checkbox",
-                                            "description": "",
-                                            "options": [
-                                                {
-                                                    "label": "Not applied for any of these grants",
-                                                    "value": "Not applied for any of these grants",
-                                                    "q_code": "843"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "block": "block77a8fcf0-6663-4372-8a78-a0eaba692e25",
-                                        "when": [
-                                            {
-                                                "id": "answer7a62b279-e8af-498b-bee4-6b861ec5d9f4",
-                                                "condition": "contains any",
-                                                "values": ["Small Business Grant Fund (SBGF)", "Sector-specific grants"]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
-                                        "when": [
-                                            {
-                                                "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
-                                                "condition": "contains any",
-                                                "values": ["Coronavirus Job Retention Scheme", "Government-backed accredited loans or finance agreements"]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "blockf3731f81-73c0-4214-a771-3e321785afd7"
-                                    }
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block77a8fcf0-6663-4372-8a78-a0eaba692e25",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question77a8fcf0-6663-4372-8a78-a0eaba692e25",
-                                    "title": "Has {{ metadata['ru_name'] }} <em>received</em> funds from any of the following UK Government (England only) grants?",
-                                    "type": "MutuallyExclusive",
-                                    "mandatory": true,
-                                    "answers": [
-                                        {
-                                            "id": "answer7df0f422-59af-44a2-9de5-35b06645f367",
-                                            "mandatory": false,
-                                            "type": "Checkbox",
-                                            "label": "Select all that apply",
-                                            "description": "",
-                                            "options": [
-                                                {
-                                                    "label": "Small Business Grant Fund (SBGF)",
-                                                    "value": "Small Business Grant Fund (SBGF)",
-                                                    "q_code": "851"
-                                                },
-                                                {
-                                                    "label": "Sector-specific grants",
-                                                    "value": "Sector-specific grants",
-                                                    "q_code": "852",
-                                                    "description": "For example, retail, hospitality, leisure or fisheries grant"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "id": "answer7df0f422-59af-44a2-9de5-35b06645f367-exclusive",
-                                            "mandatory": false,
-                                            "type": "Checkbox",
-                                            "description": "",
-                                            "options": [
-                                                {
-                                                    "label": "Not received any funds from these grants",
-                                                    "value": "Not received any funds from these grants",
-                                                    "q_code": "853"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "block": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
-                                        "when": [
-                                            {
-                                                "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
-                                                "condition": "contains any",
-                                                "values": ["Coronavirus Job Retention Scheme", "Government-backed accredited loans or finance agreements"]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "blockf3731f81-73c0-4214-a771-3e321785afd7"
-                                    }
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block1be2fd23-e68f-4b5f-9553-d7c8c4e43082",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question1be2fd23-e68f-4b5f-9553-d7c8c4e43082",
-                                    "title": "Which of the following Northern Ireland Executive grants did {{ metadata['ru_name'] }} apply for?",
-                                    "type": "MutuallyExclusive",
-                                    "mandatory": true,
-                                    "answers": [
-                                        {
-                                            "id": "answer1359bc07-ae5f-452b-8abd-00cfff28b27d",
-                                            "mandatory": false,
-                                            "type": "Checkbox",
-                                            "label": "Select all that apply",
-                                            "description": "",
-                                            "options": [
-                                                {
-                                                    "label": "Small Business Grant Scheme",
-                                                    "value": "Small Business Grant Scheme",
-                                                    "q_code": "861"
-                                                },
-                                                {
-                                                    "label": "Sector-specific grants",
-                                                    "value": "Sector-specific grants",
-                                                    "q_code": "862",
-                                                    "description": "For example, retail, hospitality, leisure or fisheries grant"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "id": "answer1359bc07-ae5f-452b-8abd-00cfff28b27d-exclusive",
-                                            "mandatory": false,
-                                            "type": "Checkbox",
-                                            "description": "",
-                                            "options": [
-                                                {
-                                                    "label": "Not applied for any of these grants",
-                                                    "value": "Not applied for any of these grants",
-                                                    "q_code": "863"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "block": "block08e3e6c9-a572-43c2-ba84-0b984a2ed299",
-                                        "when": [
-                                            {
-                                                "id": "answer1359bc07-ae5f-452b-8abd-00cfff28b27d",
-                                                "condition": "contains any",
-                                                "values": ["Small Business Grant Scheme", "Sector-specific grants"]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
-                                        "when": [
-                                            {
-                                                "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
-                                                "condition": "contains any",
-                                                "values": ["Coronavirus Job Retention Scheme", "Government-backed accredited loans or finance agreements"]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "blockf3731f81-73c0-4214-a771-3e321785afd7"
-                                    }
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block08e3e6c9-a572-43c2-ba84-0b984a2ed299",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question08e3e6c9-a572-43c2-ba84-0b984a2ed299",
-                                    "title": "Has {{ metadata['ru_name'] }} <em>received</em> funds from any of the following Northern Ireland Executive grants?",
-                                    "type": "MutuallyExclusive",
-                                    "mandatory": true,
-                                    "answers": [
-                                        {
-                                            "id": "answerb1d499f5-1ad6-469a-9ea2-9b48dea1457c",
-                                            "mandatory": false,
-                                            "type": "Checkbox",
-                                            "label": "Select all that apply",
-                                            "description": "",
-                                            "options": [
-                                                {
-                                                    "label": "Small Business Grant Scheme",
-                                                    "value": "Small Business Grant Scheme",
-                                                    "q_code": "871"
-                                                },
-                                                {
-                                                    "label": "Sector-specific grants",
-                                                    "value": "Sector-specific grants",
-                                                    "q_code": "872",
-                                                    "description": "For example, retail, hospitality, leisure or fisheries grant"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "id": "answerb1d499f5-1ad6-469a-9ea2-9b48dea1457c-exclusive",
-                                            "mandatory": false,
-                                            "type": "Checkbox",
-                                            "description": "",
-                                            "options": [
-                                                {
-                                                    "label": "Not received any funds from these grants",
-                                                    "value": "Not received any funds from these grants",
-                                                    "q_code": "873"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "block": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
-                                        "when": [
-                                            {
-                                                "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
-                                                "condition": "contains any",
-                                                "values": ["Coronavirus Job Retention Scheme", "Government-backed accredited loans or finance agreements"]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "blockf3731f81-73c0-4214-a771-3e321785afd7"
-                                    }
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "questionb305b9d6-b021-4d5e-a92e-291381c49492",
-                                    "title": "Has {{ metadata['ru_name'] }} <em>received</em> funds from any of the following schemes?",
-                                    "type": "MutuallyExclusive",
-                                    "mandatory": true,
-                                    "answers": [
-                                        {
-                                            "id": "answer30aa84e6-07cf-4887-885f-abff7788aefb",
-                                            "mandatory": false,
-                                            "type": "Checkbox",
-                                            "label": "Select all that apply",
-                                            "description": "",
-                                            "options": [
-                                                {
-                                                    "label": "Coronavirus Job Retention Scheme",
-                                                    "value": "Coronavirus Job Retention Scheme",
-                                                    "q_code": "461",
-                                                    "description": "UK Government scheme that covers 80% of pay (up to £2,500 a month) for furloughed staff"
-                                                },
-                                                {
-                                                    "label": "Government-backed accredited loans or finance agreements",
-                                                    "value": "Government-backed accredited loans or finance agreements",
-                                                    "q_code": "4629",
-                                                    "description": "For example, COVID Corporate Financing Facility (CCFF), Coronavirus Business Interruption Loan Scheme (CBILS or CLBILS), Bounce Back Loan Scheme (BBLS) or loans from devolved governments"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "id": "answer30aa84e6-07cf-4887-885f-abff7788aefb-exclusive",
-                                            "mandatory": false,
-                                            "type": "Checkbox",
-                                            "description": "",
-                                            "options": [
-                                                {
-                                                    "label": "Not received any funds from these schemes",
-                                                    "value": "Not received any funds from these schemes",
-                                                    "q_code": "467"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "blockf3731f81-73c0-4214-a771-3e321785afd7",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "questionf3731f81-73c0-4214-a771-3e321785afd7",
-                                    "title": "Please describe your experience of applying for these schemes",
-                                    "guidance": {
-                                        "content": [
-                                            {
-                                                "description": "<strong>For example:</strong>"
-                                            },
-                                            {
-                                                "list": [
-                                                    "how easy or difficult it was to apply",
-                                                    "how you heard about these schemes",
-                                                    "if there were any barriers to you applying, such as eligibility",
-                                                    "if there was enough guidance about the application process",
-                                                    "if you received funding, how long it took"
-                                                ]
-                                            }
-                                        ]
+                            }
+                        ],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "blocke46ad473-b3a0-4791-b658-d3ebcd35e785",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "questione46ad473-b3a0-4791-b658-d3ebcd35e785",
+                            "title": "Did {{ metadata['ru_name'] }} apply for the Development Bank of Wales COVID-19 Business Loan Scheme?",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer845b4b07-1ed1-4937-84f1-bd7b347f1cb4",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "label": "",
+                                "description": "",
+                                "q_code": "78",
+                                "options": [{
+                                        "label": "Yes",
+                                        "value": "Yes"
                                     },
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer96848783-ecc7-4bcb-b8c5-bb807a118585",
-                                            "mandatory": true,
-                                            "type": "TextArea",
-                                            "label": "Comments",
-                                            "description": "",
-                                            "q_code": "47",
-                                            "max_length": 2000
-                                        }
-                                    ]
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "blockd39bd617-f259-488e-baf2-a51905d69b10",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "questiond39bd617-f259-488e-baf2-a51905d69b10",
-                                    "title": "Does {{ metadata['ru_name'] }} expect to use the Coronavirus Job Retention Scheme (CJRS) in the <em>next two weeks</em>?",
-                                    "description": "<p>If you have already applied once, and you plan to apply again for the next claim period, select &quot;Yes&quot;.</p>",
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer36fe3ff1-cbba-46c6-a548-072c4ff1bd97",
-                                            "mandatory": true,
-                                            "type": "Radio",
-                                            "label": "",
-                                            "description": "",
-                                            "q_code": "88",
-                                            "options": [
-                                                {
-                                                    "label": "Yes",
-                                                    "value": "Yes"
-                                                },
-                                                {
-                                                    "label": "No",
-                                                    "value": "No"
-                                                },
-                                                {
-                                                    "label": "Not sure",
-                                                    "value": "Not sure"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block7f5c1f5d-0854-4738-b801-20d9848475c2",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question7f5c1f5d-0854-4738-b801-20d9848475c2",
-                                    "title": "Is {{ metadata['ru_name'] }} <em>intending</em> to apply for any of the following schemes?",
-                                    "guidance": {
-                                        "content": [
-                                            {
-                                                "description": "Exclude any schemes that your business has already applied for"
-                                            }
-                                        ]
+                                    {
+                                        "label": "No",
+                                        "value": "No"
                                     },
-                                    "type": "MutuallyExclusive",
-                                    "mandatory": true,
-                                    "answers": [
-                                        {
-                                            "id": "answerc05c537f-7ef0-426d-bef8-a631236e3baa",
-                                            "mandatory": false,
-                                            "type": "Checkbox",
-                                            "label": "Select all that apply",
-                                            "description": "",
-                                            "options": [
-                                                {
-                                                    "label": "Government-backed accredited loans or finance agreements",
-                                                    "value": "Government-backed accredited loans or finance agreements",
-                                                    "q_code": "4816",
-                                                    "description": "For example, COVID Corporate Financing Facility (CCFF), Coronavirus Business Interruption Loan Scheme (CBILS or CLBILS), Bounce Back Loan Scheme (BBLS) or loans from devolved governments"
-                                                },
-                                                {
-                                                    "label": "Business grants funded by the UK and devolved governments",
-                                                    "value": "Business grants funded by the UK and devolved governments",
-                                                    "q_code": "4889",
-                                                    "description": "Include small business grant funds and sector-specific grants in England, Wales, Scotland and Northern Ireland"
-                                                }
-                                            ]
+                                    {
+                                        "label": "Not sure",
+                                        "value": "Not sure"
+                                    }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "block4f715518-d276-4297-b1f5-04f4debbb713",
+                                    "when": [{
+                                        "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
+                                        "condition": "contains any",
+                                        "values": ["Business grants funded by the UK and devolved governments"]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
+                                    "when": [{
+                                        "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
+                                        "condition": "contains any",
+                                        "values": ["Coronavirus Job Retention Scheme", "Government-backed accredited loans or finance agreements"]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "blockd39bd617-f259-488e-baf2-a51905d69b10"
+                                }
+                            }
+                        ],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block4f715518-d276-4297-b1f5-04f4debbb713",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question4f715518-d276-4297-b1f5-04f4debbb713",
+                            "title": "Which government offered the business <em>grants</em> that you have applied for?",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer1f3f22db-c33a-4999-99d8-2333f0c1ad20",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "label": "",
+                                "description": "",
+                                "q_code": "79",
+                                "options": [{
+                                        "label": "Northern Ireland Executive",
+                                        "value": "Northern Ireland Executive"
+                                    },
+                                    {
+                                        "label": "Scottish Government",
+                                        "value": "Scottish Government"
+                                    },
+                                    {
+                                        "label": "UK Government (England only)",
+                                        "value": "UK Government (England only)"
+                                    },
+                                    {
+                                        "label": "Welsh Government",
+                                        "value": "Welsh Government"
+                                    },
+                                    {
+                                        "label": "Not sure",
+                                        "value": "Not sure"
+                                    }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "block182ef910-1276-449f-9184-bb7d8234e84f",
+                                    "when": [{
+                                        "id": "answer1f3f22db-c33a-4999-99d8-2333f0c1ad20",
+                                        "condition": "contains any",
+                                        "values": ["Welsh Government"]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "blockcfdf7d4f-47d0-428c-b8e0-5ec28fd525c3",
+                                    "when": [{
+                                        "id": "answer1f3f22db-c33a-4999-99d8-2333f0c1ad20",
+                                        "condition": "contains any",
+                                        "values": ["Scottish Government"]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "block5f68a3d0-365c-4247-b75e-a2ce7d5fea45",
+                                    "when": [{
+                                        "id": "answer1f3f22db-c33a-4999-99d8-2333f0c1ad20",
+                                        "condition": "contains any",
+                                        "values": ["UK Government (England only)"]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "block1be2fd23-e68f-4b5f-9553-d7c8c4e43082",
+                                    "when": [{
+                                        "id": "answer1f3f22db-c33a-4999-99d8-2333f0c1ad20",
+                                        "condition": "contains any",
+                                        "values": ["Northern Ireland Executive"]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
+                                    "when": [{
+                                        "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
+                                        "condition": "contains any",
+                                        "values": ["Coronavirus Job Retention Scheme", "Government-backed accredited loans or finance agreements"]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "blockd39bd617-f259-488e-baf2-a51905d69b10"
+                                }
+                            }
+                        ],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block182ef910-1276-449f-9184-bb7d8234e84f",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question182ef910-1276-449f-9184-bb7d8234e84f",
+                            "title": "Which of the following Welsh Government grants did {{ metadata['ru_name'] }} apply for?",
+                            "type": "MutuallyExclusive",
+                            "mandatory": true,
+                            "answers": [{
+                                    "id": "answer9d2c5b50-4e17-4b31-9c3f-3188080a16b2",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "label": "Select all that apply",
+                                    "description": "",
+                                    "options": [{
+                                            "label": "COVID-19 grant for small businesses",
+                                            "value": "COVID-19 grant for small businesses",
+                                            "q_code": "801"
                                         },
                                         {
-                                            "id": "answerc05c537f-7ef0-426d-bef8-a631236e3baa-exclusive",
-                                            "mandatory": false,
-                                            "type": "Checkbox",
-                                            "description": "",
-                                            "options": [
-                                                {
-                                                    "label": "Not intending to apply for any of these schemes",
-                                                    "value": "Not intending to apply for any of these schemes",
-                                                    "q_code": "487"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block707c4125-b078-4bf4-a5a7-4e98987640e0",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question707c4125-b078-4bf4-a5a7-4e98987640e0",
-                                    "title": "Is {{ metadata['ru_name'] }} using any of the following <em>initiatives</em>?",
-                                    "type": "MutuallyExclusive",
-                                    "mandatory": true,
-                                    "answers": [
-                                        {
-                                            "id": "answerf6103d5e-1a15-43d7-be56-1c4dcc960b3a",
-                                            "mandatory": false,
-                                            "type": "Checkbox",
-                                            "label": "Select all that apply",
-                                            "description": "",
-                                            "options": [
-                                                {
-                                                    "label": "Business rates holiday",
-                                                    "value": "Business rates holiday",
-                                                    "q_code": "891"
-                                                },
-                                                {
-                                                    "label": "Deferring VAT payments",
-                                                    "value": "Deferring VAT payments",
-                                                    "q_code": "892"
-                                                },
-                                                {
-                                                    "label": "HMRC Time To Pay scheme",
-                                                    "value": "HMRC Time To Pay scheme",
-                                                    "q_code": "893"
-                                                }
-                                            ]
+                                            "label": "Economic Resilience Fund",
+                                            "value": "Economic Resilience Fund",
+                                            "q_code": "802"
                                         },
                                         {
-                                            "id": "answerf6103d5e-1a15-43d7-be56-1c4dcc960b3a-exclusive",
-                                            "mandatory": false,
-                                            "type": "Checkbox",
-                                            "description": "",
-                                            "options": [
-                                                {
-                                                    "label": "Not using any of these initiatives",
-                                                    "value": "Not using any of these initiatives",
-                                                    "q_code": "894"
-                                                }
-                                            ]
+                                            "label": "Sector-specific grants",
+                                            "value": "Sector-specific grants",
+                                            "q_code": "803",
+                                            "description": "For example, retail, hospitality, leisure or fisheries grant"
                                         }
                                     ]
-                                }
-                            ],
-                            "skip_conditions": [
+                                },
                                 {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
+                                    "id": "answer9d2c5b50-4e17-4b31-9c3f-3188080a16b2-exclusive",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "description": "",
+                                    "options": [{
+                                        "label": "Not applied for any of these grants",
+                                        "value": "Not applied for any of these grants",
+                                        "q_code": "804"
+                                    }]
                                 }
                             ]
-                        },
-                        {
-                            "id": "block7a8cfd94-755c-4742-acfa-ca10a4c1cb87",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question7a8cfd94-755c-4742-acfa-ca10a4c1cb87",
-                                    "title": "Is {{ metadata['ru_name'] }} <em>intending</em> to use any of the following <em>initiatives</em>?",
-                                    "guidance": {
-                                        "content": [
-                                            {
-                                                "description": "Exclude any initiatives that your business is already using"
-                                            }
-                                        ]
-                                    },
-                                    "type": "MutuallyExclusive",
-                                    "mandatory": true,
-                                    "answers": [
-                                        {
-                                            "id": "answer6a654fac-abea-4b0d-8ca3-bf7340faa559",
-                                            "mandatory": false,
-                                            "type": "Checkbox",
-                                            "label": "Select all that apply",
-                                            "description": "",
-                                            "options": [
-                                                {
-                                                    "label": "Business rates holiday",
-                                                    "value": "Business rates holiday",
-                                                    "q_code": "901"
-                                                },
-                                                {
-                                                    "label": "Deferring VAT payments",
-                                                    "value": "Deferring VAT payments",
-                                                    "q_code": "902"
-                                                },
-                                                {
-                                                    "label": "HMRC Time To Pay scheme",
-                                                    "value": "HMRC Time To Pay scheme",
-                                                    "q_code": "903"
-                                                }
-                                            ]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "block525537e6-e6b5-401d-850d-2fe2f8da287a",
+                                    "when": [{
+                                        "id": "answer9d2c5b50-4e17-4b31-9c3f-3188080a16b2",
+                                        "condition": "contains any",
+                                        "values": ["COVID-19 grant for small businesses", "Economic Resilience Fund", "Sector-specific grants"]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
+                                    "when": [{
+                                        "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
+                                        "condition": "contains any",
+                                        "values": ["Coronavirus Job Retention Scheme", "Government-backed accredited loans or finance agreements"]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "blockf3731f81-73c0-4214-a771-3e321785afd7"
+                                }
+                            }
+                        ],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block525537e6-e6b5-401d-850d-2fe2f8da287a",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question525537e6-e6b5-401d-850d-2fe2f8da287a",
+                            "title": "Has {{ metadata['ru_name'] }} <em>received</em> funds from any of the following Welsh Government grants?",
+                            "type": "MutuallyExclusive",
+                            "mandatory": true,
+                            "answers": [{
+                                    "id": "answerc812da13-73e9-4f73-a310-c0a78ed38524",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "label": "Select all that apply",
+                                    "description": "",
+                                    "options": [{
+                                            "label": "COVID-19 grant for small businesses",
+                                            "value": "COVID-19 grant for small businesses",
+                                            "q_code": "811"
                                         },
                                         {
-                                            "id": "answer6a654fac-abea-4b0d-8ca3-bf7340faa559-exclusive",
-                                            "mandatory": false,
-                                            "type": "Checkbox",
-                                            "description": "",
-                                            "options": [
-                                                {
-                                                    "label": "Not intending to use any of these initiatives",
-                                                    "value": "Not intending to use any of these initiatives",
-                                                    "q_code": "904"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "block": "block4fc906bb-a55c-497a-8bd0-5427d69dc055",
-                                        "when": [
-                                            {
-                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                                "condition": "contains any",
-                                                "values": [
-                                                    "Paused trading but intends to restart in the next two weeks",
-                                                    "Paused trading and does not intend to restart in the next two weeks"
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "block35d5f073-97cd-460f-aa2e-1dd068c6f6ff",
-                                        "when": [
-                                            {
-                                                "id": "answerc812da13-73e9-4f73-a310-c0a78ed38524",
-                                                "condition": "contains any",
-                                                "values": ["COVID-19 grant for small businesses", "Economic Resilience Fund", "Sector-specific grants"]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "block35d5f073-97cd-460f-aa2e-1dd068c6f6ff",
-                                        "when": [
-                                            {
-                                                "id": "answerb579d6b0-bc9e-4d09-bf39-aed0a1f0ef0b",
-                                                "condition": "contains any",
-                                                "values": ["Small Business Support grant", "Pivotal Enterprise Resilience Fund", "Sector-specific grants"]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "block35d5f073-97cd-460f-aa2e-1dd068c6f6ff",
-                                        "when": [
-                                            {
-                                                "id": "answer7df0f422-59af-44a2-9de5-35b06645f367",
-                                                "condition": "contains any",
-                                                "values": ["Small Business Grant Fund (SBGF)", "Sector-specific grants"]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "block35d5f073-97cd-460f-aa2e-1dd068c6f6ff",
-                                        "when": [
-                                            {
-                                                "id": "answerb1d499f5-1ad6-469a-9ea2-9b48dea1457c",
-                                                "condition": "contains any",
-                                                "values": ["Small Business Grant Scheme", "Sector-specific grants"]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "block35d5f073-97cd-460f-aa2e-1dd068c6f6ff",
-                                        "when": [
-                                            {
-                                                "id": "answer30aa84e6-07cf-4887-885f-abff7788aefb",
-                                                "condition": "contains any",
-                                                "values": ["Coronavirus Job Retention Scheme", "Government-backed accredited loans or finance agreements"]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "block35d5f073-97cd-460f-aa2e-1dd068c6f6ff",
-                                        "when": [
-                                            {
-                                                "id": "answerf6103d5e-1a15-43d7-be56-1c4dcc960b3a",
-                                                "condition": "contains any",
-                                                "values": ["Business rates holiday", "Deferring VAT payments", "HMRC Time To Pay scheme"]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "block4fc906bb-a55c-497a-8bd0-5427d69dc055"
-                                    }
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
+                                            "label": "Economic Resilience Fund",
+                                            "value": "Economic Resilience Fund",
+                                            "q_code": "812"
+                                        },
                                         {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
+                                            "label": "Sector-specific grants",
+                                            "value": "Sector-specific grants",
+                                            "q_code": "813",
+                                            "description": "For example, retail, hospitality, leisure or fisheries grant"
                                         }
                                     ]
+                                },
+                                {
+                                    "id": "answerc812da13-73e9-4f73-a310-c0a78ed38524-exclusive",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "description": "",
+                                    "options": [{
+                                        "label": "Not received any funds from these grants",
+                                        "value": "Not received any funds from these grants",
+                                        "q_code": "814"
+                                    }]
                                 }
                             ]
-                        },
-                        {
-                            "id": "block35d5f073-97cd-460f-aa2e-1dd068c6f6ff",
-                            "type": "Question",
-                            "questions": [
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
+                                    "when": [{
+                                        "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
+                                        "condition": "contains any",
+                                        "values": ["Coronavirus Job Retention Scheme", "Government-backed accredited loans or finance agreements"]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "blockf3731f81-73c0-4214-a771-3e321785afd7"
+                                }
+                            }
+                        ],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "blockcfdf7d4f-47d0-428c-b8e0-5ec28fd525c3",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "questioncfdf7d4f-47d0-428c-b8e0-5ec28fd525c3",
+                            "title": "Which of the following Scottish Government grants did {{ metadata['ru_name'] }} apply for?",
+                            "type": "MutuallyExclusive",
+                            "mandatory": true,
+                            "answers": [{
+                                    "id": "answer9e33a258-d2be-40b8-ad4e-ae55f3d066f1",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "label": "Select all that apply",
+                                    "description": "",
+                                    "options": [{
+                                            "label": "Small Business Support grant",
+                                            "value": "Small Business Support grant",
+                                            "q_code": "821"
+                                        },
+                                        {
+                                            "label": "Pivotal Enterprise Resilience Fund",
+                                            "value": "Pivotal Enterprise Resilience Fund",
+                                            "q_code": "822"
+                                        },
+                                        {
+                                            "label": "Sector-specific grants",
+                                            "value": "Sector-specific grants",
+                                            "q_code": "823",
+                                            "description": "For example, retail, hospitality, leisure or fisheries grant"
+                                        }
+                                    ]
+                                },
                                 {
-                                    "id": "question35d5f073-97cd-460f-aa2e-1dd068c6f6ff",
-                                    "title": "Did the support received from these <em>initiatives</em> or <em>schemes</em> help {{ metadata['ru_name'] }} continue trading?",
-                                    "guidance": {
-                                        "content": [
-                                            {
-                                                "description": "Include any grants or loans from government"
-                                            }
-                                        ]
+                                    "id": "answer9e33a258-d2be-40b8-ad4e-ae55f3d066f1-exclusive",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "description": "",
+                                    "options": [{
+                                        "label": "Not applied for any of these grants",
+                                        "value": "Not applied for any of these grants",
+                                        "q_code": "824"
+                                    }]
+                                }
+                            ]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "blockd19893fd-7edf-405d-a04a-8986f3b691fe",
+                                    "when": [{
+                                        "id": "answer9e33a258-d2be-40b8-ad4e-ae55f3d066f1",
+                                        "condition": "contains any",
+                                        "values": ["Small Business Support grant", "Pivotal Enterprise Resilience Fund", "Sector-specific grants"]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
+                                    "when": [{
+                                        "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
+                                        "condition": "contains any",
+                                        "values": ["Coronavirus Job Retention Scheme", "Government-backed accredited loans or finance agreements"]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "blockf3731f81-73c0-4214-a771-3e321785afd7"
+                                }
+                            }
+                        ],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "blockd19893fd-7edf-405d-a04a-8986f3b691fe",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "questiond19893fd-7edf-405d-a04a-8986f3b691fe",
+                            "title": "Has {{ metadata['ru_name'] }} <em>received</em> funds from any of the following Scottish Government grants?",
+                            "type": "MutuallyExclusive",
+                            "mandatory": true,
+                            "answers": [{
+                                    "id": "answerb579d6b0-bc9e-4d09-bf39-aed0a1f0ef0b",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "label": "Select all that apply",
+                                    "description": "",
+                                    "options": [{
+                                            "label": "Small Business Support grant",
+                                            "value": "Small Business Support grant",
+                                            "q_code": "831"
+                                        },
+                                        {
+                                            "label": "Pivotal Enterprise Resilience Fund",
+                                            "value": "Pivotal Enterprise Resilience Fund",
+                                            "q_code": "832"
+                                        },
+                                        {
+                                            "label": "Sector-specific grants",
+                                            "value": "Sector-specific grants",
+                                            "q_code": "833",
+                                            "description": "For example, retail, hospitality, leisure or fisheries grant"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "answerb579d6b0-bc9e-4d09-bf39-aed0a1f0ef0b-exclusive",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "description": "",
+                                    "options": [{
+                                        "label": "Not received any funds from these grants",
+                                        "value": "Not received any funds from these grants",
+                                        "q_code": "834"
+                                    }]
+                                }
+                            ]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
+                                    "when": [{
+                                        "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
+                                        "condition": "contains any",
+                                        "values": ["Coronavirus Job Retention Scheme", "Government-backed accredited loans or finance agreements"]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "blockf3731f81-73c0-4214-a771-3e321785afd7"
+                                }
+                            }
+                        ],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block5f68a3d0-365c-4247-b75e-a2ce7d5fea45",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question5f68a3d0-365c-4247-b75e-a2ce7d5fea45",
+                            "title": "Which of the following UK Government (England only) grants did {{ metadata['ru_name'] }} apply for?",
+                            "type": "MutuallyExclusive",
+                            "mandatory": true,
+                            "answers": [{
+                                    "id": "answer7a62b279-e8af-498b-bee4-6b861ec5d9f4",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "label": "Select all that apply",
+                                    "description": "",
+                                    "options": [{
+                                            "label": "Small Business Grant Fund (SBGF)",
+                                            "value": "Small Business Grant Fund (SBGF)",
+                                            "q_code": "841"
+                                        },
+                                        {
+                                            "label": "Sector-specific grants",
+                                            "value": "Sector-specific grants",
+                                            "q_code": "842",
+                                            "description": "For example, retail, hospitality, leisure or fisheries grant"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "answer7a62b279-e8af-498b-bee4-6b861ec5d9f4-exclusive",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "description": "",
+                                    "options": [{
+                                        "label": "Not applied for any of these grants",
+                                        "value": "Not applied for any of these grants",
+                                        "q_code": "843"
+                                    }]
+                                }
+                            ]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "block77a8fcf0-6663-4372-8a78-a0eaba692e25",
+                                    "when": [{
+                                        "id": "answer7a62b279-e8af-498b-bee4-6b861ec5d9f4",
+                                        "condition": "contains any",
+                                        "values": ["Small Business Grant Fund (SBGF)", "Sector-specific grants"]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
+                                    "when": [{
+                                        "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
+                                        "condition": "contains any",
+                                        "values": ["Coronavirus Job Retention Scheme", "Government-backed accredited loans or finance agreements"]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "blockf3731f81-73c0-4214-a771-3e321785afd7"
+                                }
+                            }
+                        ],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block77a8fcf0-6663-4372-8a78-a0eaba692e25",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question77a8fcf0-6663-4372-8a78-a0eaba692e25",
+                            "title": "Has {{ metadata['ru_name'] }} <em>received</em> funds from any of the following UK Government (England only) grants?",
+                            "type": "MutuallyExclusive",
+                            "mandatory": true,
+                            "answers": [{
+                                    "id": "answer7df0f422-59af-44a2-9de5-35b06645f367",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "label": "Select all that apply",
+                                    "description": "",
+                                    "options": [{
+                                            "label": "Small Business Grant Fund (SBGF)",
+                                            "value": "Small Business Grant Fund (SBGF)",
+                                            "q_code": "851"
+                                        },
+                                        {
+                                            "label": "Sector-specific grants",
+                                            "value": "Sector-specific grants",
+                                            "q_code": "852",
+                                            "description": "For example, retail, hospitality, leisure or fisheries grant"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "answer7df0f422-59af-44a2-9de5-35b06645f367-exclusive",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "description": "",
+                                    "options": [{
+                                        "label": "Not received any funds from these grants",
+                                        "value": "Not received any funds from these grants",
+                                        "q_code": "853"
+                                    }]
+                                }
+                            ]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
+                                    "when": [{
+                                        "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
+                                        "condition": "contains any",
+                                        "values": ["Coronavirus Job Retention Scheme", "Government-backed accredited loans or finance agreements"]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "blockf3731f81-73c0-4214-a771-3e321785afd7"
+                                }
+                            }
+                        ],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block1be2fd23-e68f-4b5f-9553-d7c8c4e43082",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question1be2fd23-e68f-4b5f-9553-d7c8c4e43082",
+                            "title": "Which of the following Northern Ireland Executive grants did {{ metadata['ru_name'] }} apply for?",
+                            "type": "MutuallyExclusive",
+                            "mandatory": true,
+                            "answers": [{
+                                    "id": "answer1359bc07-ae5f-452b-8abd-00cfff28b27d",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "label": "Select all that apply",
+                                    "description": "",
+                                    "options": [{
+                                            "label": "Small Business Grant Scheme",
+                                            "value": "Small Business Grant Scheme",
+                                            "q_code": "861"
+                                        },
+                                        {
+                                            "label": "Sector-specific grants",
+                                            "value": "Sector-specific grants",
+                                            "q_code": "862",
+                                            "description": "For example, retail, hospitality, leisure or fisheries grant"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "answer1359bc07-ae5f-452b-8abd-00cfff28b27d-exclusive",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "description": "",
+                                    "options": [{
+                                        "label": "Not applied for any of these grants",
+                                        "value": "Not applied for any of these grants",
+                                        "q_code": "863"
+                                    }]
+                                }
+                            ]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "block08e3e6c9-a572-43c2-ba84-0b984a2ed299",
+                                    "when": [{
+                                        "id": "answer1359bc07-ae5f-452b-8abd-00cfff28b27d",
+                                        "condition": "contains any",
+                                        "values": ["Small Business Grant Scheme", "Sector-specific grants"]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
+                                    "when": [{
+                                        "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
+                                        "condition": "contains any",
+                                        "values": ["Coronavirus Job Retention Scheme", "Government-backed accredited loans or finance agreements"]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "blockf3731f81-73c0-4214-a771-3e321785afd7"
+                                }
+                            }
+                        ],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block08e3e6c9-a572-43c2-ba84-0b984a2ed299",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question08e3e6c9-a572-43c2-ba84-0b984a2ed299",
+                            "title": "Has {{ metadata['ru_name'] }} <em>received</em> funds from any of the following Northern Ireland Executive grants?",
+                            "type": "MutuallyExclusive",
+                            "mandatory": true,
+                            "answers": [{
+                                    "id": "answerb1d499f5-1ad6-469a-9ea2-9b48dea1457c",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "label": "Select all that apply",
+                                    "description": "",
+                                    "options": [{
+                                            "label": "Small Business Grant Scheme",
+                                            "value": "Small Business Grant Scheme",
+                                            "q_code": "871"
+                                        },
+                                        {
+                                            "label": "Sector-specific grants",
+                                            "value": "Sector-specific grants",
+                                            "q_code": "872",
+                                            "description": "For example, retail, hospitality, leisure or fisheries grant"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "answerb1d499f5-1ad6-469a-9ea2-9b48dea1457c-exclusive",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "description": "",
+                                    "options": [{
+                                        "label": "Not received any funds from these grants",
+                                        "value": "Not received any funds from these grants",
+                                        "q_code": "873"
+                                    }]
+                                }
+                            ]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
+                                    "when": [{
+                                        "id": "answerfe9092a4-fbc4-445e-960d-6050c6111503",
+                                        "condition": "contains any",
+                                        "values": ["Coronavirus Job Retention Scheme", "Government-backed accredited loans or finance agreements"]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "blockf3731f81-73c0-4214-a771-3e321785afd7"
+                                }
+                            }
+                        ],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "blockb305b9d6-b021-4d5e-a92e-291381c49492",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "questionb305b9d6-b021-4d5e-a92e-291381c49492",
+                            "title": "Has {{ metadata['ru_name'] }} <em>received</em> funds from any of the following schemes?",
+                            "type": "MutuallyExclusive",
+                            "mandatory": true,
+                            "answers": [{
+                                    "id": "answer30aa84e6-07cf-4887-885f-abff7788aefb",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "label": "Select all that apply",
+                                    "description": "",
+                                    "options": [{
+                                            "label": "Coronavirus Job Retention Scheme",
+                                            "value": "Coronavirus Job Retention Scheme",
+                                            "q_code": "461",
+                                            "description": "UK Government scheme that covers 80% of pay (up to £2,500 a month) for furloughed staff"
+                                        },
+                                        {
+                                            "label": "Government-backed accredited loans or finance agreements",
+                                            "value": "Government-backed accredited loans or finance agreements",
+                                            "q_code": "4629",
+                                            "description": "For example, COVID Corporate Financing Facility (CCFF), Coronavirus Business Interruption Loan Scheme (CBILS or CLBILS), Bounce Back Loan Scheme (BBLS) or loans from devolved governments"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "answer30aa84e6-07cf-4887-885f-abff7788aefb-exclusive",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "description": "",
+                                    "options": [{
+                                        "label": "Not received any funds from these schemes",
+                                        "value": "Not received any funds from these schemes",
+                                        "q_code": "467"
+                                    }]
+                                }
+                            ]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "blockf3731f81-73c0-4214-a771-3e321785afd7",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "questionf3731f81-73c0-4214-a771-3e321785afd7",
+                            "title": "Please describe your experience of applying for these schemes",
+                            "guidance": {
+                                "content": [{
+                                        "description": "<strong>For example:</strong>"
                                     },
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer147a73c6-2ec3-404a-8d63-d58dd8aae8eb",
-                                            "mandatory": true,
-                                            "type": "Radio",
-                                            "label": "",
-                                            "description": "",
-                                            "q_code": "91",
-                                            "options": [
-                                                {
-                                                    "label": "Yes, it helped us to continue trading",
-                                                    "value": "Yes, it helped us to continue trading"
-                                                },
-                                                {
-                                                    "label": "No, it did not impact our ability to continue trading",
-                                                    "value": "No, it did not impact our ability to continue trading"
-                                                },
-                                                {
-                                                    "label": "Not sure",
-                                                    "value": "Not sure"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block4fc906bb-a55c-497a-8bd0-5427d69dc055",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question4fc906bb-a55c-497a-8bd0-5427d69dc055",
-                                    "title": "Please describe any other support from government that you think could help {{ metadata['ru_name'] }}",
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answere5a0ad55-8183-4fb2-8b35-29442de9c916",
-                                            "mandatory": false,
-                                            "type": "TextArea",
-                                            "label": "Comments",
-                                            "description": "",
-                                            "q_code": "49",
-                                            "max_length": 2000
-                                        }
-                                    ]
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block1633314b-b819-4309-917a-1a5d44940027",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question1633314b-b819-4309-917a-1a5d44940027",
-                                    "title": "Has {{ metadata['ru_name'] }} <em>received</em> any other financial assistance from banks or building societies?",
-                                    "guidance": {
-                                        "content": [
-                                            {
-                                                "description": "Exclude government-backed loans"
-                                            }
+                                    {
+                                        "list": [
+                                            "how easy or difficult it was to apply",
+                                            "how you heard about these schemes",
+                                            "if there were any barriers to you applying, such as eligibility",
+                                            "if there was enough guidance about the application process",
+                                            "if you received funding, how long it took"
                                         ]
+                                    }
+                                ]
+                            },
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer96848783-ecc7-4bcb-b8c5-bb807a118585",
+                                "mandatory": true,
+                                "type": "TextArea",
+                                "label": "Comments",
+                                "description": "",
+                                "q_code": "47",
+                                "max_length": 2000
+                            }]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "blockd39bd617-f259-488e-baf2-a51905d69b10",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "questiond39bd617-f259-488e-baf2-a51905d69b10",
+                            "title": "Does {{ metadata['ru_name'] }} expect to use the Coronavirus Job Retention Scheme (CJRS) in the <em>next two weeks</em>?",
+                            "description": "<p>If you have already applied once, and you plan to apply again for the next claim period, select &quot;Yes&quot;.</p>",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer36fe3ff1-cbba-46c6-a548-072c4ff1bd97",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "label": "",
+                                "description": "",
+                                "q_code": "88",
+                                "options": [{
+                                        "label": "Yes",
+                                        "value": "Yes"
                                     },
-                                    "definitions": [
+                                    {
+                                        "label": "No",
+                                        "value": "No"
+                                    },
+                                    {
+                                        "label": "Not sure",
+                                        "value": "Not sure"
+                                    }
+                                ]
+                            }]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block7f5c1f5d-0854-4738-b801-20d9848475c2",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question7f5c1f5d-0854-4738-b801-20d9848475c2",
+                            "title": "Is {{ metadata['ru_name'] }} <em>intending</em> to apply for any of the following schemes?",
+                            "guidance": {
+                                "content": [{
+                                    "description": "Exclude any schemes that your business has already applied for"
+                                }]
+                            },
+                            "type": "MutuallyExclusive",
+                            "mandatory": true,
+                            "answers": [{
+                                    "id": "answerc05c537f-7ef0-426d-bef8-a631236e3baa",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "label": "Select all that apply",
+                                    "description": "",
+                                    "options": [{
+                                            "label": "Government-backed accredited loans or finance agreements",
+                                            "value": "Government-backed accredited loans or finance agreements",
+                                            "q_code": "4816",
+                                            "description": "For example, COVID Corporate Financing Facility (CCFF), Coronavirus Business Interruption Loan Scheme (CBILS or CLBILS), Bounce Back Loan Scheme (BBLS) or loans from devolved governments"
+                                        },
                                         {
-                                            "title": "Examples of financial assistance from banks or building societies",
-                                            "content": [
-                                                {
-                                                    "list": [
-                                                        "Loans or emergency loans",
-                                                        "Commercial mortgage payment holidays",
-                                                        "Outstanding loans repayment holidays",
-                                                        "Increase in business credit card and overdraft limits"
-                                                    ]
-                                                }
-                                            ]
+                                            "label": "Business grants funded by the UK and devolved governments",
+                                            "value": "Business grants funded by the UK and devolved governments",
+                                            "q_code": "4889",
+                                            "description": "Include small business grant funds and sector-specific grants in England, Wales, Scotland and Northern Ireland"
                                         }
-                                    ],
-                                    "type": "General",
-                                    "answers": [
+                                    ]
+                                },
+                                {
+                                    "id": "answerc05c537f-7ef0-426d-bef8-a631236e3baa-exclusive",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "description": "",
+                                    "options": [{
+                                        "label": "Not intending to apply for any of these schemes",
+                                        "value": "Not intending to apply for any of these schemes",
+                                        "q_code": "487"
+                                    }]
+                                }
+                            ]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block707c4125-b078-4bf4-a5a7-4e98987640e0",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question707c4125-b078-4bf4-a5a7-4e98987640e0",
+                            "title": "Is {{ metadata['ru_name'] }} using any of the following <em>initiatives</em>?",
+                            "type": "MutuallyExclusive",
+                            "mandatory": true,
+                            "answers": [{
+                                    "id": "answerf6103d5e-1a15-43d7-be56-1c4dcc960b3a",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "label": "Select all that apply",
+                                    "description": "",
+                                    "options": [{
+                                            "label": "Business rates holiday",
+                                            "value": "Business rates holiday",
+                                            "q_code": "891"
+                                        },
                                         {
+                                            "label": "Deferring VAT payments",
+                                            "value": "Deferring VAT payments",
+                                            "q_code": "892"
+                                        },
+                                        {
+                                            "label": "HMRC Time To Pay scheme",
+                                            "value": "HMRC Time To Pay scheme",
+                                            "q_code": "893"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "answerf6103d5e-1a15-43d7-be56-1c4dcc960b3a-exclusive",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "description": "",
+                                    "options": [{
+                                        "label": "Not using any of these initiatives",
+                                        "value": "Not using any of these initiatives",
+                                        "q_code": "894"
+                                    }]
+                                }
+                            ]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block7a8cfd94-755c-4742-acfa-ca10a4c1cb87",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question7a8cfd94-755c-4742-acfa-ca10a4c1cb87",
+                            "title": "Is {{ metadata['ru_name'] }} <em>intending</em> to use any of the following <em>initiatives</em>?",
+                            "guidance": {
+                                "content": [{
+                                    "description": "Exclude any initiatives that your business is already using"
+                                }]
+                            },
+                            "type": "MutuallyExclusive",
+                            "mandatory": true,
+                            "answers": [{
+                                    "id": "answer6a654fac-abea-4b0d-8ca3-bf7340faa559",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "label": "Select all that apply",
+                                    "description": "",
+                                    "options": [{
+                                            "label": "Business rates holiday",
+                                            "value": "Business rates holiday",
+                                            "q_code": "901"
+                                        },
+                                        {
+                                            "label": "Deferring VAT payments",
+                                            "value": "Deferring VAT payments",
+                                            "q_code": "902"
+                                        },
+                                        {
+                                            "label": "HMRC Time To Pay scheme",
+                                            "value": "HMRC Time To Pay scheme",
+                                            "q_code": "903"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "answer6a654fac-abea-4b0d-8ca3-bf7340faa559-exclusive",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "description": "",
+                                    "options": [{
+                                        "label": "Not intending to use any of these initiatives",
+                                        "value": "Not intending to use any of these initiatives",
+                                        "q_code": "904"
+                                    }]
+                                }
+                            ]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "block4fc906bb-a55c-497a-8bd0-5427d69dc055",
+                                    "when": [{
+                                        "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                        "condition": "contains any",
+                                        "values": [
+                                            "Paused trading but intends to restart in the next two weeks",
+                                            "Paused trading and does not intend to restart in the next two weeks"
+                                        ]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "block35d5f073-97cd-460f-aa2e-1dd068c6f6ff",
+                                    "when": [{
+                                        "id": "answerc812da13-73e9-4f73-a310-c0a78ed38524",
+                                        "condition": "contains any",
+                                        "values": ["COVID-19 grant for small businesses", "Economic Resilience Fund", "Sector-specific grants"]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "block35d5f073-97cd-460f-aa2e-1dd068c6f6ff",
+                                    "when": [{
+                                        "id": "answerb579d6b0-bc9e-4d09-bf39-aed0a1f0ef0b",
+                                        "condition": "contains any",
+                                        "values": ["Small Business Support grant", "Pivotal Enterprise Resilience Fund", "Sector-specific grants"]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "block35d5f073-97cd-460f-aa2e-1dd068c6f6ff",
+                                    "when": [{
+                                        "id": "answer7df0f422-59af-44a2-9de5-35b06645f367",
+                                        "condition": "contains any",
+                                        "values": ["Small Business Grant Fund (SBGF)", "Sector-specific grants"]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "block35d5f073-97cd-460f-aa2e-1dd068c6f6ff",
+                                    "when": [{
+                                        "id": "answerb1d499f5-1ad6-469a-9ea2-9b48dea1457c",
+                                        "condition": "contains any",
+                                        "values": ["Small Business Grant Scheme", "Sector-specific grants"]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "block35d5f073-97cd-460f-aa2e-1dd068c6f6ff",
+                                    "when": [{
+                                        "id": "answer30aa84e6-07cf-4887-885f-abff7788aefb",
+                                        "condition": "contains any",
+                                        "values": ["Coronavirus Job Retention Scheme", "Government-backed accredited loans or finance agreements"]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "block35d5f073-97cd-460f-aa2e-1dd068c6f6ff",
+                                    "when": [{
+                                        "id": "answerf6103d5e-1a15-43d7-be56-1c4dcc960b3a",
+                                        "condition": "contains any",
+                                        "values": ["Business rates holiday", "Deferring VAT payments", "HMRC Time To Pay scheme"]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "block4fc906bb-a55c-497a-8bd0-5427d69dc055"
+                                }
+                            }
+                        ],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block35d5f073-97cd-460f-aa2e-1dd068c6f6ff",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question35d5f073-97cd-460f-aa2e-1dd068c6f6ff",
+                            "title": "Did the support received from these <em>initiatives</em> or <em>schemes</em> help {{ metadata['ru_name'] }} continue trading?",
+                            "guidance": {
+                                "content": [{
+                                    "description": "Include any grants or loans from government"
+                                }]
+                            },
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer147a73c6-2ec3-404a-8d63-d58dd8aae8eb",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "label": "",
+                                "description": "",
+                                "q_code": "91",
+                                "options": [{
+                                        "label": "Yes, it helped us to continue trading",
+                                        "value": "Yes, it helped us to continue trading"
+                                    },
+                                    {
+                                        "label": "No, it did not impact our ability to continue trading",
+                                        "value": "No, it did not impact our ability to continue trading"
+                                    },
+                                    {
+                                        "label": "Not sure",
+                                        "value": "Not sure"
+                                    }
+                                ]
+                            }]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block4fc906bb-a55c-497a-8bd0-5427d69dc055",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question4fc906bb-a55c-497a-8bd0-5427d69dc055",
+                            "title": "Please describe any other support from government that you think could help {{ metadata['ru_name'] }}",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answere5a0ad55-8183-4fb2-8b35-29442de9c916",
+                                "mandatory": false,
+                                "type": "TextArea",
+                                "label": "Comments",
+                                "description": "",
+                                "q_code": "49",
+                                "max_length": 2000
+                            }]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block1633314b-b819-4309-917a-1a5d44940027",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question1633314b-b819-4309-917a-1a5d44940027",
+                            "title": "Has {{ metadata['ru_name'] }} <em>received</em> any other financial assistance from banks or building societies?",
+                            "guidance": {
+                                "content": [{
+                                    "description": "Exclude government-backed loans"
+                                }]
+                            },
+                            "definitions": [{
+                                "title": "Examples of financial assistance from banks or building societies",
+                                "content": [{
+                                    "list": [
+                                        "Loans or emergency loans",
+                                        "Commercial mortgage payment holidays",
+                                        "Outstanding loans repayment holidays",
+                                        "Increase in business credit card and overdraft limits"
+                                    ]
+                                }]
+                            }],
+                            "type": "General",
+                            "answers": [{
+                                "id": "answere72a6e53-f48d-4cf9-ad57-a4f99f2511f5",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "label": "",
+                                "description": "",
+                                "q_code": "92",
+                                "options": [{
+                                        "label": "Yes",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No",
+                                        "value": "No"
+                                    },
+                                    {
+                                        "label": "Not sure",
+                                        "value": "Not sure"
+                                    }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "block18da18a3-82ce-4b60-a710-fe4f4b1e90f6",
+                                    "when": [{
                                             "id": "answere72a6e53-f48d-4cf9-ad57-a4f99f2511f5",
-                                            "mandatory": true,
-                                            "type": "Radio",
-                                            "label": "",
-                                            "description": "",
-                                            "q_code": "92",
-                                            "options": [
-                                                {
-                                                    "label": "Yes",
-                                                    "value": "Yes"
-                                                },
-                                                {
-                                                    "label": "No",
-                                                    "value": "No"
-                                                },
-                                                {
-                                                    "label": "Not sure",
-                                                    "value": "Not sure"
-                                                }
+                                            "condition": "contains any",
+                                            "values": ["Yes"]
+                                        },
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "contains any",
+                                            "values": [
+                                                "Currently trading and has been for more than the last two weeks",
+                                                "Started trading within the last two weeks after a pause in trading"
                                             ]
                                         }
                                     ]
                                 }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "block": "block18da18a3-82ce-4b60-a710-fe4f4b1e90f6",
-                                        "when": [
-                                            {
-                                                "id": "answere72a6e53-f48d-4cf9-ad57-a4f99f2511f5",
-                                                "condition": "contains any",
-                                                "values": ["Yes"]
-                                            },
-                                            {
-                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                                "condition": "contains any",
-                                                "values": [
-                                                    "Currently trading and has been for more than the last two weeks",
-                                                    "Started trading within the last two weeks after a pause in trading"
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "blocka2d0a9ef-9bfc-4ead-867f-bad93d6a3bca"
-                                    }
+                            },
+                            {
+                                "goto": {
+                                    "block": "blocka2d0a9ef-9bfc-4ead-867f-bad93d6a3bca"
                                 }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block18da18a3-82ce-4b60-a710-fe4f4b1e90f6",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question18da18a3-82ce-4b60-a710-fe4f4b1e90f6",
-                                    "title": "Did the financial assistance received from banks or building societies help {{ metadata['ru_name'] }} continue trading?",
-                                    "guidance": {
-                                        "content": [
-                                            {
-                                                "description": "Exclude government-backed loans"
-                                            }
-                                        ]
+                            }
+                        ],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block18da18a3-82ce-4b60-a710-fe4f4b1e90f6",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question18da18a3-82ce-4b60-a710-fe4f4b1e90f6",
+                            "title": "Did the financial assistance received from banks or building societies help {{ metadata['ru_name'] }} continue trading?",
+                            "guidance": {
+                                "content": [{
+                                    "description": "Exclude government-backed loans"
+                                }]
+                            },
+                            "type": "General",
+                            "answers": [{
+                                "id": "answerfcef18bf-decf-4b70-a94c-c7c04c188c0b",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "label": "",
+                                "description": "",
+                                "q_code": "93",
+                                "options": [{
+                                        "label": "Yes, it helped us to continue trading",
+                                        "value": "Yes, it helped us to continue trading"
                                     },
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answerfcef18bf-decf-4b70-a94c-c7c04c188c0b",
-                                            "mandatory": true,
-                                            "type": "Radio",
-                                            "label": "",
-                                            "description": "",
-                                            "q_code": "93",
-                                            "options": [
-                                                {
-                                                    "label": "Yes, it helped us to continue trading",
-                                                    "value": "Yes, it helped us to continue trading"
-                                                },
-                                                {
-                                                    "label": "No, it did not impact our ability to continue trading",
-                                                    "value": "No, it did not impact our ability to continue trading"
-                                                },
-                                                {
-                                                    "label": "Not sure",
-                                                    "value": "Not sure"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "blocka2d0a9ef-9bfc-4ead-867f-bad93d6a3bca",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "questiona2d0a9ef-9bfc-4ead-867f-bad93d6a3bca",
-                                    "title": "How long do you think {{ metadata['ru_name'] }}&apos;s cash reserves will last?",
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer32a38f2a-e599-4ff7-9df9-b0419be84b96",
-                                            "mandatory": true,
-                                            "type": "Radio",
-                                            "label": "",
-                                            "description": "",
-                                            "q_code": "73",
-                                            "options": [
-                                                {
-                                                    "label": "No cash reserves",
-                                                    "value": "No cash reserves"
-                                                },
-                                                {
-                                                    "label": "Less than 1 month",
-                                                    "value": "Less than 1 month"
-                                                },
-                                                {
-                                                    "label": "1 to 3 months",
-                                                    "value": "1 to 3 months"
-                                                },
-                                                {
-                                                    "label": "4 to 6 months",
-                                                    "value": "4 to 6 months"
-                                                },
-                                                {
-                                                    "label": "More than 6 months",
-                                                    "value": "More than 6 months"
-                                                },
-                                                {
-                                                    "label": "Not sure",
-                                                    "value": "Not sure"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
-                    ],
-                    "skip_conditions": [
-                        {
-                            "when": [
-                                {
-                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                    "condition": "contains any",
-                                    "values": ["Permanently ceased trading"]
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ]
+                                    {
+                                        "label": "No, it did not impact our ability to continue trading",
+                                        "value": "No, it did not impact our ability to continue trading"
+                                    },
+                                    {
+                                        "label": "Not sure",
+                                        "value": "Not sure"
+                                    }
+                                ]
+                            }]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "blocka2d0a9ef-9bfc-4ead-867f-bad93d6a3bca",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "questiona2d0a9ef-9bfc-4ead-867f-bad93d6a3bca",
+                            "title": "How long do you think {{ metadata['ru_name'] }}&apos;s cash reserves will last?",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer32a38f2a-e599-4ff7-9df9-b0419be84b96",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "label": "",
+                                "description": "",
+                                "q_code": "73",
+                                "options": [{
+                                        "label": "No cash reserves",
+                                        "value": "No cash reserves"
+                                    },
+                                    {
+                                        "label": "Less than 1 month",
+                                        "value": "Less than 1 month"
+                                    },
+                                    {
+                                        "label": "1 to 3 months",
+                                        "value": "1 to 3 months"
+                                    },
+                                    {
+                                        "label": "4 to 6 months",
+                                        "value": "4 to 6 months"
+                                    },
+                                    {
+                                        "label": "More than 6 months",
+                                        "value": "More than 6 months"
+                                    },
+                                    {
+                                        "label": "Not sure",
+                                        "value": "Not sure"
+                                    }
+                                ]
+                            }]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    }
+                ],
+                "skip_conditions": [{
+                    "when": [{
+                        "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                        "condition": "contains any",
+                        "values": ["Permanently ceased trading"]
+                    }]
+                }]
+            }]
         },
         {
             "id": "section1760a554-060f-4e6a-bf64-970f98d84ac7",
             "title": "Operational performance",
-            "groups": [
-                {
-                    "id": "group1760a554-060f-4e6a-bf64-970f98d84ac7",
-                    "title": "Operational performance",
-                    "blocks": [
-                        {
-                            "type": "Interstitial",
-                            "id": "group1760a554-060f-4e6a-bf64-970f98d84ac7-introduction",
-                            "title": "Operational performance",
-                            "description": "<p>This section asks for information about your workforce such as the: </p><ul><li>percentage , for example, on furlough leave or working remotely </li><li>percentage returning from furlough or remote working </li><li>percentage of furloughed staff receiving top-ups in addition to the Coronavirus Job Retention Scheme (CJRS) payments</li><li>number of vacancies</li></ul><p>It also asks about safety measures in the workplace.</p>",
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block90beb26c-59f1-4f7f-9dee-e9a822e871be",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question90beb26c-59f1-4f7f-9dee-e9a822e871be",
-                                    "title": "In the <em>last two weeks</em>, approximately what percentage of {{ metadata['ru_name'] }}&apos;s workforce were:",
-                                    "description": "<p>Your answers should <em>add up to 100%</em>. If your workforce did not fall into one of the categories, enter &apos;0&apos;. </p>",
-                                    "type": "Calculated",
-                                    "answers": [
-                                        {
-                                            "id": "answer92e4004a-ceef-424e-b5fa-d93520bc4780",
-                                            "mandatory": true,
-                                            "type": "Percentage",
-                                            "label": "On furlough leave",
-                                            "description": "Under the terms of the UK Government's Coronavirus Job Retention Scheme",
-                                            "q_code": "371",
-                                            "min_value": {
-                                                "value": 0,
-                                                "exclusive": false
-                                            },
-                                            "max_value": {
-                                                "value": 100,
-                                                "exclusive": false
-                                            },
-                                            "decimal_places": 0
-                                        },
-                                        {
-                                            "id": "answerbc9d0665-2c42-4e04-988b-34423d020920",
-                                            "mandatory": true,
-                                            "type": "Percentage",
-                                            "label": "Working at their normal place of work",
-                                            "description": "Include those who are normally remote workers",
-                                            "q_code": "3741",
-                                            "min_value": {
-                                                "value": 0,
-                                                "exclusive": false
-                                            },
-                                            "max_value": {
-                                                "value": 100,
-                                                "exclusive": false
-                                            },
-                                            "decimal_places": 0
-                                        },
-                                        {
-                                            "id": "answerbec1b9cb-9f1f-471e-a874-f25ceaeef160",
-                                            "mandatory": true,
-                                            "type": "Percentage",
-                                            "label": "Working remotely instead of at their normal place of work",
-                                            "description": "Exclude those who are normally remote workers",
-                                            "q_code": "3742",
-                                            "min_value": {
-                                                "value": 0,
-                                                "exclusive": false
-                                            },
-                                            "max_value": {
-                                                "value": 100,
-                                                "exclusive": false
-                                            },
-                                            "decimal_places": 0
-                                        },
-                                        {
-                                            "id": "answerb6a74106-d408-491a-898c-42534143e246",
-                                            "mandatory": true,
-                                            "type": "Percentage",
-                                            "label": "On sick leave or in self-isolation due to coronavirus (COVID-19)",
-                                            "description": "With statutory or company pay",
-                                            "q_code": "372",
-                                            "min_value": {
-                                                "value": 0,
-                                                "exclusive": false
-                                            },
-                                            "max_value": {
-                                                "value": 100,
-                                                "exclusive": false
-                                            },
-                                            "decimal_places": 0
-                                        },
-                                        {
-                                            "id": "answer5319de32-f061-4988-88a4-95637cca3873",
-                                            "mandatory": true,
-                                            "type": "Percentage",
-                                            "label": "Made permanently redundant",
-                                            "description": "",
-                                            "q_code": "373",
-                                            "min_value": {
-                                                "value": 0,
-                                                "exclusive": false
-                                            },
-                                            "max_value": {
-                                                "value": 100,
-                                                "exclusive": false
-                                            },
-                                            "decimal_places": 0
-                                        },
-                                        {
-                                            "id": "answer2218d478-9b02-4806-babb-f6dc3a92cb55",
-                                            "mandatory": true,
-                                            "type": "Percentage",
-                                            "label": "Other",
-                                            "description": "",
-                                            "q_code": "375",
-                                            "min_value": {
-                                                "value": 0,
-                                                "exclusive": false
-                                            },
-                                            "max_value": {
-                                                "value": 100,
-                                                "exclusive": false
-                                            },
-                                            "decimal_places": 0
-                                        }
-                                    ],
-                                    "calculations": [
-                                        {
-                                            "calculation_type": "sum",
-                                            "answers_to_calculate": [
-                                                "answer92e4004a-ceef-424e-b5fa-d93520bc4780",
-                                                "answerbc9d0665-2c42-4e04-988b-34423d020920",
-                                                "answerbec1b9cb-9f1f-471e-a874-f25ceaeef160",
-                                                "answerb6a74106-d408-491a-898c-42534143e246",
-                                                "answer5319de32-f061-4988-88a4-95637cca3873",
-                                                "answer2218d478-9b02-4806-babb-f6dc3a92cb55"
-                                            ],
-                                            "conditions": ["equals"],
-                                            "value": 100
-                                        }
-                                    ]
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "block": "blockb12b5e7d-c421-4252-a174-42a2a0210c6b",
-                                        "when": [
-                                            {
-                                                "id": "answer2218d478-9b02-4806-babb-f6dc3a92cb55",
-                                                "condition": "greater than",
-                                                "value": 0
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "blockb646b254-98b4-4d42-ab91-c13b5fec21b0",
-                                        "when": [
-                                            {
-                                                "id": "answer92e4004a-ceef-424e-b5fa-d93520bc4780",
-                                                "condition": "greater than",
-                                                "value": 0
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "block66bef12d-2546-4df7-9e64-15e48bdf99c4",
-                                        "when": [
-                                            {
-                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                                "condition": "contains any",
-                                                "values": [
-                                                    "Currently trading and has been for more than the last two weeks",
-                                                    "Started trading within the last two weeks after a pause in trading"
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "block66bdbc42-37a9-4134-9f22-235e40594178",
-                                        "when": [
-                                            {
-                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                                "condition": "contains any",
-                                                "values": [
-                                                    "Paused trading but intends to restart in the next two weeks",
-                                                    "Paused trading and does not intend to restart in the next two weeks"
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "blocke94a866c-fda4-469d-ba7d-e858307138cb"
-                                    }
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "blockb12b5e7d-c421-4252-a174-42a2a0210c6b",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "questionb12b5e7d-c421-4252-a174-42a2a0210c6b",
-                                    "title": "You said that {{ answers['answer2218d478-9b02-4806-babb-f6dc3a92cb55'] }}% of your workforce were classified as &quot;other&quot;. Please describe what this includes",
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer4c92cb9c-0ac7-43ef-a57f-e44350703379",
-                                            "mandatory": true,
-                                            "type": "TextArea",
-                                            "label": "Comments",
-                                            "description": "",
-                                            "q_code": "96",
-                                            "max_length": 2000
-                                        }
-                                    ]
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "block": "blockb646b254-98b4-4d42-ab91-c13b5fec21b0",
-                                        "when": [
-                                            {
-                                                "id": "answer92e4004a-ceef-424e-b5fa-d93520bc4780",
-                                                "condition": "greater than",
-                                                "value": 0
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "block66bef12d-2546-4df7-9e64-15e48bdf99c4",
-                                        "when": [
-                                            {
-                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                                "condition": "contains any",
-                                                "values": [
-                                                    "Currently trading and has been for more than the last two weeks",
-                                                    "Started trading within the last two weeks after a pause in trading"
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "block66bdbc42-37a9-4134-9f22-235e40594178",
-                                        "when": [
-                                            {
-                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                                "condition": "contains any",
-                                                "values": [
-                                                    "Paused trading but intends to restart in the next two weeks",
-                                                    "Paused trading and does not intend to restart in the next two weeks"
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "blocke94a866c-fda4-469d-ba7d-e858307138cb"
-                                    }
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "blockb646b254-98b4-4d42-ab91-c13b5fec21b0",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "questionb646b254-98b4-4d42-ab91-c13b5fec21b0",
-                                    "title": "Is {{ metadata['ru_name'] }} providing top-ups to any <em>furloughed workers&apos;</em> pay, on top of the Coronavirus Job Retention Scheme (CJRS) payments?",
-                                    "description": "<p>The Coronavirus Job Retention Scheme (CJRS) covers 80% of pay (up to &#xA3;2,500 a month) for furloughed staff</p>",
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer3b3c0791-e310-4279-9116-92f1040606b4",
-                                            "mandatory": true,
-                                            "type": "Radio",
-                                            "label": "",
-                                            "description": "",
-                                            "q_code": "97",
-                                            "options": [
-                                                {
-                                                    "label": "Yes, the business is providing a top-up",
-                                                    "value": "Yes, the business is providing a top-up"
-                                                },
-                                                {
-                                                    "label": "No, the business is not providing a top-up",
-                                                    "value": "No, the business is not providing a top-up"
-                                                },
-                                                {
-                                                    "label": "Not sure",
-                                                    "value": "Not sure"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "block": "block4f6d1ad5-2f37-4135-92fc-339b1943fc0e",
-                                        "when": [
-                                            {
-                                                "id": "answer3b3c0791-e310-4279-9116-92f1040606b4",
-                                                "condition": "contains any",
-                                                "values": ["Yes, the business is providing a top-up"]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "block66bef12d-2546-4df7-9e64-15e48bdf99c4",
-                                        "when": [
-                                            {
-                                                "id": "answer3b3c0791-e310-4279-9116-92f1040606b4",
-                                                "condition": "contains any",
-                                                "values": ["No, the business is not providing a top-up", "Not sure"]
-                                            },
-                                            {
-                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                                "condition": "contains any",
-                                                "values": [
-                                                    "Currently trading and has been for more than the last two weeks",
-                                                    "Started trading within the last two weeks after a pause in trading"
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "block66bdbc42-37a9-4134-9f22-235e40594178",
-                                        "when": [
-                                            {
-                                                "id": "answer3b3c0791-e310-4279-9116-92f1040606b4",
-                                                "condition": "contains any",
-                                                "values": ["No, the business is not providing a top-up", "Not sure"]
-                                            },
-                                            {
-                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                                "condition": "contains any",
-                                                "values": [
-                                                    "Paused trading but intends to restart in the next two weeks",
-                                                    "Paused trading and does not intend to restart in the next two weeks"
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "blocke94a866c-fda4-469d-ba7d-e858307138cb"
-                                    }
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block4f6d1ad5-2f37-4135-92fc-339b1943fc0e",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question4f6d1ad5-2f37-4135-92fc-339b1943fc0e",
-                                    "title": "Of those on <em>furlough leave</em>, approximately what <em>percentage of workers</em> have had their pay topped up?",
-                                    "description": "<p>Your answer should be out of 100%. </p>",
-                                    "definitions": [
-                                        {
-                                            "title": "How you might answer this question",
-                                            "content": [
-                                                {
-                                                    "description": "If 50% of your workforce have been furloughed, but you are topping up the pay for <strong>all</strong> of those furloughed workers, the answer would be 100%. If you are topping up the pay for <strong>half</strong> of those furloughed workers, the answer would be 50%."
-                                                }
-                                            ]
-                                        }
-                                    ],
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer4300ee07-0122-4efc-81e2-02cec3abcb32",
-                                            "mandatory": true,
-                                            "type": "Percentage",
-                                            "label": "Percentage of furloughed workers with top-up pay",
-                                            "description": "",
-                                            "q_code": "98",
-                                            "min_value": {
-                                                "value": 0,
-                                                "exclusive": false
-                                            },
-                                            "max_value": {
-                                                "value": 100,
-                                                "exclusive": false
-                                            },
-                                            "decimal_places": 0
-                                        }
-                                    ]
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "block": "block66bdbc42-37a9-4134-9f22-235e40594178",
-                                        "when": [
-                                            {
-                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                                "condition": "contains any",
-                                                "values": [
-                                                    "Paused trading but intends to restart in the next two weeks",
-                                                    "Paused trading and does not intend to restart in the next two weeks"
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "block66bef12d-2546-4df7-9e64-15e48bdf99c4"
-                                    }
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block66bef12d-2546-4df7-9e64-15e48bdf99c4",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question66bef12d-2546-4df7-9e64-15e48bdf99c4",
-                                    "title": "In the <em>last two weeks</em>, approximately what percentage of {{ metadata['ru_name'] }}&apos;s workforce have:",
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer647b4d64-5529-44ae-8412-903ff0250f71",
-                                            "mandatory": true,
-                                            "type": "Percentage",
-                                            "label": "Returned from furlough leave",
-                                            "description": "",
-                                            "q_code": "991",
-                                            "min_value": {
-                                                "value": 0,
-                                                "exclusive": false
-                                            },
-                                            "max_value": {
-                                                "value": 100,
-                                                "exclusive": false
-                                            },
-                                            "decimal_places": 0
-                                        },
-                                        {
-                                            "id": "answer8256ff1c-5839-4b89-8d1d-9f76e6280683",
-                                            "mandatory": true,
-                                            "type": "Percentage",
-                                            "label": "Moved from remote working  to the normal workplace",
-                                            "description": "Exclude those who would normally work remotely prior to the pandemic",
-                                            "q_code": "992",
-                                            "min_value": {
-                                                "value": 0,
-                                                "exclusive": false
-                                            },
-                                            "max_value": {
-                                                "value": 100,
-                                                "exclusive": false
-                                            },
-                                            "decimal_places": 0
-                                        }
-                                    ]
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block66bdbc42-37a9-4134-9f22-235e40594178",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question66bdbc42-37a9-4134-9f22-235e40594178",
-                                    "title": "In the <em>next two weeks</em>, approximately what percentage of {{ metadata['ru_name'] }}&apos;s workforce will:",
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answerf99be2e6-938d-4adf-99b5-942b78122fda",
-                                            "mandatory": true,
-                                            "type": "Percentage",
-                                            "label": "Return to work from furlough",
-                                            "description": "Include those returning from furlough to remote working",
-                                            "q_code": "1001",
-                                            "min_value": {
-                                                "value": 0,
-                                                "exclusive": false
-                                            },
-                                            "max_value": {
-                                                "value": 100,
-                                                "exclusive": false
-                                            },
-                                            "decimal_places": 0
-                                        },
-                                        {
-                                            "id": "answer00c0324e-6deb-404a-b425-563ebaf3829d",
-                                            "mandatory": true,
-                                            "type": "Percentage",
-                                            "label": "Return to the workplace from remote working",
-                                            "description": "Exclude those who would normally work remotely prior to the pandemic",
-                                            "q_code": "1002",
-                                            "min_value": {
-                                                "value": 0,
-                                                "exclusive": false
-                                            },
-                                            "max_value": {
-                                                "value": 100,
-                                                "exclusive": false
-                                            },
-                                            "decimal_places": 0
-                                        },
-                                        {
-                                            "id": "answer325edc5e-846a-4c17-870d-fce3c9b4c9fb",
-                                            "mandatory": true,
-                                            "type": "Percentage",
-                                            "label": "Be made permanently redundant",
-                                            "description": "",
-                                            "q_code": "1003",
-                                            "decimal_places": 0
-                                        }
-                                    ]
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "blocke94a866c-fda4-469d-ba7d-e858307138cb",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "questione94a866c-fda4-469d-ba7d-e858307138cb",
-                                    "title": "How many <em>external job vacancies</em> is  {{ metadata['ru_name'] }} actively recruiting for?",
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer6fc41202-89c7-48f2-b65a-7801cd5086e4",
-                                            "mandatory": true,
-                                            "type": "Number",
-                                            "label": "Number of external job vacancies",
-                                            "description": "",
-                                            "q_code": "101",
-                                            "min_value": {
-                                                "value": 0,
-                                                "exclusive": false
-                                            },
-                                            "decimal_places": 0
-                                        }
-                                    ]
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "block": "block29eac987-68af-41fc-adaf-53c45511d4da",
-                                        "when": [
-                                            {
-                                                "id": "answer6fc41202-89c7-48f2-b65a-7801cd5086e4",
-                                                "condition": "equals",
-                                                "value": 0
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "block653770e8-e13b-440e-8146-30b8e2c5fdf9"
-                                    }
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block653770e8-e13b-440e-8146-30b8e2c5fdf9",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question653770e8-e13b-440e-8146-30b8e2c5fdf9",
-                                    "title": "Of the {{ answers['answer6fc41202-89c7-48f2-b65a-7801cd5086e4'] | format_number }} external job vacancies, how many were <em>new</em> in the <em>last two weeks</em>?",
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answerb8942943-ba5d-4772-ae72-38b84abaeec0",
-                                            "mandatory": true,
-                                            "type": "Number",
-                                            "label": "Number of new external job vacancies",
-                                            "description": "",
-                                            "q_code": "102",
-                                            "max_value": {
-                                                "answer_id": "answer6fc41202-89c7-48f2-b65a-7801cd5086e4",
-                                                "exclusive": false
-                                            },
-                                            "decimal_places": 0
-                                        }
-                                    ]
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block29eac987-68af-41fc-adaf-53c45511d4da",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question29eac987-68af-41fc-adaf-53c45511d4da",
-                                    "title": "Is {{ metadata['ru_name'] }} using, or intending to use, any of the following <em>safety measures</em> in the workplace?",
-                                    "type": "MutuallyExclusive",
+            "groups": [{
+                "id": "group1760a554-060f-4e6a-bf64-970f98d84ac7",
+                "title": "Operational performance",
+                "blocks": [{
+                        "type": "Interstitial",
+                        "id": "group1760a554-060f-4e6a-bf64-970f98d84ac7-introduction",
+                        "title": "Operational performance",
+                        "description": "<p>This section asks for information about your workforce such as the: </p><ul><li>percentage , for example, on furlough leave or working remotely </li><li>percentage returning from furlough or remote working </li><li>percentage of furloughed staff receiving top-ups in addition to the Coronavirus Job Retention Scheme (CJRS) payments</li><li>number of vacancies</li></ul><p>It also asks about safety measures in the workplace.</p>",
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block90beb26c-59f1-4f7f-9dee-e9a822e871be",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question90beb26c-59f1-4f7f-9dee-e9a822e871be",
+                            "title": "In the <em>last two weeks</em>, approximately what percentage of {{ metadata['ru_name'] }}&apos;s workforce were:",
+                            "description": "<p>Your answers should <em>add up to 100%</em>. If your workforce did not fall into one of the categories, enter &apos;0&apos;. </p>",
+                            "type": "Calculated",
+                            "answers": [{
+                                    "id": "answer92e4004a-ceef-424e-b5fa-d93520bc4780",
                                     "mandatory": true,
-                                    "answers": [
+                                    "type": "Percentage",
+                                    "label": "On furlough leave",
+                                    "description": "Under the terms of the UK Government's Coronavirus Job Retention Scheme",
+                                    "q_code": "371",
+                                    "min_value": {
+                                        "value": 0,
+                                        "exclusive": false
+                                    },
+                                    "max_value": {
+                                        "value": 100,
+                                        "exclusive": false
+                                    },
+                                    "decimal_places": 0
+                                },
+                                {
+                                    "id": "answerbc9d0665-2c42-4e04-988b-34423d020920",
+                                    "mandatory": true,
+                                    "type": "Percentage",
+                                    "label": "Working at their normal place of work",
+                                    "description": "Include those who are normally remote workers",
+                                    "q_code": "3741",
+                                    "min_value": {
+                                        "value": 0,
+                                        "exclusive": false
+                                    },
+                                    "max_value": {
+                                        "value": 100,
+                                        "exclusive": false
+                                    },
+                                    "decimal_places": 0
+                                },
+                                {
+                                    "id": "answerbec1b9cb-9f1f-471e-a874-f25ceaeef160",
+                                    "mandatory": true,
+                                    "type": "Percentage",
+                                    "label": "Working remotely instead of at their normal place of work",
+                                    "description": "Exclude those who are normally remote workers",
+                                    "q_code": "3742",
+                                    "min_value": {
+                                        "value": 0,
+                                        "exclusive": false
+                                    },
+                                    "max_value": {
+                                        "value": 100,
+                                        "exclusive": false
+                                    },
+                                    "decimal_places": 0
+                                },
+                                {
+                                    "id": "answerb6a74106-d408-491a-898c-42534143e246",
+                                    "mandatory": true,
+                                    "type": "Percentage",
+                                    "label": "On sick leave or in self-isolation due to coronavirus (COVID-19)",
+                                    "description": "With statutory or company pay",
+                                    "q_code": "372",
+                                    "min_value": {
+                                        "value": 0,
+                                        "exclusive": false
+                                    },
+                                    "max_value": {
+                                        "value": 100,
+                                        "exclusive": false
+                                    },
+                                    "decimal_places": 0
+                                },
+                                {
+                                    "id": "answer5319de32-f061-4988-88a4-95637cca3873",
+                                    "mandatory": true,
+                                    "type": "Percentage",
+                                    "label": "Made permanently redundant",
+                                    "description": "",
+                                    "q_code": "373",
+                                    "min_value": {
+                                        "value": 0,
+                                        "exclusive": false
+                                    },
+                                    "max_value": {
+                                        "value": 100,
+                                        "exclusive": false
+                                    },
+                                    "decimal_places": 0
+                                },
+                                {
+                                    "id": "answer2218d478-9b02-4806-babb-f6dc3a92cb55",
+                                    "mandatory": true,
+                                    "type": "Percentage",
+                                    "label": "Other",
+                                    "description": "",
+                                    "q_code": "375",
+                                    "min_value": {
+                                        "value": 0,
+                                        "exclusive": false
+                                    },
+                                    "max_value": {
+                                        "value": 100,
+                                        "exclusive": false
+                                    },
+                                    "decimal_places": 0
+                                }
+                            ],
+                            "calculations": [{
+                                "calculation_type": "sum",
+                                "answers_to_calculate": [
+                                    "answer92e4004a-ceef-424e-b5fa-d93520bc4780",
+                                    "answerbc9d0665-2c42-4e04-988b-34423d020920",
+                                    "answerbec1b9cb-9f1f-471e-a874-f25ceaeef160",
+                                    "answerb6a74106-d408-491a-898c-42534143e246",
+                                    "answer5319de32-f061-4988-88a4-95637cca3873",
+                                    "answer2218d478-9b02-4806-babb-f6dc3a92cb55"
+                                ],
+                                "conditions": ["equals"],
+                                "value": 100
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "blockb12b5e7d-c421-4252-a174-42a2a0210c6b",
+                                    "when": [{
+                                        "id": "answer2218d478-9b02-4806-babb-f6dc3a92cb55",
+                                        "condition": "greater than",
+                                        "value": 0
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "blockb646b254-98b4-4d42-ab91-c13b5fec21b0",
+                                    "when": [{
+                                        "id": "answer92e4004a-ceef-424e-b5fa-d93520bc4780",
+                                        "condition": "greater than",
+                                        "value": 0
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "block66bef12d-2546-4df7-9e64-15e48bdf99c4",
+                                    "when": [{
+                                        "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                        "condition": "contains any",
+                                        "values": [
+                                            "Currently trading and has been for more than the last two weeks",
+                                            "Started trading within the last two weeks after a pause in trading"
+                                        ]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "block66bdbc42-37a9-4134-9f22-235e40594178",
+                                    "when": [{
+                                        "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                        "condition": "contains any",
+                                        "values": [
+                                            "Paused trading but intends to restart in the next two weeks",
+                                            "Paused trading and does not intend to restart in the next two weeks"
+                                        ]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "blocke94a866c-fda4-469d-ba7d-e858307138cb"
+                                }
+                            }
+                        ],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "blockb12b5e7d-c421-4252-a174-42a2a0210c6b",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "questionb12b5e7d-c421-4252-a174-42a2a0210c6b",
+                            "title": "You said that {{ answers['answer2218d478-9b02-4806-babb-f6dc3a92cb55'] }}% of your workforce were classified as &quot;other&quot;. Please describe what this includes",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer4c92cb9c-0ac7-43ef-a57f-e44350703379",
+                                "mandatory": true,
+                                "type": "TextArea",
+                                "label": "Comments",
+                                "description": "",
+                                "q_code": "96",
+                                "max_length": 2000
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "blockb646b254-98b4-4d42-ab91-c13b5fec21b0",
+                                    "when": [{
+                                        "id": "answer92e4004a-ceef-424e-b5fa-d93520bc4780",
+                                        "condition": "greater than",
+                                        "value": 0
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "block66bef12d-2546-4df7-9e64-15e48bdf99c4",
+                                    "when": [{
+                                        "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                        "condition": "contains any",
+                                        "values": [
+                                            "Currently trading and has been for more than the last two weeks",
+                                            "Started trading within the last two weeks after a pause in trading"
+                                        ]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "block66bdbc42-37a9-4134-9f22-235e40594178",
+                                    "when": [{
+                                        "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                        "condition": "contains any",
+                                        "values": [
+                                            "Paused trading but intends to restart in the next two weeks",
+                                            "Paused trading and does not intend to restart in the next two weeks"
+                                        ]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "blocke94a866c-fda4-469d-ba7d-e858307138cb"
+                                }
+                            }
+                        ],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "blockb646b254-98b4-4d42-ab91-c13b5fec21b0",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "questionb646b254-98b4-4d42-ab91-c13b5fec21b0",
+                            "title": "Is {{ metadata['ru_name'] }} providing top-ups to any <em>furloughed workers&apos;</em> pay, on top of the Coronavirus Job Retention Scheme (CJRS) payments?",
+                            "description": "<p>The Coronavirus Job Retention Scheme (CJRS) covers 80% of pay (up to &#xA3;2,500 a month) for furloughed staff</p>",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer3b3c0791-e310-4279-9116-92f1040606b4",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "label": "",
+                                "description": "",
+                                "q_code": "97",
+                                "options": [{
+                                        "label": "Yes, the business is providing a top-up",
+                                        "value": "Yes, the business is providing a top-up"
+                                    },
+                                    {
+                                        "label": "No, the business is not providing a top-up",
+                                        "value": "No, the business is not providing a top-up"
+                                    },
+                                    {
+                                        "label": "Not sure",
+                                        "value": "Not sure"
+                                    }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "block4f6d1ad5-2f37-4135-92fc-339b1943fc0e",
+                                    "when": [{
+                                        "id": "answer3b3c0791-e310-4279-9116-92f1040606b4",
+                                        "condition": "contains any",
+                                        "values": ["Yes, the business is providing a top-up"]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "block66bef12d-2546-4df7-9e64-15e48bdf99c4",
+                                    "when": [{
+                                            "id": "answer3b3c0791-e310-4279-9116-92f1040606b4",
+                                            "condition": "contains any",
+                                            "values": ["No, the business is not providing a top-up", "Not sure"]
+                                        },
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "contains any",
+                                            "values": [
+                                                "Currently trading and has been for more than the last two weeks",
+                                                "Started trading within the last two weeks after a pause in trading"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "block66bdbc42-37a9-4134-9f22-235e40594178",
+                                    "when": [{
+                                            "id": "answer3b3c0791-e310-4279-9116-92f1040606b4",
+                                            "condition": "contains any",
+                                            "values": ["No, the business is not providing a top-up", "Not sure"]
+                                        },
+                                        {
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "contains any",
+                                            "values": [
+                                                "Paused trading but intends to restart in the next two weeks",
+                                                "Paused trading and does not intend to restart in the next two weeks"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "blocke94a866c-fda4-469d-ba7d-e858307138cb"
+                                }
+                            }
+                        ],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block4f6d1ad5-2f37-4135-92fc-339b1943fc0e",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question4f6d1ad5-2f37-4135-92fc-339b1943fc0e",
+                            "title": "Of those on <em>furlough leave</em>, approximately what <em>percentage of workers</em> have had their pay topped up?",
+                            "description": "<p>Your answer should be out of 100%. </p>",
+                            "definitions": [{
+                                "title": "How you might answer this question",
+                                "content": [{
+                                    "description": "If 50% of your workforce have been furloughed, but you are topping up the pay for <strong>all</strong> of those furloughed workers, the answer would be 100%. If you are topping up the pay for <strong>half</strong> of those furloughed workers, the answer would be 50%."
+                                }]
+                            }],
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer4300ee07-0122-4efc-81e2-02cec3abcb32",
+                                "mandatory": true,
+                                "type": "Percentage",
+                                "label": "Percentage of furloughed workers with top-up pay",
+                                "description": "",
+                                "q_code": "98",
+                                "min_value": {
+                                    "value": 0,
+                                    "exclusive": false
+                                },
+                                "max_value": {
+                                    "value": 100,
+                                    "exclusive": false
+                                },
+                                "decimal_places": 0
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "block66bdbc42-37a9-4134-9f22-235e40594178",
+                                    "when": [{
+                                        "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                        "condition": "contains any",
+                                        "values": [
+                                            "Paused trading but intends to restart in the next two weeks",
+                                            "Paused trading and does not intend to restart in the next two weeks"
+                                        ]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "block66bef12d-2546-4df7-9e64-15e48bdf99c4"
+                                }
+                            }
+                        ],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block66bef12d-2546-4df7-9e64-15e48bdf99c4",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question66bef12d-2546-4df7-9e64-15e48bdf99c4",
+                            "title": "In the <em>last two weeks</em>, approximately what percentage of {{ metadata['ru_name'] }}&apos;s workforce have:",
+                            "type": "General",
+                            "answers": [{
+                                    "id": "answer647b4d64-5529-44ae-8412-903ff0250f71",
+                                    "mandatory": true,
+                                    "type": "Percentage",
+                                    "label": "Returned from furlough leave",
+                                    "description": "",
+                                    "q_code": "991",
+                                    "min_value": {
+                                        "value": 0,
+                                        "exclusive": false
+                                    },
+                                    "max_value": {
+                                        "value": 100,
+                                        "exclusive": false
+                                    },
+                                    "decimal_places": 0
+                                },
+                                {
+                                    "id": "answer8256ff1c-5839-4b89-8d1d-9f76e6280683",
+                                    "mandatory": true,
+                                    "type": "Percentage",
+                                    "label": "Moved from remote working  to the normal workplace",
+                                    "description": "Exclude those who would normally work remotely prior to the pandemic",
+                                    "q_code": "992",
+                                    "min_value": {
+                                        "value": 0,
+                                        "exclusive": false
+                                    },
+                                    "max_value": {
+                                        "value": 100,
+                                        "exclusive": false
+                                    },
+                                    "decimal_places": 0
+                                }
+                            ]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block66bdbc42-37a9-4134-9f22-235e40594178",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question66bdbc42-37a9-4134-9f22-235e40594178",
+                            "title": "In the <em>next two weeks</em>, approximately what percentage of {{ metadata['ru_name'] }}&apos;s workforce will:",
+                            "type": "General",
+                            "answers": [{
+                                    "id": "answerf99be2e6-938d-4adf-99b5-942b78122fda",
+                                    "mandatory": true,
+                                    "type": "Percentage",
+                                    "label": "Return to work from furlough",
+                                    "description": "Include those returning from furlough to remote working",
+                                    "q_code": "1001",
+                                    "min_value": {
+                                        "value": 0,
+                                        "exclusive": false
+                                    },
+                                    "max_value": {
+                                        "value": 100,
+                                        "exclusive": false
+                                    },
+                                    "decimal_places": 0
+                                },
+                                {
+                                    "id": "answer00c0324e-6deb-404a-b425-563ebaf3829d",
+                                    "mandatory": true,
+                                    "type": "Percentage",
+                                    "label": "Return to the workplace from remote working",
+                                    "description": "Exclude those who would normally work remotely prior to the pandemic",
+                                    "q_code": "1002",
+                                    "min_value": {
+                                        "value": 0,
+                                        "exclusive": false
+                                    },
+                                    "max_value": {
+                                        "value": 100,
+                                        "exclusive": false
+                                    },
+                                    "decimal_places": 0
+                                },
+                                {
+                                    "id": "answer325edc5e-846a-4c17-870d-fce3c9b4c9fb",
+                                    "mandatory": true,
+                                    "type": "Percentage",
+                                    "label": "Be made permanently redundant",
+                                    "description": "",
+                                    "q_code": "1003",
+                                    "decimal_places": 0
+                                }
+                            ]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "blocke94a866c-fda4-469d-ba7d-e858307138cb",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "questione94a866c-fda4-469d-ba7d-e858307138cb",
+                            "title": "How many <em>external job vacancies</em> is  {{ metadata['ru_name'] }} actively recruiting for?",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer6fc41202-89c7-48f2-b65a-7801cd5086e4",
+                                "mandatory": true,
+                                "type": "Number",
+                                "label": "Number of external job vacancies",
+                                "description": "",
+                                "q_code": "101",
+                                "min_value": {
+                                    "value": 0,
+                                    "exclusive": false
+                                },
+                                "decimal_places": 0
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "block29eac987-68af-41fc-adaf-53c45511d4da",
+                                    "when": [{
+                                        "id": "answer6fc41202-89c7-48f2-b65a-7801cd5086e4",
+                                        "condition": "equals",
+                                        "value": 0
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "block653770e8-e13b-440e-8146-30b8e2c5fdf9"
+                                }
+                            }
+                        ],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block653770e8-e13b-440e-8146-30b8e2c5fdf9",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question653770e8-e13b-440e-8146-30b8e2c5fdf9",
+                            "title": "Of the {{ answers['answer6fc41202-89c7-48f2-b65a-7801cd5086e4'] | format_number }} external job vacancies, how many were <em>new</em> in the <em>last two weeks</em>?",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answerb8942943-ba5d-4772-ae72-38b84abaeec0",
+                                "mandatory": true,
+                                "type": "Number",
+                                "label": "Number of new external job vacancies",
+                                "description": "",
+                                "q_code": "102",
+                                "max_value": {
+                                    "answer_id": "answer6fc41202-89c7-48f2-b65a-7801cd5086e4",
+                                    "exclusive": false
+                                },
+                                "decimal_places": 0
+                            }]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block29eac987-68af-41fc-adaf-53c45511d4da",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question29eac987-68af-41fc-adaf-53c45511d4da",
+                            "title": "Is {{ metadata['ru_name'] }} using, or intending to use, any of the following <em>safety measures</em> in the workplace?",
+                            "type": "MutuallyExclusive",
+                            "mandatory": true,
+                            "answers": [{
+                                    "id": "answerc46ba0d2-68da-4098-af49-b6c5981c4e8f",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "label": "Select all that apply",
+                                    "description": "",
+                                    "options": [{
+                                            "label": "Personal Protective Equipment (PPE)",
+                                            "value": "Personal Protective Equipment (PPE)",
+                                            "q_code": "951",
+                                            "description": "For example, masks, gloves, etc."
+                                        },
+                                        {
+                                            "label": "Temperature checks",
+                                            "value": "Temperature checks",
+                                            "q_code": "959"
+                                        },
+                                        {
+                                            "label": "Routine COVID-19 testing",
+                                            "value": "Routine COVID-19 testing",
+                                            "q_code": "9510"
+                                        },
+                                        {
+                                            "label": "Social distancing",
+                                            "value": "Social distancing",
+                                            "q_code": "952"
+                                        },
+                                        {
+                                            "label": "Shift working",
+                                            "value": "Shift working",
+                                            "q_code": "953"
+                                        },
+                                        {
+                                            "label": "Working in fixed teams",
+                                            "value": "Working in fixed teams",
+                                            "q_code": "955"
+                                        },
+                                        {
+                                            "label": "Staggered breaks",
+                                            "value": "Staggered breaks",
+                                            "q_code": "954"
+                                        },
+                                        {
+                                            "label": "Hygiene measures",
+                                            "value": "Hygiene measures",
+                                            "q_code": "9511",
+                                            "description": "For example, increased cleaning of work areas and equipment"
+                                        },
+                                        {
+                                            "label": "Other",
+                                            "value": "Other",
+                                            "q_code": "956",
+                                            "detail_answer": {
+                                                "label": "Please describe",
+                                                "type": "TextField",
+                                                "id": "answer36243886-6609-4cf4-af4b-111c29e9cc4f",
+                                                "mandatory": false
+                                            }
+                                        },
+                                        {
+                                            "label": "None of these",
+                                            "value": "None of these",
+                                            "q_code": "957"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "answerc46ba0d2-68da-4098-af49-b6c5981c4e8f-exclusive",
+                                    "mandatory": false,
+                                    "type": "Checkbox",
+                                    "description": "",
+                                    "options": [{
+                                        "label": "Not sure",
+                                        "value": "Not sure",
+                                        "q_code": "958"
+                                    }]
+                                }
+                            ]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "blockb8481e29-f74a-4b32-8b95-2720c2842e0c",
+                                    "when": [{
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "contains any",
+                                            "values": [
+                                                "Currently trading and has been for more than the last two weeks",
+                                                "Started trading within the last two weeks after a pause in trading"
+                                            ]
+                                        },
                                         {
                                             "id": "answerc46ba0d2-68da-4098-af49-b6c5981c4e8f",
-                                            "mandatory": false,
-                                            "type": "Checkbox",
-                                            "label": "Select all that apply",
-                                            "description": "",
-                                            "options": [
-                                                {
-                                                    "label": "Personal Protective Equipment (PPE)",
-                                                    "value": "Personal Protective Equipment (PPE)",
-                                                    "q_code": "951",
-                                                    "description": "For example, masks, gloves, etc."
-                                                },
-                                                {
-                                                    "label": "Temperature checks",
-                                                    "value": "Temperature checks",
-                                                    "q_code": "959"
-                                                },
-                                                {
-                                                    "label": "Routine COVID-19 testing",
-                                                    "value": "Routine COVID-19 testing",
-                                                    "q_code": "9510"
-                                                },
-                                                {
-                                                    "label": "Social distancing",
-                                                    "value": "Social distancing",
-                                                    "q_code": "952"
-                                                },
-                                                {
-                                                    "label": "Shift working",
-                                                    "value": "Shift working",
-                                                    "q_code": "953"
-                                                },
-                                                {
-                                                    "label": "Working in fixed teams",
-                                                    "value": "Working in fixed teams",
-                                                    "q_code": "955"
-                                                },
-                                                {
-                                                    "label": "Staggered breaks",
-                                                    "value": "Staggered breaks",
-                                                    "q_code": "954"
-                                                },
-                                                {
-                                                    "label": "Hygiene measures",
-                                                    "value": "Hygiene measures",
-                                                    "q_code": "9511",
-                                                    "description": "For example, increased cleaning of work areas and equipment"
-                                                },
-                                                {
-                                                    "label": "Other",
-                                                    "value": "Other",
-                                                    "q_code": "956",
-                                                    "detail_answer": {
-                                                        "label": "Please describe",
-                                                        "type": "TextField",
-                                                        "id": "answer36243886-6609-4cf4-af4b-111c29e9cc4f",
-                                                        "mandatory": false
-                                                    }
-                                                },
-                                                {
-                                                    "label": "None of these",
-                                                    "value": "None of these",
-                                                    "q_code": "957"
-                                                }
+                                            "condition": "contains any",
+                                            "values": [
+                                                "Personal Protective Equipment (PPE)",
+                                                "Temperature checks",
+                                                "Routine COVID-19 testing",
+                                                "Social distancing",
+                                                "Shift working",
+                                                "Working in fixed teams",
+                                                "Staggered breaks",
+                                                "Hygiene measures",
+                                                "Other"
                                             ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8",
+                                    "when": [{
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "contains any",
+                                            "values": [
+                                                "Currently trading and has been for more than the last two weeks",
+                                                "Started trading within the last two weeks after a pause in trading"
+                                            ]
+                                        },
+                                        {
+                                            "id": "answerc46ba0d2-68da-4098-af49-b6c5981c4e8f",
+                                            "condition": "contains any",
+                                            "values": ["None of these"]
                                         },
                                         {
                                             "id": "answerc46ba0d2-68da-4098-af49-b6c5981c4e8f-exclusive",
-                                            "mandatory": false,
-                                            "type": "Checkbox",
-                                            "description": "",
-                                            "options": [
-                                                {
-                                                    "label": "Not sure",
-                                                    "value": "Not sure",
-                                                    "q_code": "958"
-                                                }
+                                            "condition": "contains any",
+                                            "values": ["Not sure"]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "block7ff4579e-ede4-4d33-804e-54df3c02d837",
+                                    "when": [{
+                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                            "condition": "contains any",
+                                            "values": [
+                                                "Paused trading but intends to restart in the next two weeks",
+                                                "Paused trading and does not intend to restart in the next two weeks"
+                                            ]
+                                        },
+                                        {
+                                            "id": "answerc46ba0d2-68da-4098-af49-b6c5981c4e8f",
+                                            "condition": "contains any",
+                                            "values": [
+                                                "Personal Protective Equipment (PPE)",
+                                                "Temperature checks",
+                                                "Routine COVID-19 testing",
+                                                "Social distancing",
+                                                "Shift working",
+                                                "Working in fixed teams",
+                                                "Staggered breaks",
+                                                "Hygiene measures",
+                                                "Other"
                                             ]
                                         }
                                     ]
                                 }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "block": "blockb8481e29-f74a-4b32-8b95-2720c2842e0c",
-                                        "when": [
-                                            {
-                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                                "condition": "contains any",
-                                                "values": [
-                                                    "Currently trading and has been for more than the last two weeks",
-                                                    "Started trading within the last two weeks after a pause in trading"
-                                                ]
-                                            },
-                                            {
-                                                "id": "answerc46ba0d2-68da-4098-af49-b6c5981c4e8f",
-                                                "condition": "contains any",
-                                                "values": [
-                                                    "Personal Protective Equipment (PPE)",
-                                                    "Temperature checks",
-                                                    "Routine COVID-19 testing",
-                                                    "Social distancing",
-                                                    "Shift working",
-                                                    "Working in fixed teams",
-                                                    "Staggered breaks",
-                                                    "Hygiene measures",
-                                                    "Other"
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8",
-                                        "when": [
-                                            {
-                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                                "condition": "contains any",
-                                                "values": [
-                                                    "Currently trading and has been for more than the last two weeks",
-                                                    "Started trading within the last two weeks after a pause in trading"
-                                                ]
-                                            },
-                                            {
-                                                "id": "answerc46ba0d2-68da-4098-af49-b6c5981c4e8f",
-                                                "condition": "contains any",
-                                                "values": ["None of these"]
-                                            },
-                                            {
-                                                "id": "answerc46ba0d2-68da-4098-af49-b6c5981c4e8f-exclusive",
-                                                "condition": "contains any",
-                                                "values": ["Not sure"]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "block7ff4579e-ede4-4d33-804e-54df3c02d837",
-                                        "when": [
-                                            {
-                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                                "condition": "contains any",
-                                                "values": [
-                                                    "Paused trading but intends to restart in the next two weeks",
-                                                    "Paused trading and does not intend to restart in the next two weeks"
-                                                ]
-                                            },
-                                            {
-                                                "id": "answerc46ba0d2-68da-4098-af49-b6c5981c4e8f",
-                                                "condition": "contains any",
-                                                "values": [
-                                                    "Personal Protective Equipment (PPE)",
-                                                    "Temperature checks",
-                                                    "Routine COVID-19 testing",
-                                                    "Social distancing",
-                                                    "Shift working",
-                                                    "Working in fixed teams",
-                                                    "Staggered breaks",
-                                                    "Hygiene measures",
-                                                    "Other"
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8",
-                                        "when": [
-                                            {
-                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                                "condition": "contains any",
-                                                "values": [
-                                                    "Paused trading but intends to restart in the next two weeks",
-                                                    "Paused trading and does not intend to restart in the next two weeks"
-                                                ]
-                                            },
-                                            {
-                                                "id": "answerc46ba0d2-68da-4098-af49-b6c5981c4e8f",
-                                                "condition": "contains any",
-                                                "values": ["None of these"]
-                                            },
-                                            {
-                                                "id": "answerc46ba0d2-68da-4098-af49-b6c5981c4e8f-exclusive",
-                                                "condition": "contains any",
-                                                "values": ["Not sure"]
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8"
-                                    }
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
+                            },
+                            {
+                                "goto": {
+                                    "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8",
+                                    "when": [{
                                             "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "blockb8481e29-f74a-4b32-8b95-2720c2842e0c",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "questionb8481e29-f74a-4b32-8b95-2720c2842e0c",
-                                    "title": "How has the implementation of these safety measures affected {{ metadata['ru_name'] }}&apos;s <em>operating costs</em>?",
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer740ce2f4-18bd-48b9-a01d-47854e1e1796",
-                                            "mandatory": true,
-                                            "type": "Radio",
-                                            "label": "",
-                                            "description": "",
-                                            "q_code": "116",
-                                            "options": [
-                                                {
-                                                    "label": "Operating costs have substantially increased",
-                                                    "value": "Operating costs have substantially increased"
-                                                },
-                                                {
-                                                    "label": "Operating costs have increased a little",
-                                                    "value": "Operating costs have increased a little"
-                                                },
-                                                {
-                                                    "label": "Operating costs have stayed the same",
-                                                    "value": "Operating costs have stayed the same"
-                                                },
-                                                {
-                                                    "label": "Operating costs have decreased a little",
-                                                    "value": "Operating costs have decreased a little"
-                                                },
-                                                {
-                                                    "label": "Operating costs have substantially decreased",
-                                                    "value": "Operating costs have substantially decreased"
-                                                },
-                                                {
-                                                    "label": "Not sure",
-                                                    "value": "Not sure"
-                                                },
-                                                {
-                                                    "label": "Not applicable",
-                                                    "value": "Not applicable"
-                                                }
+                                            "condition": "contains any",
+                                            "values": [
+                                                "Paused trading but intends to restart in the next two weeks",
+                                                "Paused trading and does not intend to restart in the next two weeks"
                                             ]
+                                        },
+                                        {
+                                            "id": "answerc46ba0d2-68da-4098-af49-b6c5981c4e8f",
+                                            "condition": "contains any",
+                                            "values": ["None of these"]
+                                        },
+                                        {
+                                            "id": "answerc46ba0d2-68da-4098-af49-b6c5981c4e8f-exclusive",
+                                            "condition": "contains any",
+                                            "values": ["Not sure"]
                                         }
                                     ]
                                 }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8",
-                                        "when": [
-                                            {
-                                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                                "condition": "contains any",
-                                                "values": [
-                                                    "Currently trading and has been for more than the last two weeks",
-                                                    "Started trading within the last two weeks after a pause in trading"
-                                                ]
-                                            }
+                            },
+                            {
+                                "goto": {
+                                    "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8"
+                                }
+                            }
+                        ],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "blockb8481e29-f74a-4b32-8b95-2720c2842e0c",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "questionb8481e29-f74a-4b32-8b95-2720c2842e0c",
+                            "title": "How has the implementation of these safety measures affected {{ metadata['ru_name'] }}&apos;s <em>operating costs</em>?",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer740ce2f4-18bd-48b9-a01d-47854e1e1796",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "label": "",
+                                "description": "",
+                                "q_code": "116",
+                                "options": [{
+                                        "label": "Operating costs have substantially increased",
+                                        "value": "Operating costs have substantially increased"
+                                    },
+                                    {
+                                        "label": "Operating costs have increased a little",
+                                        "value": "Operating costs have increased a little"
+                                    },
+                                    {
+                                        "label": "Operating costs have stayed the same",
+                                        "value": "Operating costs have stayed the same"
+                                    },
+                                    {
+                                        "label": "Operating costs have decreased a little",
+                                        "value": "Operating costs have decreased a little"
+                                    },
+                                    {
+                                        "label": "Operating costs have substantially decreased",
+                                        "value": "Operating costs have substantially decreased"
+                                    },
+                                    {
+                                        "label": "Not sure",
+                                        "value": "Not sure"
+                                    },
+                                    {
+                                        "label": "Not applicable",
+                                        "value": "Not applicable"
+                                    }
+                                ]
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "group": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8",
+                                    "when": [{
+                                        "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                        "condition": "contains any",
+                                        "values": [
+                                            "Currently trading and has been for more than the last two weeks",
+                                            "Started trading within the last two weeks after a pause in trading"
                                         ]
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "block7ff4579e-ede4-4d33-804e-54df3c02d837"
+                                }
+                            }
+                        ],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "block7ff4579e-ede4-4d33-804e-54df3c02d837",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question7ff4579e-ede4-4d33-804e-54df3c02d837",
+                            "title": "How do you expect the implementation of these safety measures to affect {{ metadata['ru_name'] }}&apos;s <em>operating costs</em>?",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answer000984b9-561c-40ba-b529-6faa4d95fc1b",
+                                "mandatory": true,
+                                "type": "Radio",
+                                "label": "",
+                                "description": "",
+                                "q_code": "117",
+                                "options": [{
+                                        "label": "Operating costs will substantially increase",
+                                        "value": "Operating costs will substantially increase"
+                                    },
+                                    {
+                                        "label": "Operating costs will increase a little",
+                                        "value": "Operating costs will increase a little"
+                                    },
+                                    {
+                                        "label": "Operating costs will stay the same",
+                                        "value": "Operating costs will stay the same"
+                                    },
+                                    {
+                                        "label": "Operating costs will decrease a little",
+                                        "value": "Operating costs will decrease a little"
+                                    },
+                                    {
+                                        "label": "Operating costs will substantially decrease",
+                                        "value": "Operating costs will substantially decrease"
+                                    },
+                                    {
+                                        "label": "Not sure",
+                                        "value": "Not sure"
+                                    },
+                                    {
+                                        "label": "Not applicable",
+                                        "value": "Not applicable"
                                     }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "block7ff4579e-ede4-4d33-804e-54df3c02d837"
-                                    }
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "block7ff4579e-ede4-4d33-804e-54df3c02d837",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question7ff4579e-ede4-4d33-804e-54df3c02d837",
-                                    "title": "How do you expect the implementation of these safety measures to affect {{ metadata['ru_name'] }}&apos;s <em>operating costs</em>?",
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answer000984b9-561c-40ba-b529-6faa4d95fc1b",
-                                            "mandatory": true,
-                                            "type": "Radio",
-                                            "label": "",
-                                            "description": "",
-                                            "q_code": "117",
-                                            "options": [
-                                                {
-                                                    "label": "Operating costs will substantially increase",
-                                                    "value": "Operating costs will substantially increase"
-                                                },
-                                                {
-                                                    "label": "Operating costs will increase a little",
-                                                    "value": "Operating costs will increase a little"
-                                                },
-                                                {
-                                                    "label": "Operating costs will stay the same",
-                                                    "value": "Operating costs will stay the same"
-                                                },
-                                                {
-                                                    "label": "Operating costs will decrease a little",
-                                                    "value": "Operating costs will decrease a little"
-                                                },
-                                                {
-                                                    "label": "Operating costs will substantially decrease",
-                                                    "value": "Operating costs will substantially decrease"
-                                                },
-                                                {
-                                                    "label": "Not sure",
-                                                    "value": "Not sure"
-                                                },
-                                                {
-                                                    "label": "Not applicable",
-                                                    "value": "Not applicable"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                            "condition": "not set"
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
-                    ],
-                    "skip_conditions": [
-                        {
-                            "when": [
-                                {
-                                    "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
-                                    "condition": "contains any",
-                                    "values": ["Permanently ceased trading"]
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ]
+                                ]
+                            }]
+                        }],
+                        "skip_conditions": [{
+                            "when": [{
+                                "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                                "condition": "not set"
+                            }]
+                        }]
+                    }
+                ],
+                "skip_conditions": [{
+                    "when": [{
+                        "id": "answer7c70ce5d-dd31-4340-95bf-9df9b9028acd",
+                        "condition": "contains any",
+                        "values": ["Permanently ceased trading"]
+                    }]
+                }]
+            }]
         },
         {
             "id": "section19187b42-33f0-4bf8-92c3-aa13bc8628f8",
             "title": "Comments",
-            "groups": [
-                {
+            "groups": [{
                     "id": "group19187b42-33f0-4bf8-92c3-aa13bc8628f8",
                     "title": "Comments",
-                    "blocks": [
-                        {
-                            "id": "block840d9b9e-842b-4307-9006-9d93de8466ce",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "question840d9b9e-842b-4307-9006-9d93de8466ce",
-                                    "title": "Let us know anything else that you think may help us understand {{ metadata['ru_name'] }}&apos;s current situation",
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "id": "answerf2cd92db-8721-45eb-be99-848705657b88",
-                                            "mandatory": false,
-                                            "type": "TextArea",
-                                            "label": "Comments",
-                                            "description": "",
-                                            "q_code": "146",
-                                            "max_length": 2000
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
-                    ]
+                    "blocks": [{
+                        "id": "block840d9b9e-842b-4307-9006-9d93de8466ce",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "question840d9b9e-842b-4307-9006-9d93de8466ce",
+                            "title": "Let us know anything else that you think may help us understand {{ metadata['ru_name'] }}&apos;s current situation",
+                            "type": "General",
+                            "answers": [{
+                                "id": "answerf2cd92db-8721-45eb-be99-848705657b88",
+                                "mandatory": false,
+                                "type": "TextArea",
+                                "label": "Comments",
+                                "description": "",
+                                "q_code": "146",
+                                "max_length": 2000
+                            }]
+                        }]
+                    }]
                 },
                 {
                     "id": "summary-group",
                     "title": "Summary",
-                    "blocks": [
-                        {
-                            "type": "Summary",
-                            "id": "summary-block"
-                        }
-                    ]
+                    "blocks": [{
+                        "type": "Summary",
+                        "id": "summary-block"
+                    }]
                 }
             ]
         }
@@ -6801,8 +5763,7 @@
     "navigation": {
         "visible": true
     },
-    "metadata": [
-        {
+    "metadata": [{
             "name": "user_id",
             "validator": "string"
         },

--- a/data/en/mbs_0106.json
+++ b/data/en/mbs_0106.json
@@ -11,363 +11,535 @@
         "enabled": true,
         "duration": 900
     },
-    "metadata": [{
-        "name": "user_id",
-        "validator": "string"
-    }, {
-        "name": "period_id",
-        "validator": "string"
-    }, {
-        "name": "ru_name",
-        "validator": "string"
-    }, {
-        "name": "ref_p_start_date",
-        "validator": "date"
-    }, {
-        "name": "ref_p_end_date",
-        "validator": "date"
-    }, {
-        "name": "trad_as",
-        "validator": "optional_string"
-    }],
-    "sections": [{
-        "id": "section",
-        "groups": [{
-            "id": "group",
-            "title": "",
-            "blocks": [{
-                "type": "Introduction",
-                "id": "introduction",
-                "primary_content": [{
-                    "type": "Basic",
-                    "id": "use-of-information",
-                    "content": [{
-                        "list": ["Data should relate to all sites in England, Scotland and Wales unless otherwise stated.", "You can provide informed estimates if actual figures aren\u2019t available.", "We will treat your data securely and confidentially."]
-                    }]
-                }],
-                "preview_content": {
-                    "id": "preview",
-                    "title": "Information you need",
-                    "content": [{
-                        "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
-                    }],
-                    "questions": [{
-                        "question": "Total Turnover",
-                        "content": [{
-                            "description": "Include:",
-                            "list": ["exports", "payments for work in progress", "costs incurred and passed on to customers", "income from sub-contracted activities", "commission", "sales of goods purchased for resale", "revenue earned from other parts of the business not named (please supply at fair value)"]
-                        }, {
-                            "description": "Exclude:",
-                            "list": ["VAT", "excise duties", "income from the sale of fixed capital assets", "grants and subsidies", "insurance claims", "interest received"]
-                        }]
-                    }, {
-                        "question": "Changes in total turnover",
-                        "content": [{
-                            "description": "Include:",
-                            "list": ["change in level of business activity", "maintenance/shutdowns", "special/calendar events", "weather", "price effects", "currency effects (increase/decrease in the currency value)"]
-                        }]
-                    }]
-                },
-                "secondary_content": [{
-                    "id": "how-we-use-your-data",
-                    "title": "How we use your data",
-                    "content": [{
-                        "list": ["You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.", "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"]
-                    }]
-                }]
-            }, {
-                "id": "reporting-period-block",
-                "type": "Question",
-                "questions": [{
-                    "answers": [{
-                        "options": [{
-                            "value": "Yes",
-                            "label": "Yes"
-                        }, {
-                            "value": "No",
-                            "label": "No"
-                        }],
-                        "id": "reporting-period-answer",
-                        "type": "Radio",
-                        "q_code": "d12",
-                        "mandatory": true
-                    }],
-                    "type": "General",
-                    "id": "reporting-period-question",
-                    "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
-                }],
-                "routing_rules": [{
-                    "goto": {
-                        "when": [{
-                            "id": "reporting-period-answer",
-                            "value": "Yes",
-                            "condition": "equals"
-                        }],
-                        "block": "turnover-block"
-                    }
-                }, {
-                    "goto": {
-                        "block": "reporting-period-block-2"
-                    }
-                }],
-                "title": "Reporting period"
-            }, {
-                "type": "Question",
-                "id": "reporting-period-block-2",
-                "title": "Reporting period",
-                "questions": [{
-                    "type": "DateRange",
-                    "id": "reporting-period-question-2",
-                    "title": "What are the dates of the period that you will be reporting for?",
-                    "period_limits": {
-                        "minimum": {
-                            "days": 10
+    "metadata": [
+        {
+            "name": "user_id",
+            "validator": "string"
+        },
+        {
+            "name": "period_id",
+            "validator": "string"
+        },
+        {
+            "name": "ru_name",
+            "validator": "string"
+        },
+        {
+            "name": "ref_p_start_date",
+            "validator": "date"
+        },
+        {
+            "name": "ref_p_end_date",
+            "validator": "date"
+        },
+        {
+            "name": "trad_as",
+            "validator": "optional_string"
+        }
+    ],
+    "sections": [
+        {
+            "id": "section",
+            "groups": [
+                {
+                    "id": "group",
+                    "title": "",
+                    "blocks": [
+                        {
+                            "type": "Introduction",
+                            "id": "introduction",
+                            "primary_content": [
+                                {
+                                    "type": "Basic",
+                                    "id": "use-of-information",
+                                    "content": [
+                                        {
+                                            "list": [
+                                                "Data should relate to all sites in England, Scotland and Wales unless otherwise stated.",
+                                                "You can provide informed estimates if actual figures aren’t available.",
+                                                "We will treat your data securely and confidentially."
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "preview_content": {
+                                "id": "preview",
+                                "title": "Information you need",
+                                "content": [
+                                    {
+                                        "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
+                                    }
+                                ],
+                                "questions": [
+                                    {
+                                        "question": "Total Turnover",
+                                        "content": [
+                                            {
+                                                "description": "Include:",
+                                                "list": [
+                                                    "exports",
+                                                    "payments for work in progress",
+                                                    "costs incurred and passed on to customers",
+                                                    "income from sub-contracted activities",
+                                                    "commission",
+                                                    "sales of goods purchased for resale",
+                                                    "revenue earned from other parts of the business not named (please supply at fair value)"
+                                                ]
+                                            },
+                                            {
+                                                "description": "Exclude:",
+                                                "list": [
+                                                    "VAT",
+                                                    "excise duties",
+                                                    "income from the sale of fixed capital assets",
+                                                    "grants and subsidies",
+                                                    "insurance claims",
+                                                    "interest received"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "question": "Changes in total turnover",
+                                        "content": [
+                                            {
+                                                "description": "Include:",
+                                                "list": [
+                                                    "change in level of business activity",
+                                                    "maintenance/shutdowns",
+                                                    "special/calendar events",
+                                                    "weather",
+                                                    "price effects",
+                                                    "currency effects (increase/decrease in the currency value)"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "secondary_content": [
+                                {
+                                    "id": "how-we-use-your-data",
+                                    "title": "How we use your data",
+                                    "content": [
+                                        {
+                                            "list": [
+                                                "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
+                                                "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
                         },
-                        "maximum": {
-                            "days": 50
-                        }
-                    },
-                    "answers": [{
-                        "type": "Date",
-                        "id": "period-from",
-                        "label": "From",
-                        "mandatory": true,
-                        "q_code": "11",
-                        "minimum": {
-                            "meta": "ref_p_start_date",
-                            "offset_by": {
-                                "days": -19
-                            }
-                        }
-                    }, {
-                        "type": "Date",
-                        "id": "period-to",
-                        "label": "To",
-                        "mandatory": true,
-                        "q_code": "12",
-                        "maximum": {
-                            "meta": "ref_p_end_date",
-                            "offset_by": {
-                                "days": 20
-                            }
-                        }
-                    }]
-                }]
-            }, {
-                "id": "turnover-block",
-                "type": "Question",
-                "questions": [{
-                    "guidance": {
-                        "content": [{
-                            "title": "Include:",
-                            "list": ["exports", "payments for work in progress", "costs incurred and passed on to customers", "income from sub-contracted activities", "commission", "sales of goods purchased for resale", "revenue earned from other parts of the business not named (please supply at fair value)"]
-                        }, {
-                            "title": "Exclude:",
-                            "list": ["VAT", "excise duties", "income from the sale of fixed capital assets", "grants and subsidies", "insurance claims", "interest received"]
-                        }]
-                    },
-                    "id": "turnover-question",
-                    "answers": [{
-                        "id": "turnover-answer",
-                        "label": "Total turnover excluding VAT",
-                        "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
-                        "type": "Currency",
-                        "currency": "GBP",
-                        "decimal_places": 2,
-                        "q_code": "40",
-                        "mandatory": true
-                    }],
-                    "type": "General",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>total turnover</em>, excluding VAT?"
-                }],
-                "title": "Total turnover"
-            }, {
-                "type": "ConfirmationQuestion",
-                "title": "Total turnover",
-                "id": "confirm-turnover-block",
-                "questions": [{
-                    "type": "General",
-                    "answers": [{
-                        "type": "Radio",
-                        "id": "confirm-turnover-answer",
-                        "q_code": "d40",
-                        "options": [{
-                            "label": "Yes this is correct",
-                            "value": "Yes"
-                        }, {
-                            "label": "No I need to change this",
-                            "value": "No"
-                        }],
-                        "mandatory": true
-                    }],
-                    "id": "confirm-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
-                }],
-                "routing_rules": [{
-                    "goto": {
-                        "when": [{
-                            "value": "No",
-                            "id": "confirm-turnover-answer",
-                            "condition": "equals"
-                        }],
-                        "block": "turnover-block"
-                    }
-                }, {
-                    "goto": {
-                        "block": "changes-in-total-turnover-block"
-                    }
-                }]
-            }, {
-                "id": "changes-in-total-turnover-block",
-                "type": "Question",
-                "questions": [{
-                    "title": "Did any significant changes occur to the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
-                    "id": "changes-in-total-turnover-question",
-                    "definitions": [{
-                        "title": "What constitutes a significant change?",
-                        "content": [{
-                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
-                        }, {
-                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
-                        }]
-                    }],
-                    "answers": [{
-                        "options": [{
-                            "value": "Yes",
-                            "label": "Yes"
-                        }, {
-                            "value": "No",
-                            "label": "No"
-                        }],
-                        "id": "changes-in-total-turnover-answer",
-                        "type": "Radio",
-                        "q_code": "146",
-                        "mandatory": true
-                    }],
-                    "guidance": {
-                        "content": [{
-                            "title": "Include",
-                            "list": ["change in level of business activity", "maintenance/shutdowns", "special/calendar events", "weather", "price effects", "currency effects (increase/decrease in the currency value)"]
-                        }]
-                    },
-                    "type": "General"
-                }],
-                "title": "Changes in total turnover",
-                "routing_rules": [{
-                    "goto": {
-                        "when": [{
-                            "id": "changes-in-total-turnover-answer",
-                            "value": "Yes",
-                            "condition": "equals"
-                        }],
-                        "block": "changes-in-total-turnover-block-2"
-                    }
-                }, {
-                    "goto": {
-                        "group": "summary-group"
-                    }
-                }]
-            }, {
-                "id": "changes-in-total-turnover-block-2",
-                "type": "Question",
-                "questions": [{
-                    "title": "Please indicate the reasons for any changes in the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
-                    "answers": [{
-                        "options": [{
-                            "q_code": "146a",
-                            "value": "Change in level of business activity",
-                            "label": "Change in level of business activity"
-                        }, {
-                            "q_code": "146b",
-                            "value": "Maintenance/shutdowns",
-                            "label": "Maintenance/shutdowns"
-                        }, {
-                            "q_code": "146c",
-                            "value": "Special/calendar events",
-                            "label": "Special/calendar events"
-                        }, {
-                            "q_code": "146d",
-                            "value": "Weather",
-                            "label": "Weather"
-                        }, {
-                            "q_code": "146e",
-                            "value": "Price effects",
-                            "label": "Price effects"
-                        }, {
-                            "q_code": "146f",
-                            "value": "Currency effects (increase/decrease in the currency value)",
-                            "label": "Currency effects (increase/decrease in the currency value)"
-                        }, {
-                            "q_code": "146g",
-                            "value": "Other",
-                            "label": "Other"
-                        }],
-                        "id": "changes-in-total-turnover-answer-2",
-                        "type": "Checkbox",
-                        "mandatory": true
-                    }],
-                    "type": "General",
-                    "id": "changes-in-total-turnover-question-2"
-                }],
-                "title": "Changes in total turnover"
-            }, {
-                "type": "Question",
-                "id": "changes-in-total-turnover-block-3",
-                "title": "Changes in total turnover",
-                "questions": [{
-                    "type": "General",
-                    "id": "changes-in-total-turnover-question-3",
-                    "title": "Please describe the changes in total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
-                    "answers": [{
-                        "guidance": {
-                            "hide_guidance": "Hide examples of commentary on changes to turnover",
-                            "show_guidance": "Show examples of commentary on changes to turnover",
-                            "content": [{
-                                "list": [],
-                                "title": "\u2018Change in level of business activity\u2019",
-                                "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
-                            }, {
-                                "list": [],
-                                "title": "\u2018Maintenance/shutdowns\u2019",
-                                "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
-                            }, {
-                                "list": [],
-                                "title": "\u2018Special/calendar events\u2019",
-                                "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
-                            }, {
-                                "list": [],
-                                "title": "\u2018Weather\u2019",
-                                "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
-                            }, {
-                                "list": [],
-                                "title": "\u2018Price effects\u2019",
-                                "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
-                            }, {
-                                "list": [],
-                                "title": "\u2018Currency effects (increase/decrease in the currency value)\u2019",
-                                "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
-                            }]
+                        {
+                            "id": "reporting-period-block",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "options": [
+                                                {
+                                                    "value": "Yes",
+                                                    "label": "Yes"
+                                                },
+                                                {
+                                                    "value": "No",
+                                                    "label": "No"
+                                                }
+                                            ],
+                                            "id": "reporting-period-answer",
+                                            "type": "Radio",
+                                            "q_code": "d12",
+                                            "mandatory": true
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "id": "reporting-period-question",
+                                    "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "when": [
+                                            {
+                                                "id": "reporting-period-answer",
+                                                "value": "Yes",
+                                                "condition": "equals"
+                                            }
+                                        ],
+                                        "block": "turnover-block"
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "reporting-period-block-2"
+                                    }
+                                }
+                            ],
+                            "title": "Reporting period"
                         },
-                        "type": "TextArea",
-                        "mandatory": true,
-                        "label": "Comments",
-                        "id": "changes-in-total-turnover-answer-3",
-                        "q_code": "146h"
-                    }],
-                    "description": "<p>We rely on your commentary to \u2018tell the story\u2019 behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
-                }]
-            }]
-        }]
-    }, {
-        "id": "summary-section",
-        "title": "Summary",
-        "groups": [{
-            "id": "summary-group",
+                        {
+                            "type": "Question",
+                            "id": "reporting-period-block-2",
+                            "title": "Reporting period",
+                            "questions": [
+                                {
+                                    "type": "DateRange",
+                                    "id": "reporting-period-question-2",
+                                    "title": "What are the dates of the period that you will be reporting for?",
+                                    "period_limits": {
+                                        "minimum": {
+                                            "days": 10
+                                        },
+                                        "maximum": {
+                                            "days": 50
+                                        }
+                                    },
+                                    "answers": [
+                                        {
+                                            "type": "Date",
+                                            "id": "period-from",
+                                            "label": "From",
+                                            "mandatory": true,
+                                            "q_code": "11",
+                                            "minimum": {
+                                                "meta": "ref_p_start_date",
+                                                "offset_by": {
+                                                    "days": -19
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "type": "Date",
+                                            "id": "period-to",
+                                            "label": "To",
+                                            "mandatory": true,
+                                            "q_code": "12",
+                                            "maximum": {
+                                                "meta": "ref_p_end_date",
+                                                "offset_by": {
+                                                    "days": 20
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "turnover-block",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "guidance": {
+                                        "content": [
+                                            {
+                                                "title": "Include:",
+                                                "list": [
+                                                    "exports",
+                                                    "payments for work in progress",
+                                                    "costs incurred and passed on to customers",
+                                                    "income from sub-contracted activities",
+                                                    "commission",
+                                                    "sales of goods purchased for resale",
+                                                    "revenue earned from other parts of the business not named (please supply at fair value)"
+                                                ]
+                                            },
+                                            {
+                                                "title": "Exclude:",
+                                                "list": [
+                                                    "VAT",
+                                                    "excise duties",
+                                                    "income from the sale of fixed capital assets",
+                                                    "grants and subsidies",
+                                                    "insurance claims",
+                                                    "interest received"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "id": "turnover-question",
+                                    "answers": [
+                                        {
+                                            "id": "turnover-answer",
+                                            "label": "Total turnover excluding VAT",
+                                            "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                                            "type": "Currency",
+                                            "currency": "GBP",
+                                            "decimal_places": 2,
+                                            "q_code": "40",
+                                            "mandatory": true
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s <em>total turnover</em>, excluding VAT?"
+                                }
+                            ],
+                            "title": "Total turnover"
+                        },
+                        {
+                            "type": "ConfirmationQuestion",
+                            "title": "Total turnover",
+                            "id": "confirm-turnover-block",
+                            "questions": [
+                                {
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "type": "Radio",
+                                            "id": "confirm-turnover-answer",
+                                            "q_code": "d40",
+                                            "options": [
+                                                {
+                                                    "label": "Yes this is correct",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No I need to change this",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "mandatory": true
+                                        }
+                                    ],
+                                    "id": "confirm-turnover-question",
+                                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "when": [
+                                            {
+                                                "value": "No",
+                                                "id": "confirm-turnover-answer",
+                                                "condition": "equals"
+                                            }
+                                        ],
+                                        "block": "turnover-block"
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "changes-in-total-turnover-block"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "id": "changes-in-total-turnover-block",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "title": "Did any significant changes occur to the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                                    "id": "changes-in-total-turnover-question",
+                                    "definitions": [
+                                        {
+                                            "title": "What constitutes a significant change?",
+                                            "content": [
+                                                {
+                                                    "description": "What constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s figures from the previous reporting period and the same reporting period last year."
+                                                },
+                                                {
+                                                    "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "answers": [
+                                        {
+                                            "options": [
+                                                {
+                                                    "value": "Yes",
+                                                    "label": "Yes"
+                                                },
+                                                {
+                                                    "value": "No",
+                                                    "label": "No"
+                                                }
+                                            ],
+                                            "id": "changes-in-total-turnover-answer",
+                                            "type": "Radio",
+                                            "q_code": "146",
+                                            "mandatory": true
+                                        }
+                                    ],
+                                    "guidance": {
+                                        "content": [
+                                            {
+                                                "title": "Include",
+                                                "list": [
+                                                    "change in level of business activity",
+                                                    "maintenance/shutdowns",
+                                                    "special/calendar events",
+                                                    "weather",
+                                                    "price effects",
+                                                    "currency effects (increase/decrease in the currency value)"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Changes in total turnover",
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "when": [
+                                            {
+                                                "id": "changes-in-total-turnover-answer",
+                                                "value": "Yes",
+                                                "condition": "equals"
+                                            }
+                                        ],
+                                        "block": "changes-in-total-turnover-block-2"
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "group": "summary-group"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "id": "changes-in-total-turnover-block-2",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "title": "Please indicate the reasons for any changes in the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
+                                    "answers": [
+                                        {
+                                            "options": [
+                                                {
+                                                    "q_code": "146a",
+                                                    "value": "Change in level of business activity",
+                                                    "label": "Change in level of business activity"
+                                                },
+                                                {
+                                                    "q_code": "146b",
+                                                    "value": "Maintenance/shutdowns",
+                                                    "label": "Maintenance/shutdowns"
+                                                },
+                                                {
+                                                    "q_code": "146c",
+                                                    "value": "Special/calendar events",
+                                                    "label": "Special/calendar events"
+                                                },
+                                                {
+                                                    "q_code": "146d",
+                                                    "value": "Weather",
+                                                    "label": "Weather"
+                                                },
+                                                {
+                                                    "q_code": "146e",
+                                                    "value": "Price effects",
+                                                    "label": "Price effects"
+                                                },
+                                                {
+                                                    "q_code": "146f",
+                                                    "value": "Currency effects (increase/decrease in the currency value)",
+                                                    "label": "Currency effects (increase/decrease in the currency value)"
+                                                },
+                                                {
+                                                    "q_code": "146g",
+                                                    "value": "Other",
+                                                    "label": "Other"
+                                                }
+                                            ],
+                                            "id": "changes-in-total-turnover-answer-2",
+                                            "type": "Checkbox",
+                                            "mandatory": true
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "id": "changes-in-total-turnover-question-2"
+                                }
+                            ],
+                            "title": "Changes in total turnover"
+                        },
+                        {
+                            "type": "Question",
+                            "id": "changes-in-total-turnover-block-3",
+                            "title": "Changes in total turnover",
+                            "questions": [
+                                {
+                                    "type": "General",
+                                    "id": "changes-in-total-turnover-question-3",
+                                    "title": "Please describe the changes in total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
+                                    "answers": [
+                                        {
+                                            "guidance": {
+                                                "hide_guidance": "Hide examples of commentary on changes to turnover",
+                                                "show_guidance": "Show examples of commentary on changes to turnover",
+                                                "content": [
+                                                    {
+                                                        "list": [],
+                                                        "title": "‘Change in level of business activity’",
+                                                        "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
+                                                    },
+                                                    {
+                                                        "list": [],
+                                                        "title": "‘Maintenance/shutdowns’",
+                                                        "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
+                                                    },
+                                                    {
+                                                        "list": [],
+                                                        "title": "‘Special/calendar events’",
+                                                        "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
+                                                    },
+                                                    {
+                                                        "list": [],
+                                                        "title": "‘Weather’",
+                                                        "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
+                                                    },
+                                                    {
+                                                        "list": [],
+                                                        "title": "‘Price effects’",
+                                                        "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
+                                                    },
+                                                    {
+                                                        "list": [],
+                                                        "title": "‘Currency effects (increase/decrease in the currency value)’",
+                                                        "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
+                                                    }
+                                                ]
+                                            },
+                                            "type": "TextArea",
+                                            "mandatory": true,
+                                            "label": "Comments",
+                                            "id": "changes-in-total-turnover-answer-3",
+                                            "q_code": "146h"
+                                        }
+                                    ],
+                                    "description": "<p>We rely on your commentary to ‘tell the story’ behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "summary-section",
             "title": "Summary",
-            "blocks": [{
-                "type": "Summary",
-                "id": "summary"
-            }]
-        }]
-    }]
+            "groups": [
+                {
+                    "id": "summary-group",
+                    "title": "Summary",
+                    "blocks": [
+                        {
+                            "type": "Summary",
+                            "id": "summary"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
 }

--- a/data/en/mbs_0106.json
+++ b/data/en/mbs_0106.json
@@ -11,8 +11,7 @@
         "enabled": true,
         "duration": 900
     },
-    "metadata": [
-        {
+    "metadata": [{
             "name": "user_id",
             "validator": "string"
         },
@@ -37,509 +36,440 @@
             "validator": "optional_string"
         }
     ],
-    "sections": [
-        {
+    "sections": [{
             "id": "section",
-            "groups": [
-                {
-                    "id": "group",
-                    "title": "",
-                    "blocks": [
-                        {
-                            "type": "Introduction",
-                            "id": "introduction",
-                            "primary_content": [
-                                {
-                                    "type": "Basic",
-                                    "id": "use-of-information",
-                                    "content": [
-                                        {
+            "groups": [{
+                "id": "group",
+                "title": "",
+                "blocks": [{
+                        "type": "Introduction",
+                        "id": "introduction",
+                        "primary_content": [{
+                            "type": "Basic",
+                            "id": "use-of-information",
+                            "content": [{
+                                "list": [
+                                    "Data should relate to all sites in England, Scotland and Wales unless otherwise stated.",
+                                    "You can provide informed estimates if actual figures aren’t available.",
+                                    "We will treat your data securely and confidentially."
+                                ]
+                            }]
+                        }],
+                        "preview_content": {
+                            "id": "preview",
+                            "title": "Information you need",
+                            "content": [{
+                                "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
+                            }],
+                            "questions": [{
+                                    "question": "Total Turnover",
+                                    "content": [{
+                                            "description": "Include:",
                                             "list": [
-                                                "Data should relate to all sites in England, Scotland and Wales unless otherwise stated.",
-                                                "You can provide informed estimates if actual figures aren’t available.",
-                                                "We will treat your data securely and confidentially."
+                                                "exports",
+                                                "payments for work in progress",
+                                                "costs incurred and passed on to customers",
+                                                "income from sub-contracted activities",
+                                                "commission",
+                                                "sales of goods purchased for resale",
+                                                "revenue earned from other parts of the business not named (please supply at fair value)"
+                                            ]
+                                        },
+                                        {
+                                            "description": "Exclude:",
+                                            "list": [
+                                                "VAT",
+                                                "excise duties",
+                                                "income from the sale of fixed capital assets",
+                                                "grants and subsidies",
+                                                "insurance claims",
+                                                "interest received"
                                             ]
                                         }
                                     ]
+                                },
+                                {
+                                    "question": "Changes in total turnover",
+                                    "content": [{
+                                        "description": "Include:",
+                                        "list": [
+                                            "change in level of business activity",
+                                            "maintenance/shutdowns",
+                                            "special/calendar events",
+                                            "weather",
+                                            "price effects",
+                                            "currency effects (increase/decrease in the currency value)"
+                                        ]
+                                    }]
                                 }
-                            ],
-                            "preview_content": {
-                                "id": "preview",
-                                "title": "Information you need",
-                                "content": [
+                            ]
+                        },
+                        "secondary_content": [{
+                            "id": "how-we-use-your-data",
+                            "title": "How we use your data",
+                            "content": [{
+                                "list": [
+                                    "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
+                                    "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"
+                                ]
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "reporting-period-block",
+                        "type": "Question",
+                        "questions": [{
+                            "answers": [{
+                                "options": [{
+                                        "value": "Yes",
+                                        "label": "Yes"
+                                    },
                                     {
-                                        "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
+                                        "value": "No",
+                                        "label": "No"
                                     }
                                 ],
-                                "questions": [
-                                    {
-                                        "question": "Total Turnover",
-                                        "content": [
-                                            {
-                                                "description": "Include:",
-                                                "list": [
-                                                    "exports",
-                                                    "payments for work in progress",
-                                                    "costs incurred and passed on to customers",
-                                                    "income from sub-contracted activities",
-                                                    "commission",
-                                                    "sales of goods purchased for resale",
-                                                    "revenue earned from other parts of the business not named (please supply at fair value)"
-                                                ]
-                                            },
-                                            {
-                                                "description": "Exclude:",
-                                                "list": [
-                                                    "VAT",
-                                                    "excise duties",
-                                                    "income from the sale of fixed capital assets",
-                                                    "grants and subsidies",
-                                                    "insurance claims",
-                                                    "interest received"
-                                                ]
-                                            }
+                                "id": "reporting-period-answer",
+                                "type": "Radio",
+                                "q_code": "d12",
+                                "mandatory": true
+                            }],
+                            "type": "General",
+                            "id": "reporting-period-question",
+                            "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "id": "reporting-period-answer",
+                                        "value": "Yes",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "turnover-block"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "reporting-period-block-2"
+                                }
+                            }
+                        ],
+                        "title": "Reporting period"
+                    },
+                    {
+                        "type": "Question",
+                        "id": "reporting-period-block-2",
+                        "title": "Reporting period",
+                        "questions": [{
+                            "type": "DateRange",
+                            "id": "reporting-period-question-2",
+                            "title": "What are the dates of the period that you will be reporting for?",
+                            "period_limits": {
+                                "minimum": {
+                                    "days": 10
+                                },
+                                "maximum": {
+                                    "days": 50
+                                }
+                            },
+                            "answers": [{
+                                    "type": "Date",
+                                    "id": "period-from",
+                                    "label": "From",
+                                    "mandatory": true,
+                                    "q_code": "11",
+                                    "minimum": {
+                                        "meta": "ref_p_start_date",
+                                        "offset_by": {
+                                            "days": -19
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "Date",
+                                    "id": "period-to",
+                                    "label": "To",
+                                    "mandatory": true,
+                                    "q_code": "12",
+                                    "maximum": {
+                                        "meta": "ref_p_end_date",
+                                        "offset_by": {
+                                            "days": 20
+                                        }
+                                    }
+                                }
+                            ]
+                        }]
+                    },
+                    {
+                        "id": "turnover-block",
+                        "type": "Question",
+                        "questions": [{
+                            "guidance": {
+                                "content": [{
+                                        "title": "Include:",
+                                        "list": [
+                                            "exports",
+                                            "payments for work in progress",
+                                            "costs incurred and passed on to customers",
+                                            "income from sub-contracted activities",
+                                            "commission",
+                                            "sales of goods purchased for resale",
+                                            "revenue earned from other parts of the business not named (please supply at fair value)"
                                         ]
                                     },
                                     {
-                                        "question": "Changes in total turnover",
-                                        "content": [
-                                            {
-                                                "description": "Include:",
-                                                "list": [
-                                                    "change in level of business activity",
-                                                    "maintenance/shutdowns",
-                                                    "special/calendar events",
-                                                    "weather",
-                                                    "price effects",
-                                                    "currency effects (increase/decrease in the currency value)"
-                                                ]
-                                            }
+                                        "title": "Exclude:",
+                                        "list": [
+                                            "VAT",
+                                            "excise duties",
+                                            "income from the sale of fixed capital assets",
+                                            "grants and subsidies",
+                                            "insurance claims",
+                                            "interest received"
                                         ]
                                     }
                                 ]
                             },
-                            "secondary_content": [
-                                {
-                                    "id": "how-we-use-your-data",
-                                    "title": "How we use your data",
-                                    "content": [
+                            "id": "turnover-question",
+                            "answers": [{
+                                "id": "turnover-answer",
+                                "label": "Total turnover excluding VAT",
+                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                                "type": "Currency",
+                                "currency": "GBP",
+                                "decimal_places": 2,
+                                "q_code": "40",
+                                "mandatory": true
+                            }],
+                            "type": "General",
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s <em>total turnover</em>, excluding VAT?"
+                        }],
+                        "title": "Total turnover"
+                    },
+                    {
+                        "type": "ConfirmationQuestion",
+                        "title": "Total turnover",
+                        "id": "confirm-turnover-block",
+                        "questions": [{
+                            "type": "General",
+                            "answers": [{
+                                "type": "Radio",
+                                "id": "confirm-turnover-answer",
+                                "q_code": "d40",
+                                "options": [{
+                                        "label": "Yes this is correct",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No I need to change this",
+                                        "value": "No"
+                                    }
+                                ],
+                                "mandatory": true
+                            }],
+                            "id": "confirm-turnover-question",
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "value": "No",
+                                        "id": "confirm-turnover-answer",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "turnover-block"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "changes-in-total-turnover-block"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "changes-in-total-turnover-block",
+                        "type": "Question",
+                        "questions": [{
+                            "title": "Did any significant changes occur to the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                            "id": "changes-in-total-turnover-question",
+                            "definitions": [{
+                                "title": "What constitutes a significant change?",
+                                "content": [{
+                                        "description": "What constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s figures from the previous reporting period and the same reporting period last year."
+                                    },
+                                    {
+                                        "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                                    }
+                                ]
+                            }],
+                            "answers": [{
+                                "options": [{
+                                        "value": "Yes",
+                                        "label": "Yes"
+                                    },
+                                    {
+                                        "value": "No",
+                                        "label": "No"
+                                    }
+                                ],
+                                "id": "changes-in-total-turnover-answer",
+                                "type": "Radio",
+                                "q_code": "146",
+                                "mandatory": true
+                            }],
+                            "guidance": {
+                                "content": [{
+                                    "title": "Include",
+                                    "list": [
+                                        "change in level of business activity",
+                                        "maintenance/shutdowns",
+                                        "special/calendar events",
+                                        "weather",
+                                        "price effects",
+                                        "currency effects (increase/decrease in the currency value)"
+                                    ]
+                                }]
+                            },
+                            "type": "General"
+                        }],
+                        "title": "Changes in total turnover",
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "id": "changes-in-total-turnover-answer",
+                                        "value": "Yes",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "changes-in-total-turnover-block-2"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "group": "summary-group"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "changes-in-total-turnover-block-2",
+                        "type": "Question",
+                        "questions": [{
+                            "title": "Please indicate the reasons for any changes in the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
+                            "answers": [{
+                                "options": [{
+                                        "q_code": "146a",
+                                        "value": "Change in level of business activity",
+                                        "label": "Change in level of business activity"
+                                    },
+                                    {
+                                        "q_code": "146b",
+                                        "value": "Maintenance/shutdowns",
+                                        "label": "Maintenance/shutdowns"
+                                    },
+                                    {
+                                        "q_code": "146c",
+                                        "value": "Special/calendar events",
+                                        "label": "Special/calendar events"
+                                    },
+                                    {
+                                        "q_code": "146d",
+                                        "value": "Weather",
+                                        "label": "Weather"
+                                    },
+                                    {
+                                        "q_code": "146e",
+                                        "value": "Price effects",
+                                        "label": "Price effects"
+                                    },
+                                    {
+                                        "q_code": "146f",
+                                        "value": "Currency effects (increase/decrease in the currency value)",
+                                        "label": "Currency effects (increase/decrease in the currency value)"
+                                    },
+                                    {
+                                        "q_code": "146g",
+                                        "value": "Other",
+                                        "label": "Other"
+                                    }
+                                ],
+                                "id": "changes-in-total-turnover-answer-2",
+                                "type": "Checkbox",
+                                "mandatory": true
+                            }],
+                            "type": "General",
+                            "id": "changes-in-total-turnover-question-2"
+                        }],
+                        "title": "Changes in total turnover"
+                    },
+                    {
+                        "type": "Question",
+                        "id": "changes-in-total-turnover-block-3",
+                        "title": "Changes in total turnover",
+                        "questions": [{
+                            "type": "General",
+                            "id": "changes-in-total-turnover-question-3",
+                            "title": "Please describe the changes in total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
+                            "answers": [{
+                                "guidance": {
+                                    "hide_guidance": "Hide examples of commentary on changes to turnover",
+                                    "show_guidance": "Show examples of commentary on changes to turnover",
+                                    "content": [{
+                                            "list": [],
+                                            "title": "‘Change in level of business activity’",
+                                            "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
+                                        },
                                         {
-                                            "list": [
-                                                "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
-                                                "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"
-                                            ]
+                                            "list": [],
+                                            "title": "‘Maintenance/shutdowns’",
+                                            "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
+                                        },
+                                        {
+                                            "list": [],
+                                            "title": "‘Special/calendar events’",
+                                            "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
+                                        },
+                                        {
+                                            "list": [],
+                                            "title": "‘Weather’",
+                                            "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
+                                        },
+                                        {
+                                            "list": [],
+                                            "title": "‘Price effects’",
+                                            "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
+                                        },
+                                        {
+                                            "list": [],
+                                            "title": "‘Currency effects (increase/decrease in the currency value)’",
+                                            "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
                                         }
                                     ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "reporting-period-block",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "answers": [
-                                        {
-                                            "options": [
-                                                {
-                                                    "value": "Yes",
-                                                    "label": "Yes"
-                                                },
-                                                {
-                                                    "value": "No",
-                                                    "label": "No"
-                                                }
-                                            ],
-                                            "id": "reporting-period-answer",
-                                            "type": "Radio",
-                                            "q_code": "d12",
-                                            "mandatory": true
-                                        }
-                                    ],
-                                    "type": "General",
-                                    "id": "reporting-period-question",
-                                    "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "when": [
-                                            {
-                                                "id": "reporting-period-answer",
-                                                "value": "Yes",
-                                                "condition": "equals"
-                                            }
-                                        ],
-                                        "block": "turnover-block"
-                                    }
                                 },
-                                {
-                                    "goto": {
-                                        "block": "reporting-period-block-2"
-                                    }
-                                }
-                            ],
-                            "title": "Reporting period"
-                        },
-                        {
-                            "type": "Question",
-                            "id": "reporting-period-block-2",
-                            "title": "Reporting period",
-                            "questions": [
-                                {
-                                    "type": "DateRange",
-                                    "id": "reporting-period-question-2",
-                                    "title": "What are the dates of the period that you will be reporting for?",
-                                    "period_limits": {
-                                        "minimum": {
-                                            "days": 10
-                                        },
-                                        "maximum": {
-                                            "days": 50
-                                        }
-                                    },
-                                    "answers": [
-                                        {
-                                            "type": "Date",
-                                            "id": "period-from",
-                                            "label": "From",
-                                            "mandatory": true,
-                                            "q_code": "11",
-                                            "minimum": {
-                                                "meta": "ref_p_start_date",
-                                                "offset_by": {
-                                                    "days": -19
-                                                }
-                                            }
-                                        },
-                                        {
-                                            "type": "Date",
-                                            "id": "period-to",
-                                            "label": "To",
-                                            "mandatory": true,
-                                            "q_code": "12",
-                                            "maximum": {
-                                                "meta": "ref_p_end_date",
-                                                "offset_by": {
-                                                    "days": 20
-                                                }
-                                            }
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "turnover-block",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "guidance": {
-                                        "content": [
-                                            {
-                                                "title": "Include:",
-                                                "list": [
-                                                    "exports",
-                                                    "payments for work in progress",
-                                                    "costs incurred and passed on to customers",
-                                                    "income from sub-contracted activities",
-                                                    "commission",
-                                                    "sales of goods purchased for resale",
-                                                    "revenue earned from other parts of the business not named (please supply at fair value)"
-                                                ]
-                                            },
-                                            {
-                                                "title": "Exclude:",
-                                                "list": [
-                                                    "VAT",
-                                                    "excise duties",
-                                                    "income from the sale of fixed capital assets",
-                                                    "grants and subsidies",
-                                                    "insurance claims",
-                                                    "interest received"
-                                                ]
-                                            }
-                                        ]
-                                    },
-                                    "id": "turnover-question",
-                                    "answers": [
-                                        {
-                                            "id": "turnover-answer",
-                                            "label": "Total turnover excluding VAT",
-                                            "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
-                                            "type": "Currency",
-                                            "currency": "GBP",
-                                            "decimal_places": 2,
-                                            "q_code": "40",
-                                            "mandatory": true
-                                        }
-                                    ],
-                                    "type": "General",
-                                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s <em>total turnover</em>, excluding VAT?"
-                                }
-                            ],
-                            "title": "Total turnover"
-                        },
-                        {
-                            "type": "ConfirmationQuestion",
-                            "title": "Total turnover",
-                            "id": "confirm-turnover-block",
-                            "questions": [
-                                {
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "type": "Radio",
-                                            "id": "confirm-turnover-answer",
-                                            "q_code": "d40",
-                                            "options": [
-                                                {
-                                                    "label": "Yes this is correct",
-                                                    "value": "Yes"
-                                                },
-                                                {
-                                                    "label": "No I need to change this",
-                                                    "value": "No"
-                                                }
-                                            ],
-                                            "mandatory": true
-                                        }
-                                    ],
-                                    "id": "confirm-turnover-question",
-                                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "when": [
-                                            {
-                                                "value": "No",
-                                                "id": "confirm-turnover-answer",
-                                                "condition": "equals"
-                                            }
-                                        ],
-                                        "block": "turnover-block"
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "changes-in-total-turnover-block"
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "id": "changes-in-total-turnover-block",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "title": "Did any significant changes occur to the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
-                                    "id": "changes-in-total-turnover-question",
-                                    "definitions": [
-                                        {
-                                            "title": "What constitutes a significant change?",
-                                            "content": [
-                                                {
-                                                    "description": "What constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s figures from the previous reporting period and the same reporting period last year."
-                                                },
-                                                {
-                                                    "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
-                                                }
-                                            ]
-                                        }
-                                    ],
-                                    "answers": [
-                                        {
-                                            "options": [
-                                                {
-                                                    "value": "Yes",
-                                                    "label": "Yes"
-                                                },
-                                                {
-                                                    "value": "No",
-                                                    "label": "No"
-                                                }
-                                            ],
-                                            "id": "changes-in-total-turnover-answer",
-                                            "type": "Radio",
-                                            "q_code": "146",
-                                            "mandatory": true
-                                        }
-                                    ],
-                                    "guidance": {
-                                        "content": [
-                                            {
-                                                "title": "Include",
-                                                "list": [
-                                                    "change in level of business activity",
-                                                    "maintenance/shutdowns",
-                                                    "special/calendar events",
-                                                    "weather",
-                                                    "price effects",
-                                                    "currency effects (increase/decrease in the currency value)"
-                                                ]
-                                            }
-                                        ]
-                                    },
-                                    "type": "General"
-                                }
-                            ],
-                            "title": "Changes in total turnover",
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "when": [
-                                            {
-                                                "id": "changes-in-total-turnover-answer",
-                                                "value": "Yes",
-                                                "condition": "equals"
-                                            }
-                                        ],
-                                        "block": "changes-in-total-turnover-block-2"
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "group": "summary-group"
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "id": "changes-in-total-turnover-block-2",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "title": "Please indicate the reasons for any changes in the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
-                                    "answers": [
-                                        {
-                                            "options": [
-                                                {
-                                                    "q_code": "146a",
-                                                    "value": "Change in level of business activity",
-                                                    "label": "Change in level of business activity"
-                                                },
-                                                {
-                                                    "q_code": "146b",
-                                                    "value": "Maintenance/shutdowns",
-                                                    "label": "Maintenance/shutdowns"
-                                                },
-                                                {
-                                                    "q_code": "146c",
-                                                    "value": "Special/calendar events",
-                                                    "label": "Special/calendar events"
-                                                },
-                                                {
-                                                    "q_code": "146d",
-                                                    "value": "Weather",
-                                                    "label": "Weather"
-                                                },
-                                                {
-                                                    "q_code": "146e",
-                                                    "value": "Price effects",
-                                                    "label": "Price effects"
-                                                },
-                                                {
-                                                    "q_code": "146f",
-                                                    "value": "Currency effects (increase/decrease in the currency value)",
-                                                    "label": "Currency effects (increase/decrease in the currency value)"
-                                                },
-                                                {
-                                                    "q_code": "146g",
-                                                    "value": "Other",
-                                                    "label": "Other"
-                                                }
-                                            ],
-                                            "id": "changes-in-total-turnover-answer-2",
-                                            "type": "Checkbox",
-                                            "mandatory": true
-                                        }
-                                    ],
-                                    "type": "General",
-                                    "id": "changes-in-total-turnover-question-2"
-                                }
-                            ],
-                            "title": "Changes in total turnover"
-                        },
-                        {
-                            "type": "Question",
-                            "id": "changes-in-total-turnover-block-3",
-                            "title": "Changes in total turnover",
-                            "questions": [
-                                {
-                                    "type": "General",
-                                    "id": "changes-in-total-turnover-question-3",
-                                    "title": "Please describe the changes in total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
-                                    "answers": [
-                                        {
-                                            "guidance": {
-                                                "hide_guidance": "Hide examples of commentary on changes to turnover",
-                                                "show_guidance": "Show examples of commentary on changes to turnover",
-                                                "content": [
-                                                    {
-                                                        "list": [],
-                                                        "title": "‘Change in level of business activity’",
-                                                        "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
-                                                    },
-                                                    {
-                                                        "list": [],
-                                                        "title": "‘Maintenance/shutdowns’",
-                                                        "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
-                                                    },
-                                                    {
-                                                        "list": [],
-                                                        "title": "‘Special/calendar events’",
-                                                        "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
-                                                    },
-                                                    {
-                                                        "list": [],
-                                                        "title": "‘Weather’",
-                                                        "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
-                                                    },
-                                                    {
-                                                        "list": [],
-                                                        "title": "‘Price effects’",
-                                                        "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
-                                                    },
-                                                    {
-                                                        "list": [],
-                                                        "title": "‘Currency effects (increase/decrease in the currency value)’",
-                                                        "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
-                                                    }
-                                                ]
-                                            },
-                                            "type": "TextArea",
-                                            "mandatory": true,
-                                            "label": "Comments",
-                                            "id": "changes-in-total-turnover-answer-3",
-                                            "q_code": "146h"
-                                        }
-                                    ],
-                                    "description": "<p>We rely on your commentary to ‘tell the story’ behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ]
+                                "type": "TextArea",
+                                "mandatory": true,
+                                "label": "Comments",
+                                "id": "changes-in-total-turnover-answer-3",
+                                "q_code": "146h"
+                            }],
+                            "description": "<p>We rely on your commentary to ‘tell the story’ behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
+                        }]
+                    }
+                ]
+            }]
         },
         {
             "id": "summary-section",
             "title": "Summary",
-            "groups": [
-                {
-                    "id": "summary-group",
-                    "title": "Summary",
-                    "blocks": [
-                        {
-                            "type": "Summary",
-                            "id": "summary"
-                        }
-                    ]
-                }
-            ]
+            "groups": [{
+                "id": "summary-group",
+                "title": "Summary",
+                "blocks": [{
+                    "type": "Summary",
+                    "id": "summary"
+                }]
+            }]
         }
     ]
 }

--- a/data/en/mbs_0106_prototype.json
+++ b/data/en/mbs_0106_prototype.json
@@ -1,0 +1,373 @@
+{
+    "title": "Monthly Business Survey",
+    "survey_id": "009",
+    "mime_type": "application/json/ons/eq",
+    "theme": "default",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.1",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
+    "description": "mbs_0106",
+    "view_submitted_response": {
+        "enabled": true,
+        "duration": 900
+    },
+    "metadata": [{
+        "name": "user_id",
+        "validator": "string"
+    }, {
+        "name": "period_id",
+        "validator": "string"
+    }, {
+        "name": "ru_name",
+        "validator": "string"
+    }, {
+        "name": "ref_p_start_date",
+        "validator": "date"
+    }, {
+        "name": "ref_p_end_date",
+        "validator": "date"
+    }, {
+        "name": "trad_as",
+        "validator": "optional_string"
+    }],
+    "sections": [{
+        "id": "section",
+        "groups": [{
+            "id": "group",
+            "title": "",
+            "blocks": [{
+                "type": "Introduction",
+                "id": "introduction",
+                "primary_content": [{
+                    "type": "Basic",
+                    "id": "use-of-information",
+                    "content": [{
+                        "list": ["Data should relate to all sites in England, Scotland and Wales unless otherwise stated.", "You can provide informed estimates if actual figures aren\u2019t available.", "We will treat your data securely and confidentially."]
+                    }]
+                }],
+                "preview_content": {
+                    "id": "preview",
+                    "title": "Information you need",
+                    "content": [{
+                        "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
+                    }],
+                    "questions": [{
+                        "question": "Total Turnover",
+                        "content": [{
+                            "description": "Include:",
+                            "list": ["exports", "payments for work in progress", "costs incurred and passed on to customers", "income from sub-contracted activities", "commission", "sales of goods purchased for resale", "revenue earned from other parts of the business not named (please supply at fair value)"]
+                        }, {
+                            "description": "Exclude:",
+                            "list": ["VAT", "excise duties", "income from the sale of fixed capital assets", "grants and subsidies", "insurance claims", "interest received"]
+                        }]
+                    }, {
+                        "question": "Changes in total turnover",
+                        "content": [{
+                            "description": "Include:",
+                            "list": ["change in level of business activity", "maintenance/shutdowns", "special/calendar events", "weather", "price effects", "currency effects (increase/decrease in the currency value)"]
+                        }]
+                    }]
+                },
+                "secondary_content": [{
+                    "id": "how-we-use-your-data",
+                    "title": "How we use your data",
+                    "content": [{
+                        "list": ["You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.", "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"]
+                    }]
+                }]
+            }, {
+                "id": "reporting-period-block",
+                "type": "Question",
+                "questions": [{
+                    "answers": [{
+                        "options": [{
+                            "value": "Yes",
+                            "label": "Yes"
+                        }, {
+                            "value": "No",
+                            "label": "No"
+                        }],
+                        "id": "reporting-period-answer",
+                        "type": "Radio",
+                        "q_code": "d12",
+                        "mandatory": true
+                    }],
+                    "type": "General",
+                    "id": "reporting-period-question",
+                    "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
+                }],
+                "routing_rules": [{
+                    "goto": {
+                        "when": [{
+                            "id": "reporting-period-answer",
+                            "value": "Yes",
+                            "condition": "equals"
+                        }],
+                        "block": "turnover-block"
+                    }
+                }, {
+                    "goto": {
+                        "block": "reporting-period-block-2"
+                    }
+                }],
+                "title": "Reporting period"
+            }, {
+                "type": "Question",
+                "id": "reporting-period-block-2",
+                "title": "Reporting period",
+                "questions": [{
+                    "type": "DateRange",
+                    "id": "reporting-period-question-2",
+                    "title": "What are the dates of the period that you will be reporting for?",
+                    "period_limits": {
+                        "minimum": {
+                            "days": 10
+                        },
+                        "maximum": {
+                            "days": 50
+                        }
+                    },
+                    "answers": [{
+                        "type": "Date",
+                        "id": "period-from",
+                        "label": "From",
+                        "mandatory": true,
+                        "q_code": "11",
+                        "minimum": {
+                            "meta": "ref_p_start_date",
+                            "offset_by": {
+                                "days": -19
+                            }
+                        }
+                    }, {
+                        "type": "Date",
+                        "id": "period-to",
+                        "label": "To",
+                        "mandatory": true,
+                        "q_code": "12",
+                        "maximum": {
+                            "meta": "ref_p_end_date",
+                            "offset_by": {
+                                "days": 20
+                            }
+                        }
+                    }]
+                }]
+            }, {
+                "id": "turnover-block",
+                "type": "Question",
+                "questions": [{
+                    "guidance": {
+                        "content": [{
+                            "title": "Include:",
+                            "list": ["exports", "payments for work in progress", "costs incurred and passed on to customers", "income from sub-contracted activities", "commission", "sales of goods purchased for resale", "revenue earned from other parts of the business not named (please supply at fair value)"]
+                        }, {
+                            "title": "Exclude:",
+                            "list": ["VAT", "excise duties", "income from the sale of fixed capital assets", "grants and subsidies", "insurance claims", "interest received"]
+                        }]
+                    },
+                    "id": "turnover-question",
+                    "answers": [{
+                        "id": "turnover-answer",
+                        "label": "Total turnover excluding VAT",
+                        "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                        "type": "Currency",
+                        "currency": "GBP",
+                        "decimal_places": 2,
+                        "q_code": "40",
+                        "mandatory": true
+                    }],
+                    "type": "General",
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>total turnover</em>, excluding VAT?"
+                }],
+                "title": "Total turnover"
+            }, {
+                "type": "ConfirmationQuestion",
+                "title": "Total turnover",
+                "id": "confirm-turnover-block",
+                "questions": [{
+                    "type": "General",
+                    "answers": [{
+                        "type": "Radio",
+                        "id": "confirm-turnover-answer",
+                        "q_code": "d40",
+                        "options": [{
+                            "label": "Yes this is correct",
+                            "value": "Yes"
+                        }, {
+                            "label": "No I need to change this",
+                            "value": "No"
+                        }],
+                        "mandatory": true
+                    }],
+                    "id": "confirm-turnover-question",
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
+                }],
+                "routing_rules": [{
+                    "goto": {
+                        "when": [{
+                            "value": "No",
+                            "id": "confirm-turnover-answer",
+                            "condition": "equals"
+                        }],
+                        "block": "turnover-block"
+                    }
+                }, {
+                    "goto": {
+                        "block": "changes-in-total-turnover-block"
+                    }
+                }]
+            }, {
+                "id": "changes-in-total-turnover-block",
+                "type": "Question",
+                "questions": [{
+                    "title": "Did any significant changes occur to the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                    "id": "changes-in-total-turnover-question",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
+                        }, {
+                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }]
+                    }],
+                    "answers": [{
+                        "options": [{
+                            "value": "Yes",
+                            "label": "Yes"
+                        }, {
+                            "value": "No",
+                            "label": "No"
+                        }],
+                        "id": "changes-in-total-turnover-answer",
+                        "type": "Radio",
+                        "q_code": "146",
+                        "mandatory": true
+                    }],
+                    "guidance": {
+                        "content": [{
+                            "title": "Include",
+                            "list": ["change in level of business activity", "maintenance/shutdowns", "special/calendar events", "weather", "price effects", "currency effects (increase/decrease in the currency value)"]
+                        }]
+                    },
+                    "type": "General"
+                }],
+                "title": "Changes in total turnover",
+                "routing_rules": [{
+                    "goto": {
+                        "when": [{
+                            "id": "changes-in-total-turnover-answer",
+                            "value": "Yes",
+                            "condition": "equals"
+                        }],
+                        "block": "changes-in-total-turnover-block-2"
+                    }
+                }, {
+                    "goto": {
+                        "group": "summary-group"
+                    }
+                }]
+            }, {
+                "id": "changes-in-total-turnover-block-2",
+                "type": "Question",
+                "questions": [{
+                    "title": "Please indicate the reasons for any changes in the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
+                    "answers": [{
+                        "options": [{
+                            "q_code": "146a",
+                            "value": "Change in level of business activity",
+                            "label": "Change in level of business activity"
+                        }, {
+                            "q_code": "146b",
+                            "value": "Maintenance/shutdowns",
+                            "label": "Maintenance/shutdowns"
+                        }, {
+                            "q_code": "146c",
+                            "value": "Special/calendar events",
+                            "label": "Special/calendar events"
+                        }, {
+                            "q_code": "146d",
+                            "value": "Weather",
+                            "label": "Weather"
+                        }, {
+                            "q_code": "146e",
+                            "value": "Price effects",
+                            "label": "Price effects"
+                        }, {
+                            "q_code": "146f",
+                            "value": "Currency effects (increase/decrease in the currency value)",
+                            "label": "Currency effects (increase/decrease in the currency value)"
+                        }, {
+                            "q_code": "146g",
+                            "value": "Other",
+                            "label": "Other"
+                        }],
+                        "id": "changes-in-total-turnover-answer-2",
+                        "type": "Checkbox",
+                        "mandatory": true
+                    }],
+                    "type": "General",
+                    "id": "changes-in-total-turnover-question-2"
+                }],
+                "title": "Changes in total turnover"
+            }, {
+                "type": "Question",
+                "id": "changes-in-total-turnover-block-3",
+                "title": "Changes in total turnover",
+                "questions": [{
+                    "type": "General",
+                    "id": "changes-in-total-turnover-question-3",
+                    "title": "Please describe the changes in total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
+                    "answers": [{
+                        "guidance": {
+                            "hide_guidance": "Hide examples of commentary on changes to turnover",
+                            "show_guidance": "Show examples of commentary on changes to turnover",
+                            "content": [{
+                                "list": [],
+                                "title": "\u2018Change in level of business activity\u2019",
+                                "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
+                            }, {
+                                "list": [],
+                                "title": "\u2018Maintenance/shutdowns\u2019",
+                                "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
+                            }, {
+                                "list": [],
+                                "title": "\u2018Special/calendar events\u2019",
+                                "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
+                            }, {
+                                "list": [],
+                                "title": "\u2018Weather\u2019",
+                                "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
+                            }, {
+                                "list": [],
+                                "title": "\u2018Price effects\u2019",
+                                "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
+                            }, {
+                                "list": [],
+                                "title": "\u2018Currency effects (increase/decrease in the currency value)\u2019",
+                                "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
+                            }]
+                        },
+                        "type": "TextArea",
+                        "mandatory": true,
+                        "label": "Comments",
+                        "id": "changes-in-total-turnover-answer-3",
+                        "q_code": "146h"
+                    }],
+                    "description": "<p>We rely on your commentary to \u2018tell the story\u2019 behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
+                }]
+            }]
+        }]
+    }, {
+        "id": "summary-section",
+        "title": "Summary",
+        "groups": [{
+            "id": "summary-group",
+            "title": "Summary",
+            "blocks": [{
+                "type": "Summary",
+                "id": "summary"
+            }]
+        }]
+    }]
+}

--- a/data/en/mbs_0111.json
+++ b/data/en/mbs_0111.json
@@ -13,363 +13,533 @@
         "enabled": true,
         "duration": 900
     },
-    "metadata": [{
-        "name": "user_id",
-        "validator": "string"
-    }, {
-        "name": "period_id",
-        "validator": "string"
-    }, {
-        "name": "ru_name",
-        "validator": "string"
-    }, {
-        "name": "ref_p_start_date",
-        "validator": "date"
-    }, {
-        "name": "ref_p_end_date",
-        "validator": "date"
-    }, {
-        "name": "trad_as",
-        "validator": "optional_string"
-    }],
-    "sections": [{
-        "id": "section",
-        "groups": [{
-            "id": "group",
-            "title": "",
-            "blocks": [{
-                "type": "Introduction",
-                "id": "introduction",
-                "primary_content": [{
-                    "type": "Basic",
-                    "id": "use-of-information",
-                    "content": [{
-                        "list": ["Data should relate to all sites in England, Scotland and Wales unless otherwise stated.", "You can provide informed estimates if actual figures aren\u2019t available.", "We will treat your data securely and confidentially."]
-                    }]
-                }],
-                "preview_content": {
-                    "id": "preview",
-                    "title": "Information you need",
-                    "content": [{
-                        "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
-                    }],
-                    "questions": [{
-                        "question": "Total Turnover",
-                        "content": [{
-                            "description": "Include:",
-                            "list": ["exports", "payments for work in progress", "costs incurred and passed on to customers", "income from sub-contracted activities", "commission", "sales of goods purchased for resale", "revenue earned from other parts of the business not named (please supply at fair value)"]
-                        }, {
-                            "description": "Exclude:",
-                            "list": ["VAT", "income from the sale of fixed capital assets", "grants and subsidies", "insurance claims", "interest received"]
-                        }]
-                    }, {
-                        "question": "Changes in total turnover",
-                        "content": [{
-                            "description": "Include:",
-                            "list": ["change in level of business activity", "maintenance/shutdowns", "special/calendar events", "weather", "price effects", "currency effects (increase/decrease in the currency value)"]
-                        }]
-                    }]
-                },
-                "secondary_content": [{
-                    "id": "how-we-use-your-data",
-                    "title": "How we use your data",
-                    "content": [{
-                        "list": ["You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.", "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"]
-                    }]
-                }]
-            }, {
-                "id": "reporting-period-block",
-                "type": "Question",
-                "questions": [{
-                    "answers": [{
-                        "options": [{
-                            "value": "Yes",
-                            "label": "Yes"
-                        }, {
-                            "value": "No",
-                            "label": "No"
-                        }],
-                        "id": "reporting-period-answer",
-                        "type": "Radio",
-                        "q_code": "d12",
-                        "mandatory": true
-                    }],
-                    "type": "General",
-                    "id": "reporting-period-question",
-                    "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
-                }],
-                "routing_rules": [{
-                    "goto": {
-                        "when": [{
-                            "id": "reporting-period-answer",
-                            "value": "Yes",
-                            "condition": "equals"
-                        }],
-                        "block": "turnover-block"
-                    }
-                }, {
-                    "goto": {
-                        "block": "reporting-period-block-2"
-                    }
-                }],
-                "title": "Reporting period"
-            }, {
-                "type": "Question",
-                "id": "reporting-period-block-2",
-                "title": "Reporting period",
-                "questions": [{
-                    "type": "DateRange",
-                    "id": "reporting-period-question-2",
-                    "title": "What are the dates of the period that you will be reporting for?",
-                    "period_limits": {
-                        "minimum": {
-                            "days": 10
+    "metadata": [
+        {
+            "name": "user_id",
+            "validator": "string"
+        },
+        {
+            "name": "period_id",
+            "validator": "string"
+        },
+        {
+            "name": "ru_name",
+            "validator": "string"
+        },
+        {
+            "name": "ref_p_start_date",
+            "validator": "date"
+        },
+        {
+            "name": "ref_p_end_date",
+            "validator": "date"
+        },
+        {
+            "name": "trad_as",
+            "validator": "optional_string"
+        }
+    ],
+    "sections": [
+        {
+            "id": "section",
+            "groups": [
+                {
+                    "id": "group",
+                    "title": "",
+                    "blocks": [
+                        {
+                            "type": "Introduction",
+                            "id": "introduction",
+                            "primary_content": [
+                                {
+                                    "type": "Basic",
+                                    "id": "use-of-information",
+                                    "content": [
+                                        {
+                                            "list": [
+                                                "Data should relate to all sites in England, Scotland and Wales unless otherwise stated.",
+                                                "You can provide informed estimates if actual figures aren’t available.",
+                                                "We will treat your data securely and confidentially."
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "preview_content": {
+                                "id": "preview",
+                                "title": "Information you need",
+                                "content": [
+                                    {
+                                        "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
+                                    }
+                                ],
+                                "questions": [
+                                    {
+                                        "question": "Total Turnover",
+                                        "content": [
+                                            {
+                                                "description": "Include:",
+                                                "list": [
+                                                    "exports",
+                                                    "payments for work in progress",
+                                                    "costs incurred and passed on to customers",
+                                                    "income from sub-contracted activities",
+                                                    "commission",
+                                                    "sales of goods purchased for resale",
+                                                    "revenue earned from other parts of the business not named (please supply at fair value)"
+                                                ]
+                                            },
+                                            {
+                                                "description": "Exclude:",
+                                                "list": [
+                                                    "VAT",
+                                                    "income from the sale of fixed capital assets",
+                                                    "grants and subsidies",
+                                                    "insurance claims",
+                                                    "interest received"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "question": "Changes in total turnover",
+                                        "content": [
+                                            {
+                                                "description": "Include:",
+                                                "list": [
+                                                    "change in level of business activity",
+                                                    "maintenance/shutdowns",
+                                                    "special/calendar events",
+                                                    "weather",
+                                                    "price effects",
+                                                    "currency effects (increase/decrease in the currency value)"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "secondary_content": [
+                                {
+                                    "id": "how-we-use-your-data",
+                                    "title": "How we use your data",
+                                    "content": [
+                                        {
+                                            "list": [
+                                                "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
+                                                "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
                         },
-                        "maximum": {
-                            "days": 50
-                        }
-                    },
-                    "answers": [{
-                        "type": "Date",
-                        "id": "period-from",
-                        "label": "From",
-                        "mandatory": true,
-                        "q_code": "11",
-                        "minimum": {
-                            "meta": "ref_p_start_date",
-                            "offset_by": {
-                                "days": -19
-                            }
-                        }
-                    }, {
-                        "type": "Date",
-                        "id": "period-to",
-                        "label": "To",
-                        "mandatory": true,
-                        "q_code": "12",
-                        "maximum": {
-                            "meta": "ref_p_end_date",
-                            "offset_by": {
-                                "days": 20
-                            }
-                        }
-                    }]
-                }]
-            }, {
-                "id": "turnover-block",
-                "type": "Question",
-                "questions": [{
-                    "guidance": {
-                        "content": [{
-                            "title": "Include:",
-                            "list": ["exports", "payments for work in progress", "costs incurred and passed on to customers", "income from sub-contracted activities", "commission", "sales of goods purchased for resale", "revenue earned from other parts of the business not named (please supply at fair value)"]
-                        }, {
-                            "title": "Exclude:",
-                            "list": ["VAT", "income from the sale of fixed capital assets", "grants and subsidies", "insurance claims", "interest received"]
-                        }]
-                    },
-                    "id": "turnover-question",
-                    "answers": [{
-                        "id": "turnover-answer",
-                        "label": "Total turnover excluding VAT",
-                        "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
-                        "type": "Currency",
-                        "currency": "GBP",
-                        "decimal_places": 2,
-                        "q_code": "40",
-                        "mandatory": true
-                    }],
-                    "type": "General",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>total turnover</em>, excluding VAT?"
-                }],
-                "title": "Total Turnover"
-            }, {
-                "type": "ConfirmationQuestion",
-                "title": "Total turnover",
-                "id": "confirm-turnover-block",
-                "questions": [{
-                    "type": "General",
-                    "answers": [{
-                        "type": "Radio",
-                        "id": "confirm-turnover-answer",
-                        "q_code": "d40",
-                        "options": [{
-                            "label": "Yes this is correct",
-                            "value": "Yes"
-                        }, {
-                            "label": "No I need to change this",
-                            "value": "No"
-                        }],
-                        "mandatory": true
-                    }],
-                    "id": "confirm-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
-                }],
-                "routing_rules": [{
-                    "goto": {
-                        "when": [{
-                            "value": "No",
-                            "id": "confirm-turnover-answer",
-                            "condition": "equals"
-                        }],
-                        "block": "turnover-block"
-                    }
-                }, {
-                    "goto": {
-                        "block": "changes-in-turnover-block"
-                    }
-                }]
-            }, {
-                "id": "changes-in-turnover-block",
-                "type": "Question",
-                "questions": [{
-                    "title": "Did any significant changes occur to the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
-                    "id": "changes-in-turnover-question",
-                    "definitions": [{
-                        "title": "What constitutes a significant change?",
-                        "content": [{
-                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
-                        }, {
-                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
-                        }]
-                    }],
-                    "answers": [{
-                        "options": [{
-                            "value": "Yes",
-                            "label": "Yes"
-                        }, {
-                            "value": "No",
-                            "label": "No"
-                        }],
-                        "id": "changes-in-turnover-answer",
-                        "type": "Radio",
-                        "q_code": "146",
-                        "mandatory": false
-                    }],
-                    "guidance": {
-                        "content": [{
-                            "title": "Include",
-                            "list": ["change in level of business activity", "maintenance/shutdowns", "special/calendar events", "weather", "price effects", "currency effects (increase/decrease in the currency value)"]
-                        }]
-                    },
-                    "type": "General"
-                }],
-                "title": "Changes in total turnover",
-                "routing_rules": [{
-                    "goto": {
-                        "when": [{
-                            "id": "changes-in-turnover-answer",
-                            "value": "Yes",
-                            "condition": "equals"
-                        }],
-                        "block": "changes-in-turnover-block-2"
-                    }
-                }, {
-                    "goto": {
-                        "group": "summary-group"
-                    }
-                }]
-            }, {
-                "id": "changes-in-turnover-block-2",
-                "type": "Question",
-                "questions": [{
-                    "title": "Please indicate the reasons for any changes in the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
-                    "answers": [{
-                        "options": [{
-                            "q_code": "146a",
-                            "value": "Change in level of business activity",
-                            "label": "Change in level of business activity"
-                        }, {
-                            "q_code": "146b",
-                            "value": "Maintenance/shutdowns",
-                            "label": "Maintenance/shutdowns"
-                        }, {
-                            "q_code": "146c",
-                            "value": "Special/calendar events",
-                            "label": "Special/calendar events"
-                        }, {
-                            "q_code": "146d",
-                            "value": "Weather",
-                            "label": "Weather"
-                        }, {
-                            "q_code": "146e",
-                            "value": "Price effects",
-                            "label": "Price effects"
-                        }, {
-                            "q_code": "146f",
-                            "value": "Currency effects (increase/decrease in the currency value)",
-                            "label": "Currency effects (increase/decrease in the currency value)"
-                        }, {
-                            "q_code": "146g",
-                            "value": "Other",
-                            "label": "Other"
-                        }],
-                        "id": "changes-in-turnover-answer-2",
-                        "type": "Checkbox",
-                        "mandatory": false
-                    }],
-                    "type": "General",
-                    "id": "changes-in-turnover-question-2"
-                }],
-                "title": "Changes in total turnover"
-            }, {
-                "type": "Question",
-                "id": "changes-in-turnover-block-3",
-                "title": "Changes in total turnover",
-                "questions": [{
-                    "type": "General",
-                    "id": "changes-in-turnover-question-3",
-                    "title": "Please describe the changes in total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
-                    "answers": [{
-                        "guidance": {
-                            "hide_guidance": "Hide examples of commentary on changes to total turnover",
-                            "show_guidance": "Show examples of commentary on changes to total turnover",
-                            "content": [{
-                                "list": [],
-                                "title": "\u2018Change in level of business activity\u2019",
-                                "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
-                            }, {
-                                "list": [],
-                                "title": "\u2018Maintenance/shutdowns\u2019",
-                                "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
-                            }, {
-                                "list": [],
-                                "title": "\u2018Special/calendar events\u2019",
-                                "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
-                            }, {
-                                "list": [],
-                                "title": "\u2018Weather\u2019",
-                                "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
-                            }, {
-                                "list": [],
-                                "title": "\u2018Price effects\u2019",
-                                "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
-                            }, {
-                                "list": [],
-                                "title": "\u2018Currency effects (increase/decrease in the currency value)\u2019",
-                                "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
-                            }]
+                        {
+                            "id": "reporting-period-block",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "options": [
+                                                {
+                                                    "value": "Yes",
+                                                    "label": "Yes"
+                                                },
+                                                {
+                                                    "value": "No",
+                                                    "label": "No"
+                                                }
+                                            ],
+                                            "id": "reporting-period-answer",
+                                            "type": "Radio",
+                                            "q_code": "d12",
+                                            "mandatory": true
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "id": "reporting-period-question",
+                                    "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "when": [
+                                            {
+                                                "id": "reporting-period-answer",
+                                                "value": "Yes",
+                                                "condition": "equals"
+                                            }
+                                        ],
+                                        "block": "turnover-block"
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "reporting-period-block-2"
+                                    }
+                                }
+                            ],
+                            "title": "Reporting period"
                         },
-                        "type": "TextArea",
-                        "mandatory": true,
-                        "label": "Comments",
-                        "id": "changes-in-turnover-answer-3",
-                        "q_code": "146h"
-                    }],
-                    "description": "<p>We rely on your commentary to \u2018tell the story\u2019 behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
-                }]
-            }]
-        }]
-    }, {
-        "id": "summary-section",
-        "title": "Summary",
-        "groups": [{
-            "id": "summary-group",
+                        {
+                            "type": "Question",
+                            "id": "reporting-period-block-2",
+                            "title": "Reporting period",
+                            "questions": [
+                                {
+                                    "type": "DateRange",
+                                    "id": "reporting-period-question-2",
+                                    "title": "What are the dates of the period that you will be reporting for?",
+                                    "period_limits": {
+                                        "minimum": {
+                                            "days": 10
+                                        },
+                                        "maximum": {
+                                            "days": 50
+                                        }
+                                    },
+                                    "answers": [
+                                        {
+                                            "type": "Date",
+                                            "id": "period-from",
+                                            "label": "From",
+                                            "mandatory": true,
+                                            "q_code": "11",
+                                            "minimum": {
+                                                "meta": "ref_p_start_date",
+                                                "offset_by": {
+                                                    "days": -19
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "type": "Date",
+                                            "id": "period-to",
+                                            "label": "To",
+                                            "mandatory": true,
+                                            "q_code": "12",
+                                            "maximum": {
+                                                "meta": "ref_p_end_date",
+                                                "offset_by": {
+                                                    "days": 20
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "turnover-block",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "guidance": {
+                                        "content": [
+                                            {
+                                                "title": "Include:",
+                                                "list": [
+                                                    "exports",
+                                                    "payments for work in progress",
+                                                    "costs incurred and passed on to customers",
+                                                    "income from sub-contracted activities",
+                                                    "commission",
+                                                    "sales of goods purchased for resale",
+                                                    "revenue earned from other parts of the business not named (please supply at fair value)"
+                                                ]
+                                            },
+                                            {
+                                                "title": "Exclude:",
+                                                "list": [
+                                                    "VAT",
+                                                    "income from the sale of fixed capital assets",
+                                                    "grants and subsidies",
+                                                    "insurance claims",
+                                                    "interest received"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "id": "turnover-question",
+                                    "answers": [
+                                        {
+                                            "id": "turnover-answer",
+                                            "label": "Total turnover excluding VAT",
+                                            "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                                            "type": "Currency",
+                                            "currency": "GBP",
+                                            "decimal_places": 2,
+                                            "q_code": "40",
+                                            "mandatory": true
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s <em>total turnover</em>, excluding VAT?"
+                                }
+                            ],
+                            "title": "Total Turnover"
+                        },
+                        {
+                            "type": "ConfirmationQuestion",
+                            "title": "Total turnover",
+                            "id": "confirm-turnover-block",
+                            "questions": [
+                                {
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "type": "Radio",
+                                            "id": "confirm-turnover-answer",
+                                            "q_code": "d40",
+                                            "options": [
+                                                {
+                                                    "label": "Yes this is correct",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No I need to change this",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "mandatory": true
+                                        }
+                                    ],
+                                    "id": "confirm-turnover-question",
+                                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "when": [
+                                            {
+                                                "value": "No",
+                                                "id": "confirm-turnover-answer",
+                                                "condition": "equals"
+                                            }
+                                        ],
+                                        "block": "turnover-block"
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "changes-in-turnover-block"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "id": "changes-in-turnover-block",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "title": "Did any significant changes occur to the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                                    "id": "changes-in-turnover-question",
+                                    "definitions": [
+                                        {
+                                            "title": "What constitutes a significant change?",
+                                            "content": [
+                                                {
+                                                    "description": "What constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s figures from the previous reporting period and the same reporting period last year."
+                                                },
+                                                {
+                                                    "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "answers": [
+                                        {
+                                            "options": [
+                                                {
+                                                    "value": "Yes",
+                                                    "label": "Yes"
+                                                },
+                                                {
+                                                    "value": "No",
+                                                    "label": "No"
+                                                }
+                                            ],
+                                            "id": "changes-in-turnover-answer",
+                                            "type": "Radio",
+                                            "q_code": "146",
+                                            "mandatory": false
+                                        }
+                                    ],
+                                    "guidance": {
+                                        "content": [
+                                            {
+                                                "title": "Include",
+                                                "list": [
+                                                    "change in level of business activity",
+                                                    "maintenance/shutdowns",
+                                                    "special/calendar events",
+                                                    "weather",
+                                                    "price effects",
+                                                    "currency effects (increase/decrease in the currency value)"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Changes in total turnover",
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "when": [
+                                            {
+                                                "id": "changes-in-turnover-answer",
+                                                "value": "Yes",
+                                                "condition": "equals"
+                                            }
+                                        ],
+                                        "block": "changes-in-turnover-block-2"
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "group": "summary-group"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "id": "changes-in-turnover-block-2",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "title": "Please indicate the reasons for any changes in the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
+                                    "answers": [
+                                        {
+                                            "options": [
+                                                {
+                                                    "q_code": "146a",
+                                                    "value": "Change in level of business activity",
+                                                    "label": "Change in level of business activity"
+                                                },
+                                                {
+                                                    "q_code": "146b",
+                                                    "value": "Maintenance/shutdowns",
+                                                    "label": "Maintenance/shutdowns"
+                                                },
+                                                {
+                                                    "q_code": "146c",
+                                                    "value": "Special/calendar events",
+                                                    "label": "Special/calendar events"
+                                                },
+                                                {
+                                                    "q_code": "146d",
+                                                    "value": "Weather",
+                                                    "label": "Weather"
+                                                },
+                                                {
+                                                    "q_code": "146e",
+                                                    "value": "Price effects",
+                                                    "label": "Price effects"
+                                                },
+                                                {
+                                                    "q_code": "146f",
+                                                    "value": "Currency effects (increase/decrease in the currency value)",
+                                                    "label": "Currency effects (increase/decrease in the currency value)"
+                                                },
+                                                {
+                                                    "q_code": "146g",
+                                                    "value": "Other",
+                                                    "label": "Other"
+                                                }
+                                            ],
+                                            "id": "changes-in-turnover-answer-2",
+                                            "type": "Checkbox",
+                                            "mandatory": false
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "id": "changes-in-turnover-question-2"
+                                }
+                            ],
+                            "title": "Changes in total turnover"
+                        },
+                        {
+                            "type": "Question",
+                            "id": "changes-in-turnover-block-3",
+                            "title": "Changes in total turnover",
+                            "questions": [
+                                {
+                                    "type": "General",
+                                    "id": "changes-in-turnover-question-3",
+                                    "title": "Please describe the changes in total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
+                                    "answers": [
+                                        {
+                                            "guidance": {
+                                                "hide_guidance": "Hide examples of commentary on changes to total turnover",
+                                                "show_guidance": "Show examples of commentary on changes to total turnover",
+                                                "content": [
+                                                    {
+                                                        "list": [],
+                                                        "title": "‘Change in level of business activity’",
+                                                        "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
+                                                    },
+                                                    {
+                                                        "list": [],
+                                                        "title": "‘Maintenance/shutdowns’",
+                                                        "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
+                                                    },
+                                                    {
+                                                        "list": [],
+                                                        "title": "‘Special/calendar events’",
+                                                        "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
+                                                    },
+                                                    {
+                                                        "list": [],
+                                                        "title": "‘Weather’",
+                                                        "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
+                                                    },
+                                                    {
+                                                        "list": [],
+                                                        "title": "‘Price effects’",
+                                                        "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
+                                                    },
+                                                    {
+                                                        "list": [],
+                                                        "title": "‘Currency effects (increase/decrease in the currency value)’",
+                                                        "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
+                                                    }
+                                                ]
+                                            },
+                                            "type": "TextArea",
+                                            "mandatory": true,
+                                            "label": "Comments",
+                                            "id": "changes-in-turnover-answer-3",
+                                            "q_code": "146h"
+                                        }
+                                    ],
+                                    "description": "<p>We rely on your commentary to ‘tell the story’ behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "summary-section",
             "title": "Summary",
-            "blocks": [{
-                "type": "Summary",
-                "id": "summary"
-            }]
-        }]
-    }]
+            "groups": [
+                {
+                    "id": "summary-group",
+                    "title": "Summary",
+                    "blocks": [
+                        {
+                            "type": "Summary",
+                            "id": "summary"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
 }

--- a/data/en/mbs_0111.json
+++ b/data/en/mbs_0111.json
@@ -13,8 +13,7 @@
         "enabled": true,
         "duration": 900
     },
-    "metadata": [
-        {
+    "metadata": [{
             "name": "user_id",
             "validator": "string"
         },
@@ -39,507 +38,438 @@
             "validator": "optional_string"
         }
     ],
-    "sections": [
-        {
+    "sections": [{
             "id": "section",
-            "groups": [
-                {
-                    "id": "group",
-                    "title": "",
-                    "blocks": [
-                        {
-                            "type": "Introduction",
-                            "id": "introduction",
-                            "primary_content": [
-                                {
-                                    "type": "Basic",
-                                    "id": "use-of-information",
-                                    "content": [
-                                        {
+            "groups": [{
+                "id": "group",
+                "title": "",
+                "blocks": [{
+                        "type": "Introduction",
+                        "id": "introduction",
+                        "primary_content": [{
+                            "type": "Basic",
+                            "id": "use-of-information",
+                            "content": [{
+                                "list": [
+                                    "Data should relate to all sites in England, Scotland and Wales unless otherwise stated.",
+                                    "You can provide informed estimates if actual figures aren’t available.",
+                                    "We will treat your data securely and confidentially."
+                                ]
+                            }]
+                        }],
+                        "preview_content": {
+                            "id": "preview",
+                            "title": "Information you need",
+                            "content": [{
+                                "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
+                            }],
+                            "questions": [{
+                                    "question": "Total Turnover",
+                                    "content": [{
+                                            "description": "Include:",
                                             "list": [
-                                                "Data should relate to all sites in England, Scotland and Wales unless otherwise stated.",
-                                                "You can provide informed estimates if actual figures aren’t available.",
-                                                "We will treat your data securely and confidentially."
+                                                "exports",
+                                                "payments for work in progress",
+                                                "costs incurred and passed on to customers",
+                                                "income from sub-contracted activities",
+                                                "commission",
+                                                "sales of goods purchased for resale",
+                                                "revenue earned from other parts of the business not named (please supply at fair value)"
+                                            ]
+                                        },
+                                        {
+                                            "description": "Exclude:",
+                                            "list": [
+                                                "VAT",
+                                                "income from the sale of fixed capital assets",
+                                                "grants and subsidies",
+                                                "insurance claims",
+                                                "interest received"
                                             ]
                                         }
                                     ]
+                                },
+                                {
+                                    "question": "Changes in total turnover",
+                                    "content": [{
+                                        "description": "Include:",
+                                        "list": [
+                                            "change in level of business activity",
+                                            "maintenance/shutdowns",
+                                            "special/calendar events",
+                                            "weather",
+                                            "price effects",
+                                            "currency effects (increase/decrease in the currency value)"
+                                        ]
+                                    }]
                                 }
-                            ],
-                            "preview_content": {
-                                "id": "preview",
-                                "title": "Information you need",
-                                "content": [
+                            ]
+                        },
+                        "secondary_content": [{
+                            "id": "how-we-use-your-data",
+                            "title": "How we use your data",
+                            "content": [{
+                                "list": [
+                                    "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
+                                    "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"
+                                ]
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "reporting-period-block",
+                        "type": "Question",
+                        "questions": [{
+                            "answers": [{
+                                "options": [{
+                                        "value": "Yes",
+                                        "label": "Yes"
+                                    },
                                     {
-                                        "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
+                                        "value": "No",
+                                        "label": "No"
                                     }
                                 ],
-                                "questions": [
-                                    {
-                                        "question": "Total Turnover",
-                                        "content": [
-                                            {
-                                                "description": "Include:",
-                                                "list": [
-                                                    "exports",
-                                                    "payments for work in progress",
-                                                    "costs incurred and passed on to customers",
-                                                    "income from sub-contracted activities",
-                                                    "commission",
-                                                    "sales of goods purchased for resale",
-                                                    "revenue earned from other parts of the business not named (please supply at fair value)"
-                                                ]
-                                            },
-                                            {
-                                                "description": "Exclude:",
-                                                "list": [
-                                                    "VAT",
-                                                    "income from the sale of fixed capital assets",
-                                                    "grants and subsidies",
-                                                    "insurance claims",
-                                                    "interest received"
-                                                ]
-                                            }
+                                "id": "reporting-period-answer",
+                                "type": "Radio",
+                                "q_code": "d12",
+                                "mandatory": true
+                            }],
+                            "type": "General",
+                            "id": "reporting-period-question",
+                            "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "id": "reporting-period-answer",
+                                        "value": "Yes",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "turnover-block"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "reporting-period-block-2"
+                                }
+                            }
+                        ],
+                        "title": "Reporting period"
+                    },
+                    {
+                        "type": "Question",
+                        "id": "reporting-period-block-2",
+                        "title": "Reporting period",
+                        "questions": [{
+                            "type": "DateRange",
+                            "id": "reporting-period-question-2",
+                            "title": "What are the dates of the period that you will be reporting for?",
+                            "period_limits": {
+                                "minimum": {
+                                    "days": 10
+                                },
+                                "maximum": {
+                                    "days": 50
+                                }
+                            },
+                            "answers": [{
+                                    "type": "Date",
+                                    "id": "period-from",
+                                    "label": "From",
+                                    "mandatory": true,
+                                    "q_code": "11",
+                                    "minimum": {
+                                        "meta": "ref_p_start_date",
+                                        "offset_by": {
+                                            "days": -19
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "Date",
+                                    "id": "period-to",
+                                    "label": "To",
+                                    "mandatory": true,
+                                    "q_code": "12",
+                                    "maximum": {
+                                        "meta": "ref_p_end_date",
+                                        "offset_by": {
+                                            "days": 20
+                                        }
+                                    }
+                                }
+                            ]
+                        }]
+                    },
+                    {
+                        "id": "turnover-block",
+                        "type": "Question",
+                        "questions": [{
+                            "guidance": {
+                                "content": [{
+                                        "title": "Include:",
+                                        "list": [
+                                            "exports",
+                                            "payments for work in progress",
+                                            "costs incurred and passed on to customers",
+                                            "income from sub-contracted activities",
+                                            "commission",
+                                            "sales of goods purchased for resale",
+                                            "revenue earned from other parts of the business not named (please supply at fair value)"
                                         ]
                                     },
                                     {
-                                        "question": "Changes in total turnover",
-                                        "content": [
-                                            {
-                                                "description": "Include:",
-                                                "list": [
-                                                    "change in level of business activity",
-                                                    "maintenance/shutdowns",
-                                                    "special/calendar events",
-                                                    "weather",
-                                                    "price effects",
-                                                    "currency effects (increase/decrease in the currency value)"
-                                                ]
-                                            }
+                                        "title": "Exclude:",
+                                        "list": [
+                                            "VAT",
+                                            "income from the sale of fixed capital assets",
+                                            "grants and subsidies",
+                                            "insurance claims",
+                                            "interest received"
                                         ]
                                     }
                                 ]
                             },
-                            "secondary_content": [
-                                {
-                                    "id": "how-we-use-your-data",
-                                    "title": "How we use your data",
-                                    "content": [
+                            "id": "turnover-question",
+                            "answers": [{
+                                "id": "turnover-answer",
+                                "label": "Total turnover excluding VAT",
+                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                                "type": "Currency",
+                                "currency": "GBP",
+                                "decimal_places": 2,
+                                "q_code": "40",
+                                "mandatory": true
+                            }],
+                            "type": "General",
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s <em>total turnover</em>, excluding VAT?"
+                        }],
+                        "title": "Total Turnover"
+                    },
+                    {
+                        "type": "ConfirmationQuestion",
+                        "title": "Total turnover",
+                        "id": "confirm-turnover-block",
+                        "questions": [{
+                            "type": "General",
+                            "answers": [{
+                                "type": "Radio",
+                                "id": "confirm-turnover-answer",
+                                "q_code": "d40",
+                                "options": [{
+                                        "label": "Yes this is correct",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No I need to change this",
+                                        "value": "No"
+                                    }
+                                ],
+                                "mandatory": true
+                            }],
+                            "id": "confirm-turnover-question",
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "value": "No",
+                                        "id": "confirm-turnover-answer",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "turnover-block"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "changes-in-turnover-block"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "changes-in-turnover-block",
+                        "type": "Question",
+                        "questions": [{
+                            "title": "Did any significant changes occur to the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                            "id": "changes-in-turnover-question",
+                            "definitions": [{
+                                "title": "What constitutes a significant change?",
+                                "content": [{
+                                        "description": "What constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s figures from the previous reporting period and the same reporting period last year."
+                                    },
+                                    {
+                                        "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                                    }
+                                ]
+                            }],
+                            "answers": [{
+                                "options": [{
+                                        "value": "Yes",
+                                        "label": "Yes"
+                                    },
+                                    {
+                                        "value": "No",
+                                        "label": "No"
+                                    }
+                                ],
+                                "id": "changes-in-turnover-answer",
+                                "type": "Radio",
+                                "q_code": "146",
+                                "mandatory": false
+                            }],
+                            "guidance": {
+                                "content": [{
+                                    "title": "Include",
+                                    "list": [
+                                        "change in level of business activity",
+                                        "maintenance/shutdowns",
+                                        "special/calendar events",
+                                        "weather",
+                                        "price effects",
+                                        "currency effects (increase/decrease in the currency value)"
+                                    ]
+                                }]
+                            },
+                            "type": "General"
+                        }],
+                        "title": "Changes in total turnover",
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "id": "changes-in-turnover-answer",
+                                        "value": "Yes",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "changes-in-turnover-block-2"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "group": "summary-group"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "changes-in-turnover-block-2",
+                        "type": "Question",
+                        "questions": [{
+                            "title": "Please indicate the reasons for any changes in the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
+                            "answers": [{
+                                "options": [{
+                                        "q_code": "146a",
+                                        "value": "Change in level of business activity",
+                                        "label": "Change in level of business activity"
+                                    },
+                                    {
+                                        "q_code": "146b",
+                                        "value": "Maintenance/shutdowns",
+                                        "label": "Maintenance/shutdowns"
+                                    },
+                                    {
+                                        "q_code": "146c",
+                                        "value": "Special/calendar events",
+                                        "label": "Special/calendar events"
+                                    },
+                                    {
+                                        "q_code": "146d",
+                                        "value": "Weather",
+                                        "label": "Weather"
+                                    },
+                                    {
+                                        "q_code": "146e",
+                                        "value": "Price effects",
+                                        "label": "Price effects"
+                                    },
+                                    {
+                                        "q_code": "146f",
+                                        "value": "Currency effects (increase/decrease in the currency value)",
+                                        "label": "Currency effects (increase/decrease in the currency value)"
+                                    },
+                                    {
+                                        "q_code": "146g",
+                                        "value": "Other",
+                                        "label": "Other"
+                                    }
+                                ],
+                                "id": "changes-in-turnover-answer-2",
+                                "type": "Checkbox",
+                                "mandatory": false
+                            }],
+                            "type": "General",
+                            "id": "changes-in-turnover-question-2"
+                        }],
+                        "title": "Changes in total turnover"
+                    },
+                    {
+                        "type": "Question",
+                        "id": "changes-in-turnover-block-3",
+                        "title": "Changes in total turnover",
+                        "questions": [{
+                            "type": "General",
+                            "id": "changes-in-turnover-question-3",
+                            "title": "Please describe the changes in total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
+                            "answers": [{
+                                "guidance": {
+                                    "hide_guidance": "Hide examples of commentary on changes to total turnover",
+                                    "show_guidance": "Show examples of commentary on changes to total turnover",
+                                    "content": [{
+                                            "list": [],
+                                            "title": "‘Change in level of business activity’",
+                                            "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
+                                        },
                                         {
-                                            "list": [
-                                                "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
-                                                "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"
-                                            ]
+                                            "list": [],
+                                            "title": "‘Maintenance/shutdowns’",
+                                            "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
+                                        },
+                                        {
+                                            "list": [],
+                                            "title": "‘Special/calendar events’",
+                                            "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
+                                        },
+                                        {
+                                            "list": [],
+                                            "title": "‘Weather’",
+                                            "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
+                                        },
+                                        {
+                                            "list": [],
+                                            "title": "‘Price effects’",
+                                            "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
+                                        },
+                                        {
+                                            "list": [],
+                                            "title": "‘Currency effects (increase/decrease in the currency value)’",
+                                            "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
                                         }
                                     ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "reporting-period-block",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "answers": [
-                                        {
-                                            "options": [
-                                                {
-                                                    "value": "Yes",
-                                                    "label": "Yes"
-                                                },
-                                                {
-                                                    "value": "No",
-                                                    "label": "No"
-                                                }
-                                            ],
-                                            "id": "reporting-period-answer",
-                                            "type": "Radio",
-                                            "q_code": "d12",
-                                            "mandatory": true
-                                        }
-                                    ],
-                                    "type": "General",
-                                    "id": "reporting-period-question",
-                                    "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "when": [
-                                            {
-                                                "id": "reporting-period-answer",
-                                                "value": "Yes",
-                                                "condition": "equals"
-                                            }
-                                        ],
-                                        "block": "turnover-block"
-                                    }
                                 },
-                                {
-                                    "goto": {
-                                        "block": "reporting-period-block-2"
-                                    }
-                                }
-                            ],
-                            "title": "Reporting period"
-                        },
-                        {
-                            "type": "Question",
-                            "id": "reporting-period-block-2",
-                            "title": "Reporting period",
-                            "questions": [
-                                {
-                                    "type": "DateRange",
-                                    "id": "reporting-period-question-2",
-                                    "title": "What are the dates of the period that you will be reporting for?",
-                                    "period_limits": {
-                                        "minimum": {
-                                            "days": 10
-                                        },
-                                        "maximum": {
-                                            "days": 50
-                                        }
-                                    },
-                                    "answers": [
-                                        {
-                                            "type": "Date",
-                                            "id": "period-from",
-                                            "label": "From",
-                                            "mandatory": true,
-                                            "q_code": "11",
-                                            "minimum": {
-                                                "meta": "ref_p_start_date",
-                                                "offset_by": {
-                                                    "days": -19
-                                                }
-                                            }
-                                        },
-                                        {
-                                            "type": "Date",
-                                            "id": "period-to",
-                                            "label": "To",
-                                            "mandatory": true,
-                                            "q_code": "12",
-                                            "maximum": {
-                                                "meta": "ref_p_end_date",
-                                                "offset_by": {
-                                                    "days": 20
-                                                }
-                                            }
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "turnover-block",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "guidance": {
-                                        "content": [
-                                            {
-                                                "title": "Include:",
-                                                "list": [
-                                                    "exports",
-                                                    "payments for work in progress",
-                                                    "costs incurred and passed on to customers",
-                                                    "income from sub-contracted activities",
-                                                    "commission",
-                                                    "sales of goods purchased for resale",
-                                                    "revenue earned from other parts of the business not named (please supply at fair value)"
-                                                ]
-                                            },
-                                            {
-                                                "title": "Exclude:",
-                                                "list": [
-                                                    "VAT",
-                                                    "income from the sale of fixed capital assets",
-                                                    "grants and subsidies",
-                                                    "insurance claims",
-                                                    "interest received"
-                                                ]
-                                            }
-                                        ]
-                                    },
-                                    "id": "turnover-question",
-                                    "answers": [
-                                        {
-                                            "id": "turnover-answer",
-                                            "label": "Total turnover excluding VAT",
-                                            "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
-                                            "type": "Currency",
-                                            "currency": "GBP",
-                                            "decimal_places": 2,
-                                            "q_code": "40",
-                                            "mandatory": true
-                                        }
-                                    ],
-                                    "type": "General",
-                                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s <em>total turnover</em>, excluding VAT?"
-                                }
-                            ],
-                            "title": "Total Turnover"
-                        },
-                        {
-                            "type": "ConfirmationQuestion",
-                            "title": "Total turnover",
-                            "id": "confirm-turnover-block",
-                            "questions": [
-                                {
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "type": "Radio",
-                                            "id": "confirm-turnover-answer",
-                                            "q_code": "d40",
-                                            "options": [
-                                                {
-                                                    "label": "Yes this is correct",
-                                                    "value": "Yes"
-                                                },
-                                                {
-                                                    "label": "No I need to change this",
-                                                    "value": "No"
-                                                }
-                                            ],
-                                            "mandatory": true
-                                        }
-                                    ],
-                                    "id": "confirm-turnover-question",
-                                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "when": [
-                                            {
-                                                "value": "No",
-                                                "id": "confirm-turnover-answer",
-                                                "condition": "equals"
-                                            }
-                                        ],
-                                        "block": "turnover-block"
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "changes-in-turnover-block"
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "id": "changes-in-turnover-block",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "title": "Did any significant changes occur to the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
-                                    "id": "changes-in-turnover-question",
-                                    "definitions": [
-                                        {
-                                            "title": "What constitutes a significant change?",
-                                            "content": [
-                                                {
-                                                    "description": "What constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s figures from the previous reporting period and the same reporting period last year."
-                                                },
-                                                {
-                                                    "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
-                                                }
-                                            ]
-                                        }
-                                    ],
-                                    "answers": [
-                                        {
-                                            "options": [
-                                                {
-                                                    "value": "Yes",
-                                                    "label": "Yes"
-                                                },
-                                                {
-                                                    "value": "No",
-                                                    "label": "No"
-                                                }
-                                            ],
-                                            "id": "changes-in-turnover-answer",
-                                            "type": "Radio",
-                                            "q_code": "146",
-                                            "mandatory": false
-                                        }
-                                    ],
-                                    "guidance": {
-                                        "content": [
-                                            {
-                                                "title": "Include",
-                                                "list": [
-                                                    "change in level of business activity",
-                                                    "maintenance/shutdowns",
-                                                    "special/calendar events",
-                                                    "weather",
-                                                    "price effects",
-                                                    "currency effects (increase/decrease in the currency value)"
-                                                ]
-                                            }
-                                        ]
-                                    },
-                                    "type": "General"
-                                }
-                            ],
-                            "title": "Changes in total turnover",
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "when": [
-                                            {
-                                                "id": "changes-in-turnover-answer",
-                                                "value": "Yes",
-                                                "condition": "equals"
-                                            }
-                                        ],
-                                        "block": "changes-in-turnover-block-2"
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "group": "summary-group"
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "id": "changes-in-turnover-block-2",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "title": "Please indicate the reasons for any changes in the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
-                                    "answers": [
-                                        {
-                                            "options": [
-                                                {
-                                                    "q_code": "146a",
-                                                    "value": "Change in level of business activity",
-                                                    "label": "Change in level of business activity"
-                                                },
-                                                {
-                                                    "q_code": "146b",
-                                                    "value": "Maintenance/shutdowns",
-                                                    "label": "Maintenance/shutdowns"
-                                                },
-                                                {
-                                                    "q_code": "146c",
-                                                    "value": "Special/calendar events",
-                                                    "label": "Special/calendar events"
-                                                },
-                                                {
-                                                    "q_code": "146d",
-                                                    "value": "Weather",
-                                                    "label": "Weather"
-                                                },
-                                                {
-                                                    "q_code": "146e",
-                                                    "value": "Price effects",
-                                                    "label": "Price effects"
-                                                },
-                                                {
-                                                    "q_code": "146f",
-                                                    "value": "Currency effects (increase/decrease in the currency value)",
-                                                    "label": "Currency effects (increase/decrease in the currency value)"
-                                                },
-                                                {
-                                                    "q_code": "146g",
-                                                    "value": "Other",
-                                                    "label": "Other"
-                                                }
-                                            ],
-                                            "id": "changes-in-turnover-answer-2",
-                                            "type": "Checkbox",
-                                            "mandatory": false
-                                        }
-                                    ],
-                                    "type": "General",
-                                    "id": "changes-in-turnover-question-2"
-                                }
-                            ],
-                            "title": "Changes in total turnover"
-                        },
-                        {
-                            "type": "Question",
-                            "id": "changes-in-turnover-block-3",
-                            "title": "Changes in total turnover",
-                            "questions": [
-                                {
-                                    "type": "General",
-                                    "id": "changes-in-turnover-question-3",
-                                    "title": "Please describe the changes in total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
-                                    "answers": [
-                                        {
-                                            "guidance": {
-                                                "hide_guidance": "Hide examples of commentary on changes to total turnover",
-                                                "show_guidance": "Show examples of commentary on changes to total turnover",
-                                                "content": [
-                                                    {
-                                                        "list": [],
-                                                        "title": "‘Change in level of business activity’",
-                                                        "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
-                                                    },
-                                                    {
-                                                        "list": [],
-                                                        "title": "‘Maintenance/shutdowns’",
-                                                        "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
-                                                    },
-                                                    {
-                                                        "list": [],
-                                                        "title": "‘Special/calendar events’",
-                                                        "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
-                                                    },
-                                                    {
-                                                        "list": [],
-                                                        "title": "‘Weather’",
-                                                        "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
-                                                    },
-                                                    {
-                                                        "list": [],
-                                                        "title": "‘Price effects’",
-                                                        "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
-                                                    },
-                                                    {
-                                                        "list": [],
-                                                        "title": "‘Currency effects (increase/decrease in the currency value)’",
-                                                        "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
-                                                    }
-                                                ]
-                                            },
-                                            "type": "TextArea",
-                                            "mandatory": true,
-                                            "label": "Comments",
-                                            "id": "changes-in-turnover-answer-3",
-                                            "q_code": "146h"
-                                        }
-                                    ],
-                                    "description": "<p>We rely on your commentary to ‘tell the story’ behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ]
+                                "type": "TextArea",
+                                "mandatory": true,
+                                "label": "Comments",
+                                "id": "changes-in-turnover-answer-3",
+                                "q_code": "146h"
+                            }],
+                            "description": "<p>We rely on your commentary to ‘tell the story’ behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
+                        }]
+                    }
+                ]
+            }]
         },
         {
             "id": "summary-section",
             "title": "Summary",
-            "groups": [
-                {
-                    "id": "summary-group",
-                    "title": "Summary",
-                    "blocks": [
-                        {
-                            "type": "Summary",
-                            "id": "summary"
-                        }
-                    ]
-                }
-            ]
+            "groups": [{
+                "id": "summary-group",
+                "title": "Summary",
+                "blocks": [{
+                    "type": "Summary",
+                    "id": "summary"
+                }]
+            }]
         }
     ]
 }

--- a/data/en/mbs_0111_prototype.json
+++ b/data/en/mbs_0111_prototype.json
@@ -1,0 +1,375 @@
+{
+    "title": "Monthly Business Survey",
+    "survey_id": "009",
+    "mime_type": "application/json/ons/eq",
+    "theme": "default",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.1",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
+    "description": "mbs",
+    "eq_id": "mbs",
+    "form_type": "0161",
+    "view_submitted_response": {
+        "enabled": true,
+        "duration": 900
+    },
+    "metadata": [{
+        "name": "user_id",
+        "validator": "string"
+    }, {
+        "name": "period_id",
+        "validator": "string"
+    }, {
+        "name": "ru_name",
+        "validator": "string"
+    }, {
+        "name": "ref_p_start_date",
+        "validator": "date"
+    }, {
+        "name": "ref_p_end_date",
+        "validator": "date"
+    }, {
+        "name": "trad_as",
+        "validator": "optional_string"
+    }],
+    "sections": [{
+        "id": "section",
+        "groups": [{
+            "id": "group",
+            "title": "",
+            "blocks": [{
+                "type": "Introduction",
+                "id": "introduction",
+                "primary_content": [{
+                    "type": "Basic",
+                    "id": "use-of-information",
+                    "content": [{
+                        "list": ["Data should relate to all sites in England, Scotland and Wales unless otherwise stated.", "You can provide informed estimates if actual figures aren\u2019t available.", "We will treat your data securely and confidentially."]
+                    }]
+                }],
+                "preview_content": {
+                    "id": "preview",
+                    "title": "Information you need",
+                    "content": [{
+                        "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
+                    }],
+                    "questions": [{
+                        "question": "Total Turnover",
+                        "content": [{
+                            "description": "Include:",
+                            "list": ["exports", "payments for work in progress", "costs incurred and passed on to customers", "income from sub-contracted activities", "commission", "sales of goods purchased for resale", "revenue earned from other parts of the business not named (please supply at fair value)"]
+                        }, {
+                            "description": "Exclude:",
+                            "list": ["VAT", "income from the sale of fixed capital assets", "grants and subsidies", "insurance claims", "interest received"]
+                        }]
+                    }, {
+                        "question": "Changes in total turnover",
+                        "content": [{
+                            "description": "Include:",
+                            "list": ["change in level of business activity", "maintenance/shutdowns", "special/calendar events", "weather", "price effects", "currency effects (increase/decrease in the currency value)"]
+                        }]
+                    }]
+                },
+                "secondary_content": [{
+                    "id": "how-we-use-your-data",
+                    "title": "How we use your data",
+                    "content": [{
+                        "list": ["You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.", "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"]
+                    }]
+                }]
+            }, {
+                "id": "reporting-period-block",
+                "type": "Question",
+                "questions": [{
+                    "answers": [{
+                        "options": [{
+                            "value": "Yes",
+                            "label": "Yes"
+                        }, {
+                            "value": "No",
+                            "label": "No"
+                        }],
+                        "id": "reporting-period-answer",
+                        "type": "Radio",
+                        "q_code": "d12",
+                        "mandatory": true
+                    }],
+                    "type": "General",
+                    "id": "reporting-period-question",
+                    "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
+                }],
+                "routing_rules": [{
+                    "goto": {
+                        "when": [{
+                            "id": "reporting-period-answer",
+                            "value": "Yes",
+                            "condition": "equals"
+                        }],
+                        "block": "turnover-block"
+                    }
+                }, {
+                    "goto": {
+                        "block": "reporting-period-block-2"
+                    }
+                }],
+                "title": "Reporting period"
+            }, {
+                "type": "Question",
+                "id": "reporting-period-block-2",
+                "title": "Reporting period",
+                "questions": [{
+                    "type": "DateRange",
+                    "id": "reporting-period-question-2",
+                    "title": "What are the dates of the period that you will be reporting for?",
+                    "period_limits": {
+                        "minimum": {
+                            "days": 10
+                        },
+                        "maximum": {
+                            "days": 50
+                        }
+                    },
+                    "answers": [{
+                        "type": "Date",
+                        "id": "period-from",
+                        "label": "From",
+                        "mandatory": true,
+                        "q_code": "11",
+                        "minimum": {
+                            "meta": "ref_p_start_date",
+                            "offset_by": {
+                                "days": -19
+                            }
+                        }
+                    }, {
+                        "type": "Date",
+                        "id": "period-to",
+                        "label": "To",
+                        "mandatory": true,
+                        "q_code": "12",
+                        "maximum": {
+                            "meta": "ref_p_end_date",
+                            "offset_by": {
+                                "days": 20
+                            }
+                        }
+                    }]
+                }]
+            }, {
+                "id": "turnover-block",
+                "type": "Question",
+                "questions": [{
+                    "guidance": {
+                        "content": [{
+                            "title": "Include:",
+                            "list": ["exports", "payments for work in progress", "costs incurred and passed on to customers", "income from sub-contracted activities", "commission", "sales of goods purchased for resale", "revenue earned from other parts of the business not named (please supply at fair value)"]
+                        }, {
+                            "title": "Exclude:",
+                            "list": ["VAT", "income from the sale of fixed capital assets", "grants and subsidies", "insurance claims", "interest received"]
+                        }]
+                    },
+                    "id": "turnover-question",
+                    "answers": [{
+                        "id": "turnover-answer",
+                        "label": "Total turnover excluding VAT",
+                        "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                        "type": "Currency",
+                        "currency": "GBP",
+                        "decimal_places": 2,
+                        "q_code": "40",
+                        "mandatory": true
+                    }],
+                    "type": "General",
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>total turnover</em>, excluding VAT?"
+                }],
+                "title": "Total Turnover"
+            }, {
+                "type": "ConfirmationQuestion",
+                "title": "Total turnover",
+                "id": "confirm-turnover-block",
+                "questions": [{
+                    "type": "General",
+                    "answers": [{
+                        "type": "Radio",
+                        "id": "confirm-turnover-answer",
+                        "q_code": "d40",
+                        "options": [{
+                            "label": "Yes this is correct",
+                            "value": "Yes"
+                        }, {
+                            "label": "No I need to change this",
+                            "value": "No"
+                        }],
+                        "mandatory": true
+                    }],
+                    "id": "confirm-turnover-question",
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
+                }],
+                "routing_rules": [{
+                    "goto": {
+                        "when": [{
+                            "value": "No",
+                            "id": "confirm-turnover-answer",
+                            "condition": "equals"
+                        }],
+                        "block": "turnover-block"
+                    }
+                }, {
+                    "goto": {
+                        "block": "changes-in-turnover-block"
+                    }
+                }]
+            }, {
+                "id": "changes-in-turnover-block",
+                "type": "Question",
+                "questions": [{
+                    "title": "Did any significant changes occur to the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                    "id": "changes-in-turnover-question",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
+                        }, {
+                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }]
+                    }],
+                    "answers": [{
+                        "options": [{
+                            "value": "Yes",
+                            "label": "Yes"
+                        }, {
+                            "value": "No",
+                            "label": "No"
+                        }],
+                        "id": "changes-in-turnover-answer",
+                        "type": "Radio",
+                        "q_code": "146",
+                        "mandatory": false
+                    }],
+                    "guidance": {
+                        "content": [{
+                            "title": "Include",
+                            "list": ["change in level of business activity", "maintenance/shutdowns", "special/calendar events", "weather", "price effects", "currency effects (increase/decrease in the currency value)"]
+                        }]
+                    },
+                    "type": "General"
+                }],
+                "title": "Changes in total turnover",
+                "routing_rules": [{
+                    "goto": {
+                        "when": [{
+                            "id": "changes-in-turnover-answer",
+                            "value": "Yes",
+                            "condition": "equals"
+                        }],
+                        "block": "changes-in-turnover-block-2"
+                    }
+                }, {
+                    "goto": {
+                        "group": "summary-group"
+                    }
+                }]
+            }, {
+                "id": "changes-in-turnover-block-2",
+                "type": "Question",
+                "questions": [{
+                    "title": "Please indicate the reasons for any changes in the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
+                    "answers": [{
+                        "options": [{
+                            "q_code": "146a",
+                            "value": "Change in level of business activity",
+                            "label": "Change in level of business activity"
+                        }, {
+                            "q_code": "146b",
+                            "value": "Maintenance/shutdowns",
+                            "label": "Maintenance/shutdowns"
+                        }, {
+                            "q_code": "146c",
+                            "value": "Special/calendar events",
+                            "label": "Special/calendar events"
+                        }, {
+                            "q_code": "146d",
+                            "value": "Weather",
+                            "label": "Weather"
+                        }, {
+                            "q_code": "146e",
+                            "value": "Price effects",
+                            "label": "Price effects"
+                        }, {
+                            "q_code": "146f",
+                            "value": "Currency effects (increase/decrease in the currency value)",
+                            "label": "Currency effects (increase/decrease in the currency value)"
+                        }, {
+                            "q_code": "146g",
+                            "value": "Other",
+                            "label": "Other"
+                        }],
+                        "id": "changes-in-turnover-answer-2",
+                        "type": "Checkbox",
+                        "mandatory": false
+                    }],
+                    "type": "General",
+                    "id": "changes-in-turnover-question-2"
+                }],
+                "title": "Changes in total turnover"
+            }, {
+                "type": "Question",
+                "id": "changes-in-turnover-block-3",
+                "title": "Changes in total turnover",
+                "questions": [{
+                    "type": "General",
+                    "id": "changes-in-turnover-question-3",
+                    "title": "Please describe the changes in total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
+                    "answers": [{
+                        "guidance": {
+                            "hide_guidance": "Hide examples of commentary on changes to total turnover",
+                            "show_guidance": "Show examples of commentary on changes to total turnover",
+                            "content": [{
+                                "list": [],
+                                "title": "\u2018Change in level of business activity\u2019",
+                                "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
+                            }, {
+                                "list": [],
+                                "title": "\u2018Maintenance/shutdowns\u2019",
+                                "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
+                            }, {
+                                "list": [],
+                                "title": "\u2018Special/calendar events\u2019",
+                                "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
+                            }, {
+                                "list": [],
+                                "title": "\u2018Weather\u2019",
+                                "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
+                            }, {
+                                "list": [],
+                                "title": "\u2018Price effects\u2019",
+                                "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
+                            }, {
+                                "list": [],
+                                "title": "\u2018Currency effects (increase/decrease in the currency value)\u2019",
+                                "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
+                            }]
+                        },
+                        "type": "TextArea",
+                        "mandatory": true,
+                        "label": "Comments",
+                        "id": "changes-in-turnover-answer-3",
+                        "q_code": "146h"
+                    }],
+                    "description": "<p>We rely on your commentary to \u2018tell the story\u2019 behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
+                }]
+            }]
+        }]
+    }, {
+        "id": "summary-section",
+        "title": "Summary",
+        "groups": [{
+            "id": "summary-group",
+            "title": "Summary",
+            "blocks": [{
+                "type": "Summary",
+                "id": "summary"
+            }]
+        }]
+    }]
+}

--- a/data/en/mbs_0117.json
+++ b/data/en/mbs_0117.json
@@ -1,399 +1,593 @@
 {
-    "title": "Monthly Business Survey",
-    "survey_id": "009",
-    "mime_type": "application/json/ons/eq",
-    "theme": "default",
-    "schema_version": "0.0.1",
-    "data_version": "0.0.1",
-    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
-    "description": "mbs",
-    "form_type": "0117",
-    "view_submitted_response": {
-        "enabled": true,
-        "duration": 900
+  "title": "Monthly Business Survey",
+  "survey_id": "009",
+  "mime_type": "application/json/ons/eq",
+  "theme": "default",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.1",
+  "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
+  "description": "mbs",
+  "form_type": "0117",
+  "view_submitted_response": {
+    "enabled": true,
+    "duration": 900
+  },
+  "metadata": [
+    {
+      "name": "user_id",
+      "validator": "string"
     },
-    "metadata": [{
-        "name": "user_id",
-        "validator": "string"
-    }, {
-        "name": "period_id",
-        "validator": "string"
-    }, {
-        "name": "ru_name",
-        "validator": "string"
-    }, {
-        "name": "ref_p_start_date",
-        "validator": "date"
-    }, {
-        "name": "ref_p_end_date",
-        "validator": "date"
-    }, {
-        "name": "trad_as",
-        "validator": "optional_string"
-    }],
-    "sections": [{
-        "id": "section",
-        "groups": [{
-            "id": "group",
-            "title": "",
-            "blocks": [{
-                "type": "Introduction",
-                "id": "introduction",
-                "primary_content": [{
-                    "type": "Basic",
-                    "id": "use-of-information",
-                    "content": [{
-                        "list": ["Data should relate to all sites in England, Scotland and Wales unless otherwise stated.", "You can provide informed estimates if actual figures aren\u2019t available.", "We will treat your data securely and confidentially."]
-                    }]
-                }],
-                "preview_content": {
-                    "id": "preview",
-                    "title": "Information you need",
-                    "content": [{
-                        "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
-                    }],
-                    "questions": [{
-                        "question": "Turnover",
-                        "content": [{
-                            "description": "Include:",
-                            "list": ["exports", "payment for work in progress", "costs incurred and passed on to customers", "income from sub-contracted activities", "commission", "sales of goods purchased for resale", "royalty payments", "revenue earned from other parts of the business not named (please supply at fair value)"]
-                        }, {
-                            "description": "Exclude:",
-                            "list": ["VAT", "income from the sale of fixed capital assets", "grants, funding, donations etc", "insurance claims", "interest received"]
-                        }]
-                    }, {
-                        "question": "Value of grants, funding, donations and investment income",
-                        "content": [{
-                            "description": "Exclude:",
-                            "list": ["VAT"]
-                        }]
-                    }, {
-                        "question": "Changes in turnover",
-                        "content": [{
-                            "description": "Include:",
-                            "list": ["change in level of business activity", "maintenance/shutdowns", "special/calendar events", "weather", "price effects", "currency effects (increase/decrease in the currency value)"]
-                        }]
-                    }]
-                },
-                "secondary_content": [{
-                    "id": "how-we-use-your-data",
-                    "title": "How we use your data",
-                    "content": [{
-                        "list": ["You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.", "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"]
-                    }]
-                }]
-            }, {
-                "id": "reporting-period-block",
-                "type": "Question",
-                "questions": [{
-                    "answers": [{
-                        "options": [{
-                            "value": "Yes",
-                            "label": "Yes"
-                        }, {
-                            "value": "No",
-                            "label": "No"
-                        }],
+    {
+      "name": "period_id",
+      "validator": "string"
+    },
+    {
+      "name": "ru_name",
+      "validator": "string"
+    },
+    {
+      "name": "ref_p_start_date",
+      "validator": "date"
+    },
+    {
+      "name": "ref_p_end_date",
+      "validator": "date"
+    },
+    {
+      "name": "trad_as",
+      "validator": "optional_string"
+    }
+  ],
+  "sections": [
+    {
+      "id": "section",
+      "groups": [
+        {
+          "id": "group",
+          "title": "",
+          "blocks": [
+            {
+              "type": "Introduction",
+              "id": "introduction",
+              "primary_content": [
+                {
+                  "type": "Basic",
+                  "id": "use-of-information",
+                  "content": [
+                    {
+                      "list": [
+                        "Data should relate to all sites in England, Scotland and Wales unless otherwise stated.",
+                        "You can provide informed estimates if actual figures aren’t available.",
+                        "We will treat your data securely and confidentially."
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "preview_content": {
+                "id": "preview",
+                "title": "Information you need",
+                "content": [
+                  {
+                    "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
+                  }
+                ],
+                "questions": [
+                  {
+                    "question": "Turnover",
+                    "content": [
+                      {
+                        "description": "Include:",
+                        "list": [
+                          "exports",
+                          "payment for work in progress",
+                          "costs incurred and passed on to customers",
+                          "income from sub-contracted activities",
+                          "commission",
+                          "sales of goods purchased for resale",
+                          "royalty payments",
+                          "revenue earned from other parts of the business not named (please supply at fair value)"
+                        ]
+                      },
+                      {
+                        "description": "Exclude:",
+                        "list": [
+                          "VAT",
+                          "income from the sale of fixed capital assets",
+                          "grants, funding, donations etc",
+                          "insurance claims",
+                          "interest received"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "question": "Value of grants, funding, donations and investment income",
+                    "content": [
+                      {
+                        "description": "Exclude:",
+                        "list": [
+                          "VAT"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "question": "Changes in turnover",
+                    "content": [
+                      {
+                        "description": "Include:",
+                        "list": [
+                          "change in level of business activity",
+                          "maintenance/shutdowns",
+                          "special/calendar events",
+                          "weather",
+                          "price effects",
+                          "currency effects (increase/decrease in the currency value)"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              "secondary_content": [
+                {
+                  "id": "how-we-use-your-data",
+                  "title": "How we use your data",
+                  "content": [
+                    {
+                      "list": [
+                        "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
+                        "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "reporting-period-block",
+              "type": "Question",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "options": [
+                        {
+                          "value": "Yes",
+                          "label": "Yes"
+                        },
+                        {
+                          "value": "No",
+                          "label": "No"
+                        }
+                      ],
+                      "id": "reporting-period-answer",
+                      "type": "Radio",
+                      "q_code": "d12",
+                      "mandatory": true
+                    }
+                  ],
+                  "type": "General",
+                  "id": "reporting-period-question",
+                  "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "when": [
+                      {
                         "id": "reporting-period-answer",
-                        "type": "Radio",
-                        "q_code": "d12",
-                        "mandatory": true
-                    }],
-                    "type": "General",
-                    "id": "reporting-period-question",
-                    "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
-                }],
-                "routing_rules": [{
-                    "goto": {
-                        "when": [{
-                            "id": "reporting-period-answer",
-                            "value": "Yes",
-                            "condition": "equals"
-                        }],
-                        "block": "turnover-block"
+                        "value": "Yes",
+                        "condition": "equals"
+                      }
+                    ],
+                    "block": "turnover-block"
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "reporting-period-block-2"
+                  }
+                }
+              ],
+              "title": "Reporting period"
+            },
+            {
+              "type": "Question",
+              "id": "reporting-period-block-2",
+              "title": "Reporting period",
+              "questions": [
+                {
+                  "type": "DateRange",
+                  "id": "reporting-period-question-2",
+                  "title": "What are the dates of the period that you will be reporting for?",
+                  "period_limits": {
+                    "minimum": {
+                      "days": 10
+                    },
+                    "maximum": {
+                      "days": 50
                     }
-                }, {
-                    "goto": {
-                        "block": "reporting-period-block-2"
+                  },
+                  "answers": [
+                    {
+                      "type": "Date",
+                      "id": "period-from",
+                      "label": "From",
+                      "mandatory": true,
+                      "q_code": "11",
+                      "minimum": {
+                        "meta": "ref_p_start_date",
+                        "offset_by": {
+                          "days": -19
+                        }
+                      }
+                    },
+                    {
+                      "type": "Date",
+                      "id": "period-to",
+                      "label": "To",
+                      "mandatory": true,
+                      "q_code": "12",
+                      "maximum": {
+                        "meta": "ref_p_end_date",
+                        "offset_by": {
+                          "days": 20
+                        }
+                      }
                     }
-                }],
-                "title": "Reporting period"
-            }, {
-                "type": "Question",
-                "id": "reporting-period-block-2",
-                "title": "Reporting period",
-                "questions": [{
-                    "type": "DateRange",
-                    "id": "reporting-period-question-2",
-                    "title": "What are the dates of the period that you will be reporting for?",
-                    "period_limits": {
-                        "minimum": {
-                            "days": 10
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "turnover-block",
+              "type": "Question",
+              "questions": [
+                {
+                  "guidance": {
+                    "content": [
+                      {
+                        "title": "Include:",
+                        "list": [
+                          "exports",
+                          "payment for work in progress",
+                          "costs incurred and passed on to customers",
+                          "income from sub-contracted activities",
+                          "commission",
+                          "sales of goods purchased for resale",
+                          "royalty payments",
+                          "revenue earned from other parts of the business not named (please supply at fair value)"
+                        ]
+                      },
+                      {
+                        "title": "Exclude:",
+                        "list": [
+                          "VAT",
+                          "income from the sale of fixed capital assets",
+                          "grants, funding, donations etc.",
+                          "insurance claims",
+                          "interest received"
+                        ]
+                      }
+                    ]
+                  },
+                  "id": "turnover-question",
+                  "answers": [
+                    {
+                      "id": "turnover-answer",
+                      "label": "Turnover excluding VAT",
+                      "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                      "type": "Currency",
+                      "currency": "GBP",
+                      "decimal_places": 2,
+                      "q_code": "46",
+                      "mandatory": true
+                    }
+                  ],
+                  "type": "General",
+                  "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s <em>turnover</em>, excluding VAT?"
+                }
+              ],
+              "title": "Turnover"
+            },
+            {
+              "type": "ConfirmationQuestion",
+              "title": "Turnover",
+              "id": "confirm-turnover-block",
+              "questions": [
+                {
+                  "type": "General",
+                  "answers": [
+                    {
+                      "type": "Radio",
+                      "id": "confirm-turnover-answer",
+                      "q_code": "d40",
+                      "options": [
+                        {
+                          "label": "Yes this is correct",
+                          "value": "Yes"
                         },
-                        "maximum": {
-                            "days": 50
+                        {
+                          "label": "No I need to change this",
+                          "value": "No"
                         }
-                    },
-                    "answers": [{
-                        "type": "Date",
-                        "id": "period-from",
-                        "label": "From",
-                        "mandatory": true,
-                        "q_code": "11",
-                        "minimum": {
-                            "meta": "ref_p_start_date",
-                            "offset_by": {
-                                "days": -19
-                            }
-                        }
-                    }, {
-                        "type": "Date",
-                        "id": "period-to",
-                        "label": "To",
-                        "mandatory": true,
-                        "q_code": "12",
-                        "maximum": {
-                            "meta": "ref_p_end_date",
-                            "offset_by": {
-                                "days": 20
-                            }
-                        }
-                    }]
-                }]
-            }, {
-                "id": "turnover-block",
-                "type": "Question",
-                "questions": [{
-                    "guidance": {
-                        "content": [{
-                            "title": "Include:",
-                            "list": ["exports", "payment for work in progress", "costs incurred and passed on to customers", "income from sub-contracted activities", "commission", "sales of goods purchased for resale", "royalty payments", "revenue earned from other parts of the business not named (please supply at fair value)"]
-                        }, {
-                            "title": "Exclude:",
-                            "list": ["VAT", "income from the sale of fixed capital assets", "grants, funding, donations etc.", "insurance claims", "interest received"]
-                        }]
-                    },
-                    "id": "turnover-question",
-                    "answers": [{
-                        "id": "turnover-answer",
-                        "label": "Turnover excluding VAT",
-                        "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
-                        "type": "Currency",
-                        "currency": "GBP",
-                        "decimal_places": 2,
-                        "q_code": "46",
-                        "mandatory": true
-                    }],
-                    "type": "General",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>turnover</em>, excluding VAT?"
-                }],
-                "title": "Turnover"
-            }, {
-                "type": "ConfirmationQuestion",
-                "title": "Turnover",
-                "id": "confirm-turnover-block",
-                "questions": [{
-                    "type": "General",
-                    "answers": [{
-                        "type": "Radio",
+                      ],
+                      "mandatory": true
+                    }
+                  ],
+                  "id": "confirm-turnover-question",
+                  "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "when": [
+                      {
+                        "value": "No",
                         "id": "confirm-turnover-answer",
-                        "q_code": "d40",
-                        "options": [{
-                            "label": "Yes this is correct",
-                            "value": "Yes"
-                        }, {
-                            "label": "No I need to change this",
-                            "value": "No"
-                        }],
-                        "mandatory": true
-                    }],
-                    "id": "confirm-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
-                }],
-                "routing_rules": [{
-                    "goto": {
-                        "when": [{
-                            "value": "No",
-                            "id": "confirm-turnover-answer",
-                            "condition": "equals"
-                        }],
-                        "block": "turnover-block"
+                        "condition": "equals"
+                      }
+                    ],
+                    "block": "turnover-block"
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "grants-funding-block"
+                  }
+                }
+              ]
+            },
+            {
+              "id": "grants-funding-block",
+              "type": "Question",
+              "questions": [
+                {
+                  "id": "grants-funding-question",
+                  "answers": [
+                    {
+                      "id": "grants-funding-answer",
+                      "label": "Grants, funding, donations and investment income, excluding VAT",
+                      "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                      "type": "Currency",
+                      "currency": "GBP",
+                      "decimal_places": 2,
+                      "q_code": "47",
+                      "mandatory": true
                     }
-                }, {
-                    "goto": {
-                        "block": "grants-funding-block"
-                    }
-                }]
-            }, {
-                "id": "grants-funding-block",
-                "type": "Question",
-                "questions": [{
-                    "id": "grants-funding-question",
-                    "answers": [{
-                        "id": "grants-funding-answer",
-                        "label": "Grants, funding, donations and investment income, excluding VAT",
-                        "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
-                        "type": "Currency",
-                        "currency": "GBP",
-                        "decimal_places": 2,
-                        "q_code": "47",
-                        "mandatory": true
-                    }],
-                    "type": "General",
-                    "title": "What was the value of <em>grants, funding, donations and investment income</em>, excluding VAT?"
-                }],
-                "title": "Grants and funding"
-            }, {
-                "id": "changes-in-turnover-block",
-                "type": "Question",
-                "questions": [{
-                    "title": "Did any significant changes occur to the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
-                    "id": "changes-in-turnover-question",
-                    "definitions": [{
-                        "title": "What constitutes a significant change?",
-                        "content": [{
-                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
-                        }, {
-                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
-                        }]
-                    }],
-                    "answers": [{
-                        "options": [{
-                            "value": "Yes",
-                            "label": "Yes"
-                        }, {
-                            "value": "No",
-                            "label": "No"
-                        }],
-                        "id": "changes-in-turnover-answer",
-                        "type": "Radio",
-                        "q_code": "146",
-                        "mandatory": true
-                    }],
-                    "guidance": {
-                        "content": [{
-                            "title": "Include",
-                            "list": ["change in level of business activity", "maintenance/shutdowns", "special/calendar events", "weather", "price effects", "currency effects (increase/decrease in the currency value)"]
-                        }]
-                    },
-                    "type": "General"
-                }],
-                "title": "Changes in turnover",
-                "routing_rules": [{
-                    "goto": {
-                        "when": [{
-                            "id": "changes-in-turnover-answer",
-                            "value": "Yes",
-                            "condition": "equals"
-                        }],
-                        "block": "changes-in-turnover-block-2"
-                    }
-                }, {
-                    "goto": {
-                        "group": "summary-group"
-                    }
-                }]
-            }, {
-                "id": "changes-in-turnover-block-2",
-                "type": "Question",
-                "questions": [{
-                    "title": "Please indicate the reasons for any changes in the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
-                    "answers": [{
-                        "options": [{
-                            "q_code": "146a",
-                            "value": "Change in level of business activity",
-                            "label": "Change in level of business activity"
-                        }, {
-                            "q_code": "146b",
-                            "value": "Maintenance/shutdowns",
-                            "label": "Maintenance/shutdowns"
-                        }, {
-                            "q_code": "146c",
-                            "value": "Special/calendar events",
-                            "label": "Special/calendar events"
-                        }, {
-                            "q_code": "146d",
-                            "value": "Weather",
-                            "label": "Weather"
-                        }, {
-                            "q_code": "146e",
-                            "value": "Price effects",
-                            "label": "Price effects"
-                        }, {
-                            "q_code": "146f",
-                            "value": "Currency effects (increase/decrease in the currency value)",
-                            "label": "Currency effects (increase/decrease in the currency value)"
-                        }, {
-                            "q_code": "146g",
-                            "value": "Other",
-                            "label": "Other"
-                        }],
-                        "id": "changes-in-turnover-answer-2",
-                        "type": "Checkbox",
-                        "mandatory": true
-                    }],
-                    "type": "General",
-                    "id": "changes-in-turnover-question-2"
-                }],
-                "title": "Changes in turnover"
-            }, {
-                "type": "Question",
-                "id": "changes-in-turnover-block-3",
-                "title": "Changes in turnover",
-                "questions": [{
-                    "type": "General",
-                    "id": "changes-in-turnover-question-3",
-                    "title": "Please describe the changes in turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
-                    "answers": [{
-                        "guidance": {
-                            "hide_guidance": "Hide examples of commentary on changes to turnover",
-                            "show_guidance": "Show examples of commentary on changes to turnover",
-                            "content": [{
-                                "list": [],
-                                "title": "\u2018Change in level of business activity\u2019",
-                                "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
-                            }, {
-                                "list": [],
-                                "title": "\u2018Maintenance/shutdowns\u2019",
-                                "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
-                            }, {
-                                "list": [],
-                                "title": "\u2018Special/calendar events\u2019",
-                                "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
-                            }, {
-                                "list": [],
-                                "title": "\u2018Weather\u2019",
-                                "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
-                            }, {
-                                "list": [],
-                                "title": "\u2018Price effects\u2019",
-                                "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
-                            }, {
-                                "list": [],
-                                "title": "\u2018Currency effects (increase/decrease in the currency value)\u2019",
-                                "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
-                            }]
+                  ],
+                  "type": "General",
+                  "title": "What was the value of <em>grants, funding, donations and investment income</em>, excluding VAT?"
+                }
+              ],
+              "title": "Grants and funding"
+            },
+            {
+              "id": "changes-in-turnover-block",
+              "type": "Question",
+              "questions": [
+                {
+                  "title": "Did any significant changes occur to the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                  "id": "changes-in-turnover-question",
+                  "definitions": [
+                    {
+                      "title": "What constitutes a significant change?",
+                      "content": [
+                        {
+                          "description": "What constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s figures from the previous reporting period and the same reporting period last year."
                         },
-                        "type": "TextArea",
-                        "mandatory": true,
-                        "label": "Comments",
-                        "id": "changes-in-turnover-answer-3",
-                        "q_code": "146h"
-                    }],
-                    "description": "<p>We rely on your commentary to \u2018tell the story\u2019 behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
-                }]
-            }]
-        }]
-    }, {
-        "id": "summary-section",
-        "title": "Summary",
-        "groups": [{
-            "id": "summary-group",
-            "title": "Summary",
-            "blocks": [{
-                "type": "Summary",
-                "id": "summary"
-            }]
-        }]
-    }]
+                        {
+                          "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }
+                      ]
+                    }
+                  ],
+                  "answers": [
+                    {
+                      "options": [
+                        {
+                          "value": "Yes",
+                          "label": "Yes"
+                        },
+                        {
+                          "value": "No",
+                          "label": "No"
+                        }
+                      ],
+                      "id": "changes-in-turnover-answer",
+                      "type": "Radio",
+                      "q_code": "146",
+                      "mandatory": true
+                    }
+                  ],
+                  "guidance": {
+                    "content": [
+                      {
+                        "title": "Include",
+                        "list": [
+                          "change in level of business activity",
+                          "maintenance/shutdowns",
+                          "special/calendar events",
+                          "weather",
+                          "price effects",
+                          "currency effects (increase/decrease in the currency value)"
+                        ]
+                      }
+                    ]
+                  },
+                  "type": "General"
+                }
+              ],
+              "title": "Changes in turnover",
+              "routing_rules": [
+                {
+                  "goto": {
+                    "when": [
+                      {
+                        "id": "changes-in-turnover-answer",
+                        "value": "Yes",
+                        "condition": "equals"
+                      }
+                    ],
+                    "block": "changes-in-turnover-block-2"
+                  }
+                },
+                {
+                  "goto": {
+                    "group": "summary-group"
+                  }
+                }
+              ]
+            },
+            {
+              "id": "changes-in-turnover-block-2",
+              "type": "Question",
+              "questions": [
+                {
+                  "title": "Please indicate the reasons for any changes in the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
+                  "answers": [
+                    {
+                      "options": [
+                        {
+                          "q_code": "146a",
+                          "value": "Change in level of business activity",
+                          "label": "Change in level of business activity"
+                        },
+                        {
+                          "q_code": "146b",
+                          "value": "Maintenance/shutdowns",
+                          "label": "Maintenance/shutdowns"
+                        },
+                        {
+                          "q_code": "146c",
+                          "value": "Special/calendar events",
+                          "label": "Special/calendar events"
+                        },
+                        {
+                          "q_code": "146d",
+                          "value": "Weather",
+                          "label": "Weather"
+                        },
+                        {
+                          "q_code": "146e",
+                          "value": "Price effects",
+                          "label": "Price effects"
+                        },
+                        {
+                          "q_code": "146f",
+                          "value": "Currency effects (increase/decrease in the currency value)",
+                          "label": "Currency effects (increase/decrease in the currency value)"
+                        },
+                        {
+                          "q_code": "146g",
+                          "value": "Other",
+                          "label": "Other"
+                        }
+                      ],
+                      "id": "changes-in-turnover-answer-2",
+                      "type": "Checkbox",
+                      "mandatory": true
+                    }
+                  ],
+                  "type": "General",
+                  "id": "changes-in-turnover-question-2"
+                }
+              ],
+              "title": "Changes in turnover"
+            },
+            {
+              "type": "Question",
+              "id": "changes-in-turnover-block-3",
+              "title": "Changes in turnover",
+              "questions": [
+                {
+                  "type": "General",
+                  "id": "changes-in-turnover-question-3",
+                  "title": "Please describe the changes in turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
+                  "answers": [
+                    {
+                      "guidance": {
+                        "hide_guidance": "Hide examples of commentary on changes to turnover",
+                        "show_guidance": "Show examples of commentary on changes to turnover",
+                        "content": [
+                          {
+                            "list": [
+                              
+                            ],
+                            "title": "‘Change in level of business activity’",
+                            "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
+                          },
+                          {
+                            "list": [
+                              
+                            ],
+                            "title": "‘Maintenance/shutdowns’",
+                            "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
+                          },
+                          {
+                            "list": [
+                              
+                            ],
+                            "title": "‘Special/calendar events’",
+                            "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
+                          },
+                          {
+                            "list": [
+                              
+                            ],
+                            "title": "‘Weather’",
+                            "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
+                          },
+                          {
+                            "list": [
+                              
+                            ],
+                            "title": "‘Price effects’",
+                            "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
+                          },
+                          {
+                            "list": [
+                              
+                            ],
+                            "title": "‘Currency effects (increase/decrease in the currency value)’",
+                            "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
+                          }
+                        ]
+                      },
+                      "type": "TextArea",
+                      "mandatory": true,
+                      "label": "Comments",
+                      "id": "changes-in-turnover-answer-3",
+                      "q_code": "146h"
+                    }
+                  ],
+                  "description": "<p>We rely on your commentary to ‘tell the story’ behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "summary-section",
+      "title": "Summary",
+      "groups": [
+        {
+          "id": "summary-group",
+          "title": "Summary",
+          "blocks": [
+            {
+              "type": "Summary",
+              "id": "summary"
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/data/en/mbs_0117.json
+++ b/data/en/mbs_0117.json
@@ -1,593 +1,517 @@
 {
-  "title": "Monthly Business Survey",
-  "survey_id": "009",
-  "mime_type": "application/json/ons/eq",
-  "theme": "default",
-  "schema_version": "0.0.1",
-  "data_version": "0.0.1",
-  "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
-  "description": "mbs",
-  "form_type": "0117",
-  "view_submitted_response": {
-    "enabled": true,
-    "duration": 900
-  },
-  "metadata": [
-    {
-      "name": "user_id",
-      "validator": "string"
+    "title": "Monthly Business Survey",
+    "survey_id": "009",
+    "mime_type": "application/json/ons/eq",
+    "theme": "default",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.1",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
+    "description": "mbs",
+    "form_type": "0117",
+    "view_submitted_response": {
+        "enabled": true,
+        "duration": 900
     },
-    {
-      "name": "period_id",
-      "validator": "string"
-    },
-    {
-      "name": "ru_name",
-      "validator": "string"
-    },
-    {
-      "name": "ref_p_start_date",
-      "validator": "date"
-    },
-    {
-      "name": "ref_p_end_date",
-      "validator": "date"
-    },
-    {
-      "name": "trad_as",
-      "validator": "optional_string"
-    }
-  ],
-  "sections": [
-    {
-      "id": "section",
-      "groups": [
+    "metadata": [{
+            "name": "user_id",
+            "validator": "string"
+        },
         {
-          "id": "group",
-          "title": "",
-          "blocks": [
-            {
-              "type": "Introduction",
-              "id": "introduction",
-              "primary_content": [
-                {
-                  "type": "Basic",
-                  "id": "use-of-information",
-                  "content": [
+            "name": "period_id",
+            "validator": "string"
+        },
+        {
+            "name": "ru_name",
+            "validator": "string"
+        },
+        {
+            "name": "ref_p_start_date",
+            "validator": "date"
+        },
+        {
+            "name": "ref_p_end_date",
+            "validator": "date"
+        },
+        {
+            "name": "trad_as",
+            "validator": "optional_string"
+        }
+    ],
+    "sections": [{
+            "id": "section",
+            "groups": [{
+                "id": "group",
+                "title": "",
+                "blocks": [{
+                        "type": "Introduction",
+                        "id": "introduction",
+                        "primary_content": [{
+                            "type": "Basic",
+                            "id": "use-of-information",
+                            "content": [{
+                                "list": [
+                                    "Data should relate to all sites in England, Scotland and Wales unless otherwise stated.",
+                                    "You can provide informed estimates if actual figures aren’t available.",
+                                    "We will treat your data securely and confidentially."
+                                ]
+                            }]
+                        }],
+                        "preview_content": {
+                            "id": "preview",
+                            "title": "Information you need",
+                            "content": [{
+                                "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
+                            }],
+                            "questions": [{
+                                    "question": "Turnover",
+                                    "content": [{
+                                            "description": "Include:",
+                                            "list": [
+                                                "exports",
+                                                "payment for work in progress",
+                                                "costs incurred and passed on to customers",
+                                                "income from sub-contracted activities",
+                                                "commission",
+                                                "sales of goods purchased for resale",
+                                                "royalty payments",
+                                                "revenue earned from other parts of the business not named (please supply at fair value)"
+                                            ]
+                                        },
+                                        {
+                                            "description": "Exclude:",
+                                            "list": [
+                                                "VAT",
+                                                "income from the sale of fixed capital assets",
+                                                "grants, funding, donations etc",
+                                                "insurance claims",
+                                                "interest received"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": "Value of grants, funding, donations and investment income",
+                                    "content": [{
+                                        "description": "Exclude:",
+                                        "list": [
+                                            "VAT"
+                                        ]
+                                    }]
+                                },
+                                {
+                                    "question": "Changes in turnover",
+                                    "content": [{
+                                        "description": "Include:",
+                                        "list": [
+                                            "change in level of business activity",
+                                            "maintenance/shutdowns",
+                                            "special/calendar events",
+                                            "weather",
+                                            "price effects",
+                                            "currency effects (increase/decrease in the currency value)"
+                                        ]
+                                    }]
+                                }
+                            ]
+                        },
+                        "secondary_content": [{
+                            "id": "how-we-use-your-data",
+                            "title": "How we use your data",
+                            "content": [{
+                                "list": [
+                                    "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
+                                    "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"
+                                ]
+                            }]
+                        }]
+                    },
                     {
-                      "list": [
-                        "Data should relate to all sites in England, Scotland and Wales unless otherwise stated.",
-                        "You can provide informed estimates if actual figures aren’t available.",
-                        "We will treat your data securely and confidentially."
-                      ]
+                        "id": "reporting-period-block",
+                        "type": "Question",
+                        "questions": [{
+                            "answers": [{
+                                "options": [{
+                                        "value": "Yes",
+                                        "label": "Yes"
+                                    },
+                                    {
+                                        "value": "No",
+                                        "label": "No"
+                                    }
+                                ],
+                                "id": "reporting-period-answer",
+                                "type": "Radio",
+                                "q_code": "d12",
+                                "mandatory": true
+                            }],
+                            "type": "General",
+                            "id": "reporting-period-question",
+                            "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "id": "reporting-period-answer",
+                                        "value": "Yes",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "turnover-block"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "reporting-period-block-2"
+                                }
+                            }
+                        ],
+                        "title": "Reporting period"
+                    },
+                    {
+                        "type": "Question",
+                        "id": "reporting-period-block-2",
+                        "title": "Reporting period",
+                        "questions": [{
+                            "type": "DateRange",
+                            "id": "reporting-period-question-2",
+                            "title": "What are the dates of the period that you will be reporting for?",
+                            "period_limits": {
+                                "minimum": {
+                                    "days": 10
+                                },
+                                "maximum": {
+                                    "days": 50
+                                }
+                            },
+                            "answers": [{
+                                    "type": "Date",
+                                    "id": "period-from",
+                                    "label": "From",
+                                    "mandatory": true,
+                                    "q_code": "11",
+                                    "minimum": {
+                                        "meta": "ref_p_start_date",
+                                        "offset_by": {
+                                            "days": -19
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "Date",
+                                    "id": "period-to",
+                                    "label": "To",
+                                    "mandatory": true,
+                                    "q_code": "12",
+                                    "maximum": {
+                                        "meta": "ref_p_end_date",
+                                        "offset_by": {
+                                            "days": 20
+                                        }
+                                    }
+                                }
+                            ]
+                        }]
+                    },
+                    {
+                        "id": "turnover-block",
+                        "type": "Question",
+                        "questions": [{
+                            "guidance": {
+                                "content": [{
+                                        "title": "Include:",
+                                        "list": [
+                                            "exports",
+                                            "payment for work in progress",
+                                            "costs incurred and passed on to customers",
+                                            "income from sub-contracted activities",
+                                            "commission",
+                                            "sales of goods purchased for resale",
+                                            "royalty payments",
+                                            "revenue earned from other parts of the business not named (please supply at fair value)"
+                                        ]
+                                    },
+                                    {
+                                        "title": "Exclude:",
+                                        "list": [
+                                            "VAT",
+                                            "income from the sale of fixed capital assets",
+                                            "grants, funding, donations etc.",
+                                            "insurance claims",
+                                            "interest received"
+                                        ]
+                                    }
+                                ]
+                            },
+                            "id": "turnover-question",
+                            "answers": [{
+                                "id": "turnover-answer",
+                                "label": "Turnover excluding VAT",
+                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                                "type": "Currency",
+                                "currency": "GBP",
+                                "decimal_places": 2,
+                                "q_code": "46",
+                                "mandatory": true
+                            }],
+                            "type": "General",
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s <em>turnover</em>, excluding VAT?"
+                        }],
+                        "title": "Turnover"
+                    },
+                    {
+                        "type": "ConfirmationQuestion",
+                        "title": "Turnover",
+                        "id": "confirm-turnover-block",
+                        "questions": [{
+                            "type": "General",
+                            "answers": [{
+                                "type": "Radio",
+                                "id": "confirm-turnover-answer",
+                                "q_code": "d40",
+                                "options": [{
+                                        "label": "Yes this is correct",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No I need to change this",
+                                        "value": "No"
+                                    }
+                                ],
+                                "mandatory": true
+                            }],
+                            "id": "confirm-turnover-question",
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "value": "No",
+                                        "id": "confirm-turnover-answer",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "turnover-block"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "grants-funding-block"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "grants-funding-block",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "grants-funding-question",
+                            "answers": [{
+                                "id": "grants-funding-answer",
+                                "label": "Grants, funding, donations and investment income, excluding VAT",
+                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                                "type": "Currency",
+                                "currency": "GBP",
+                                "decimal_places": 2,
+                                "q_code": "47",
+                                "mandatory": true
+                            }],
+                            "type": "General",
+                            "title": "What was the value of <em>grants, funding, donations and investment income</em>, excluding VAT?"
+                        }],
+                        "title": "Grants and funding"
+                    },
+                    {
+                        "id": "changes-in-turnover-block",
+                        "type": "Question",
+                        "questions": [{
+                            "title": "Did any significant changes occur to the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                            "id": "changes-in-turnover-question",
+                            "definitions": [{
+                                "title": "What constitutes a significant change?",
+                                "content": [{
+                                        "description": "What constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s figures from the previous reporting period and the same reporting period last year."
+                                    },
+                                    {
+                                        "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                                    }
+                                ]
+                            }],
+                            "answers": [{
+                                "options": [{
+                                        "value": "Yes",
+                                        "label": "Yes"
+                                    },
+                                    {
+                                        "value": "No",
+                                        "label": "No"
+                                    }
+                                ],
+                                "id": "changes-in-turnover-answer",
+                                "type": "Radio",
+                                "q_code": "146",
+                                "mandatory": true
+                            }],
+                            "guidance": {
+                                "content": [{
+                                    "title": "Include",
+                                    "list": [
+                                        "change in level of business activity",
+                                        "maintenance/shutdowns",
+                                        "special/calendar events",
+                                        "weather",
+                                        "price effects",
+                                        "currency effects (increase/decrease in the currency value)"
+                                    ]
+                                }]
+                            },
+                            "type": "General"
+                        }],
+                        "title": "Changes in turnover",
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "id": "changes-in-turnover-answer",
+                                        "value": "Yes",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "changes-in-turnover-block-2"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "group": "summary-group"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "changes-in-turnover-block-2",
+                        "type": "Question",
+                        "questions": [{
+                            "title": "Please indicate the reasons for any changes in the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
+                            "answers": [{
+                                "options": [{
+                                        "q_code": "146a",
+                                        "value": "Change in level of business activity",
+                                        "label": "Change in level of business activity"
+                                    },
+                                    {
+                                        "q_code": "146b",
+                                        "value": "Maintenance/shutdowns",
+                                        "label": "Maintenance/shutdowns"
+                                    },
+                                    {
+                                        "q_code": "146c",
+                                        "value": "Special/calendar events",
+                                        "label": "Special/calendar events"
+                                    },
+                                    {
+                                        "q_code": "146d",
+                                        "value": "Weather",
+                                        "label": "Weather"
+                                    },
+                                    {
+                                        "q_code": "146e",
+                                        "value": "Price effects",
+                                        "label": "Price effects"
+                                    },
+                                    {
+                                        "q_code": "146f",
+                                        "value": "Currency effects (increase/decrease in the currency value)",
+                                        "label": "Currency effects (increase/decrease in the currency value)"
+                                    },
+                                    {
+                                        "q_code": "146g",
+                                        "value": "Other",
+                                        "label": "Other"
+                                    }
+                                ],
+                                "id": "changes-in-turnover-answer-2",
+                                "type": "Checkbox",
+                                "mandatory": true
+                            }],
+                            "type": "General",
+                            "id": "changes-in-turnover-question-2"
+                        }],
+                        "title": "Changes in turnover"
+                    },
+                    {
+                        "type": "Question",
+                        "id": "changes-in-turnover-block-3",
+                        "title": "Changes in turnover",
+                        "questions": [{
+                            "type": "General",
+                            "id": "changes-in-turnover-question-3",
+                            "title": "Please describe the changes in turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
+                            "answers": [{
+                                "guidance": {
+                                    "hide_guidance": "Hide examples of commentary on changes to turnover",
+                                    "show_guidance": "Show examples of commentary on changes to turnover",
+                                    "content": [{
+                                            "list": [
+
+                                            ],
+                                            "title": "‘Change in level of business activity’",
+                                            "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
+                                        },
+                                        {
+                                            "list": [
+
+                                            ],
+                                            "title": "‘Maintenance/shutdowns’",
+                                            "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
+                                        },
+                                        {
+                                            "list": [
+
+                                            ],
+                                            "title": "‘Special/calendar events’",
+                                            "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
+                                        },
+                                        {
+                                            "list": [
+
+                                            ],
+                                            "title": "‘Weather’",
+                                            "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
+                                        },
+                                        {
+                                            "list": [
+
+                                            ],
+                                            "title": "‘Price effects’",
+                                            "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
+                                        },
+                                        {
+                                            "list": [
+
+                                            ],
+                                            "title": "‘Currency effects (increase/decrease in the currency value)’",
+                                            "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
+                                        }
+                                    ]
+                                },
+                                "type": "TextArea",
+                                "mandatory": true,
+                                "label": "Comments",
+                                "id": "changes-in-turnover-answer-3",
+                                "q_code": "146h"
+                            }],
+                            "description": "<p>We rely on your commentary to ‘tell the story’ behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
+                        }]
                     }
-                  ]
-                }
-              ],
-              "preview_content": {
-                "id": "preview",
-                "title": "Information you need",
-                "content": [
-                  {
-                    "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
-                  }
-                ],
-                "questions": [
-                  {
-                    "question": "Turnover",
-                    "content": [
-                      {
-                        "description": "Include:",
-                        "list": [
-                          "exports",
-                          "payment for work in progress",
-                          "costs incurred and passed on to customers",
-                          "income from sub-contracted activities",
-                          "commission",
-                          "sales of goods purchased for resale",
-                          "royalty payments",
-                          "revenue earned from other parts of the business not named (please supply at fair value)"
-                        ]
-                      },
-                      {
-                        "description": "Exclude:",
-                        "list": [
-                          "VAT",
-                          "income from the sale of fixed capital assets",
-                          "grants, funding, donations etc",
-                          "insurance claims",
-                          "interest received"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "question": "Value of grants, funding, donations and investment income",
-                    "content": [
-                      {
-                        "description": "Exclude:",
-                        "list": [
-                          "VAT"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "question": "Changes in turnover",
-                    "content": [
-                      {
-                        "description": "Include:",
-                        "list": [
-                          "change in level of business activity",
-                          "maintenance/shutdowns",
-                          "special/calendar events",
-                          "weather",
-                          "price effects",
-                          "currency effects (increase/decrease in the currency value)"
-                        ]
-                      }
-                    ]
-                  }
                 ]
-              },
-              "secondary_content": [
-                {
-                  "id": "how-we-use-your-data",
-                  "title": "How we use your data",
-                  "content": [
-                    {
-                      "list": [
-                        "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
-                        "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "id": "reporting-period-block",
-              "type": "Question",
-              "questions": [
-                {
-                  "answers": [
-                    {
-                      "options": [
-                        {
-                          "value": "Yes",
-                          "label": "Yes"
-                        },
-                        {
-                          "value": "No",
-                          "label": "No"
-                        }
-                      ],
-                      "id": "reporting-period-answer",
-                      "type": "Radio",
-                      "q_code": "d12",
-                      "mandatory": true
-                    }
-                  ],
-                  "type": "General",
-                  "id": "reporting-period-question",
-                  "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
-                }
-              ],
-              "routing_rules": [
-                {
-                  "goto": {
-                    "when": [
-                      {
-                        "id": "reporting-period-answer",
-                        "value": "Yes",
-                        "condition": "equals"
-                      }
-                    ],
-                    "block": "turnover-block"
-                  }
-                },
-                {
-                  "goto": {
-                    "block": "reporting-period-block-2"
-                  }
-                }
-              ],
-              "title": "Reporting period"
-            },
-            {
-              "type": "Question",
-              "id": "reporting-period-block-2",
-              "title": "Reporting period",
-              "questions": [
-                {
-                  "type": "DateRange",
-                  "id": "reporting-period-question-2",
-                  "title": "What are the dates of the period that you will be reporting for?",
-                  "period_limits": {
-                    "minimum": {
-                      "days": 10
-                    },
-                    "maximum": {
-                      "days": 50
-                    }
-                  },
-                  "answers": [
-                    {
-                      "type": "Date",
-                      "id": "period-from",
-                      "label": "From",
-                      "mandatory": true,
-                      "q_code": "11",
-                      "minimum": {
-                        "meta": "ref_p_start_date",
-                        "offset_by": {
-                          "days": -19
-                        }
-                      }
-                    },
-                    {
-                      "type": "Date",
-                      "id": "period-to",
-                      "label": "To",
-                      "mandatory": true,
-                      "q_code": "12",
-                      "maximum": {
-                        "meta": "ref_p_end_date",
-                        "offset_by": {
-                          "days": 20
-                        }
-                      }
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "id": "turnover-block",
-              "type": "Question",
-              "questions": [
-                {
-                  "guidance": {
-                    "content": [
-                      {
-                        "title": "Include:",
-                        "list": [
-                          "exports",
-                          "payment for work in progress",
-                          "costs incurred and passed on to customers",
-                          "income from sub-contracted activities",
-                          "commission",
-                          "sales of goods purchased for resale",
-                          "royalty payments",
-                          "revenue earned from other parts of the business not named (please supply at fair value)"
-                        ]
-                      },
-                      {
-                        "title": "Exclude:",
-                        "list": [
-                          "VAT",
-                          "income from the sale of fixed capital assets",
-                          "grants, funding, donations etc.",
-                          "insurance claims",
-                          "interest received"
-                        ]
-                      }
-                    ]
-                  },
-                  "id": "turnover-question",
-                  "answers": [
-                    {
-                      "id": "turnover-answer",
-                      "label": "Turnover excluding VAT",
-                      "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
-                      "type": "Currency",
-                      "currency": "GBP",
-                      "decimal_places": 2,
-                      "q_code": "46",
-                      "mandatory": true
-                    }
-                  ],
-                  "type": "General",
-                  "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s <em>turnover</em>, excluding VAT?"
-                }
-              ],
-              "title": "Turnover"
-            },
-            {
-              "type": "ConfirmationQuestion",
-              "title": "Turnover",
-              "id": "confirm-turnover-block",
-              "questions": [
-                {
-                  "type": "General",
-                  "answers": [
-                    {
-                      "type": "Radio",
-                      "id": "confirm-turnover-answer",
-                      "q_code": "d40",
-                      "options": [
-                        {
-                          "label": "Yes this is correct",
-                          "value": "Yes"
-                        },
-                        {
-                          "label": "No I need to change this",
-                          "value": "No"
-                        }
-                      ],
-                      "mandatory": true
-                    }
-                  ],
-                  "id": "confirm-turnover-question",
-                  "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
-                }
-              ],
-              "routing_rules": [
-                {
-                  "goto": {
-                    "when": [
-                      {
-                        "value": "No",
-                        "id": "confirm-turnover-answer",
-                        "condition": "equals"
-                      }
-                    ],
-                    "block": "turnover-block"
-                  }
-                },
-                {
-                  "goto": {
-                    "block": "grants-funding-block"
-                  }
-                }
-              ]
-            },
-            {
-              "id": "grants-funding-block",
-              "type": "Question",
-              "questions": [
-                {
-                  "id": "grants-funding-question",
-                  "answers": [
-                    {
-                      "id": "grants-funding-answer",
-                      "label": "Grants, funding, donations and investment income, excluding VAT",
-                      "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
-                      "type": "Currency",
-                      "currency": "GBP",
-                      "decimal_places": 2,
-                      "q_code": "47",
-                      "mandatory": true
-                    }
-                  ],
-                  "type": "General",
-                  "title": "What was the value of <em>grants, funding, donations and investment income</em>, excluding VAT?"
-                }
-              ],
-              "title": "Grants and funding"
-            },
-            {
-              "id": "changes-in-turnover-block",
-              "type": "Question",
-              "questions": [
-                {
-                  "title": "Did any significant changes occur to the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
-                  "id": "changes-in-turnover-question",
-                  "definitions": [
-                    {
-                      "title": "What constitutes a significant change?",
-                      "content": [
-                        {
-                          "description": "What constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s figures from the previous reporting period and the same reporting period last year."
-                        },
-                        {
-                          "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
-                        }
-                      ]
-                    }
-                  ],
-                  "answers": [
-                    {
-                      "options": [
-                        {
-                          "value": "Yes",
-                          "label": "Yes"
-                        },
-                        {
-                          "value": "No",
-                          "label": "No"
-                        }
-                      ],
-                      "id": "changes-in-turnover-answer",
-                      "type": "Radio",
-                      "q_code": "146",
-                      "mandatory": true
-                    }
-                  ],
-                  "guidance": {
-                    "content": [
-                      {
-                        "title": "Include",
-                        "list": [
-                          "change in level of business activity",
-                          "maintenance/shutdowns",
-                          "special/calendar events",
-                          "weather",
-                          "price effects",
-                          "currency effects (increase/decrease in the currency value)"
-                        ]
-                      }
-                    ]
-                  },
-                  "type": "General"
-                }
-              ],
-              "title": "Changes in turnover",
-              "routing_rules": [
-                {
-                  "goto": {
-                    "when": [
-                      {
-                        "id": "changes-in-turnover-answer",
-                        "value": "Yes",
-                        "condition": "equals"
-                      }
-                    ],
-                    "block": "changes-in-turnover-block-2"
-                  }
-                },
-                {
-                  "goto": {
-                    "group": "summary-group"
-                  }
-                }
-              ]
-            },
-            {
-              "id": "changes-in-turnover-block-2",
-              "type": "Question",
-              "questions": [
-                {
-                  "title": "Please indicate the reasons for any changes in the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
-                  "answers": [
-                    {
-                      "options": [
-                        {
-                          "q_code": "146a",
-                          "value": "Change in level of business activity",
-                          "label": "Change in level of business activity"
-                        },
-                        {
-                          "q_code": "146b",
-                          "value": "Maintenance/shutdowns",
-                          "label": "Maintenance/shutdowns"
-                        },
-                        {
-                          "q_code": "146c",
-                          "value": "Special/calendar events",
-                          "label": "Special/calendar events"
-                        },
-                        {
-                          "q_code": "146d",
-                          "value": "Weather",
-                          "label": "Weather"
-                        },
-                        {
-                          "q_code": "146e",
-                          "value": "Price effects",
-                          "label": "Price effects"
-                        },
-                        {
-                          "q_code": "146f",
-                          "value": "Currency effects (increase/decrease in the currency value)",
-                          "label": "Currency effects (increase/decrease in the currency value)"
-                        },
-                        {
-                          "q_code": "146g",
-                          "value": "Other",
-                          "label": "Other"
-                        }
-                      ],
-                      "id": "changes-in-turnover-answer-2",
-                      "type": "Checkbox",
-                      "mandatory": true
-                    }
-                  ],
-                  "type": "General",
-                  "id": "changes-in-turnover-question-2"
-                }
-              ],
-              "title": "Changes in turnover"
-            },
-            {
-              "type": "Question",
-              "id": "changes-in-turnover-block-3",
-              "title": "Changes in turnover",
-              "questions": [
-                {
-                  "type": "General",
-                  "id": "changes-in-turnover-question-3",
-                  "title": "Please describe the changes in turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
-                  "answers": [
-                    {
-                      "guidance": {
-                        "hide_guidance": "Hide examples of commentary on changes to turnover",
-                        "show_guidance": "Show examples of commentary on changes to turnover",
-                        "content": [
-                          {
-                            "list": [
-                              
-                            ],
-                            "title": "‘Change in level of business activity’",
-                            "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
-                          },
-                          {
-                            "list": [
-                              
-                            ],
-                            "title": "‘Maintenance/shutdowns’",
-                            "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
-                          },
-                          {
-                            "list": [
-                              
-                            ],
-                            "title": "‘Special/calendar events’",
-                            "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
-                          },
-                          {
-                            "list": [
-                              
-                            ],
-                            "title": "‘Weather’",
-                            "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
-                          },
-                          {
-                            "list": [
-                              
-                            ],
-                            "title": "‘Price effects’",
-                            "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
-                          },
-                          {
-                            "list": [
-                              
-                            ],
-                            "title": "‘Currency effects (increase/decrease in the currency value)’",
-                            "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
-                          }
-                        ]
-                      },
-                      "type": "TextArea",
-                      "mandatory": true,
-                      "label": "Comments",
-                      "id": "changes-in-turnover-answer-3",
-                      "q_code": "146h"
-                    }
-                  ],
-                  "description": "<p>We rely on your commentary to ‘tell the story’ behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "summary-section",
-      "title": "Summary",
-      "groups": [
+            }]
+        },
         {
-          "id": "summary-group",
-          "title": "Summary",
-          "blocks": [
-            {
-              "type": "Summary",
-              "id": "summary"
-            }
-          ]
+            "id": "summary-section",
+            "title": "Summary",
+            "groups": [{
+                "id": "summary-group",
+                "title": "Summary",
+                "blocks": [{
+                    "type": "Summary",
+                    "id": "summary"
+                }]
+            }]
         }
-      ]
-    }
-  ]
+    ]
 }

--- a/data/en/mbs_0117_prototype.json
+++ b/data/en/mbs_0117_prototype.json
@@ -1,0 +1,399 @@
+{
+    "title": "Monthly Business Survey",
+    "survey_id": "009",
+    "mime_type": "application/json/ons/eq",
+    "theme": "default",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.1",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
+    "description": "mbs",
+    "form_type": "0117",
+    "view_submitted_response": {
+        "enabled": true,
+        "duration": 900
+    },
+    "metadata": [{
+        "name": "user_id",
+        "validator": "string"
+    }, {
+        "name": "period_id",
+        "validator": "string"
+    }, {
+        "name": "ru_name",
+        "validator": "string"
+    }, {
+        "name": "ref_p_start_date",
+        "validator": "date"
+    }, {
+        "name": "ref_p_end_date",
+        "validator": "date"
+    }, {
+        "name": "trad_as",
+        "validator": "optional_string"
+    }],
+    "sections": [{
+        "id": "section",
+        "groups": [{
+            "id": "group",
+            "title": "",
+            "blocks": [{
+                "type": "Introduction",
+                "id": "introduction",
+                "primary_content": [{
+                    "type": "Basic",
+                    "id": "use-of-information",
+                    "content": [{
+                        "list": ["Data should relate to all sites in England, Scotland and Wales unless otherwise stated.", "You can provide informed estimates if actual figures aren\u2019t available.", "We will treat your data securely and confidentially."]
+                    }]
+                }],
+                "preview_content": {
+                    "id": "preview",
+                    "title": "Information you need",
+                    "content": [{
+                        "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
+                    }],
+                    "questions": [{
+                        "question": "Turnover",
+                        "content": [{
+                            "description": "Include:",
+                            "list": ["exports", "payment for work in progress", "costs incurred and passed on to customers", "income from sub-contracted activities", "commission", "sales of goods purchased for resale", "royalty payments", "revenue earned from other parts of the business not named (please supply at fair value)"]
+                        }, {
+                            "description": "Exclude:",
+                            "list": ["VAT", "income from the sale of fixed capital assets", "grants, funding, donations etc", "insurance claims", "interest received"]
+                        }]
+                    }, {
+                        "question": "Value of grants, funding, donations and investment income",
+                        "content": [{
+                            "description": "Exclude:",
+                            "list": ["VAT"]
+                        }]
+                    }, {
+                        "question": "Changes in turnover",
+                        "content": [{
+                            "description": "Include:",
+                            "list": ["change in level of business activity", "maintenance/shutdowns", "special/calendar events", "weather", "price effects", "currency effects (increase/decrease in the currency value)"]
+                        }]
+                    }]
+                },
+                "secondary_content": [{
+                    "id": "how-we-use-your-data",
+                    "title": "How we use your data",
+                    "content": [{
+                        "list": ["You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.", "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"]
+                    }]
+                }]
+            }, {
+                "id": "reporting-period-block",
+                "type": "Question",
+                "questions": [{
+                    "answers": [{
+                        "options": [{
+                            "value": "Yes",
+                            "label": "Yes"
+                        }, {
+                            "value": "No",
+                            "label": "No"
+                        }],
+                        "id": "reporting-period-answer",
+                        "type": "Radio",
+                        "q_code": "d12",
+                        "mandatory": true
+                    }],
+                    "type": "General",
+                    "id": "reporting-period-question",
+                    "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
+                }],
+                "routing_rules": [{
+                    "goto": {
+                        "when": [{
+                            "id": "reporting-period-answer",
+                            "value": "Yes",
+                            "condition": "equals"
+                        }],
+                        "block": "turnover-block"
+                    }
+                }, {
+                    "goto": {
+                        "block": "reporting-period-block-2"
+                    }
+                }],
+                "title": "Reporting period"
+            }, {
+                "type": "Question",
+                "id": "reporting-period-block-2",
+                "title": "Reporting period",
+                "questions": [{
+                    "type": "DateRange",
+                    "id": "reporting-period-question-2",
+                    "title": "What are the dates of the period that you will be reporting for?",
+                    "period_limits": {
+                        "minimum": {
+                            "days": 10
+                        },
+                        "maximum": {
+                            "days": 50
+                        }
+                    },
+                    "answers": [{
+                        "type": "Date",
+                        "id": "period-from",
+                        "label": "From",
+                        "mandatory": true,
+                        "q_code": "11",
+                        "minimum": {
+                            "meta": "ref_p_start_date",
+                            "offset_by": {
+                                "days": -19
+                            }
+                        }
+                    }, {
+                        "type": "Date",
+                        "id": "period-to",
+                        "label": "To",
+                        "mandatory": true,
+                        "q_code": "12",
+                        "maximum": {
+                            "meta": "ref_p_end_date",
+                            "offset_by": {
+                                "days": 20
+                            }
+                        }
+                    }]
+                }]
+            }, {
+                "id": "turnover-block",
+                "type": "Question",
+                "questions": [{
+                    "guidance": {
+                        "content": [{
+                            "title": "Include:",
+                            "list": ["exports", "payment for work in progress", "costs incurred and passed on to customers", "income from sub-contracted activities", "commission", "sales of goods purchased for resale", "royalty payments", "revenue earned from other parts of the business not named (please supply at fair value)"]
+                        }, {
+                            "title": "Exclude:",
+                            "list": ["VAT", "income from the sale of fixed capital assets", "grants, funding, donations etc.", "insurance claims", "interest received"]
+                        }]
+                    },
+                    "id": "turnover-question",
+                    "answers": [{
+                        "id": "turnover-answer",
+                        "label": "Turnover excluding VAT",
+                        "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                        "type": "Currency",
+                        "currency": "GBP",
+                        "decimal_places": 2,
+                        "q_code": "46",
+                        "mandatory": true
+                    }],
+                    "type": "General",
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>turnover</em>, excluding VAT?"
+                }],
+                "title": "Turnover"
+            }, {
+                "type": "ConfirmationQuestion",
+                "title": "Turnover",
+                "id": "confirm-turnover-block",
+                "questions": [{
+                    "type": "General",
+                    "answers": [{
+                        "type": "Radio",
+                        "id": "confirm-turnover-answer",
+                        "q_code": "d40",
+                        "options": [{
+                            "label": "Yes this is correct",
+                            "value": "Yes"
+                        }, {
+                            "label": "No I need to change this",
+                            "value": "No"
+                        }],
+                        "mandatory": true
+                    }],
+                    "id": "confirm-turnover-question",
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
+                }],
+                "routing_rules": [{
+                    "goto": {
+                        "when": [{
+                            "value": "No",
+                            "id": "confirm-turnover-answer",
+                            "condition": "equals"
+                        }],
+                        "block": "turnover-block"
+                    }
+                }, {
+                    "goto": {
+                        "block": "grants-funding-block"
+                    }
+                }]
+            }, {
+                "id": "grants-funding-block",
+                "type": "Question",
+                "questions": [{
+                    "id": "grants-funding-question",
+                    "answers": [{
+                        "id": "grants-funding-answer",
+                        "label": "Grants, funding, donations and investment income, excluding VAT",
+                        "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                        "type": "Currency",
+                        "currency": "GBP",
+                        "decimal_places": 2,
+                        "q_code": "47",
+                        "mandatory": true
+                    }],
+                    "type": "General",
+                    "title": "What was the value of <em>grants, funding, donations and investment income</em>, excluding VAT?"
+                }],
+                "title": "Grants and funding"
+            }, {
+                "id": "changes-in-turnover-block",
+                "type": "Question",
+                "questions": [{
+                    "title": "Did any significant changes occur to the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                    "id": "changes-in-turnover-question",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
+                        }, {
+                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }]
+                    }],
+                    "answers": [{
+                        "options": [{
+                            "value": "Yes",
+                            "label": "Yes"
+                        }, {
+                            "value": "No",
+                            "label": "No"
+                        }],
+                        "id": "changes-in-turnover-answer",
+                        "type": "Radio",
+                        "q_code": "146",
+                        "mandatory": true
+                    }],
+                    "guidance": {
+                        "content": [{
+                            "title": "Include",
+                            "list": ["change in level of business activity", "maintenance/shutdowns", "special/calendar events", "weather", "price effects", "currency effects (increase/decrease in the currency value)"]
+                        }]
+                    },
+                    "type": "General"
+                }],
+                "title": "Changes in turnover",
+                "routing_rules": [{
+                    "goto": {
+                        "when": [{
+                            "id": "changes-in-turnover-answer",
+                            "value": "Yes",
+                            "condition": "equals"
+                        }],
+                        "block": "changes-in-turnover-block-2"
+                    }
+                }, {
+                    "goto": {
+                        "group": "summary-group"
+                    }
+                }]
+            }, {
+                "id": "changes-in-turnover-block-2",
+                "type": "Question",
+                "questions": [{
+                    "title": "Please indicate the reasons for any changes in the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
+                    "answers": [{
+                        "options": [{
+                            "q_code": "146a",
+                            "value": "Change in level of business activity",
+                            "label": "Change in level of business activity"
+                        }, {
+                            "q_code": "146b",
+                            "value": "Maintenance/shutdowns",
+                            "label": "Maintenance/shutdowns"
+                        }, {
+                            "q_code": "146c",
+                            "value": "Special/calendar events",
+                            "label": "Special/calendar events"
+                        }, {
+                            "q_code": "146d",
+                            "value": "Weather",
+                            "label": "Weather"
+                        }, {
+                            "q_code": "146e",
+                            "value": "Price effects",
+                            "label": "Price effects"
+                        }, {
+                            "q_code": "146f",
+                            "value": "Currency effects (increase/decrease in the currency value)",
+                            "label": "Currency effects (increase/decrease in the currency value)"
+                        }, {
+                            "q_code": "146g",
+                            "value": "Other",
+                            "label": "Other"
+                        }],
+                        "id": "changes-in-turnover-answer-2",
+                        "type": "Checkbox",
+                        "mandatory": true
+                    }],
+                    "type": "General",
+                    "id": "changes-in-turnover-question-2"
+                }],
+                "title": "Changes in turnover"
+            }, {
+                "type": "Question",
+                "id": "changes-in-turnover-block-3",
+                "title": "Changes in turnover",
+                "questions": [{
+                    "type": "General",
+                    "id": "changes-in-turnover-question-3",
+                    "title": "Please describe the changes in turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
+                    "answers": [{
+                        "guidance": {
+                            "hide_guidance": "Hide examples of commentary on changes to turnover",
+                            "show_guidance": "Show examples of commentary on changes to turnover",
+                            "content": [{
+                                "list": [],
+                                "title": "\u2018Change in level of business activity\u2019",
+                                "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
+                            }, {
+                                "list": [],
+                                "title": "\u2018Maintenance/shutdowns\u2019",
+                                "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
+                            }, {
+                                "list": [],
+                                "title": "\u2018Special/calendar events\u2019",
+                                "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
+                            }, {
+                                "list": [],
+                                "title": "\u2018Weather\u2019",
+                                "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
+                            }, {
+                                "list": [],
+                                "title": "\u2018Price effects\u2019",
+                                "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
+                            }, {
+                                "list": [],
+                                "title": "\u2018Currency effects (increase/decrease in the currency value)\u2019",
+                                "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
+                            }]
+                        },
+                        "type": "TextArea",
+                        "mandatory": true,
+                        "label": "Comments",
+                        "id": "changes-in-turnover-answer-3",
+                        "q_code": "146h"
+                    }],
+                    "description": "<p>We rely on your commentary to \u2018tell the story\u2019 behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
+                }]
+            }]
+        }]
+    }, {
+        "id": "summary-section",
+        "title": "Summary",
+        "groups": [{
+            "id": "summary-group",
+            "title": "Summary",
+            "blocks": [{
+                "type": "Summary",
+                "id": "summary"
+            }]
+        }]
+    }]
+}

--- a/data/en/mbs_0123.json
+++ b/data/en/mbs_0123.json
@@ -1,548 +1,470 @@
 {
-  "title": "Monthly Business Survey",
-  "survey_id": "009",
-  "mime_type": "application/json/ons/eq",
-  "theme": "default",
-  "schema_version": "0.0.1",
-  "data_version": "0.0.1",
-  "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
-  "description": "mbs 0123",
-  "eq_id": "mbs",
-  "form_type": "0123",
-  "view_submitted_response": {
-    "enabled": true,
-    "duration": 900
-  },
-  "metadata": [
-    {
-      "name": "user_id",
-      "validator": "string"
+    "title": "Monthly Business Survey",
+    "survey_id": "009",
+    "mime_type": "application/json/ons/eq",
+    "theme": "default",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.1",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
+    "description": "mbs 0123",
+    "eq_id": "mbs",
+    "form_type": "0123",
+    "view_submitted_response": {
+        "enabled": true,
+        "duration": 900
     },
-    {
-      "name": "period_id",
-      "validator": "string"
-    },
-    {
-      "name": "ru_name",
-      "validator": "string"
-    },
-    {
-      "name": "ref_p_start_date",
-      "validator": "date"
-    },
-    {
-      "name": "ref_p_end_date",
-      "validator": "date"
-    },
-    {
-      "name": "trad_as",
-      "validator": "optional_string"
-    }
-  ],
-  "sections": [
-    {
-      "id": "section",
-      "groups": [
+    "metadata": [{
+            "name": "user_id",
+            "validator": "string"
+        },
         {
-          "id": "group",
-          "title": "",
-          "blocks": [
-            {
-              "type": "Introduction",
-              "id": "introduction",
-              "primary_content": [
-                {
-                  "type": "Basic",
-                  "id": "use-of-information",
-                  "content": [
+            "name": "period_id",
+            "validator": "string"
+        },
+        {
+            "name": "ru_name",
+            "validator": "string"
+        },
+        {
+            "name": "ref_p_start_date",
+            "validator": "date"
+        },
+        {
+            "name": "ref_p_end_date",
+            "validator": "date"
+        },
+        {
+            "name": "trad_as",
+            "validator": "optional_string"
+        }
+    ],
+    "sections": [{
+            "id": "section",
+            "groups": [{
+                "id": "group",
+                "title": "",
+                "blocks": [{
+                        "type": "Introduction",
+                        "id": "introduction",
+                        "primary_content": [{
+                            "type": "Basic",
+                            "id": "use-of-information",
+                            "content": [{
+                                "list": [
+                                    "Data should relate to all sites in England, Scotland and Wales unless otherwise stated.",
+                                    "You can provide informed estimates if actual figures aren’t available.",
+                                    "We will treat your data securely and confidentially."
+                                ]
+                            }]
+                        }],
+                        "preview_content": {
+                            "id": "preview",
+                            "title": "Information you need",
+                            "content": [{
+                                "title": "",
+                                "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
+                            }],
+                            "questions": [{
+                                    "question": "Commission and fees",
+                                    "content": [{
+                                        "description": "Exclude VAT"
+                                    }]
+                                },
+                                {
+                                    "question": "Sales on own account and turnover from other activities",
+                                    "content": [{
+                                        "description": "Exclude:",
+                                        "list": [
+                                            "VAT",
+                                            "commission and fees",
+                                            "income from sale of fixed capital assets",
+                                            "grants"
+                                        ]
+                                    }]
+                                },
+                                {
+                                    "question": "Significant changes",
+                                    "content": [{
+                                        "description": "Include:",
+                                        "list": [
+                                            "change in level of business activity",
+                                            "maintenance/shutdowns",
+                                            "special/calendar events",
+                                            "weather",
+                                            "price effects",
+                                            "currency effects (increase/decrease in the currency value)"
+                                        ]
+                                    }]
+                                }
+                            ]
+                        },
+                        "secondary_content": [{
+                            "id": "how-we-use-your-data",
+                            "title": "How we use your data",
+                            "content": [{
+                                "list": [
+                                    "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
+                                    "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"
+                                ]
+                            }]
+                        }]
+                    },
                     {
-                      "list": [
-                        "Data should relate to all sites in England, Scotland and Wales unless otherwise stated.",
-                        "You can provide informed estimates if actual figures aren’t available.",
-                        "We will treat your data securely and confidentially."
-                      ]
+                        "id": "reporting-period-block",
+                        "type": "Question",
+                        "questions": [{
+                            "answers": [{
+                                "options": [{
+                                        "value": "Yes",
+                                        "label": "Yes"
+                                    },
+                                    {
+                                        "value": "No",
+                                        "label": "No"
+                                    }
+                                ],
+                                "id": "reporting-period-answer",
+                                "type": "Radio",
+                                "q_code": "d12",
+                                "mandatory": true
+                            }],
+                            "type": "General",
+                            "id": "reporting-period-question",
+                            "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "id": "reporting-period-answer",
+                                        "value": "Yes",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "commission-and-fees-block"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "reporting-period-block-2"
+                                }
+                            }
+                        ],
+                        "title": "Reporting period"
+                    },
+                    {
+                        "type": "Question",
+                        "id": "reporting-period-block-2",
+                        "title": "Reporting period",
+                        "questions": [{
+                            "type": "DateRange",
+                            "id": "reporting-period-question-2",
+                            "title": "What are the dates of the period that you will be reporting for?",
+                            "period_limits": {
+                                "minimum": {
+                                    "days": 10
+                                },
+                                "maximum": {
+                                    "days": 50
+                                }
+                            },
+                            "answers": [{
+                                    "type": "Date",
+                                    "id": "period-from",
+                                    "label": "From",
+                                    "mandatory": true,
+                                    "q_code": "11",
+                                    "minimum": {
+                                        "meta": "ref_p_start_date",
+                                        "offset_by": {
+                                            "days": -19
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "Date",
+                                    "id": "period-to",
+                                    "label": "To",
+                                    "mandatory": true,
+                                    "q_code": "12",
+                                    "maximum": {
+                                        "meta": "ref_p_end_date",
+                                        "offset_by": {
+                                            "days": 20
+                                        }
+                                    }
+                                }
+                            ]
+                        }]
+                    },
+                    {
+                        "id": "commission-and-fees-block",
+                        "type": "Question",
+                        "title": "Commission and fees",
+                        "questions": [{
+                            "description": "For example, as a travel agent, where you do not hold title to goods/services",
+                            "id": "commission-and-fees-question",
+                            "type": "General",
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s <em>commission and fees</em>, excluding VAT?",
+                            "answers": [{
+                                "id": "commission-and-fees-answer",
+                                "label": "Total commission and fees excluding VAT",
+                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                                "type": "Currency",
+                                "currency": "GBP",
+                                "decimal_places": 2,
+                                "q_code": "42",
+                                "mandatory": true
+                            }]
+                        }]
+                    },
+                    {
+                        "type": "ConfirmationQuestion",
+                        "title": "Commission and fees",
+                        "id": "confirm-commission-and-fees-block",
+                        "questions": [{
+                            "type": "General",
+                            "answers": [{
+                                "type": "Radio",
+                                "id": "confirm-commission-and-fees-answer",
+                                "q_code": "d40",
+                                "options": [{
+                                        "label": "Yes this is correct",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No I need to change this",
+                                        "value": "No"
+                                    }
+                                ],
+                                "mandatory": true
+                            }],
+                            "id": "confirm-commission-and-fees-question",
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total commission and fees was <em>{{format_currency(answers['commission-and-fees-answer'])}}</em>, is this correct?"
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "value": "No",
+                                        "id": "confirm-commission-and-fees-answer",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "commission-and-fees-block"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "sales-on-own-account-block"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "sales-on-own-account-block",
+                        "type": "Question",
+                        "title": "Sales on own account and turnover from other activities",
+                        "questions": [{
+                            "guidance": {
+                                "content": [{
+                                    "title": "Exclude",
+                                    "list": [
+                                        "VAT",
+                                        "commission and fees",
+                                        "income from sales of fixed capital assets",
+                                        "grants"
+                                    ]
+                                }]
+                            },
+                            "id": "sales-on-own-account-question",
+                            "type": "General",
+                            "description": "For example, as a tour operator",
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s <em>sales on own account and turnover from other activities</em>, excluding VAT?",
+                            "answers": [{
+                                "id": "sales-on-own-account-answer",
+                                "label": "Total Sales on own account and turnover from other activities  excluding VAT",
+                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                                "type": "Currency",
+                                "currency": "GBP",
+                                "decimal_places": 2,
+                                "q_code": "43",
+                                "mandatory": true
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "changes-block",
+                        "type": "Question",
+                        "questions": [{
+                            "title": "Did any significant changes occur to the figures provided for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                            "id": "changes-question",
+                            "definitions": [{
+                                "title": "What constitutes a significant change?",
+                                "content": [{
+                                        "description": "What constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s figures from the previous reporting period and the same reporting period last year."
+                                    },
+                                    {
+                                        "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                                    }
+                                ]
+                            }],
+                            "answers": [{
+                                "options": [{
+                                        "value": "Yes",
+                                        "label": "Yes"
+                                    },
+                                    {
+                                        "value": "No",
+                                        "label": "No"
+                                    }
+                                ],
+                                "id": "changes-answer",
+                                "type": "Radio",
+                                "q_code": "146",
+                                "mandatory": true
+                            }],
+                            "guidance": {
+                                "content": [{
+                                    "title": "Include",
+                                    "list": [
+                                        "change in level of business activity",
+                                        "maintenance/shutdowns",
+                                        "special/calendar events",
+                                        "weather",
+                                        "price effects",
+                                        "currency effects (increase/decrease in the currency value)"
+                                    ]
+                                }]
+                            },
+                            "type": "General"
+                        }],
+                        "title": "Significant changes",
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "id": "changes-answer",
+                                        "value": "Yes",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "changes-block-2"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "group": "summary-group"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "changes-block-2",
+                        "type": "Question",
+                        "questions": [{
+                            "title": "Please indicate the reasons for any changes in the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
+                            "type": "General",
+                            "id": "changes-question-2",
+                            "answers": [{
+                                "options": [{
+                                        "q_code": "146a",
+                                        "value": "Change in level of business activity",
+                                        "label": "Change in level of business activity"
+                                    },
+                                    {
+                                        "q_code": "146b",
+                                        "value": "Maintenance/shutdowns",
+                                        "label": "Maintenance/shutdowns"
+                                    },
+                                    {
+                                        "q_code": "146c",
+                                        "value": "Special/calendar events",
+                                        "label": "Special/calendar events"
+                                    },
+                                    {
+                                        "q_code": "146d",
+                                        "value": "Weather",
+                                        "label": "Weather"
+                                    },
+                                    {
+                                        "q_code": "146e",
+                                        "value": "Price effects",
+                                        "label": "Price effects"
+                                    },
+                                    {
+                                        "q_code": "146f",
+                                        "value": "Currency effects (increase/decrease in the currency value)",
+                                        "label": "Currency effects (increase/decrease in the currency value)"
+                                    },
+                                    {
+                                        "q_code": "146g",
+                                        "value": "Other",
+                                        "label": "Other"
+                                    }
+                                ],
+                                "id": "changes-answer-2",
+                                "type": "Checkbox",
+                                "mandatory": true
+                            }]
+                        }],
+                        "title": "Significant changes"
+                    },
+                    {
+                        "type": "Question",
+                        "id": "changes-block-3",
+                        "title": "Changes",
+                        "questions": [{
+                            "type": "General",
+                            "id": "changes-question-3",
+                            "title": "Please describe the changes in turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
+                            "answers": [{
+                                "guidance": {
+                                    "hide_guidance": "Hide examples of commentary on changes to turnover",
+                                    "show_guidance": "Show examples of commentary on changes to turnover",
+                                    "content": [{
+                                            "title": "‘Change in level of business activity’",
+                                            "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
+                                        },
+                                        {
+                                            "title": "‘Maintenance/shutdowns’",
+                                            "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
+                                        },
+                                        {
+                                            "title": "‘Special/calendar events’",
+                                            "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
+                                        },
+                                        {
+                                            "title": "‘Weather’",
+                                            "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
+                                        },
+                                        {
+                                            "title": "‘Price effects’",
+                                            "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
+                                        },
+                                        {
+                                            "title": "‘Currency effects (increase/decrease in the currency value)’",
+                                            "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
+                                        }
+                                    ]
+                                },
+                                "type": "TextArea",
+                                "mandatory": true,
+                                "label": "Comments",
+                                "id": "changes-answer-3",
+                                "q_code": "146h"
+                            }],
+                            "description": "<p>We rely on your commentary to ‘tell the story’ behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
+                        }]
                     }
-                  ]
-                }
-              ],
-              "preview_content": {
-                "id": "preview",
-                "title": "Information you need",
-                "content": [
-                  {
-                    "title": "",
-                    "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
-                  }
-                ],
-                "questions": [
-                  {
-                    "question": "Commission and fees",
-                    "content": [
-                      {
-                        "description": "Exclude VAT"
-                      }
-                    ]
-                  },
-                  {
-                    "question": "Sales on own account and turnover from other activities",
-                    "content": [
-                      {
-                        "description": "Exclude:",
-                        "list": [
-                          "VAT",
-                          "commission and fees",
-                          "income from sale of fixed capital assets",
-                          "grants"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "question": "Significant changes",
-                    "content": [
-                      {
-                        "description": "Include:",
-                        "list": [
-                          "change in level of business activity",
-                          "maintenance/shutdowns",
-                          "special/calendar events",
-                          "weather",
-                          "price effects",
-                          "currency effects (increase/decrease in the currency value)"
-                        ]
-                      }
-                    ]
-                  }
                 ]
-              },
-              "secondary_content": [
-                {
-                  "id": "how-we-use-your-data",
-                  "title": "How we use your data",
-                  "content": [
-                    {
-                      "list": [
-                        "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
-                        "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "id": "reporting-period-block",
-              "type": "Question",
-              "questions": [
-                {
-                  "answers": [
-                    {
-                      "options": [
-                        {
-                          "value": "Yes",
-                          "label": "Yes"
-                        },
-                        {
-                          "value": "No",
-                          "label": "No"
-                        }
-                      ],
-                      "id": "reporting-period-answer",
-                      "type": "Radio",
-                      "q_code": "d12",
-                      "mandatory": true
-                    }
-                  ],
-                  "type": "General",
-                  "id": "reporting-period-question",
-                  "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
-                }
-              ],
-              "routing_rules": [
-                {
-                  "goto": {
-                    "when": [
-                      {
-                        "id": "reporting-period-answer",
-                        "value": "Yes",
-                        "condition": "equals"
-                      }
-                    ],
-                    "block": "commission-and-fees-block"
-                  }
-                },
-                {
-                  "goto": {
-                    "block": "reporting-period-block-2"
-                  }
-                }
-              ],
-              "title": "Reporting period"
-            },
-            {
-              "type": "Question",
-              "id": "reporting-period-block-2",
-              "title": "Reporting period",
-              "questions": [
-                {
-                  "type": "DateRange",
-                  "id": "reporting-period-question-2",
-                  "title": "What are the dates of the period that you will be reporting for?",
-                  "period_limits": {
-                    "minimum": {
-                      "days": 10
-                    },
-                    "maximum": {
-                      "days": 50
-                    }
-                  },
-                  "answers": [
-                    {
-                      "type": "Date",
-                      "id": "period-from",
-                      "label": "From",
-                      "mandatory": true,
-                      "q_code": "11",
-                      "minimum": {
-                        "meta": "ref_p_start_date",
-                        "offset_by": {
-                          "days": -19
-                        }
-                      }
-                    },
-                    {
-                      "type": "Date",
-                      "id": "period-to",
-                      "label": "To",
-                      "mandatory": true,
-                      "q_code": "12",
-                      "maximum": {
-                        "meta": "ref_p_end_date",
-                        "offset_by": {
-                          "days": 20
-                        }
-                      }
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "id": "commission-and-fees-block",
-              "type": "Question",
-              "title": "Commission and fees",
-              "questions": [
-                {
-                  "description": "For example, as a travel agent, where you do not hold title to goods/services",
-                  "id": "commission-and-fees-question",
-                  "type": "General",
-                  "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s <em>commission and fees</em>, excluding VAT?",
-                  "answers": [
-                    {
-                      "id": "commission-and-fees-answer",
-                      "label": "Total commission and fees excluding VAT",
-                      "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
-                      "type": "Currency",
-                      "currency": "GBP",
-                      "decimal_places": 2,
-                      "q_code": "42",
-                      "mandatory": true
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "ConfirmationQuestion",
-              "title": "Commission and fees",
-              "id": "confirm-commission-and-fees-block",
-              "questions": [
-                {
-                  "type": "General",
-                  "answers": [
-                    {
-                      "type": "Radio",
-                      "id": "confirm-commission-and-fees-answer",
-                      "q_code": "d40",
-                      "options": [
-                        {
-                          "label": "Yes this is correct",
-                          "value": "Yes"
-                        },
-                        {
-                          "label": "No I need to change this",
-                          "value": "No"
-                        }
-                      ],
-                      "mandatory": true
-                    }
-                  ],
-                  "id": "confirm-commission-and-fees-question",
-                  "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total commission and fees was <em>{{format_currency(answers['commission-and-fees-answer'])}}</em>, is this correct?"
-                }
-              ],
-              "routing_rules": [
-                {
-                  "goto": {
-                    "when": [
-                      {
-                        "value": "No",
-                        "id": "confirm-commission-and-fees-answer",
-                        "condition": "equals"
-                      }
-                    ],
-                    "block": "commission-and-fees-block"
-                  }
-                },
-                {
-                  "goto": {
-                    "block": "sales-on-own-account-block"
-                  }
-                }
-              ]
-            },
-            {
-              "id": "sales-on-own-account-block",
-              "type": "Question",
-              "title": "Sales on own account and turnover from other activities",
-              "questions": [
-                {
-                  "guidance": {
-                    "content": [
-                      {
-                        "title": "Exclude",
-                        "list": [
-                          "VAT",
-                          "commission and fees",
-                          "income from sales of fixed capital assets",
-                          "grants"
-                        ]
-                      }
-                    ]
-                  },
-                  "id": "sales-on-own-account-question",
-                  "type": "General",
-                  "description": "For example, as a tour operator",
-                  "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s <em>sales on own account and turnover from other activities</em>, excluding VAT?",
-                  "answers": [
-                    {
-                      "id": "sales-on-own-account-answer",
-                      "label": "Total Sales on own account and turnover from other activities  excluding VAT",
-                      "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
-                      "type": "Currency",
-                      "currency": "GBP",
-                      "decimal_places": 2,
-                      "q_code": "43",
-                      "mandatory": true
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "id": "changes-block",
-              "type": "Question",
-              "questions": [
-                {
-                  "title": "Did any significant changes occur to the figures provided for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
-                  "id": "changes-question",
-                  "definitions": [
-                    {
-                      "title": "What constitutes a significant change?",
-                      "content": [
-                        {
-                          "description": "What constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s figures from the previous reporting period and the same reporting period last year."
-                        },
-                        {
-                          "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
-                        }
-                      ]
-                    }
-                  ],
-                  "answers": [
-                    {
-                      "options": [
-                        {
-                          "value": "Yes",
-                          "label": "Yes"
-                        },
-                        {
-                          "value": "No",
-                          "label": "No"
-                        }
-                      ],
-                      "id": "changes-answer",
-                      "type": "Radio",
-                      "q_code": "146",
-                      "mandatory": true
-                    }
-                  ],
-                  "guidance": {
-                    "content": [
-                      {
-                        "title": "Include",
-                        "list": [
-                          "change in level of business activity",
-                          "maintenance/shutdowns",
-                          "special/calendar events",
-                          "weather",
-                          "price effects",
-                          "currency effects (increase/decrease in the currency value)"
-                        ]
-                      }
-                    ]
-                  },
-                  "type": "General"
-                }
-              ],
-              "title": "Significant changes",
-              "routing_rules": [
-                {
-                  "goto": {
-                    "when": [
-                      {
-                        "id": "changes-answer",
-                        "value": "Yes",
-                        "condition": "equals"
-                      }
-                    ],
-                    "block": "changes-block-2"
-                  }
-                },
-                {
-                  "goto": {
-                    "group": "summary-group"
-                  }
-                }
-              ]
-            },
-            {
-              "id": "changes-block-2",
-              "type": "Question",
-              "questions": [
-                {
-                  "title": "Please indicate the reasons for any changes in the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
-                  "type": "General",
-                  "id": "changes-question-2",
-                  "answers": [
-                    {
-                      "options": [
-                        {
-                          "q_code": "146a",
-                          "value": "Change in level of business activity",
-                          "label": "Change in level of business activity"
-                        },
-                        {
-                          "q_code": "146b",
-                          "value": "Maintenance/shutdowns",
-                          "label": "Maintenance/shutdowns"
-                        },
-                        {
-                          "q_code": "146c",
-                          "value": "Special/calendar events",
-                          "label": "Special/calendar events"
-                        },
-                        {
-                          "q_code": "146d",
-                          "value": "Weather",
-                          "label": "Weather"
-                        },
-                        {
-                          "q_code": "146e",
-                          "value": "Price effects",
-                          "label": "Price effects"
-                        },
-                        {
-                          "q_code": "146f",
-                          "value": "Currency effects (increase/decrease in the currency value)",
-                          "label": "Currency effects (increase/decrease in the currency value)"
-                        },
-                        {
-                          "q_code": "146g",
-                          "value": "Other",
-                          "label": "Other"
-                        }
-                      ],
-                      "id": "changes-answer-2",
-                      "type": "Checkbox",
-                      "mandatory": true
-                    }
-                  ]
-                }
-              ],
-              "title": "Significant changes"
-            },
-            {
-              "type": "Question",
-              "id": "changes-block-3",
-              "title": "Changes",
-              "questions": [
-                {
-                  "type": "General",
-                  "id": "changes-question-3",
-                  "title": "Please describe the changes in turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
-                  "answers": [
-                    {
-                      "guidance": {
-                        "hide_guidance": "Hide examples of commentary on changes to turnover",
-                        "show_guidance": "Show examples of commentary on changes to turnover",
-                        "content": [
-                          {
-                            "title": "‘Change in level of business activity’",
-                            "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
-                          },
-                          {
-                            "title": "‘Maintenance/shutdowns’",
-                            "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
-                          },
-                          {
-                            "title": "‘Special/calendar events’",
-                            "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
-                          },
-                          {
-                            "title": "‘Weather’",
-                            "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
-                          },
-                          {
-                            "title": "‘Price effects’",
-                            "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
-                          },
-                          {
-                            "title": "‘Currency effects (increase/decrease in the currency value)’",
-                            "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
-                          }
-                        ]
-                      },
-                      "type": "TextArea",
-                      "mandatory": true,
-                      "label": "Comments",
-                      "id": "changes-answer-3",
-                      "q_code": "146h"
-                    }
-                  ],
-                  "description": "<p>We rely on your commentary to ‘tell the story’ behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "summary-section",
-      "title": "Summary",
-      "groups": [
+            }]
+        },
         {
-          "id": "summary-group",
-          "title": "Summary",
-          "blocks": [
-            {
-              "type": "Summary",
-              "id": "summary"
-            }
-          ]
+            "id": "summary-section",
+            "title": "Summary",
+            "groups": [{
+                "id": "summary-group",
+                "title": "Summary",
+                "blocks": [{
+                    "type": "Summary",
+                    "id": "summary"
+                }]
+            }]
         }
-      ]
-    }
-  ]
+    ]
 }

--- a/data/en/mbs_0123.json
+++ b/data/en/mbs_0123.json
@@ -1,390 +1,548 @@
 {
-    "title": "Monthly Business Survey",
-    "survey_id": "009",
-    "mime_type": "application/json/ons/eq",
-    "theme": "default",
-    "schema_version": "0.0.1",
-    "data_version": "0.0.1",
-    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
-    "description": "mbs 0123",
-    "eq_id": "mbs",
-    "form_type": "0123",
-    "view_submitted_response": {
-        "enabled": true,
-        "duration": 900
+  "title": "Monthly Business Survey",
+  "survey_id": "009",
+  "mime_type": "application/json/ons/eq",
+  "theme": "default",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.1",
+  "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
+  "description": "mbs 0123",
+  "eq_id": "mbs",
+  "form_type": "0123",
+  "view_submitted_response": {
+    "enabled": true,
+    "duration": 900
+  },
+  "metadata": [
+    {
+      "name": "user_id",
+      "validator": "string"
     },
-    "metadata": [{
-        "name": "user_id",
-        "validator": "string"
-    }, {
-        "name": "period_id",
-        "validator": "string"
-    }, {
-        "name": "ru_name",
-        "validator": "string"
-    }, {
-        "name": "ref_p_start_date",
-        "validator": "date"
-    }, {
-        "name": "ref_p_end_date",
-        "validator": "date"
-    }, {
-        "name": "trad_as",
-        "validator": "optional_string"
-    }],
-    "sections": [{
-        "id": "section",
-        "groups": [{
-            "id": "group",
-            "title": "",
-            "blocks": [{
-                "type": "Introduction",
-                "id": "introduction",
-                "primary_content": [{
-                    "type": "Basic",
-                    "id": "use-of-information",
-                    "content": [{
-                        "list": ["Data should relate to all sites in England, Scotland and Wales unless otherwise stated.", "You can provide informed estimates if actual figures aren\u2019t available.", "We will treat your data securely and confidentially."]
-                    }]
-                }],
-                "preview_content": {
-                    "id": "preview",
-                    "title": "Information you need",
-                    "content": [{
-                        "title": "",
-                        "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
-                    }],
-                    "questions": [{
-                        "question": "Commission and fees",
-                        "content": [{
-                            "description": "Exclude VAT"
-                        }]
-                    }, {
-                        "question": "Sales on own account and turnover from other activities",
-                        "content": [{
-                            "description": "Exclude:",
-                            "list": ["VAT", "commission and fees", "income from sale of fixed capital assets", "grants"]
-                        }]
-                    }, {
-                        "question": "Significant changes",
-                        "content": [{
-                            "description": "Include:",
-                            "list": ["change in level of business activity", "maintenance/shutdowns", "special/calendar events", "weather", "price effects", "currency effects (increase/decrease in the currency value)"]
-                        }]
-                    }]
-                },
-                "secondary_content": [{
-                    "id": "how-we-use-your-data",
-                    "title": "How we use your data",
-                    "content": [{
-                        "list": ["You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.", "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"]
-                    }]
-                }]
-            }, {
-                "id": "reporting-period-block",
-                "type": "Question",
-                "questions": [{
-                    "answers": [{
-                        "options": [{
-                            "value": "Yes",
-                            "label": "Yes"
-                        }, {
-                            "value": "No",
-                            "label": "No"
-                        }],
+    {
+      "name": "period_id",
+      "validator": "string"
+    },
+    {
+      "name": "ru_name",
+      "validator": "string"
+    },
+    {
+      "name": "ref_p_start_date",
+      "validator": "date"
+    },
+    {
+      "name": "ref_p_end_date",
+      "validator": "date"
+    },
+    {
+      "name": "trad_as",
+      "validator": "optional_string"
+    }
+  ],
+  "sections": [
+    {
+      "id": "section",
+      "groups": [
+        {
+          "id": "group",
+          "title": "",
+          "blocks": [
+            {
+              "type": "Introduction",
+              "id": "introduction",
+              "primary_content": [
+                {
+                  "type": "Basic",
+                  "id": "use-of-information",
+                  "content": [
+                    {
+                      "list": [
+                        "Data should relate to all sites in England, Scotland and Wales unless otherwise stated.",
+                        "You can provide informed estimates if actual figures aren’t available.",
+                        "We will treat your data securely and confidentially."
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "preview_content": {
+                "id": "preview",
+                "title": "Information you need",
+                "content": [
+                  {
+                    "title": "",
+                    "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
+                  }
+                ],
+                "questions": [
+                  {
+                    "question": "Commission and fees",
+                    "content": [
+                      {
+                        "description": "Exclude VAT"
+                      }
+                    ]
+                  },
+                  {
+                    "question": "Sales on own account and turnover from other activities",
+                    "content": [
+                      {
+                        "description": "Exclude:",
+                        "list": [
+                          "VAT",
+                          "commission and fees",
+                          "income from sale of fixed capital assets",
+                          "grants"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "question": "Significant changes",
+                    "content": [
+                      {
+                        "description": "Include:",
+                        "list": [
+                          "change in level of business activity",
+                          "maintenance/shutdowns",
+                          "special/calendar events",
+                          "weather",
+                          "price effects",
+                          "currency effects (increase/decrease in the currency value)"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              "secondary_content": [
+                {
+                  "id": "how-we-use-your-data",
+                  "title": "How we use your data",
+                  "content": [
+                    {
+                      "list": [
+                        "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
+                        "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "reporting-period-block",
+              "type": "Question",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "options": [
+                        {
+                          "value": "Yes",
+                          "label": "Yes"
+                        },
+                        {
+                          "value": "No",
+                          "label": "No"
+                        }
+                      ],
+                      "id": "reporting-period-answer",
+                      "type": "Radio",
+                      "q_code": "d12",
+                      "mandatory": true
+                    }
+                  ],
+                  "type": "General",
+                  "id": "reporting-period-question",
+                  "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "when": [
+                      {
                         "id": "reporting-period-answer",
-                        "type": "Radio",
-                        "q_code": "d12",
-                        "mandatory": true
-                    }],
-                    "type": "General",
-                    "id": "reporting-period-question",
-                    "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
-                }],
-                "routing_rules": [{
-                    "goto": {
-                        "when": [{
-                            "id": "reporting-period-answer",
-                            "value": "Yes",
-                            "condition": "equals"
-                        }],
-                        "block": "commission-and-fees-block"
-                    }
-                }, {
-                    "goto": {
-                        "block": "reporting-period-block-2"
-                    }
-                }],
-                "title": "Reporting period"
-            }, {
-                "type": "Question",
-                "id": "reporting-period-block-2",
-                "title": "Reporting period",
-                "questions": [{
-                    "type": "DateRange",
-                    "id": "reporting-period-question-2",
-                    "title": "What are the dates of the period that you will be reporting for?",
-                    "period_limits": {
-                        "minimum": {
-                            "days": 10
-                        },
-                        "maximum": {
-                            "days": 50
-                        }
+                        "value": "Yes",
+                        "condition": "equals"
+                      }
+                    ],
+                    "block": "commission-and-fees-block"
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "reporting-period-block-2"
+                  }
+                }
+              ],
+              "title": "Reporting period"
+            },
+            {
+              "type": "Question",
+              "id": "reporting-period-block-2",
+              "title": "Reporting period",
+              "questions": [
+                {
+                  "type": "DateRange",
+                  "id": "reporting-period-question-2",
+                  "title": "What are the dates of the period that you will be reporting for?",
+                  "period_limits": {
+                    "minimum": {
+                      "days": 10
                     },
-                    "answers": [{
-                        "type": "Date",
-                        "id": "period-from",
-                        "label": "From",
-                        "mandatory": true,
-                        "q_code": "11",
-                        "minimum": {
-                            "meta": "ref_p_start_date",
-                            "offset_by": {
-                                "days": -19
-                            }
+                    "maximum": {
+                      "days": 50
+                    }
+                  },
+                  "answers": [
+                    {
+                      "type": "Date",
+                      "id": "period-from",
+                      "label": "From",
+                      "mandatory": true,
+                      "q_code": "11",
+                      "minimum": {
+                        "meta": "ref_p_start_date",
+                        "offset_by": {
+                          "days": -19
                         }
-                    }, {
-                        "type": "Date",
-                        "id": "period-to",
-                        "label": "To",
-                        "mandatory": true,
-                        "q_code": "12",
-                        "maximum": {
-                            "meta": "ref_p_end_date",
-                            "offset_by": {
-                                "days": 20
-                            }
+                      }
+                    },
+                    {
+                      "type": "Date",
+                      "id": "period-to",
+                      "label": "To",
+                      "mandatory": true,
+                      "q_code": "12",
+                      "maximum": {
+                        "meta": "ref_p_end_date",
+                        "offset_by": {
+                          "days": 20
                         }
-                    }]
-                }]
-            }, {
-                "id": "commission-and-fees-block",
-                "type": "Question",
-                "title": "Commission and fees",
-                "questions": [{
-                    "description": "For example, as a travel agent, where you do not hold title to goods/services",
-                    "id": "commission-and-fees-question",
-                    "type": "General",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>commission and fees</em>, excluding VAT?",
-                    "answers": [{
-                        "id": "commission-and-fees-answer",
-                        "label": "Total commission and fees excluding VAT",
-                        "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
-                        "type": "Currency",
-                        "currency": "GBP",
-                        "decimal_places": 2,
-                        "q_code": "42",
-                        "mandatory": true
-                    }]
-                }]
-            }, {
-                "type": "ConfirmationQuestion",
-                "title": "Commission and fees",
-                "id": "confirm-commission-and-fees-block",
-                "questions": [{
-                    "type": "General",
-                    "answers": [{
-                        "type": "Radio",
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "commission-and-fees-block",
+              "type": "Question",
+              "title": "Commission and fees",
+              "questions": [
+                {
+                  "description": "For example, as a travel agent, where you do not hold title to goods/services",
+                  "id": "commission-and-fees-question",
+                  "type": "General",
+                  "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s <em>commission and fees</em>, excluding VAT?",
+                  "answers": [
+                    {
+                      "id": "commission-and-fees-answer",
+                      "label": "Total commission and fees excluding VAT",
+                      "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                      "type": "Currency",
+                      "currency": "GBP",
+                      "decimal_places": 2,
+                      "q_code": "42",
+                      "mandatory": true
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "ConfirmationQuestion",
+              "title": "Commission and fees",
+              "id": "confirm-commission-and-fees-block",
+              "questions": [
+                {
+                  "type": "General",
+                  "answers": [
+                    {
+                      "type": "Radio",
+                      "id": "confirm-commission-and-fees-answer",
+                      "q_code": "d40",
+                      "options": [
+                        {
+                          "label": "Yes this is correct",
+                          "value": "Yes"
+                        },
+                        {
+                          "label": "No I need to change this",
+                          "value": "No"
+                        }
+                      ],
+                      "mandatory": true
+                    }
+                  ],
+                  "id": "confirm-commission-and-fees-question",
+                  "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total commission and fees was <em>{{format_currency(answers['commission-and-fees-answer'])}}</em>, is this correct?"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "when": [
+                      {
+                        "value": "No",
                         "id": "confirm-commission-and-fees-answer",
-                        "q_code": "d40",
-                        "options": [{
-                            "label": "Yes this is correct",
-                            "value": "Yes"
-                        }, {
-                            "label": "No I need to change this",
-                            "value": "No"
-                        }],
-                        "mandatory": true
-                    }],
-                    "id": "confirm-commission-and-fees-question",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total commission and fees was <em>{{format_currency(answers['commission-and-fees-answer'])}}</em>, is this correct?"
-                }],
-                "routing_rules": [{
-                    "goto": {
-                        "when": [{
-                            "value": "No",
-                            "id": "confirm-commission-and-fees-answer",
-                            "condition": "equals"
-                        }],
-                        "block": "commission-and-fees-block"
+                        "condition": "equals"
+                      }
+                    ],
+                    "block": "commission-and-fees-block"
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "sales-on-own-account-block"
+                  }
+                }
+              ]
+            },
+            {
+              "id": "sales-on-own-account-block",
+              "type": "Question",
+              "title": "Sales on own account and turnover from other activities",
+              "questions": [
+                {
+                  "guidance": {
+                    "content": [
+                      {
+                        "title": "Exclude",
+                        "list": [
+                          "VAT",
+                          "commission and fees",
+                          "income from sales of fixed capital assets",
+                          "grants"
+                        ]
+                      }
+                    ]
+                  },
+                  "id": "sales-on-own-account-question",
+                  "type": "General",
+                  "description": "For example, as a tour operator",
+                  "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s <em>sales on own account and turnover from other activities</em>, excluding VAT?",
+                  "answers": [
+                    {
+                      "id": "sales-on-own-account-answer",
+                      "label": "Total Sales on own account and turnover from other activities  excluding VAT",
+                      "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                      "type": "Currency",
+                      "currency": "GBP",
+                      "decimal_places": 2,
+                      "q_code": "43",
+                      "mandatory": true
                     }
-                }, {
-                    "goto": {
-                        "block": "sales-on-own-account-block"
-                    }
-                }]
-            }, {
-                "id": "sales-on-own-account-block",
-                "type": "Question",
-                "title": "Sales on own account and turnover from other activities",
-                "questions": [{
-                    "guidance": {
-                        "content": [{
-                            "title": "Exclude",
-                            "list": ["VAT", "commission and fees", "income from sales of fixed capital assets", "grants"]
-                        }]
-                    },
-                    "id": "sales-on-own-account-question",
-                    "type": "General",
-                    "description": "For example, as a tour operator",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>sales on own account and turnover from other activities</em>, excluding VAT?",
-                    "answers": [{
-                        "id": "sales-on-own-account-answer",
-                        "label": "Total Sales on own account and turnover from other activities  excluding VAT",
-                        "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
-                        "type": "Currency",
-                        "currency": "GBP",
-                        "decimal_places": 2,
-                        "q_code": "43",
-                        "mandatory": true
-                    }]
-                }]
-            }, {
-                "id": "changes-block",
-                "type": "Question",
-                "questions": [{
-                    "title": "Did any significant changes occur to the figures provided for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
-                    "id": "changes-question",
-                    "definitions": [{
-                        "title": "What constitutes a significant change?",
-                        "content": [{
-                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
-                        }, {
-                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
-                        }]
-                    }],
-                    "answers": [{
-                        "options": [{
-                            "value": "Yes",
-                            "label": "Yes"
-                        }, {
-                            "value": "No",
-                            "label": "No"
-                        }],
-                        "id": "changes-answer",
-                        "type": "Radio",
-                        "q_code": "146",
-                        "mandatory": true
-                    }],
-                    "guidance": {
-                        "content": [{
-                            "title": "Include",
-                            "list": ["change in level of business activity", "maintenance/shutdowns", "special/calendar events", "weather", "price effects", "currency effects (increase/decrease in the currency value)"]
-                        }]
-                    },
-                    "type": "General"
-                }],
-                "title": "Significant changes",
-                "routing_rules": [{
-                    "goto": {
-                        "when": [{
-                            "id": "changes-answer",
-                            "value": "Yes",
-                            "condition": "equals"
-                        }],
-                        "block": "changes-block-2"
-                    }
-                }, {
-                    "goto": {
-                        "group": "summary-group"
-                    }
-                }]
-            }, {
-                "id": "changes-block-2",
-                "type": "Question",
-                "questions": [{
-                    "title": "Please indicate the reasons for any changes in the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
-                    "type": "General",
-                    "id": "changes-question-2",
-                    "answers": [{
-                        "options": [{
-                            "q_code": "146a",
-                            "value": "Change in level of business activity",
-                            "label": "Change in level of business activity"
-                        }, {
-                            "q_code": "146b",
-                            "value": "Maintenance/shutdowns",
-                            "label": "Maintenance/shutdowns"
-                        }, {
-                            "q_code": "146c",
-                            "value": "Special/calendar events",
-                            "label": "Special/calendar events"
-                        }, {
-                            "q_code": "146d",
-                            "value": "Weather",
-                            "label": "Weather"
-                        }, {
-                            "q_code": "146e",
-                            "value": "Price effects",
-                            "label": "Price effects"
-                        }, {
-                            "q_code": "146f",
-                            "value": "Currency effects (increase/decrease in the currency value)",
-                            "label": "Currency effects (increase/decrease in the currency value)"
-                        }, {
-                            "q_code": "146g",
-                            "value": "Other",
-                            "label": "Other"
-                        }],
-                        "id": "changes-answer-2",
-                        "type": "Checkbox",
-                        "mandatory": true
-                    }]
-                }],
-                "title": "Significant changes"
-            }, {
-                "type": "Question",
-                "id": "changes-block-3",
-                "title": "Changes",
-                "questions": [{
-                    "type": "General",
-                    "id": "changes-question-3",
-                    "title": "Please describe the changes in turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
-                    "answers": [{
-                        "guidance": {
-                            "hide_guidance": "Hide examples of commentary on changes to turnover",
-                            "show_guidance": "Show examples of commentary on changes to turnover",
-                            "content": [{
-                                "title": "\u2018Change in level of business activity\u2019",
-                                "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
-                            }, {
-                                "title": "\u2018Maintenance/shutdowns\u2019",
-                                "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
-                            }, {
-                                "title": "\u2018Special/calendar events\u2019",
-                                "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
-                            }, {
-                                "title": "\u2018Weather\u2019",
-                                "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
-                            }, {
-                                "title": "\u2018Price effects\u2019",
-                                "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
-                            }, {
-                                "title": "\u2018Currency effects (increase/decrease in the currency value)\u2019",
-                                "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
-                            }]
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "changes-block",
+              "type": "Question",
+              "questions": [
+                {
+                  "title": "Did any significant changes occur to the figures provided for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                  "id": "changes-question",
+                  "definitions": [
+                    {
+                      "title": "What constitutes a significant change?",
+                      "content": [
+                        {
+                          "description": "What constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s figures from the previous reporting period and the same reporting period last year."
                         },
-                        "type": "TextArea",
-                        "mandatory": true,
-                        "label": "Comments",
-                        "id": "changes-answer-3",
-                        "q_code": "146h"
-                    }],
-                    "description": "<p>We rely on your commentary to \u2018tell the story\u2019 behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
-                }]
-            }]
-        }]
-    }, {
-        "id": "summary-section",
-        "title": "Summary",
-        "groups": [{
-            "id": "summary-group",
-            "title": "Summary",
-            "blocks": [{
-                "type": "Summary",
-                "id": "summary"
-            }]
-        }]
-    }]
+                        {
+                          "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }
+                      ]
+                    }
+                  ],
+                  "answers": [
+                    {
+                      "options": [
+                        {
+                          "value": "Yes",
+                          "label": "Yes"
+                        },
+                        {
+                          "value": "No",
+                          "label": "No"
+                        }
+                      ],
+                      "id": "changes-answer",
+                      "type": "Radio",
+                      "q_code": "146",
+                      "mandatory": true
+                    }
+                  ],
+                  "guidance": {
+                    "content": [
+                      {
+                        "title": "Include",
+                        "list": [
+                          "change in level of business activity",
+                          "maintenance/shutdowns",
+                          "special/calendar events",
+                          "weather",
+                          "price effects",
+                          "currency effects (increase/decrease in the currency value)"
+                        ]
+                      }
+                    ]
+                  },
+                  "type": "General"
+                }
+              ],
+              "title": "Significant changes",
+              "routing_rules": [
+                {
+                  "goto": {
+                    "when": [
+                      {
+                        "id": "changes-answer",
+                        "value": "Yes",
+                        "condition": "equals"
+                      }
+                    ],
+                    "block": "changes-block-2"
+                  }
+                },
+                {
+                  "goto": {
+                    "group": "summary-group"
+                  }
+                }
+              ]
+            },
+            {
+              "id": "changes-block-2",
+              "type": "Question",
+              "questions": [
+                {
+                  "title": "Please indicate the reasons for any changes in the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
+                  "type": "General",
+                  "id": "changes-question-2",
+                  "answers": [
+                    {
+                      "options": [
+                        {
+                          "q_code": "146a",
+                          "value": "Change in level of business activity",
+                          "label": "Change in level of business activity"
+                        },
+                        {
+                          "q_code": "146b",
+                          "value": "Maintenance/shutdowns",
+                          "label": "Maintenance/shutdowns"
+                        },
+                        {
+                          "q_code": "146c",
+                          "value": "Special/calendar events",
+                          "label": "Special/calendar events"
+                        },
+                        {
+                          "q_code": "146d",
+                          "value": "Weather",
+                          "label": "Weather"
+                        },
+                        {
+                          "q_code": "146e",
+                          "value": "Price effects",
+                          "label": "Price effects"
+                        },
+                        {
+                          "q_code": "146f",
+                          "value": "Currency effects (increase/decrease in the currency value)",
+                          "label": "Currency effects (increase/decrease in the currency value)"
+                        },
+                        {
+                          "q_code": "146g",
+                          "value": "Other",
+                          "label": "Other"
+                        }
+                      ],
+                      "id": "changes-answer-2",
+                      "type": "Checkbox",
+                      "mandatory": true
+                    }
+                  ]
+                }
+              ],
+              "title": "Significant changes"
+            },
+            {
+              "type": "Question",
+              "id": "changes-block-3",
+              "title": "Changes",
+              "questions": [
+                {
+                  "type": "General",
+                  "id": "changes-question-3",
+                  "title": "Please describe the changes in turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
+                  "answers": [
+                    {
+                      "guidance": {
+                        "hide_guidance": "Hide examples of commentary on changes to turnover",
+                        "show_guidance": "Show examples of commentary on changes to turnover",
+                        "content": [
+                          {
+                            "title": "‘Change in level of business activity’",
+                            "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
+                          },
+                          {
+                            "title": "‘Maintenance/shutdowns’",
+                            "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
+                          },
+                          {
+                            "title": "‘Special/calendar events’",
+                            "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
+                          },
+                          {
+                            "title": "‘Weather’",
+                            "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
+                          },
+                          {
+                            "title": "‘Price effects’",
+                            "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
+                          },
+                          {
+                            "title": "‘Currency effects (increase/decrease in the currency value)’",
+                            "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
+                          }
+                        ]
+                      },
+                      "type": "TextArea",
+                      "mandatory": true,
+                      "label": "Comments",
+                      "id": "changes-answer-3",
+                      "q_code": "146h"
+                    }
+                  ],
+                  "description": "<p>We rely on your commentary to ‘tell the story’ behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "summary-section",
+      "title": "Summary",
+      "groups": [
+        {
+          "id": "summary-group",
+          "title": "Summary",
+          "blocks": [
+            {
+              "type": "Summary",
+              "id": "summary"
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/data/en/mbs_0123_prototype.json
+++ b/data/en/mbs_0123_prototype.json
@@ -1,0 +1,390 @@
+{
+    "title": "Monthly Business Survey",
+    "survey_id": "009",
+    "mime_type": "application/json/ons/eq",
+    "theme": "default",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.1",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
+    "description": "mbs 0123",
+    "eq_id": "mbs",
+    "form_type": "0123",
+    "view_submitted_response": {
+        "enabled": true,
+        "duration": 900
+    },
+    "metadata": [{
+        "name": "user_id",
+        "validator": "string"
+    }, {
+        "name": "period_id",
+        "validator": "string"
+    }, {
+        "name": "ru_name",
+        "validator": "string"
+    }, {
+        "name": "ref_p_start_date",
+        "validator": "date"
+    }, {
+        "name": "ref_p_end_date",
+        "validator": "date"
+    }, {
+        "name": "trad_as",
+        "validator": "optional_string"
+    }],
+    "sections": [{
+        "id": "section",
+        "groups": [{
+            "id": "group",
+            "title": "",
+            "blocks": [{
+                "type": "Introduction",
+                "id": "introduction",
+                "primary_content": [{
+                    "type": "Basic",
+                    "id": "use-of-information",
+                    "content": [{
+                        "list": ["Data should relate to all sites in England, Scotland and Wales unless otherwise stated.", "You can provide informed estimates if actual figures aren\u2019t available.", "We will treat your data securely and confidentially."]
+                    }]
+                }],
+                "preview_content": {
+                    "id": "preview",
+                    "title": "Information you need",
+                    "content": [{
+                        "title": "",
+                        "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
+                    }],
+                    "questions": [{
+                        "question": "Commission and fees",
+                        "content": [{
+                            "description": "Exclude VAT"
+                        }]
+                    }, {
+                        "question": "Sales on own account and turnover from other activities",
+                        "content": [{
+                            "description": "Exclude:",
+                            "list": ["VAT", "commission and fees", "income from sale of fixed capital assets", "grants"]
+                        }]
+                    }, {
+                        "question": "Significant changes",
+                        "content": [{
+                            "description": "Include:",
+                            "list": ["change in level of business activity", "maintenance/shutdowns", "special/calendar events", "weather", "price effects", "currency effects (increase/decrease in the currency value)"]
+                        }]
+                    }]
+                },
+                "secondary_content": [{
+                    "id": "how-we-use-your-data",
+                    "title": "How we use your data",
+                    "content": [{
+                        "list": ["You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.", "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"]
+                    }]
+                }]
+            }, {
+                "id": "reporting-period-block",
+                "type": "Question",
+                "questions": [{
+                    "answers": [{
+                        "options": [{
+                            "value": "Yes",
+                            "label": "Yes"
+                        }, {
+                            "value": "No",
+                            "label": "No"
+                        }],
+                        "id": "reporting-period-answer",
+                        "type": "Radio",
+                        "q_code": "d12",
+                        "mandatory": true
+                    }],
+                    "type": "General",
+                    "id": "reporting-period-question",
+                    "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
+                }],
+                "routing_rules": [{
+                    "goto": {
+                        "when": [{
+                            "id": "reporting-period-answer",
+                            "value": "Yes",
+                            "condition": "equals"
+                        }],
+                        "block": "commission-and-fees-block"
+                    }
+                }, {
+                    "goto": {
+                        "block": "reporting-period-block-2"
+                    }
+                }],
+                "title": "Reporting period"
+            }, {
+                "type": "Question",
+                "id": "reporting-period-block-2",
+                "title": "Reporting period",
+                "questions": [{
+                    "type": "DateRange",
+                    "id": "reporting-period-question-2",
+                    "title": "What are the dates of the period that you will be reporting for?",
+                    "period_limits": {
+                        "minimum": {
+                            "days": 10
+                        },
+                        "maximum": {
+                            "days": 50
+                        }
+                    },
+                    "answers": [{
+                        "type": "Date",
+                        "id": "period-from",
+                        "label": "From",
+                        "mandatory": true,
+                        "q_code": "11",
+                        "minimum": {
+                            "meta": "ref_p_start_date",
+                            "offset_by": {
+                                "days": -19
+                            }
+                        }
+                    }, {
+                        "type": "Date",
+                        "id": "period-to",
+                        "label": "To",
+                        "mandatory": true,
+                        "q_code": "12",
+                        "maximum": {
+                            "meta": "ref_p_end_date",
+                            "offset_by": {
+                                "days": 20
+                            }
+                        }
+                    }]
+                }]
+            }, {
+                "id": "commission-and-fees-block",
+                "type": "Question",
+                "title": "Commission and fees",
+                "questions": [{
+                    "description": "For example, as a travel agent, where you do not hold title to goods/services",
+                    "id": "commission-and-fees-question",
+                    "type": "General",
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>commission and fees</em>, excluding VAT?",
+                    "answers": [{
+                        "id": "commission-and-fees-answer",
+                        "label": "Total commission and fees excluding VAT",
+                        "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                        "type": "Currency",
+                        "currency": "GBP",
+                        "decimal_places": 2,
+                        "q_code": "42",
+                        "mandatory": true
+                    }]
+                }]
+            }, {
+                "type": "ConfirmationQuestion",
+                "title": "Commission and fees",
+                "id": "confirm-commission-and-fees-block",
+                "questions": [{
+                    "type": "General",
+                    "answers": [{
+                        "type": "Radio",
+                        "id": "confirm-commission-and-fees-answer",
+                        "q_code": "d40",
+                        "options": [{
+                            "label": "Yes this is correct",
+                            "value": "Yes"
+                        }, {
+                            "label": "No I need to change this",
+                            "value": "No"
+                        }],
+                        "mandatory": true
+                    }],
+                    "id": "confirm-commission-and-fees-question",
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total commission and fees was <em>{{format_currency(answers['commission-and-fees-answer'])}}</em>, is this correct?"
+                }],
+                "routing_rules": [{
+                    "goto": {
+                        "when": [{
+                            "value": "No",
+                            "id": "confirm-commission-and-fees-answer",
+                            "condition": "equals"
+                        }],
+                        "block": "commission-and-fees-block"
+                    }
+                }, {
+                    "goto": {
+                        "block": "sales-on-own-account-block"
+                    }
+                }]
+            }, {
+                "id": "sales-on-own-account-block",
+                "type": "Question",
+                "title": "Sales on own account and turnover from other activities",
+                "questions": [{
+                    "guidance": {
+                        "content": [{
+                            "title": "Exclude",
+                            "list": ["VAT", "commission and fees", "income from sales of fixed capital assets", "grants"]
+                        }]
+                    },
+                    "id": "sales-on-own-account-question",
+                    "type": "General",
+                    "description": "For example, as a tour operator",
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>sales on own account and turnover from other activities</em>, excluding VAT?",
+                    "answers": [{
+                        "id": "sales-on-own-account-answer",
+                        "label": "Total Sales on own account and turnover from other activities  excluding VAT",
+                        "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                        "type": "Currency",
+                        "currency": "GBP",
+                        "decimal_places": 2,
+                        "q_code": "43",
+                        "mandatory": true
+                    }]
+                }]
+            }, {
+                "id": "changes-block",
+                "type": "Question",
+                "questions": [{
+                    "title": "Did any significant changes occur to the figures provided for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                    "id": "changes-question",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
+                        }, {
+                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }]
+                    }],
+                    "answers": [{
+                        "options": [{
+                            "value": "Yes",
+                            "label": "Yes"
+                        }, {
+                            "value": "No",
+                            "label": "No"
+                        }],
+                        "id": "changes-answer",
+                        "type": "Radio",
+                        "q_code": "146",
+                        "mandatory": true
+                    }],
+                    "guidance": {
+                        "content": [{
+                            "title": "Include",
+                            "list": ["change in level of business activity", "maintenance/shutdowns", "special/calendar events", "weather", "price effects", "currency effects (increase/decrease in the currency value)"]
+                        }]
+                    },
+                    "type": "General"
+                }],
+                "title": "Significant changes",
+                "routing_rules": [{
+                    "goto": {
+                        "when": [{
+                            "id": "changes-answer",
+                            "value": "Yes",
+                            "condition": "equals"
+                        }],
+                        "block": "changes-block-2"
+                    }
+                }, {
+                    "goto": {
+                        "group": "summary-group"
+                    }
+                }]
+            }, {
+                "id": "changes-block-2",
+                "type": "Question",
+                "questions": [{
+                    "title": "Please indicate the reasons for any changes in the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
+                    "type": "General",
+                    "id": "changes-question-2",
+                    "answers": [{
+                        "options": [{
+                            "q_code": "146a",
+                            "value": "Change in level of business activity",
+                            "label": "Change in level of business activity"
+                        }, {
+                            "q_code": "146b",
+                            "value": "Maintenance/shutdowns",
+                            "label": "Maintenance/shutdowns"
+                        }, {
+                            "q_code": "146c",
+                            "value": "Special/calendar events",
+                            "label": "Special/calendar events"
+                        }, {
+                            "q_code": "146d",
+                            "value": "Weather",
+                            "label": "Weather"
+                        }, {
+                            "q_code": "146e",
+                            "value": "Price effects",
+                            "label": "Price effects"
+                        }, {
+                            "q_code": "146f",
+                            "value": "Currency effects (increase/decrease in the currency value)",
+                            "label": "Currency effects (increase/decrease in the currency value)"
+                        }, {
+                            "q_code": "146g",
+                            "value": "Other",
+                            "label": "Other"
+                        }],
+                        "id": "changes-answer-2",
+                        "type": "Checkbox",
+                        "mandatory": true
+                    }]
+                }],
+                "title": "Significant changes"
+            }, {
+                "type": "Question",
+                "id": "changes-block-3",
+                "title": "Changes",
+                "questions": [{
+                    "type": "General",
+                    "id": "changes-question-3",
+                    "title": "Please describe the changes in turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
+                    "answers": [{
+                        "guidance": {
+                            "hide_guidance": "Hide examples of commentary on changes to turnover",
+                            "show_guidance": "Show examples of commentary on changes to turnover",
+                            "content": [{
+                                "title": "\u2018Change in level of business activity\u2019",
+                                "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
+                            }, {
+                                "title": "\u2018Maintenance/shutdowns\u2019",
+                                "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
+                            }, {
+                                "title": "\u2018Special/calendar events\u2019",
+                                "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
+                            }, {
+                                "title": "\u2018Weather\u2019",
+                                "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
+                            }, {
+                                "title": "\u2018Price effects\u2019",
+                                "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
+                            }, {
+                                "title": "\u2018Currency effects (increase/decrease in the currency value)\u2019",
+                                "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
+                            }]
+                        },
+                        "type": "TextArea",
+                        "mandatory": true,
+                        "label": "Comments",
+                        "id": "changes-answer-3",
+                        "q_code": "146h"
+                    }],
+                    "description": "<p>We rely on your commentary to \u2018tell the story\u2019 behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
+                }]
+            }]
+        }]
+    }, {
+        "id": "summary-section",
+        "title": "Summary",
+        "groups": [{
+            "id": "summary-group",
+            "title": "Summary",
+            "blocks": [{
+                "type": "Summary",
+                "id": "summary"
+            }]
+        }]
+    }]
+}

--- a/data/en/mbs_0201.json
+++ b/data/en/mbs_0201.json
@@ -1,459 +1,671 @@
 {
-    "title": "Monthly Business Survey",
-    "survey_id": "009",
-    "mime_type": "application/json/ons/eq",
-    "theme": "default",
-    "schema_version": "0.0.1",
-    "data_version": "0.0.1",
-    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
-    "description": "mbs",
-    "form_type": "0251",
-    "view_submitted_response": {
-        "enabled": true,
-        "duration": 900
+  "title": "Monthly Business Survey",
+  "survey_id": "009",
+  "mime_type": "application/json/ons/eq",
+  "theme": "default",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.1",
+  "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
+  "description": "mbs",
+  "form_type": "0251",
+  "view_submitted_response": {
+    "enabled": true,
+    "duration": 900
+  },
+  "metadata": [
+    {
+      "name": "user_id",
+      "validator": "string"
     },
-    "metadata": [{
-        "name": "user_id",
-        "validator": "string"
-    }, {
-        "name": "period_id",
-        "validator": "string"
-    }, {
-        "name": "ru_name",
-        "validator": "string"
-    }, {
-        "name": "ref_p_start_date",
-        "validator": "date"
-    }, {
-        "name": "ref_p_end_date",
-        "validator": "date"
-    }, {
-        "name": "trad_as",
-        "validator": "optional_string"
-    }],
-    "sections": [{
-        "id": "section",
-        "groups": [{
-            "id": "group",
-            "title": "",
-            "blocks": [{
-                "type": "Introduction",
-                "id": "introduction",
-                "primary_content": [{
-                    "type": "Basic",
-                    "id": "use-of-information",
-                    "content": [{
-                        "list": ["Data should relate to all sites in England, Scotland, Wales and Northern Ireland unless otherwise stated.", "You can provide informed estimates if actual figures aren\u2019t available.", "We will treat your data securely and confidentially."]
-                    }]
-                }],
-                "preview_content": {
-                    "id": "preview",
-                    "title": "Information you need",
-                    "content": [{
-                        "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
-                    }],
-                    "questions": [{
-                        "question": "Total turnover",
-                        "content": [{
-                            "description": "Include:",
-                            "list": ["exports", "income from sub-contracted activities", "commission", "sales of goods purchased for resale", "transport, insurance and packaging charges", "revenue earned from other parts of the business not named at the top of this page (please supply at fair value)"]
-                        }, {
-                            "description": "Exclude:",
-                            "list": ["VAT", "income from the sale of fixed capital assets", "grants and subsidies", "insurance claims", "interest received"]
-                        }]
-                    }, {
-                        "question": "Value of exports",
-                        "content": [{
-                            "description": "Include:",
-                            "list": ["all countries outside of England, Scotland, Wales and Northern Ireland"]
-                        }]
-                    }, {
-                        "question": "Changes in total turnover",
-                        "content": [{
-                            "description": "Include:",
-                            "list": ["change in level of business activity", "maintenance/shutdowns", "special/calendar events", "weather", "price effects", "currency effects (increase/decrease in the currency value)"]
-                        }]
-                    }]
-                },
-                "secondary_content": [{
-                    "id": "how-we-use-your-data",
-                    "title": "How we use your data",
-                    "content": [{
-                        "list": ["You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.", "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"]
-                    }]
-                }]
-            }, {
-                "id": "reporting-period-block",
-                "type": "Question",
-                "questions": [{
-                    "answers": [{
-                        "options": [{
-                            "value": "Yes",
-                            "label": "Yes"
-                        }, {
-                            "value": "No",
-                            "label": "No"
-                        }],
+    {
+      "name": "period_id",
+      "validator": "string"
+    },
+    {
+      "name": "ru_name",
+      "validator": "string"
+    },
+    {
+      "name": "ref_p_start_date",
+      "validator": "date"
+    },
+    {
+      "name": "ref_p_end_date",
+      "validator": "date"
+    },
+    {
+      "name": "trad_as",
+      "validator": "optional_string"
+    }
+  ],
+  "sections": [
+    {
+      "id": "section",
+      "groups": [
+        {
+          "id": "group",
+          "title": "",
+          "blocks": [
+            {
+              "type": "Introduction",
+              "id": "introduction",
+              "primary_content": [
+                {
+                  "type": "Basic",
+                  "id": "use-of-information",
+                  "content": [
+                    {
+                      "list": [
+                        "Data should relate to all sites in England, Scotland, Wales and Northern Ireland unless otherwise stated.",
+                        "You can provide informed estimates if actual figures aren’t available.",
+                        "We will treat your data securely and confidentially."
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "preview_content": {
+                "id": "preview",
+                "title": "Information you need",
+                "content": [
+                  {
+                    "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
+                  }
+                ],
+                "questions": [
+                  {
+                    "question": "Total turnover",
+                    "content": [
+                      {
+                        "description": "Include:",
+                        "list": [
+                          "exports",
+                          "income from sub-contracted activities",
+                          "commission",
+                          "sales of goods purchased for resale",
+                          "transport, insurance and packaging charges",
+                          "revenue earned from other parts of the business not named at the top of this page (please supply at fair value)"
+                        ]
+                      },
+                      {
+                        "description": "Exclude:",
+                        "list": [
+                          "VAT",
+                          "income from the sale of fixed capital assets",
+                          "grants and subsidies",
+                          "insurance claims",
+                          "interest received"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "question": "Value of exports",
+                    "content": [
+                      {
+                        "description": "Include:",
+                        "list": [
+                          "all countries outside of England, Scotland, Wales and Northern Ireland"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "question": "Changes in total turnover",
+                    "content": [
+                      {
+                        "description": "Include:",
+                        "list": [
+                          "change in level of business activity",
+                          "maintenance/shutdowns",
+                          "special/calendar events",
+                          "weather",
+                          "price effects",
+                          "currency effects (increase/decrease in the currency value)"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              "secondary_content": [
+                {
+                  "id": "how-we-use-your-data",
+                  "title": "How we use your data",
+                  "content": [
+                    {
+                      "list": [
+                        "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
+                        "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "reporting-period-block",
+              "type": "Question",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "options": [
+                        {
+                          "value": "Yes",
+                          "label": "Yes"
+                        },
+                        {
+                          "value": "No",
+                          "label": "No"
+                        }
+                      ],
+                      "id": "reporting-period-answer",
+                      "type": "Radio",
+                      "q_code": "d12",
+                      "mandatory": true
+                    }
+                  ],
+                  "type": "General",
+                  "id": "reporting-period-question",
+                  "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "when": [
+                      {
                         "id": "reporting-period-answer",
-                        "type": "Radio",
-                        "q_code": "d12",
-                        "mandatory": true
-                    }],
-                    "type": "General",
-                    "id": "reporting-period-question",
-                    "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
-                }],
-                "routing_rules": [{
-                    "goto": {
-                        "when": [{
-                            "id": "reporting-period-answer",
-                            "value": "Yes",
-                            "condition": "equals"
-                        }],
-                        "block": "turnover-block"
-                    }
-                }, {
-                    "goto": {
-                        "block": "reporting-period-block-2"
-                    }
-                }],
-                "title": "Reporting period"
-            }, {
-                "type": "Question",
-                "id": "reporting-period-block-2",
-                "title": "Reporting period",
-                "questions": [{
-                    "type": "DateRange",
-                    "id": "reporting-period-question-2",
-                    "title": "What are the dates of the period that you will be reporting for?",
-                    "period_limits": {
-                        "minimum": {
-                            "days": 10
-                        },
-                        "maximum": {
-                            "days": 50
-                        }
+                        "value": "Yes",
+                        "condition": "equals"
+                      }
+                    ],
+                    "block": "turnover-block"
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "reporting-period-block-2"
+                  }
+                }
+              ],
+              "title": "Reporting period"
+            },
+            {
+              "type": "Question",
+              "id": "reporting-period-block-2",
+              "title": "Reporting period",
+              "questions": [
+                {
+                  "type": "DateRange",
+                  "id": "reporting-period-question-2",
+                  "title": "What are the dates of the period that you will be reporting for?",
+                  "period_limits": {
+                    "minimum": {
+                      "days": 10
                     },
-                    "answers": [{
-                        "type": "Date",
-                        "id": "period-from",
-                        "label": "From",
-                        "mandatory": true,
-                        "q_code": "11",
-                        "minimum": {
-                            "meta": "ref_p_start_date",
-                            "offset_by": {
-                                "days": -19
-                            }
+                    "maximum": {
+                      "days": 50
+                    }
+                  },
+                  "answers": [
+                    {
+                      "type": "Date",
+                      "id": "period-from",
+                      "label": "From",
+                      "mandatory": true,
+                      "q_code": "11",
+                      "minimum": {
+                        "meta": "ref_p_start_date",
+                        "offset_by": {
+                          "days": -19
                         }
-                    }, {
-                        "type": "Date",
-                        "id": "period-to",
-                        "label": "To",
-                        "mandatory": true,
-                        "q_code": "12",
-                        "maximum": {
-                            "meta": "ref_p_end_date",
-                            "offset_by": {
-                                "days": 20
-                            }
-                        }
-                    }]
-                }]
-            }, {
-                "id": "turnover-block",
-                "type": "Question",
-                "title": "Total turnover",
-                "questions": [{
-                    "guidance": {
-                        "content": [{
-                            "title": "Include:",
-                            "list": ["exports", "income from sub-contracted activities", "commission", "sales of goods purchased for resale", "transport, insurance and packaging charges", "revenue earned from other parts of the business not named at the top of this page (please supply at fair value)"]
-                        }, {
-                            "title": "Exclude:",
-                            "list": ["VAT", "income from the sale of fixed capital assets", "grants and subsidies", "insurance claims", "interest received"]
-                        }]
+                      }
                     },
-                    "id": "turnover-question",
-                    "answers": [{
+                    {
+                      "type": "Date",
+                      "id": "period-to",
+                      "label": "To",
+                      "mandatory": true,
+                      "q_code": "12",
+                      "maximum": {
+                        "meta": "ref_p_end_date",
+                        "offset_by": {
+                          "days": 20
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "turnover-block",
+              "type": "Question",
+              "title": "Total turnover",
+              "questions": [
+                {
+                  "guidance": {
+                    "content": [
+                      {
+                        "title": "Include:",
+                        "list": [
+                          "exports",
+                          "income from sub-contracted activities",
+                          "commission",
+                          "sales of goods purchased for resale",
+                          "transport, insurance and packaging charges",
+                          "revenue earned from other parts of the business not named at the top of this page (please supply at fair value)"
+                        ]
+                      },
+                      {
+                        "title": "Exclude:",
+                        "list": [
+                          "VAT",
+                          "income from the sale of fixed capital assets",
+                          "grants and subsidies",
+                          "insurance claims",
+                          "interest received"
+                        ]
+                      }
+                    ]
+                  },
+                  "id": "turnover-question",
+                  "answers": [
+                    {
+                      "id": "turnover-answer",
+                      "label": "Total turnover excluding VAT",
+                      "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                      "type": "Currency",
+                      "currency": "GBP",
+                      "decimal_places": 2,
+                      "q_code": "40",
+                      "mandatory": false,
+                      "default": 0
+                    }
+                  ],
+                  "type": "General",
+                  "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s <em>total turnover</em>, excluding VAT?"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "when": [
+                      {
                         "id": "turnover-answer",
-                        "label": "Total turnover excluding VAT",
-                        "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
-                        "type": "Currency",
-                        "currency": "GBP",
-                        "decimal_places": 2,
-                        "q_code": "40",
-                        "mandatory": false,
-                        "default": 0
-                    }],
-                    "type": "General",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>total turnover</em>, excluding VAT?"
-                }],
-                "routing_rules": [{
-                    "goto": {
-                        "when": [{
-                            "id": "turnover-answer",
-                            "condition": "greater than",
-                            "value": 0
-                        }],
-                        "block": "confirm-turnover-block"
-                    }
-                }, {
-                    "goto": {
-                        "block": "confirm-zero-turnover-block"
-                    }
-                }]
-            }, {
-                "type": "ConfirmationQuestion",
-                "title": "Total turnover",
-                "id": "confirm-turnover-block",
-                "questions": [{
-                    "type": "General",
-                    "answers": [{
-                        "type": "Radio",
-                        "id": "confirm-turnover-answer",
-                        "q_code": "d40",
-                        "options": [{
-                            "label": "Yes this is correct",
-                            "value": "Yes"
-                        }, {
-                            "label": "No I need to change this",
-                            "value": "No"
-                        }],
-                        "mandatory": true
-                    }],
-                    "id": "confirm-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
-                }],
-                "routing_rules": [{
-                    "goto": {
-                        "when": [{
-                            "value": "No",
-                            "id": "confirm-turnover-answer",
-                            "condition": "equals"
-                        }],
-                        "block": "turnover-block"
-                    }
-                }, {
-                    "goto": {
-                        "block": "exports-block"
-                    }
-                }]
-            }, {
-                "type": "ConfirmationQuestion",
-                "title": "Total turnover",
-                "id": "confirm-zero-turnover-block",
-                "questions": [{
-                    "type": "General",
-                    "answers": [{
-                        "type": "Radio",
-                        "id": "confirm-zero-turnover-answer",
-                        "q_code": "d49",
-                        "options": [{
-                            "label": "Yes this is correct",
-                            "value": "Yes"
-                        }, {
-                            "label": "No I need to change this",
-                            "value": "No"
-                        }],
-                        "mandatory": true
-                    }],
-                    "id": "confirm-zero-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
-                }],
-                "routing_rules": [{
-                    "goto": {
-                        "when": [{
-                            "value": "No",
-                            "id": "confirm-zero-turnover-answer",
-                            "condition": "equals"
-                        }],
-                        "block": "turnover-block"
-                    }
-                }, {
-                    "goto": {
-                        "block": "changes-in-turnover-block"
-                    }
-                }]
-            }, {
-                "id": "exports-block",
-                "type": "Question",
-                "questions": [{
-                    "id": "exports-question",
-                    "guidance": {
-                        "content": [{
-                            "title": "Include:",
-                            "list": ["All countries outside of England, Scotland, Wales and Northern Ireland"]
-                        }]
-                    },
-                    "answers": [{
-                        "id": "exports-answer",
-                        "label": "Exports",
-                        "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
-                        "type": "Currency",
-                        "currency": "GBP",
-                        "decimal_places": 2,
-                        "q_code": "49",
-                        "mandatory": true,
-                        "max_value": {
-                            "answer_id": "turnover-answer"
-                        }
-                    }],
-                    "type": "General",
-                    "title": "Of the <em>{{format_currency(answers['turnover-answer'])}}</em> total turnover, what was the value of <em>exports?</em>"
-                }],
-                "title": "Exports"
-            }, {
-                "id": "changes-in-turnover-block",
-                "type": "Question",
-                "questions": [{
-                    "title": "Did any significant changes occur to the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
-                    "id": "changes-in-turnover-question",
-                    "definitions": [{
-                        "title": "What constitutes a significant change?",
-                        "content": [{
-                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
-                        }, {
-                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
-                        }]
-                    }],
-                    "answers": [{
-                        "options": [{
-                            "value": "Yes",
-                            "label": "Yes"
-                        }, {
-                            "value": "No",
-                            "label": "No"
-                        }],
-                        "id": "changes-in-turnover-answer",
-                        "type": "Radio",
-                        "q_code": "146",
-                        "mandatory": true
-                    }],
-                    "guidance": {
-                        "content": [{
-                            "title": "Include",
-                            "list": ["change in level of business activity", "maintenance/shutdowns", "special/calendar events", "weather", "price effects", "currency effects (increase/decrease in the currency value)"]
-                        }]
-                    },
-                    "type": "General"
-                }],
-                "title": "Changes in total turnover",
-                "routing_rules": [{
-                    "goto": {
-                        "when": [{
-                            "id": "changes-in-turnover-answer",
-                            "value": "Yes",
-                            "condition": "equals"
-                        }],
-                        "block": "changes-in-turnover-block-2"
-                    }
-                }, {
-                    "goto": {
-                        "group": "summary-group"
-                    }
-                }]
-            }, {
-                "id": "changes-in-turnover-block-2",
-                "type": "Question",
-                "questions": [{
-                    "title": "Please indicate the reasons for any changes in the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
-                    "answers": [{
-                        "options": [{
-                            "q_code": "146a",
-                            "value": "Change in level of business activity",
-                            "label": "Change in level of business activity"
-                        }, {
-                            "q_code": "146b",
-                            "value": "Maintenance/shutdowns",
-                            "label": "Maintenance/shutdowns"
-                        }, {
-                            "q_code": "146c",
-                            "value": "Special/calendar events",
-                            "label": "Special/calendar events"
-                        }, {
-                            "q_code": "146d",
-                            "value": "Weather",
-                            "label": "Weather"
-                        }, {
-                            "q_code": "146e",
-                            "value": "Price effects",
-                            "label": "Price effects"
-                        }, {
-                            "q_code": "146f",
-                            "value": "Currency effects (increase/decrease in the currency value)",
-                            "label": "Currency effects (increase/decrease in the currency value)"
-                        }, {
-                            "q_code": "146g",
-                            "value": "Other",
-                            "label": "Other"
-                        }],
-                        "id": "changes-in-turnover-answer-2",
-                        "type": "Checkbox",
-                        "mandatory": true
-                    }],
-                    "type": "General",
-                    "id": "changes-in-turnover-question-2"
-                }],
-                "title": "Changes in total turnover"
-            }, {
-                "type": "Question",
-                "id": "changes-in-turnover-block-3",
-                "title": "Changes in total turnover",
-                "questions": [{
-                    "type": "General",
-                    "id": "changes-in-turnover-question-3",
-                    "title": "Please describe the changes in total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
-                    "answers": [{
-                        "guidance": {
-                            "hide_guidance": "Hide examples of commentary on changes to total turnover",
-                            "show_guidance": "Show examples of commentary on changes to total turnover",
-                            "content": [{
-                                "list": [],
-                                "title": "\u2018Change in level of business activity\u2019",
-                                "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
-                            }, {
-                                "list": [],
-                                "title": "\u2018Maintenance/shutdowns\u2019",
-                                "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
-                            }, {
-                                "list": [],
-                                "title": "\u2018Special/calendar events\u2019",
-                                "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
-                            }, {
-                                "list": [],
-                                "title": "\u2018Weather\u2019",
-                                "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
-                            }, {
-                                "list": [],
-                                "title": "\u2018Price effects\u2019",
-                                "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
-                            }, {
-                                "list": [],
-                                "title": "\u2018Currency effects (increase/decrease in the currency value)\u2019",
-                                "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
-                            }]
+                        "condition": "greater than",
+                        "value": 0
+                      }
+                    ],
+                    "block": "confirm-turnover-block"
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "confirm-zero-turnover-block"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "ConfirmationQuestion",
+              "title": "Total turnover",
+              "id": "confirm-turnover-block",
+              "questions": [
+                {
+                  "type": "General",
+                  "answers": [
+                    {
+                      "type": "Radio",
+                      "id": "confirm-turnover-answer",
+                      "q_code": "d40",
+                      "options": [
+                        {
+                          "label": "Yes this is correct",
+                          "value": "Yes"
                         },
-                        "type": "TextArea",
-                        "mandatory": true,
-                        "label": "Comments",
-                        "id": "changes-in-turnover-answer-3",
-                        "q_code": "146h"
-                    }],
-                    "description": "<p>We rely on your commentary to \u2018tell the story\u2019 behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
-                }]
-            }]
-        }]
-    }, {
-        "id": "summary-section",
-        "title": "Summary",
-        "groups": [{
-            "id": "summary-group",
-            "title": "Summary",
-            "blocks": [{
-                "type": "Summary",
-                "id": "summary"
-            }]
-        }]
-    }]
+                        {
+                          "label": "No I need to change this",
+                          "value": "No"
+                        }
+                      ],
+                      "mandatory": true
+                    }
+                  ],
+                  "id": "confirm-turnover-question",
+                  "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "when": [
+                      {
+                        "value": "No",
+                        "id": "confirm-turnover-answer",
+                        "condition": "equals"
+                      }
+                    ],
+                    "block": "turnover-block"
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "exports-block"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "ConfirmationQuestion",
+              "title": "Total turnover",
+              "id": "confirm-zero-turnover-block",
+              "questions": [
+                {
+                  "type": "General",
+                  "answers": [
+                    {
+                      "type": "Radio",
+                      "id": "confirm-zero-turnover-answer",
+                      "q_code": "d49",
+                      "options": [
+                        {
+                          "label": "Yes this is correct",
+                          "value": "Yes"
+                        },
+                        {
+                          "label": "No I need to change this",
+                          "value": "No"
+                        }
+                      ],
+                      "mandatory": true
+                    }
+                  ],
+                  "id": "confirm-zero-turnover-question",
+                  "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "when": [
+                      {
+                        "value": "No",
+                        "id": "confirm-zero-turnover-answer",
+                        "condition": "equals"
+                      }
+                    ],
+                    "block": "turnover-block"
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "changes-in-turnover-block"
+                  }
+                }
+              ]
+            },
+            {
+              "id": "exports-block",
+              "type": "Question",
+              "questions": [
+                {
+                  "id": "exports-question",
+                  "guidance": {
+                    "content": [
+                      {
+                        "title": "Include:",
+                        "list": [
+                          "All countries outside of England, Scotland, Wales and Northern Ireland"
+                        ]
+                      }
+                    ]
+                  },
+                  "answers": [
+                    {
+                      "id": "exports-answer",
+                      "label": "Exports",
+                      "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                      "type": "Currency",
+                      "currency": "GBP",
+                      "decimal_places": 2,
+                      "q_code": "49",
+                      "mandatory": true,
+                      "max_value": {
+                        "answer_id": "turnover-answer"
+                      }
+                    }
+                  ],
+                  "type": "General",
+                  "title": "Of the <em>{{format_currency(answers['turnover-answer'])}}</em> total turnover, what was the value of <em>exports?</em>"
+                }
+              ],
+              "title": "Exports"
+            },
+            {
+              "id": "changes-in-turnover-block",
+              "type": "Question",
+              "questions": [
+                {
+                  "title": "Did any significant changes occur to the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                  "id": "changes-in-turnover-question",
+                  "definitions": [
+                    {
+                      "title": "What constitutes a significant change?",
+                      "content": [
+                        {
+                          "description": "What constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s figures from the previous reporting period and the same reporting period last year."
+                        },
+                        {
+                          "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }
+                      ]
+                    }
+                  ],
+                  "answers": [
+                    {
+                      "options": [
+                        {
+                          "value": "Yes",
+                          "label": "Yes"
+                        },
+                        {
+                          "value": "No",
+                          "label": "No"
+                        }
+                      ],
+                      "id": "changes-in-turnover-answer",
+                      "type": "Radio",
+                      "q_code": "146",
+                      "mandatory": true
+                    }
+                  ],
+                  "guidance": {
+                    "content": [
+                      {
+                        "title": "Include",
+                        "list": [
+                          "change in level of business activity",
+                          "maintenance/shutdowns",
+                          "special/calendar events",
+                          "weather",
+                          "price effects",
+                          "currency effects (increase/decrease in the currency value)"
+                        ]
+                      }
+                    ]
+                  },
+                  "type": "General"
+                }
+              ],
+              "title": "Changes in total turnover",
+              "routing_rules": [
+                {
+                  "goto": {
+                    "when": [
+                      {
+                        "id": "changes-in-turnover-answer",
+                        "value": "Yes",
+                        "condition": "equals"
+                      }
+                    ],
+                    "block": "changes-in-turnover-block-2"
+                  }
+                },
+                {
+                  "goto": {
+                    "group": "summary-group"
+                  }
+                }
+              ]
+            },
+            {
+              "id": "changes-in-turnover-block-2",
+              "type": "Question",
+              "questions": [
+                {
+                  "title": "Please indicate the reasons for any changes in the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
+                  "answers": [
+                    {
+                      "options": [
+                        {
+                          "q_code": "146a",
+                          "value": "Change in level of business activity",
+                          "label": "Change in level of business activity"
+                        },
+                        {
+                          "q_code": "146b",
+                          "value": "Maintenance/shutdowns",
+                          "label": "Maintenance/shutdowns"
+                        },
+                        {
+                          "q_code": "146c",
+                          "value": "Special/calendar events",
+                          "label": "Special/calendar events"
+                        },
+                        {
+                          "q_code": "146d",
+                          "value": "Weather",
+                          "label": "Weather"
+                        },
+                        {
+                          "q_code": "146e",
+                          "value": "Price effects",
+                          "label": "Price effects"
+                        },
+                        {
+                          "q_code": "146f",
+                          "value": "Currency effects (increase/decrease in the currency value)",
+                          "label": "Currency effects (increase/decrease in the currency value)"
+                        },
+                        {
+                          "q_code": "146g",
+                          "value": "Other",
+                          "label": "Other"
+                        }
+                      ],
+                      "id": "changes-in-turnover-answer-2",
+                      "type": "Checkbox",
+                      "mandatory": true
+                    }
+                  ],
+                  "type": "General",
+                  "id": "changes-in-turnover-question-2"
+                }
+              ],
+              "title": "Changes in total turnover"
+            },
+            {
+              "type": "Question",
+              "id": "changes-in-turnover-block-3",
+              "title": "Changes in total turnover",
+              "questions": [
+                {
+                  "type": "General",
+                  "id": "changes-in-turnover-question-3",
+                  "title": "Please describe the changes in total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
+                  "answers": [
+                    {
+                      "guidance": {
+                        "hide_guidance": "Hide examples of commentary on changes to total turnover",
+                        "show_guidance": "Show examples of commentary on changes to total turnover",
+                        "content": [
+                          {
+                            "list": [
+                              
+                            ],
+                            "title": "‘Change in level of business activity’",
+                            "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
+                          },
+                          {
+                            "list": [
+                              
+                            ],
+                            "title": "‘Maintenance/shutdowns’",
+                            "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
+                          },
+                          {
+                            "list": [
+                              
+                            ],
+                            "title": "‘Special/calendar events’",
+                            "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
+                          },
+                          {
+                            "list": [
+                              
+                            ],
+                            "title": "‘Weather’",
+                            "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
+                          },
+                          {
+                            "list": [
+                              
+                            ],
+                            "title": "‘Price effects’",
+                            "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
+                          },
+                          {
+                            "list": [
+                              
+                            ],
+                            "title": "‘Currency effects (increase/decrease in the currency value)’",
+                            "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
+                          }
+                        ]
+                      },
+                      "type": "TextArea",
+                      "mandatory": true,
+                      "label": "Comments",
+                      "id": "changes-in-turnover-answer-3",
+                      "q_code": "146h"
+                    }
+                  ],
+                  "description": "<p>We rely on your commentary to ‘tell the story’ behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "summary-section",
+      "title": "Summary",
+      "groups": [
+        {
+          "id": "summary-group",
+          "title": "Summary",
+          "blocks": [
+            {
+              "type": "Summary",
+              "id": "summary"
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/data/en/mbs_0201.json
+++ b/data/en/mbs_0201.json
@@ -1,671 +1,582 @@
 {
-  "title": "Monthly Business Survey",
-  "survey_id": "009",
-  "mime_type": "application/json/ons/eq",
-  "theme": "default",
-  "schema_version": "0.0.1",
-  "data_version": "0.0.1",
-  "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
-  "description": "mbs",
-  "form_type": "0251",
-  "view_submitted_response": {
-    "enabled": true,
-    "duration": 900
-  },
-  "metadata": [
-    {
-      "name": "user_id",
-      "validator": "string"
+    "title": "Monthly Business Survey",
+    "survey_id": "009",
+    "mime_type": "application/json/ons/eq",
+    "theme": "default",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.1",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
+    "description": "mbs",
+    "form_type": "0251",
+    "view_submitted_response": {
+        "enabled": true,
+        "duration": 900
     },
-    {
-      "name": "period_id",
-      "validator": "string"
-    },
-    {
-      "name": "ru_name",
-      "validator": "string"
-    },
-    {
-      "name": "ref_p_start_date",
-      "validator": "date"
-    },
-    {
-      "name": "ref_p_end_date",
-      "validator": "date"
-    },
-    {
-      "name": "trad_as",
-      "validator": "optional_string"
-    }
-  ],
-  "sections": [
-    {
-      "id": "section",
-      "groups": [
+    "metadata": [{
+            "name": "user_id",
+            "validator": "string"
+        },
         {
-          "id": "group",
-          "title": "",
-          "blocks": [
-            {
-              "type": "Introduction",
-              "id": "introduction",
-              "primary_content": [
-                {
-                  "type": "Basic",
-                  "id": "use-of-information",
-                  "content": [
+            "name": "period_id",
+            "validator": "string"
+        },
+        {
+            "name": "ru_name",
+            "validator": "string"
+        },
+        {
+            "name": "ref_p_start_date",
+            "validator": "date"
+        },
+        {
+            "name": "ref_p_end_date",
+            "validator": "date"
+        },
+        {
+            "name": "trad_as",
+            "validator": "optional_string"
+        }
+    ],
+    "sections": [{
+            "id": "section",
+            "groups": [{
+                "id": "group",
+                "title": "",
+                "blocks": [{
+                        "type": "Introduction",
+                        "id": "introduction",
+                        "primary_content": [{
+                            "type": "Basic",
+                            "id": "use-of-information",
+                            "content": [{
+                                "list": [
+                                    "Data should relate to all sites in England, Scotland, Wales and Northern Ireland unless otherwise stated.",
+                                    "You can provide informed estimates if actual figures aren’t available.",
+                                    "We will treat your data securely and confidentially."
+                                ]
+                            }]
+                        }],
+                        "preview_content": {
+                            "id": "preview",
+                            "title": "Information you need",
+                            "content": [{
+                                "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
+                            }],
+                            "questions": [{
+                                    "question": "Total turnover",
+                                    "content": [{
+                                            "description": "Include:",
+                                            "list": [
+                                                "exports",
+                                                "income from sub-contracted activities",
+                                                "commission",
+                                                "sales of goods purchased for resale",
+                                                "transport, insurance and packaging charges",
+                                                "revenue earned from other parts of the business not named at the top of this page (please supply at fair value)"
+                                            ]
+                                        },
+                                        {
+                                            "description": "Exclude:",
+                                            "list": [
+                                                "VAT",
+                                                "income from the sale of fixed capital assets",
+                                                "grants and subsidies",
+                                                "insurance claims",
+                                                "interest received"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": "Value of exports",
+                                    "content": [{
+                                        "description": "Include:",
+                                        "list": [
+                                            "all countries outside of England, Scotland, Wales and Northern Ireland"
+                                        ]
+                                    }]
+                                },
+                                {
+                                    "question": "Changes in total turnover",
+                                    "content": [{
+                                        "description": "Include:",
+                                        "list": [
+                                            "change in level of business activity",
+                                            "maintenance/shutdowns",
+                                            "special/calendar events",
+                                            "weather",
+                                            "price effects",
+                                            "currency effects (increase/decrease in the currency value)"
+                                        ]
+                                    }]
+                                }
+                            ]
+                        },
+                        "secondary_content": [{
+                            "id": "how-we-use-your-data",
+                            "title": "How we use your data",
+                            "content": [{
+                                "list": [
+                                    "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
+                                    "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"
+                                ]
+                            }]
+                        }]
+                    },
                     {
-                      "list": [
-                        "Data should relate to all sites in England, Scotland, Wales and Northern Ireland unless otherwise stated.",
-                        "You can provide informed estimates if actual figures aren’t available.",
-                        "We will treat your data securely and confidentially."
-                      ]
+                        "id": "reporting-period-block",
+                        "type": "Question",
+                        "questions": [{
+                            "answers": [{
+                                "options": [{
+                                        "value": "Yes",
+                                        "label": "Yes"
+                                    },
+                                    {
+                                        "value": "No",
+                                        "label": "No"
+                                    }
+                                ],
+                                "id": "reporting-period-answer",
+                                "type": "Radio",
+                                "q_code": "d12",
+                                "mandatory": true
+                            }],
+                            "type": "General",
+                            "id": "reporting-period-question",
+                            "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "id": "reporting-period-answer",
+                                        "value": "Yes",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "turnover-block"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "reporting-period-block-2"
+                                }
+                            }
+                        ],
+                        "title": "Reporting period"
+                    },
+                    {
+                        "type": "Question",
+                        "id": "reporting-period-block-2",
+                        "title": "Reporting period",
+                        "questions": [{
+                            "type": "DateRange",
+                            "id": "reporting-period-question-2",
+                            "title": "What are the dates of the period that you will be reporting for?",
+                            "period_limits": {
+                                "minimum": {
+                                    "days": 10
+                                },
+                                "maximum": {
+                                    "days": 50
+                                }
+                            },
+                            "answers": [{
+                                    "type": "Date",
+                                    "id": "period-from",
+                                    "label": "From",
+                                    "mandatory": true,
+                                    "q_code": "11",
+                                    "minimum": {
+                                        "meta": "ref_p_start_date",
+                                        "offset_by": {
+                                            "days": -19
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "Date",
+                                    "id": "period-to",
+                                    "label": "To",
+                                    "mandatory": true,
+                                    "q_code": "12",
+                                    "maximum": {
+                                        "meta": "ref_p_end_date",
+                                        "offset_by": {
+                                            "days": 20
+                                        }
+                                    }
+                                }
+                            ]
+                        }]
+                    },
+                    {
+                        "id": "turnover-block",
+                        "type": "Question",
+                        "title": "Total turnover",
+                        "questions": [{
+                            "guidance": {
+                                "content": [{
+                                        "title": "Include:",
+                                        "list": [
+                                            "exports",
+                                            "income from sub-contracted activities",
+                                            "commission",
+                                            "sales of goods purchased for resale",
+                                            "transport, insurance and packaging charges",
+                                            "revenue earned from other parts of the business not named at the top of this page (please supply at fair value)"
+                                        ]
+                                    },
+                                    {
+                                        "title": "Exclude:",
+                                        "list": [
+                                            "VAT",
+                                            "income from the sale of fixed capital assets",
+                                            "grants and subsidies",
+                                            "insurance claims",
+                                            "interest received"
+                                        ]
+                                    }
+                                ]
+                            },
+                            "id": "turnover-question",
+                            "answers": [{
+                                "id": "turnover-answer",
+                                "label": "Total turnover excluding VAT",
+                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                                "type": "Currency",
+                                "currency": "GBP",
+                                "decimal_places": 2,
+                                "q_code": "40",
+                                "mandatory": false,
+                                "default": 0
+                            }],
+                            "type": "General",
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s <em>total turnover</em>, excluding VAT?"
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "id": "turnover-answer",
+                                        "condition": "greater than",
+                                        "value": 0
+                                    }],
+                                    "block": "confirm-turnover-block"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "confirm-zero-turnover-block"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "type": "ConfirmationQuestion",
+                        "title": "Total turnover",
+                        "id": "confirm-turnover-block",
+                        "questions": [{
+                            "type": "General",
+                            "answers": [{
+                                "type": "Radio",
+                                "id": "confirm-turnover-answer",
+                                "q_code": "d40",
+                                "options": [{
+                                        "label": "Yes this is correct",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No I need to change this",
+                                        "value": "No"
+                                    }
+                                ],
+                                "mandatory": true
+                            }],
+                            "id": "confirm-turnover-question",
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "value": "No",
+                                        "id": "confirm-turnover-answer",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "turnover-block"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "exports-block"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "type": "ConfirmationQuestion",
+                        "title": "Total turnover",
+                        "id": "confirm-zero-turnover-block",
+                        "questions": [{
+                            "type": "General",
+                            "answers": [{
+                                "type": "Radio",
+                                "id": "confirm-zero-turnover-answer",
+                                "q_code": "d49",
+                                "options": [{
+                                        "label": "Yes this is correct",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No I need to change this",
+                                        "value": "No"
+                                    }
+                                ],
+                                "mandatory": true
+                            }],
+                            "id": "confirm-zero-turnover-question",
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "value": "No",
+                                        "id": "confirm-zero-turnover-answer",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "turnover-block"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "changes-in-turnover-block"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "exports-block",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "exports-question",
+                            "guidance": {
+                                "content": [{
+                                    "title": "Include:",
+                                    "list": [
+                                        "All countries outside of England, Scotland, Wales and Northern Ireland"
+                                    ]
+                                }]
+                            },
+                            "answers": [{
+                                "id": "exports-answer",
+                                "label": "Exports",
+                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                                "type": "Currency",
+                                "currency": "GBP",
+                                "decimal_places": 2,
+                                "q_code": "49",
+                                "mandatory": true,
+                                "max_value": {
+                                    "answer_id": "turnover-answer"
+                                }
+                            }],
+                            "type": "General",
+                            "title": "Of the <em>{{format_currency(answers['turnover-answer'])}}</em> total turnover, what was the value of <em>exports?</em>"
+                        }],
+                        "title": "Exports"
+                    },
+                    {
+                        "id": "changes-in-turnover-block",
+                        "type": "Question",
+                        "questions": [{
+                            "title": "Did any significant changes occur to the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                            "id": "changes-in-turnover-question",
+                            "definitions": [{
+                                "title": "What constitutes a significant change?",
+                                "content": [{
+                                        "description": "What constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s figures from the previous reporting period and the same reporting period last year."
+                                    },
+                                    {
+                                        "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                                    }
+                                ]
+                            }],
+                            "answers": [{
+                                "options": [{
+                                        "value": "Yes",
+                                        "label": "Yes"
+                                    },
+                                    {
+                                        "value": "No",
+                                        "label": "No"
+                                    }
+                                ],
+                                "id": "changes-in-turnover-answer",
+                                "type": "Radio",
+                                "q_code": "146",
+                                "mandatory": true
+                            }],
+                            "guidance": {
+                                "content": [{
+                                    "title": "Include",
+                                    "list": [
+                                        "change in level of business activity",
+                                        "maintenance/shutdowns",
+                                        "special/calendar events",
+                                        "weather",
+                                        "price effects",
+                                        "currency effects (increase/decrease in the currency value)"
+                                    ]
+                                }]
+                            },
+                            "type": "General"
+                        }],
+                        "title": "Changes in total turnover",
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "id": "changes-in-turnover-answer",
+                                        "value": "Yes",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "changes-in-turnover-block-2"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "group": "summary-group"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "changes-in-turnover-block-2",
+                        "type": "Question",
+                        "questions": [{
+                            "title": "Please indicate the reasons for any changes in the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
+                            "answers": [{
+                                "options": [{
+                                        "q_code": "146a",
+                                        "value": "Change in level of business activity",
+                                        "label": "Change in level of business activity"
+                                    },
+                                    {
+                                        "q_code": "146b",
+                                        "value": "Maintenance/shutdowns",
+                                        "label": "Maintenance/shutdowns"
+                                    },
+                                    {
+                                        "q_code": "146c",
+                                        "value": "Special/calendar events",
+                                        "label": "Special/calendar events"
+                                    },
+                                    {
+                                        "q_code": "146d",
+                                        "value": "Weather",
+                                        "label": "Weather"
+                                    },
+                                    {
+                                        "q_code": "146e",
+                                        "value": "Price effects",
+                                        "label": "Price effects"
+                                    },
+                                    {
+                                        "q_code": "146f",
+                                        "value": "Currency effects (increase/decrease in the currency value)",
+                                        "label": "Currency effects (increase/decrease in the currency value)"
+                                    },
+                                    {
+                                        "q_code": "146g",
+                                        "value": "Other",
+                                        "label": "Other"
+                                    }
+                                ],
+                                "id": "changes-in-turnover-answer-2",
+                                "type": "Checkbox",
+                                "mandatory": true
+                            }],
+                            "type": "General",
+                            "id": "changes-in-turnover-question-2"
+                        }],
+                        "title": "Changes in total turnover"
+                    },
+                    {
+                        "type": "Question",
+                        "id": "changes-in-turnover-block-3",
+                        "title": "Changes in total turnover",
+                        "questions": [{
+                            "type": "General",
+                            "id": "changes-in-turnover-question-3",
+                            "title": "Please describe the changes in total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
+                            "answers": [{
+                                "guidance": {
+                                    "hide_guidance": "Hide examples of commentary on changes to total turnover",
+                                    "show_guidance": "Show examples of commentary on changes to total turnover",
+                                    "content": [{
+                                            "list": [
+
+                                            ],
+                                            "title": "‘Change in level of business activity’",
+                                            "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
+                                        },
+                                        {
+                                            "list": [
+
+                                            ],
+                                            "title": "‘Maintenance/shutdowns’",
+                                            "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
+                                        },
+                                        {
+                                            "list": [
+
+                                            ],
+                                            "title": "‘Special/calendar events’",
+                                            "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
+                                        },
+                                        {
+                                            "list": [
+
+                                            ],
+                                            "title": "‘Weather’",
+                                            "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
+                                        },
+                                        {
+                                            "list": [
+
+                                            ],
+                                            "title": "‘Price effects’",
+                                            "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
+                                        },
+                                        {
+                                            "list": [
+
+                                            ],
+                                            "title": "‘Currency effects (increase/decrease in the currency value)’",
+                                            "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
+                                        }
+                                    ]
+                                },
+                                "type": "TextArea",
+                                "mandatory": true,
+                                "label": "Comments",
+                                "id": "changes-in-turnover-answer-3",
+                                "q_code": "146h"
+                            }],
+                            "description": "<p>We rely on your commentary to ‘tell the story’ behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
+                        }]
                     }
-                  ]
-                }
-              ],
-              "preview_content": {
-                "id": "preview",
-                "title": "Information you need",
-                "content": [
-                  {
-                    "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
-                  }
-                ],
-                "questions": [
-                  {
-                    "question": "Total turnover",
-                    "content": [
-                      {
-                        "description": "Include:",
-                        "list": [
-                          "exports",
-                          "income from sub-contracted activities",
-                          "commission",
-                          "sales of goods purchased for resale",
-                          "transport, insurance and packaging charges",
-                          "revenue earned from other parts of the business not named at the top of this page (please supply at fair value)"
-                        ]
-                      },
-                      {
-                        "description": "Exclude:",
-                        "list": [
-                          "VAT",
-                          "income from the sale of fixed capital assets",
-                          "grants and subsidies",
-                          "insurance claims",
-                          "interest received"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "question": "Value of exports",
-                    "content": [
-                      {
-                        "description": "Include:",
-                        "list": [
-                          "all countries outside of England, Scotland, Wales and Northern Ireland"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "question": "Changes in total turnover",
-                    "content": [
-                      {
-                        "description": "Include:",
-                        "list": [
-                          "change in level of business activity",
-                          "maintenance/shutdowns",
-                          "special/calendar events",
-                          "weather",
-                          "price effects",
-                          "currency effects (increase/decrease in the currency value)"
-                        ]
-                      }
-                    ]
-                  }
                 ]
-              },
-              "secondary_content": [
-                {
-                  "id": "how-we-use-your-data",
-                  "title": "How we use your data",
-                  "content": [
-                    {
-                      "list": [
-                        "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
-                        "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "id": "reporting-period-block",
-              "type": "Question",
-              "questions": [
-                {
-                  "answers": [
-                    {
-                      "options": [
-                        {
-                          "value": "Yes",
-                          "label": "Yes"
-                        },
-                        {
-                          "value": "No",
-                          "label": "No"
-                        }
-                      ],
-                      "id": "reporting-period-answer",
-                      "type": "Radio",
-                      "q_code": "d12",
-                      "mandatory": true
-                    }
-                  ],
-                  "type": "General",
-                  "id": "reporting-period-question",
-                  "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
-                }
-              ],
-              "routing_rules": [
-                {
-                  "goto": {
-                    "when": [
-                      {
-                        "id": "reporting-period-answer",
-                        "value": "Yes",
-                        "condition": "equals"
-                      }
-                    ],
-                    "block": "turnover-block"
-                  }
-                },
-                {
-                  "goto": {
-                    "block": "reporting-period-block-2"
-                  }
-                }
-              ],
-              "title": "Reporting period"
-            },
-            {
-              "type": "Question",
-              "id": "reporting-period-block-2",
-              "title": "Reporting period",
-              "questions": [
-                {
-                  "type": "DateRange",
-                  "id": "reporting-period-question-2",
-                  "title": "What are the dates of the period that you will be reporting for?",
-                  "period_limits": {
-                    "minimum": {
-                      "days": 10
-                    },
-                    "maximum": {
-                      "days": 50
-                    }
-                  },
-                  "answers": [
-                    {
-                      "type": "Date",
-                      "id": "period-from",
-                      "label": "From",
-                      "mandatory": true,
-                      "q_code": "11",
-                      "minimum": {
-                        "meta": "ref_p_start_date",
-                        "offset_by": {
-                          "days": -19
-                        }
-                      }
-                    },
-                    {
-                      "type": "Date",
-                      "id": "period-to",
-                      "label": "To",
-                      "mandatory": true,
-                      "q_code": "12",
-                      "maximum": {
-                        "meta": "ref_p_end_date",
-                        "offset_by": {
-                          "days": 20
-                        }
-                      }
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "id": "turnover-block",
-              "type": "Question",
-              "title": "Total turnover",
-              "questions": [
-                {
-                  "guidance": {
-                    "content": [
-                      {
-                        "title": "Include:",
-                        "list": [
-                          "exports",
-                          "income from sub-contracted activities",
-                          "commission",
-                          "sales of goods purchased for resale",
-                          "transport, insurance and packaging charges",
-                          "revenue earned from other parts of the business not named at the top of this page (please supply at fair value)"
-                        ]
-                      },
-                      {
-                        "title": "Exclude:",
-                        "list": [
-                          "VAT",
-                          "income from the sale of fixed capital assets",
-                          "grants and subsidies",
-                          "insurance claims",
-                          "interest received"
-                        ]
-                      }
-                    ]
-                  },
-                  "id": "turnover-question",
-                  "answers": [
-                    {
-                      "id": "turnover-answer",
-                      "label": "Total turnover excluding VAT",
-                      "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
-                      "type": "Currency",
-                      "currency": "GBP",
-                      "decimal_places": 2,
-                      "q_code": "40",
-                      "mandatory": false,
-                      "default": 0
-                    }
-                  ],
-                  "type": "General",
-                  "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s <em>total turnover</em>, excluding VAT?"
-                }
-              ],
-              "routing_rules": [
-                {
-                  "goto": {
-                    "when": [
-                      {
-                        "id": "turnover-answer",
-                        "condition": "greater than",
-                        "value": 0
-                      }
-                    ],
-                    "block": "confirm-turnover-block"
-                  }
-                },
-                {
-                  "goto": {
-                    "block": "confirm-zero-turnover-block"
-                  }
-                }
-              ]
-            },
-            {
-              "type": "ConfirmationQuestion",
-              "title": "Total turnover",
-              "id": "confirm-turnover-block",
-              "questions": [
-                {
-                  "type": "General",
-                  "answers": [
-                    {
-                      "type": "Radio",
-                      "id": "confirm-turnover-answer",
-                      "q_code": "d40",
-                      "options": [
-                        {
-                          "label": "Yes this is correct",
-                          "value": "Yes"
-                        },
-                        {
-                          "label": "No I need to change this",
-                          "value": "No"
-                        }
-                      ],
-                      "mandatory": true
-                    }
-                  ],
-                  "id": "confirm-turnover-question",
-                  "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
-                }
-              ],
-              "routing_rules": [
-                {
-                  "goto": {
-                    "when": [
-                      {
-                        "value": "No",
-                        "id": "confirm-turnover-answer",
-                        "condition": "equals"
-                      }
-                    ],
-                    "block": "turnover-block"
-                  }
-                },
-                {
-                  "goto": {
-                    "block": "exports-block"
-                  }
-                }
-              ]
-            },
-            {
-              "type": "ConfirmationQuestion",
-              "title": "Total turnover",
-              "id": "confirm-zero-turnover-block",
-              "questions": [
-                {
-                  "type": "General",
-                  "answers": [
-                    {
-                      "type": "Radio",
-                      "id": "confirm-zero-turnover-answer",
-                      "q_code": "d49",
-                      "options": [
-                        {
-                          "label": "Yes this is correct",
-                          "value": "Yes"
-                        },
-                        {
-                          "label": "No I need to change this",
-                          "value": "No"
-                        }
-                      ],
-                      "mandatory": true
-                    }
-                  ],
-                  "id": "confirm-zero-turnover-question",
-                  "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
-                }
-              ],
-              "routing_rules": [
-                {
-                  "goto": {
-                    "when": [
-                      {
-                        "value": "No",
-                        "id": "confirm-zero-turnover-answer",
-                        "condition": "equals"
-                      }
-                    ],
-                    "block": "turnover-block"
-                  }
-                },
-                {
-                  "goto": {
-                    "block": "changes-in-turnover-block"
-                  }
-                }
-              ]
-            },
-            {
-              "id": "exports-block",
-              "type": "Question",
-              "questions": [
-                {
-                  "id": "exports-question",
-                  "guidance": {
-                    "content": [
-                      {
-                        "title": "Include:",
-                        "list": [
-                          "All countries outside of England, Scotland, Wales and Northern Ireland"
-                        ]
-                      }
-                    ]
-                  },
-                  "answers": [
-                    {
-                      "id": "exports-answer",
-                      "label": "Exports",
-                      "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
-                      "type": "Currency",
-                      "currency": "GBP",
-                      "decimal_places": 2,
-                      "q_code": "49",
-                      "mandatory": true,
-                      "max_value": {
-                        "answer_id": "turnover-answer"
-                      }
-                    }
-                  ],
-                  "type": "General",
-                  "title": "Of the <em>{{format_currency(answers['turnover-answer'])}}</em> total turnover, what was the value of <em>exports?</em>"
-                }
-              ],
-              "title": "Exports"
-            },
-            {
-              "id": "changes-in-turnover-block",
-              "type": "Question",
-              "questions": [
-                {
-                  "title": "Did any significant changes occur to the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
-                  "id": "changes-in-turnover-question",
-                  "definitions": [
-                    {
-                      "title": "What constitutes a significant change?",
-                      "content": [
-                        {
-                          "description": "What constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s figures from the previous reporting period and the same reporting period last year."
-                        },
-                        {
-                          "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
-                        }
-                      ]
-                    }
-                  ],
-                  "answers": [
-                    {
-                      "options": [
-                        {
-                          "value": "Yes",
-                          "label": "Yes"
-                        },
-                        {
-                          "value": "No",
-                          "label": "No"
-                        }
-                      ],
-                      "id": "changes-in-turnover-answer",
-                      "type": "Radio",
-                      "q_code": "146",
-                      "mandatory": true
-                    }
-                  ],
-                  "guidance": {
-                    "content": [
-                      {
-                        "title": "Include",
-                        "list": [
-                          "change in level of business activity",
-                          "maintenance/shutdowns",
-                          "special/calendar events",
-                          "weather",
-                          "price effects",
-                          "currency effects (increase/decrease in the currency value)"
-                        ]
-                      }
-                    ]
-                  },
-                  "type": "General"
-                }
-              ],
-              "title": "Changes in total turnover",
-              "routing_rules": [
-                {
-                  "goto": {
-                    "when": [
-                      {
-                        "id": "changes-in-turnover-answer",
-                        "value": "Yes",
-                        "condition": "equals"
-                      }
-                    ],
-                    "block": "changes-in-turnover-block-2"
-                  }
-                },
-                {
-                  "goto": {
-                    "group": "summary-group"
-                  }
-                }
-              ]
-            },
-            {
-              "id": "changes-in-turnover-block-2",
-              "type": "Question",
-              "questions": [
-                {
-                  "title": "Please indicate the reasons for any changes in the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
-                  "answers": [
-                    {
-                      "options": [
-                        {
-                          "q_code": "146a",
-                          "value": "Change in level of business activity",
-                          "label": "Change in level of business activity"
-                        },
-                        {
-                          "q_code": "146b",
-                          "value": "Maintenance/shutdowns",
-                          "label": "Maintenance/shutdowns"
-                        },
-                        {
-                          "q_code": "146c",
-                          "value": "Special/calendar events",
-                          "label": "Special/calendar events"
-                        },
-                        {
-                          "q_code": "146d",
-                          "value": "Weather",
-                          "label": "Weather"
-                        },
-                        {
-                          "q_code": "146e",
-                          "value": "Price effects",
-                          "label": "Price effects"
-                        },
-                        {
-                          "q_code": "146f",
-                          "value": "Currency effects (increase/decrease in the currency value)",
-                          "label": "Currency effects (increase/decrease in the currency value)"
-                        },
-                        {
-                          "q_code": "146g",
-                          "value": "Other",
-                          "label": "Other"
-                        }
-                      ],
-                      "id": "changes-in-turnover-answer-2",
-                      "type": "Checkbox",
-                      "mandatory": true
-                    }
-                  ],
-                  "type": "General",
-                  "id": "changes-in-turnover-question-2"
-                }
-              ],
-              "title": "Changes in total turnover"
-            },
-            {
-              "type": "Question",
-              "id": "changes-in-turnover-block-3",
-              "title": "Changes in total turnover",
-              "questions": [
-                {
-                  "type": "General",
-                  "id": "changes-in-turnover-question-3",
-                  "title": "Please describe the changes in total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
-                  "answers": [
-                    {
-                      "guidance": {
-                        "hide_guidance": "Hide examples of commentary on changes to total turnover",
-                        "show_guidance": "Show examples of commentary on changes to total turnover",
-                        "content": [
-                          {
-                            "list": [
-                              
-                            ],
-                            "title": "‘Change in level of business activity’",
-                            "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
-                          },
-                          {
-                            "list": [
-                              
-                            ],
-                            "title": "‘Maintenance/shutdowns’",
-                            "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
-                          },
-                          {
-                            "list": [
-                              
-                            ],
-                            "title": "‘Special/calendar events’",
-                            "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
-                          },
-                          {
-                            "list": [
-                              
-                            ],
-                            "title": "‘Weather’",
-                            "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
-                          },
-                          {
-                            "list": [
-                              
-                            ],
-                            "title": "‘Price effects’",
-                            "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
-                          },
-                          {
-                            "list": [
-                              
-                            ],
-                            "title": "‘Currency effects (increase/decrease in the currency value)’",
-                            "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
-                          }
-                        ]
-                      },
-                      "type": "TextArea",
-                      "mandatory": true,
-                      "label": "Comments",
-                      "id": "changes-in-turnover-answer-3",
-                      "q_code": "146h"
-                    }
-                  ],
-                  "description": "<p>We rely on your commentary to ‘tell the story’ behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "summary-section",
-      "title": "Summary",
-      "groups": [
+            }]
+        },
         {
-          "id": "summary-group",
-          "title": "Summary",
-          "blocks": [
-            {
-              "type": "Summary",
-              "id": "summary"
-            }
-          ]
+            "id": "summary-section",
+            "title": "Summary",
+            "groups": [{
+                "id": "summary-group",
+                "title": "Summary",
+                "blocks": [{
+                    "type": "Summary",
+                    "id": "summary"
+                }]
+            }]
         }
-      ]
-    }
-  ]
+    ]
 }

--- a/data/en/mbs_0201_prototype.json
+++ b/data/en/mbs_0201_prototype.json
@@ -1,0 +1,459 @@
+{
+    "title": "Monthly Business Survey",
+    "survey_id": "009",
+    "mime_type": "application/json/ons/eq",
+    "theme": "default",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.1",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
+    "description": "mbs",
+    "form_type": "0251",
+    "view_submitted_response": {
+        "enabled": true,
+        "duration": 900
+    },
+    "metadata": [{
+        "name": "user_id",
+        "validator": "string"
+    }, {
+        "name": "period_id",
+        "validator": "string"
+    }, {
+        "name": "ru_name",
+        "validator": "string"
+    }, {
+        "name": "ref_p_start_date",
+        "validator": "date"
+    }, {
+        "name": "ref_p_end_date",
+        "validator": "date"
+    }, {
+        "name": "trad_as",
+        "validator": "optional_string"
+    }],
+    "sections": [{
+        "id": "section",
+        "groups": [{
+            "id": "group",
+            "title": "",
+            "blocks": [{
+                "type": "Introduction",
+                "id": "introduction",
+                "primary_content": [{
+                    "type": "Basic",
+                    "id": "use-of-information",
+                    "content": [{
+                        "list": ["Data should relate to all sites in England, Scotland, Wales and Northern Ireland unless otherwise stated.", "You can provide informed estimates if actual figures aren\u2019t available.", "We will treat your data securely and confidentially."]
+                    }]
+                }],
+                "preview_content": {
+                    "id": "preview",
+                    "title": "Information you need",
+                    "content": [{
+                        "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
+                    }],
+                    "questions": [{
+                        "question": "Total turnover",
+                        "content": [{
+                            "description": "Include:",
+                            "list": ["exports", "income from sub-contracted activities", "commission", "sales of goods purchased for resale", "transport, insurance and packaging charges", "revenue earned from other parts of the business not named at the top of this page (please supply at fair value)"]
+                        }, {
+                            "description": "Exclude:",
+                            "list": ["VAT", "income from the sale of fixed capital assets", "grants and subsidies", "insurance claims", "interest received"]
+                        }]
+                    }, {
+                        "question": "Value of exports",
+                        "content": [{
+                            "description": "Include:",
+                            "list": ["all countries outside of England, Scotland, Wales and Northern Ireland"]
+                        }]
+                    }, {
+                        "question": "Changes in total turnover",
+                        "content": [{
+                            "description": "Include:",
+                            "list": ["change in level of business activity", "maintenance/shutdowns", "special/calendar events", "weather", "price effects", "currency effects (increase/decrease in the currency value)"]
+                        }]
+                    }]
+                },
+                "secondary_content": [{
+                    "id": "how-we-use-your-data",
+                    "title": "How we use your data",
+                    "content": [{
+                        "list": ["You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.", "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"]
+                    }]
+                }]
+            }, {
+                "id": "reporting-period-block",
+                "type": "Question",
+                "questions": [{
+                    "answers": [{
+                        "options": [{
+                            "value": "Yes",
+                            "label": "Yes"
+                        }, {
+                            "value": "No",
+                            "label": "No"
+                        }],
+                        "id": "reporting-period-answer",
+                        "type": "Radio",
+                        "q_code": "d12",
+                        "mandatory": true
+                    }],
+                    "type": "General",
+                    "id": "reporting-period-question",
+                    "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
+                }],
+                "routing_rules": [{
+                    "goto": {
+                        "when": [{
+                            "id": "reporting-period-answer",
+                            "value": "Yes",
+                            "condition": "equals"
+                        }],
+                        "block": "turnover-block"
+                    }
+                }, {
+                    "goto": {
+                        "block": "reporting-period-block-2"
+                    }
+                }],
+                "title": "Reporting period"
+            }, {
+                "type": "Question",
+                "id": "reporting-period-block-2",
+                "title": "Reporting period",
+                "questions": [{
+                    "type": "DateRange",
+                    "id": "reporting-period-question-2",
+                    "title": "What are the dates of the period that you will be reporting for?",
+                    "period_limits": {
+                        "minimum": {
+                            "days": 10
+                        },
+                        "maximum": {
+                            "days": 50
+                        }
+                    },
+                    "answers": [{
+                        "type": "Date",
+                        "id": "period-from",
+                        "label": "From",
+                        "mandatory": true,
+                        "q_code": "11",
+                        "minimum": {
+                            "meta": "ref_p_start_date",
+                            "offset_by": {
+                                "days": -19
+                            }
+                        }
+                    }, {
+                        "type": "Date",
+                        "id": "period-to",
+                        "label": "To",
+                        "mandatory": true,
+                        "q_code": "12",
+                        "maximum": {
+                            "meta": "ref_p_end_date",
+                            "offset_by": {
+                                "days": 20
+                            }
+                        }
+                    }]
+                }]
+            }, {
+                "id": "turnover-block",
+                "type": "Question",
+                "title": "Total turnover",
+                "questions": [{
+                    "guidance": {
+                        "content": [{
+                            "title": "Include:",
+                            "list": ["exports", "income from sub-contracted activities", "commission", "sales of goods purchased for resale", "transport, insurance and packaging charges", "revenue earned from other parts of the business not named at the top of this page (please supply at fair value)"]
+                        }, {
+                            "title": "Exclude:",
+                            "list": ["VAT", "income from the sale of fixed capital assets", "grants and subsidies", "insurance claims", "interest received"]
+                        }]
+                    },
+                    "id": "turnover-question",
+                    "answers": [{
+                        "id": "turnover-answer",
+                        "label": "Total turnover excluding VAT",
+                        "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                        "type": "Currency",
+                        "currency": "GBP",
+                        "decimal_places": 2,
+                        "q_code": "40",
+                        "mandatory": false,
+                        "default": 0
+                    }],
+                    "type": "General",
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>total turnover</em>, excluding VAT?"
+                }],
+                "routing_rules": [{
+                    "goto": {
+                        "when": [{
+                            "id": "turnover-answer",
+                            "condition": "greater than",
+                            "value": 0
+                        }],
+                        "block": "confirm-turnover-block"
+                    }
+                }, {
+                    "goto": {
+                        "block": "confirm-zero-turnover-block"
+                    }
+                }]
+            }, {
+                "type": "ConfirmationQuestion",
+                "title": "Total turnover",
+                "id": "confirm-turnover-block",
+                "questions": [{
+                    "type": "General",
+                    "answers": [{
+                        "type": "Radio",
+                        "id": "confirm-turnover-answer",
+                        "q_code": "d40",
+                        "options": [{
+                            "label": "Yes this is correct",
+                            "value": "Yes"
+                        }, {
+                            "label": "No I need to change this",
+                            "value": "No"
+                        }],
+                        "mandatory": true
+                    }],
+                    "id": "confirm-turnover-question",
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
+                }],
+                "routing_rules": [{
+                    "goto": {
+                        "when": [{
+                            "value": "No",
+                            "id": "confirm-turnover-answer",
+                            "condition": "equals"
+                        }],
+                        "block": "turnover-block"
+                    }
+                }, {
+                    "goto": {
+                        "block": "exports-block"
+                    }
+                }]
+            }, {
+                "type": "ConfirmationQuestion",
+                "title": "Total turnover",
+                "id": "confirm-zero-turnover-block",
+                "questions": [{
+                    "type": "General",
+                    "answers": [{
+                        "type": "Radio",
+                        "id": "confirm-zero-turnover-answer",
+                        "q_code": "d49",
+                        "options": [{
+                            "label": "Yes this is correct",
+                            "value": "Yes"
+                        }, {
+                            "label": "No I need to change this",
+                            "value": "No"
+                        }],
+                        "mandatory": true
+                    }],
+                    "id": "confirm-zero-turnover-question",
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
+                }],
+                "routing_rules": [{
+                    "goto": {
+                        "when": [{
+                            "value": "No",
+                            "id": "confirm-zero-turnover-answer",
+                            "condition": "equals"
+                        }],
+                        "block": "turnover-block"
+                    }
+                }, {
+                    "goto": {
+                        "block": "changes-in-turnover-block"
+                    }
+                }]
+            }, {
+                "id": "exports-block",
+                "type": "Question",
+                "questions": [{
+                    "id": "exports-question",
+                    "guidance": {
+                        "content": [{
+                            "title": "Include:",
+                            "list": ["All countries outside of England, Scotland, Wales and Northern Ireland"]
+                        }]
+                    },
+                    "answers": [{
+                        "id": "exports-answer",
+                        "label": "Exports",
+                        "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                        "type": "Currency",
+                        "currency": "GBP",
+                        "decimal_places": 2,
+                        "q_code": "49",
+                        "mandatory": true,
+                        "max_value": {
+                            "answer_id": "turnover-answer"
+                        }
+                    }],
+                    "type": "General",
+                    "title": "Of the <em>{{format_currency(answers['turnover-answer'])}}</em> total turnover, what was the value of <em>exports?</em>"
+                }],
+                "title": "Exports"
+            }, {
+                "id": "changes-in-turnover-block",
+                "type": "Question",
+                "questions": [{
+                    "title": "Did any significant changes occur to the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                    "id": "changes-in-turnover-question",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
+                        }, {
+                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }]
+                    }],
+                    "answers": [{
+                        "options": [{
+                            "value": "Yes",
+                            "label": "Yes"
+                        }, {
+                            "value": "No",
+                            "label": "No"
+                        }],
+                        "id": "changes-in-turnover-answer",
+                        "type": "Radio",
+                        "q_code": "146",
+                        "mandatory": true
+                    }],
+                    "guidance": {
+                        "content": [{
+                            "title": "Include",
+                            "list": ["change in level of business activity", "maintenance/shutdowns", "special/calendar events", "weather", "price effects", "currency effects (increase/decrease in the currency value)"]
+                        }]
+                    },
+                    "type": "General"
+                }],
+                "title": "Changes in total turnover",
+                "routing_rules": [{
+                    "goto": {
+                        "when": [{
+                            "id": "changes-in-turnover-answer",
+                            "value": "Yes",
+                            "condition": "equals"
+                        }],
+                        "block": "changes-in-turnover-block-2"
+                    }
+                }, {
+                    "goto": {
+                        "group": "summary-group"
+                    }
+                }]
+            }, {
+                "id": "changes-in-turnover-block-2",
+                "type": "Question",
+                "questions": [{
+                    "title": "Please indicate the reasons for any changes in the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
+                    "answers": [{
+                        "options": [{
+                            "q_code": "146a",
+                            "value": "Change in level of business activity",
+                            "label": "Change in level of business activity"
+                        }, {
+                            "q_code": "146b",
+                            "value": "Maintenance/shutdowns",
+                            "label": "Maintenance/shutdowns"
+                        }, {
+                            "q_code": "146c",
+                            "value": "Special/calendar events",
+                            "label": "Special/calendar events"
+                        }, {
+                            "q_code": "146d",
+                            "value": "Weather",
+                            "label": "Weather"
+                        }, {
+                            "q_code": "146e",
+                            "value": "Price effects",
+                            "label": "Price effects"
+                        }, {
+                            "q_code": "146f",
+                            "value": "Currency effects (increase/decrease in the currency value)",
+                            "label": "Currency effects (increase/decrease in the currency value)"
+                        }, {
+                            "q_code": "146g",
+                            "value": "Other",
+                            "label": "Other"
+                        }],
+                        "id": "changes-in-turnover-answer-2",
+                        "type": "Checkbox",
+                        "mandatory": true
+                    }],
+                    "type": "General",
+                    "id": "changes-in-turnover-question-2"
+                }],
+                "title": "Changes in total turnover"
+            }, {
+                "type": "Question",
+                "id": "changes-in-turnover-block-3",
+                "title": "Changes in total turnover",
+                "questions": [{
+                    "type": "General",
+                    "id": "changes-in-turnover-question-3",
+                    "title": "Please describe the changes in total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
+                    "answers": [{
+                        "guidance": {
+                            "hide_guidance": "Hide examples of commentary on changes to total turnover",
+                            "show_guidance": "Show examples of commentary on changes to total turnover",
+                            "content": [{
+                                "list": [],
+                                "title": "\u2018Change in level of business activity\u2019",
+                                "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
+                            }, {
+                                "list": [],
+                                "title": "\u2018Maintenance/shutdowns\u2019",
+                                "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
+                            }, {
+                                "list": [],
+                                "title": "\u2018Special/calendar events\u2019",
+                                "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
+                            }, {
+                                "list": [],
+                                "title": "\u2018Weather\u2019",
+                                "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
+                            }, {
+                                "list": [],
+                                "title": "\u2018Price effects\u2019",
+                                "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
+                            }, {
+                                "list": [],
+                                "title": "\u2018Currency effects (increase/decrease in the currency value)\u2019",
+                                "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
+                            }]
+                        },
+                        "type": "TextArea",
+                        "mandatory": true,
+                        "label": "Comments",
+                        "id": "changes-in-turnover-answer-3",
+                        "q_code": "146h"
+                    }],
+                    "description": "<p>We rely on your commentary to \u2018tell the story\u2019 behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
+                }]
+            }]
+        }]
+    }, {
+        "id": "summary-section",
+        "title": "Summary",
+        "groups": [{
+            "id": "summary-group",
+            "title": "Summary",
+            "blocks": [{
+                "type": "Summary",
+                "id": "summary"
+            }]
+        }]
+    }]
+}

--- a/data/en/mbs_0202.json
+++ b/data/en/mbs_0202.json
@@ -1,671 +1,582 @@
 {
-  "title": "Monthly Business Survey",
-  "survey_id": "009",
-  "mime_type": "application/json/ons/eq",
-  "theme": "northernireland",
-  "schema_version": "0.0.1",
-  "data_version": "0.0.1",
-  "legal_basis": "Notice is given under article 5 of the Statistics of Trade and Employment (Northern Ireland) Order 1988.",
-  "description": "mbs",
-  "form_type": "0202",
-  "view_submitted_response": {
-    "enabled": true,
-    "duration": 900
-  },
-  "metadata": [
-    {
-      "name": "user_id",
-      "validator": "string"
+    "title": "Monthly Business Survey",
+    "survey_id": "009",
+    "mime_type": "application/json/ons/eq",
+    "theme": "northernireland",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.1",
+    "legal_basis": "Notice is given under article 5 of the Statistics of Trade and Employment (Northern Ireland) Order 1988.",
+    "description": "mbs",
+    "form_type": "0202",
+    "view_submitted_response": {
+        "enabled": true,
+        "duration": 900
     },
-    {
-      "name": "period_id",
-      "validator": "string"
-    },
-    {
-      "name": "ru_name",
-      "validator": "string"
-    },
-    {
-      "name": "ref_p_start_date",
-      "validator": "date"
-    },
-    {
-      "name": "ref_p_end_date",
-      "validator": "date"
-    },
-    {
-      "name": "trad_as",
-      "validator": "optional_string"
-    }
-  ],
-  "sections": [
-    {
-      "id": "section",
-      "groups": [
+    "metadata": [{
+            "name": "user_id",
+            "validator": "string"
+        },
         {
-          "id": "group",
-          "title": "",
-          "blocks": [
-            {
-              "type": "Introduction",
-              "id": "introduction",
-              "primary_content": [
-                {
-                  "type": "Basic",
-                  "id": "use-of-information",
-                  "content": [
+            "name": "period_id",
+            "validator": "string"
+        },
+        {
+            "name": "ru_name",
+            "validator": "string"
+        },
+        {
+            "name": "ref_p_start_date",
+            "validator": "date"
+        },
+        {
+            "name": "ref_p_end_date",
+            "validator": "date"
+        },
+        {
+            "name": "trad_as",
+            "validator": "optional_string"
+        }
+    ],
+    "sections": [{
+            "id": "section",
+            "groups": [{
+                "id": "group",
+                "title": "",
+                "blocks": [{
+                        "type": "Introduction",
+                        "id": "introduction",
+                        "primary_content": [{
+                            "type": "Basic",
+                            "id": "use-of-information",
+                            "content": [{
+                                "list": [
+                                    "Data should relate to all sites in England, Scotland, Wales and Northern Ireland unless otherwise stated.",
+                                    "You can provide informed estimates if actual figures aren’t available.",
+                                    "We will treat your data securely and confidentially."
+                                ]
+                            }]
+                        }],
+                        "preview_content": {
+                            "id": "preview",
+                            "title": "Information you need",
+                            "content": [{
+                                "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
+                            }],
+                            "questions": [{
+                                    "question": "Total turnover",
+                                    "content": [{
+                                            "description": "Include:",
+                                            "list": [
+                                                "exports",
+                                                "income from sub-contracted activities",
+                                                "commission",
+                                                "sales of goods purchased for resale",
+                                                "transport, insurance and packaging charges",
+                                                "revenue earned from other parts of the business not named at the top of this page (please supply at fair value)"
+                                            ]
+                                        },
+                                        {
+                                            "description": "Exclude:",
+                                            "list": [
+                                                "VAT",
+                                                "income from the sale of fixed capital assets",
+                                                "grants and subsidies",
+                                                "insurance claims",
+                                                "interest received"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": "Value of exports",
+                                    "content": [{
+                                        "description": "Include:",
+                                        "list": [
+                                            "all countries outside of England, Scotland, Wales and Northern Ireland"
+                                        ]
+                                    }]
+                                },
+                                {
+                                    "question": "Changes in total turnover",
+                                    "content": [{
+                                        "description": "Include:",
+                                        "list": [
+                                            "change in level of business activity",
+                                            "maintenance/shutdowns",
+                                            "special/calendar events",
+                                            "weather",
+                                            "price effects",
+                                            "currency effects (increase/decrease in the currency value)"
+                                        ]
+                                    }]
+                                }
+                            ]
+                        },
+                        "secondary_content": [{
+                            "id": "how-we-use-your-data",
+                            "title": "How we use your data",
+                            "content": [{
+                                "list": [
+                                    "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
+                                    "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"
+                                ]
+                            }]
+                        }]
+                    },
                     {
-                      "list": [
-                        "Data should relate to all sites in England, Scotland, Wales and Northern Ireland unless otherwise stated.",
-                        "You can provide informed estimates if actual figures aren’t available.",
-                        "We will treat your data securely and confidentially."
-                      ]
+                        "id": "reporting-period-block",
+                        "type": "Question",
+                        "questions": [{
+                            "answers": [{
+                                "options": [{
+                                        "value": "Yes",
+                                        "label": "Yes"
+                                    },
+                                    {
+                                        "value": "No",
+                                        "label": "No"
+                                    }
+                                ],
+                                "id": "reporting-period-answer",
+                                "type": "Radio",
+                                "q_code": "d12",
+                                "mandatory": true
+                            }],
+                            "type": "General",
+                            "id": "reporting-period-question",
+                            "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "id": "reporting-period-answer",
+                                        "value": "Yes",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "turnover-block"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "reporting-period-block-2"
+                                }
+                            }
+                        ],
+                        "title": "Reporting period"
+                    },
+                    {
+                        "type": "Question",
+                        "id": "reporting-period-block-2",
+                        "title": "Reporting period",
+                        "questions": [{
+                            "type": "DateRange",
+                            "id": "reporting-period-question-2",
+                            "title": "What are the dates of the period that you will be reporting for?",
+                            "period_limits": {
+                                "minimum": {
+                                    "days": 10
+                                },
+                                "maximum": {
+                                    "days": 50
+                                }
+                            },
+                            "answers": [{
+                                    "type": "Date",
+                                    "id": "period-from",
+                                    "label": "From",
+                                    "mandatory": true,
+                                    "q_code": "11",
+                                    "minimum": {
+                                        "meta": "ref_p_start_date",
+                                        "offset_by": {
+                                            "days": -19
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "Date",
+                                    "id": "period-to",
+                                    "label": "To",
+                                    "mandatory": true,
+                                    "q_code": "12",
+                                    "maximum": {
+                                        "meta": "ref_p_end_date",
+                                        "offset_by": {
+                                            "days": 20
+                                        }
+                                    }
+                                }
+                            ]
+                        }]
+                    },
+                    {
+                        "id": "turnover-block",
+                        "type": "Question",
+                        "title": "Total turnover",
+                        "questions": [{
+                            "guidance": {
+                                "content": [{
+                                        "title": "Include:",
+                                        "list": [
+                                            "exports",
+                                            "income from sub-contracted activities",
+                                            "commission",
+                                            "sales of goods purchased for resale",
+                                            "transport, insurance and packaging charges",
+                                            "revenue earned from other parts of the business not named at the top of this page (please supply at fair value)"
+                                        ]
+                                    },
+                                    {
+                                        "title": "Exclude:",
+                                        "list": [
+                                            "VAT",
+                                            "income from the sale of fixed capital assets",
+                                            "grants and subsidies",
+                                            "insurance claims",
+                                            "interest received"
+                                        ]
+                                    }
+                                ]
+                            },
+                            "id": "turnover-question",
+                            "answers": [{
+                                "id": "turnover-answer",
+                                "label": "Total turnover excluding VAT",
+                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                                "type": "Currency",
+                                "currency": "GBP",
+                                "decimal_places": 2,
+                                "q_code": "40",
+                                "mandatory": false,
+                                "default": 0
+                            }],
+                            "type": "General",
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s <em>total turnover</em>, excluding VAT?"
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "id": "turnover-answer",
+                                        "condition": "greater than",
+                                        "value": 0
+                                    }],
+                                    "block": "confirm-turnover-block"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "confirm-zero-turnover-block"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "type": "ConfirmationQuestion",
+                        "title": "Total turnover",
+                        "id": "confirm-turnover-block",
+                        "questions": [{
+                            "type": "General",
+                            "answers": [{
+                                "type": "Radio",
+                                "id": "confirm-turnover-answer",
+                                "q_code": "d40",
+                                "options": [{
+                                        "label": "Yes this is correct",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No I need to change this",
+                                        "value": "No"
+                                    }
+                                ],
+                                "mandatory": true
+                            }],
+                            "id": "confirm-turnover-question",
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "value": "No",
+                                        "id": "confirm-turnover-answer",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "turnover-block"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "exports-block"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "type": "ConfirmationQuestion",
+                        "title": "Total turnover",
+                        "id": "confirm-zero-turnover-block",
+                        "questions": [{
+                            "type": "General",
+                            "answers": [{
+                                "type": "Radio",
+                                "id": "confirm-zero-turnover-answer",
+                                "q_code": "d49",
+                                "options": [{
+                                        "label": "Yes this is correct",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No I need to change this",
+                                        "value": "No"
+                                    }
+                                ],
+                                "mandatory": true
+                            }],
+                            "id": "confirm-zero-turnover-question",
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "value": "No",
+                                        "id": "confirm-zero-turnover-answer",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "turnover-block"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "changes-in-turnover-block"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "exports-block",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "exports-question",
+                            "guidance": {
+                                "content": [{
+                                    "title": "Include:",
+                                    "list": [
+                                        "All countries outside of England, Scotland, Wales and Northern Ireland"
+                                    ]
+                                }]
+                            },
+                            "answers": [{
+                                "id": "exports-answer",
+                                "label": "Exports",
+                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                                "type": "Currency",
+                                "currency": "GBP",
+                                "decimal_places": 2,
+                                "q_code": "49",
+                                "mandatory": true,
+                                "max_value": {
+                                    "answer_id": "turnover-answer"
+                                }
+                            }],
+                            "type": "General",
+                            "title": "Of the <em>{{format_currency(answers['turnover-answer'])}}</em> total turnover, what was the value of <em>exports?</em>"
+                        }],
+                        "title": "Exports"
+                    },
+                    {
+                        "id": "changes-in-turnover-block",
+                        "type": "Question",
+                        "questions": [{
+                            "title": "Did any significant changes occur to the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                            "id": "changes-in-turnover-question",
+                            "definitions": [{
+                                "title": "What constitutes a significant change?",
+                                "content": [{
+                                        "description": "What constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s figures from the previous reporting period and the same reporting period last year."
+                                    },
+                                    {
+                                        "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                                    }
+                                ]
+                            }],
+                            "answers": [{
+                                "options": [{
+                                        "value": "Yes",
+                                        "label": "Yes"
+                                    },
+                                    {
+                                        "value": "No",
+                                        "label": "No"
+                                    }
+                                ],
+                                "id": "changes-in-turnover-answer",
+                                "type": "Radio",
+                                "q_code": "146",
+                                "mandatory": true
+                            }],
+                            "guidance": {
+                                "content": [{
+                                    "title": "Include",
+                                    "list": [
+                                        "change in level of business activity",
+                                        "maintenance/shutdowns",
+                                        "special/calendar events",
+                                        "weather",
+                                        "price effects",
+                                        "currency effects (increase/decrease in the currency value)"
+                                    ]
+                                }]
+                            },
+                            "type": "General"
+                        }],
+                        "title": "Changes in total turnover",
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "id": "changes-in-turnover-answer",
+                                        "value": "Yes",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "changes-in-turnover-block-2"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "group": "summary-group"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "changes-in-turnover-block-2",
+                        "type": "Question",
+                        "questions": [{
+                            "title": "Please indicate the reasons for any changes in the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
+                            "answers": [{
+                                "options": [{
+                                        "q_code": "146a",
+                                        "value": "Change in level of business activity",
+                                        "label": "Change in level of business activity"
+                                    },
+                                    {
+                                        "q_code": "146b",
+                                        "value": "Maintenance/shutdowns",
+                                        "label": "Maintenance/shutdowns"
+                                    },
+                                    {
+                                        "q_code": "146c",
+                                        "value": "Special/calendar events",
+                                        "label": "Special/calendar events"
+                                    },
+                                    {
+                                        "q_code": "146d",
+                                        "value": "Weather",
+                                        "label": "Weather"
+                                    },
+                                    {
+                                        "q_code": "146e",
+                                        "value": "Price effects",
+                                        "label": "Price effects"
+                                    },
+                                    {
+                                        "q_code": "146f",
+                                        "value": "Currency effects (increase/decrease in the currency value)",
+                                        "label": "Currency effects (increase/decrease in the currency value)"
+                                    },
+                                    {
+                                        "q_code": "146g",
+                                        "value": "Other",
+                                        "label": "Other"
+                                    }
+                                ],
+                                "id": "changes-in-turnover-answer-2",
+                                "type": "Checkbox",
+                                "mandatory": true
+                            }],
+                            "type": "General",
+                            "id": "changes-in-turnover-question-2"
+                        }],
+                        "title": "Changes in total turnover"
+                    },
+                    {
+                        "type": "Question",
+                        "id": "changes-in-turnover-block-3",
+                        "title": "Changes in total turnover",
+                        "questions": [{
+                            "type": "General",
+                            "id": "changes-in-turnover-question-3",
+                            "title": "Please describe the changes in total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
+                            "answers": [{
+                                "guidance": {
+                                    "hide_guidance": "Hide examples of commentary on changes to total turnover",
+                                    "show_guidance": "Show examples of commentary on changes to total turnover",
+                                    "content": [{
+                                            "list": [
+
+                                            ],
+                                            "title": "‘Change in level of business activity’",
+                                            "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
+                                        },
+                                        {
+                                            "list": [
+
+                                            ],
+                                            "title": "‘Maintenance/shutdowns’",
+                                            "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
+                                        },
+                                        {
+                                            "list": [
+
+                                            ],
+                                            "title": "‘Special/calendar events’",
+                                            "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
+                                        },
+                                        {
+                                            "list": [
+
+                                            ],
+                                            "title": "‘Weather’",
+                                            "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
+                                        },
+                                        {
+                                            "list": [
+
+                                            ],
+                                            "title": "‘Price effects’",
+                                            "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
+                                        },
+                                        {
+                                            "list": [
+
+                                            ],
+                                            "title": "‘Currency effects (increase/decrease in the currency value)’",
+                                            "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
+                                        }
+                                    ]
+                                },
+                                "type": "TextArea",
+                                "mandatory": true,
+                                "label": "Comments",
+                                "id": "changes-in-turnover-answer-3",
+                                "q_code": "146h"
+                            }],
+                            "description": "<p>We rely on your commentary to ‘tell the story’ behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
+                        }]
                     }
-                  ]
-                }
-              ],
-              "preview_content": {
-                "id": "preview",
-                "title": "Information you need",
-                "content": [
-                  {
-                    "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
-                  }
-                ],
-                "questions": [
-                  {
-                    "question": "Total turnover",
-                    "content": [
-                      {
-                        "description": "Include:",
-                        "list": [
-                          "exports",
-                          "income from sub-contracted activities",
-                          "commission",
-                          "sales of goods purchased for resale",
-                          "transport, insurance and packaging charges",
-                          "revenue earned from other parts of the business not named at the top of this page (please supply at fair value)"
-                        ]
-                      },
-                      {
-                        "description": "Exclude:",
-                        "list": [
-                          "VAT",
-                          "income from the sale of fixed capital assets",
-                          "grants and subsidies",
-                          "insurance claims",
-                          "interest received"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "question": "Value of exports",
-                    "content": [
-                      {
-                        "description": "Include:",
-                        "list": [
-                          "all countries outside of England, Scotland, Wales and Northern Ireland"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "question": "Changes in total turnover",
-                    "content": [
-                      {
-                        "description": "Include:",
-                        "list": [
-                          "change in level of business activity",
-                          "maintenance/shutdowns",
-                          "special/calendar events",
-                          "weather",
-                          "price effects",
-                          "currency effects (increase/decrease in the currency value)"
-                        ]
-                      }
-                    ]
-                  }
                 ]
-              },
-              "secondary_content": [
-                {
-                  "id": "how-we-use-your-data",
-                  "title": "How we use your data",
-                  "content": [
-                    {
-                      "list": [
-                        "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
-                        "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "id": "reporting-period-block",
-              "type": "Question",
-              "questions": [
-                {
-                  "answers": [
-                    {
-                      "options": [
-                        {
-                          "value": "Yes",
-                          "label": "Yes"
-                        },
-                        {
-                          "value": "No",
-                          "label": "No"
-                        }
-                      ],
-                      "id": "reporting-period-answer",
-                      "type": "Radio",
-                      "q_code": "d12",
-                      "mandatory": true
-                    }
-                  ],
-                  "type": "General",
-                  "id": "reporting-period-question",
-                  "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
-                }
-              ],
-              "routing_rules": [
-                {
-                  "goto": {
-                    "when": [
-                      {
-                        "id": "reporting-period-answer",
-                        "value": "Yes",
-                        "condition": "equals"
-                      }
-                    ],
-                    "block": "turnover-block"
-                  }
-                },
-                {
-                  "goto": {
-                    "block": "reporting-period-block-2"
-                  }
-                }
-              ],
-              "title": "Reporting period"
-            },
-            {
-              "type": "Question",
-              "id": "reporting-period-block-2",
-              "title": "Reporting period",
-              "questions": [
-                {
-                  "type": "DateRange",
-                  "id": "reporting-period-question-2",
-                  "title": "What are the dates of the period that you will be reporting for?",
-                  "period_limits": {
-                    "minimum": {
-                      "days": 10
-                    },
-                    "maximum": {
-                      "days": 50
-                    }
-                  },
-                  "answers": [
-                    {
-                      "type": "Date",
-                      "id": "period-from",
-                      "label": "From",
-                      "mandatory": true,
-                      "q_code": "11",
-                      "minimum": {
-                        "meta": "ref_p_start_date",
-                        "offset_by": {
-                          "days": -19
-                        }
-                      }
-                    },
-                    {
-                      "type": "Date",
-                      "id": "period-to",
-                      "label": "To",
-                      "mandatory": true,
-                      "q_code": "12",
-                      "maximum": {
-                        "meta": "ref_p_end_date",
-                        "offset_by": {
-                          "days": 20
-                        }
-                      }
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "id": "turnover-block",
-              "type": "Question",
-              "title": "Total turnover",
-              "questions": [
-                {
-                  "guidance": {
-                    "content": [
-                      {
-                        "title": "Include:",
-                        "list": [
-                          "exports",
-                          "income from sub-contracted activities",
-                          "commission",
-                          "sales of goods purchased for resale",
-                          "transport, insurance and packaging charges",
-                          "revenue earned from other parts of the business not named at the top of this page (please supply at fair value)"
-                        ]
-                      },
-                      {
-                        "title": "Exclude:",
-                        "list": [
-                          "VAT",
-                          "income from the sale of fixed capital assets",
-                          "grants and subsidies",
-                          "insurance claims",
-                          "interest received"
-                        ]
-                      }
-                    ]
-                  },
-                  "id": "turnover-question",
-                  "answers": [
-                    {
-                      "id": "turnover-answer",
-                      "label": "Total turnover excluding VAT",
-                      "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
-                      "type": "Currency",
-                      "currency": "GBP",
-                      "decimal_places": 2,
-                      "q_code": "40",
-                      "mandatory": false,
-                      "default": 0
-                    }
-                  ],
-                  "type": "General",
-                  "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s <em>total turnover</em>, excluding VAT?"
-                }
-              ],
-              "routing_rules": [
-                {
-                  "goto": {
-                    "when": [
-                      {
-                        "id": "turnover-answer",
-                        "condition": "greater than",
-                        "value": 0
-                      }
-                    ],
-                    "block": "confirm-turnover-block"
-                  }
-                },
-                {
-                  "goto": {
-                    "block": "confirm-zero-turnover-block"
-                  }
-                }
-              ]
-            },
-            {
-              "type": "ConfirmationQuestion",
-              "title": "Total turnover",
-              "id": "confirm-turnover-block",
-              "questions": [
-                {
-                  "type": "General",
-                  "answers": [
-                    {
-                      "type": "Radio",
-                      "id": "confirm-turnover-answer",
-                      "q_code": "d40",
-                      "options": [
-                        {
-                          "label": "Yes this is correct",
-                          "value": "Yes"
-                        },
-                        {
-                          "label": "No I need to change this",
-                          "value": "No"
-                        }
-                      ],
-                      "mandatory": true
-                    }
-                  ],
-                  "id": "confirm-turnover-question",
-                  "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
-                }
-              ],
-              "routing_rules": [
-                {
-                  "goto": {
-                    "when": [
-                      {
-                        "value": "No",
-                        "id": "confirm-turnover-answer",
-                        "condition": "equals"
-                      }
-                    ],
-                    "block": "turnover-block"
-                  }
-                },
-                {
-                  "goto": {
-                    "block": "exports-block"
-                  }
-                }
-              ]
-            },
-            {
-              "type": "ConfirmationQuestion",
-              "title": "Total turnover",
-              "id": "confirm-zero-turnover-block",
-              "questions": [
-                {
-                  "type": "General",
-                  "answers": [
-                    {
-                      "type": "Radio",
-                      "id": "confirm-zero-turnover-answer",
-                      "q_code": "d49",
-                      "options": [
-                        {
-                          "label": "Yes this is correct",
-                          "value": "Yes"
-                        },
-                        {
-                          "label": "No I need to change this",
-                          "value": "No"
-                        }
-                      ],
-                      "mandatory": true
-                    }
-                  ],
-                  "id": "confirm-zero-turnover-question",
-                  "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
-                }
-              ],
-              "routing_rules": [
-                {
-                  "goto": {
-                    "when": [
-                      {
-                        "value": "No",
-                        "id": "confirm-zero-turnover-answer",
-                        "condition": "equals"
-                      }
-                    ],
-                    "block": "turnover-block"
-                  }
-                },
-                {
-                  "goto": {
-                    "block": "changes-in-turnover-block"
-                  }
-                }
-              ]
-            },
-            {
-              "id": "exports-block",
-              "type": "Question",
-              "questions": [
-                {
-                  "id": "exports-question",
-                  "guidance": {
-                    "content": [
-                      {
-                        "title": "Include:",
-                        "list": [
-                          "All countries outside of England, Scotland, Wales and Northern Ireland"
-                        ]
-                      }
-                    ]
-                  },
-                  "answers": [
-                    {
-                      "id": "exports-answer",
-                      "label": "Exports",
-                      "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
-                      "type": "Currency",
-                      "currency": "GBP",
-                      "decimal_places": 2,
-                      "q_code": "49",
-                      "mandatory": true,
-                      "max_value": {
-                        "answer_id": "turnover-answer"
-                      }
-                    }
-                  ],
-                  "type": "General",
-                  "title": "Of the <em>{{format_currency(answers['turnover-answer'])}}</em> total turnover, what was the value of <em>exports?</em>"
-                }
-              ],
-              "title": "Exports"
-            },
-            {
-              "id": "changes-in-turnover-block",
-              "type": "Question",
-              "questions": [
-                {
-                  "title": "Did any significant changes occur to the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
-                  "id": "changes-in-turnover-question",
-                  "definitions": [
-                    {
-                      "title": "What constitutes a significant change?",
-                      "content": [
-                        {
-                          "description": "What constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s figures from the previous reporting period and the same reporting period last year."
-                        },
-                        {
-                          "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
-                        }
-                      ]
-                    }
-                  ],
-                  "answers": [
-                    {
-                      "options": [
-                        {
-                          "value": "Yes",
-                          "label": "Yes"
-                        },
-                        {
-                          "value": "No",
-                          "label": "No"
-                        }
-                      ],
-                      "id": "changes-in-turnover-answer",
-                      "type": "Radio",
-                      "q_code": "146",
-                      "mandatory": true
-                    }
-                  ],
-                  "guidance": {
-                    "content": [
-                      {
-                        "title": "Include",
-                        "list": [
-                          "change in level of business activity",
-                          "maintenance/shutdowns",
-                          "special/calendar events",
-                          "weather",
-                          "price effects",
-                          "currency effects (increase/decrease in the currency value)"
-                        ]
-                      }
-                    ]
-                  },
-                  "type": "General"
-                }
-              ],
-              "title": "Changes in total turnover",
-              "routing_rules": [
-                {
-                  "goto": {
-                    "when": [
-                      {
-                        "id": "changes-in-turnover-answer",
-                        "value": "Yes",
-                        "condition": "equals"
-                      }
-                    ],
-                    "block": "changes-in-turnover-block-2"
-                  }
-                },
-                {
-                  "goto": {
-                    "group": "summary-group"
-                  }
-                }
-              ]
-            },
-            {
-              "id": "changes-in-turnover-block-2",
-              "type": "Question",
-              "questions": [
-                {
-                  "title": "Please indicate the reasons for any changes in the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
-                  "answers": [
-                    {
-                      "options": [
-                        {
-                          "q_code": "146a",
-                          "value": "Change in level of business activity",
-                          "label": "Change in level of business activity"
-                        },
-                        {
-                          "q_code": "146b",
-                          "value": "Maintenance/shutdowns",
-                          "label": "Maintenance/shutdowns"
-                        },
-                        {
-                          "q_code": "146c",
-                          "value": "Special/calendar events",
-                          "label": "Special/calendar events"
-                        },
-                        {
-                          "q_code": "146d",
-                          "value": "Weather",
-                          "label": "Weather"
-                        },
-                        {
-                          "q_code": "146e",
-                          "value": "Price effects",
-                          "label": "Price effects"
-                        },
-                        {
-                          "q_code": "146f",
-                          "value": "Currency effects (increase/decrease in the currency value)",
-                          "label": "Currency effects (increase/decrease in the currency value)"
-                        },
-                        {
-                          "q_code": "146g",
-                          "value": "Other",
-                          "label": "Other"
-                        }
-                      ],
-                      "id": "changes-in-turnover-answer-2",
-                      "type": "Checkbox",
-                      "mandatory": true
-                    }
-                  ],
-                  "type": "General",
-                  "id": "changes-in-turnover-question-2"
-                }
-              ],
-              "title": "Changes in total turnover"
-            },
-            {
-              "type": "Question",
-              "id": "changes-in-turnover-block-3",
-              "title": "Changes in total turnover",
-              "questions": [
-                {
-                  "type": "General",
-                  "id": "changes-in-turnover-question-3",
-                  "title": "Please describe the changes in total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
-                  "answers": [
-                    {
-                      "guidance": {
-                        "hide_guidance": "Hide examples of commentary on changes to total turnover",
-                        "show_guidance": "Show examples of commentary on changes to total turnover",
-                        "content": [
-                          {
-                            "list": [
-                              
-                            ],
-                            "title": "‘Change in level of business activity’",
-                            "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
-                          },
-                          {
-                            "list": [
-                              
-                            ],
-                            "title": "‘Maintenance/shutdowns’",
-                            "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
-                          },
-                          {
-                            "list": [
-                              
-                            ],
-                            "title": "‘Special/calendar events’",
-                            "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
-                          },
-                          {
-                            "list": [
-                              
-                            ],
-                            "title": "‘Weather’",
-                            "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
-                          },
-                          {
-                            "list": [
-                              
-                            ],
-                            "title": "‘Price effects’",
-                            "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
-                          },
-                          {
-                            "list": [
-                              
-                            ],
-                            "title": "‘Currency effects (increase/decrease in the currency value)’",
-                            "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
-                          }
-                        ]
-                      },
-                      "type": "TextArea",
-                      "mandatory": true,
-                      "label": "Comments",
-                      "id": "changes-in-turnover-answer-3",
-                      "q_code": "146h"
-                    }
-                  ],
-                  "description": "<p>We rely on your commentary to ‘tell the story’ behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "summary-section",
-      "title": "Summary",
-      "groups": [
+            }]
+        },
         {
-          "id": "summary-group",
-          "title": "Summary",
-          "blocks": [
-            {
-              "type": "Summary",
-              "id": "summary"
-            }
-          ]
+            "id": "summary-section",
+            "title": "Summary",
+            "groups": [{
+                "id": "summary-group",
+                "title": "Summary",
+                "blocks": [{
+                    "type": "Summary",
+                    "id": "summary"
+                }]
+            }]
         }
-      ]
-    }
-  ]
+    ]
 }

--- a/data/en/mbs_0202.json
+++ b/data/en/mbs_0202.json
@@ -1,459 +1,671 @@
 {
-    "title": "Monthly Business Survey",
-    "survey_id": "009",
-    "mime_type": "application/json/ons/eq",
-    "theme": "northernireland",
-    "schema_version": "0.0.1",
-    "data_version": "0.0.1",
-    "legal_basis": "Notice is given under article 5 of the Statistics of Trade and Employment (Northern Ireland) Order 1988.",
-    "description": "mbs",
-    "form_type": "0202",
-    "view_submitted_response": {
-        "enabled": true,
-        "duration": 900
+  "title": "Monthly Business Survey",
+  "survey_id": "009",
+  "mime_type": "application/json/ons/eq",
+  "theme": "northernireland",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.1",
+  "legal_basis": "Notice is given under article 5 of the Statistics of Trade and Employment (Northern Ireland) Order 1988.",
+  "description": "mbs",
+  "form_type": "0202",
+  "view_submitted_response": {
+    "enabled": true,
+    "duration": 900
+  },
+  "metadata": [
+    {
+      "name": "user_id",
+      "validator": "string"
     },
-    "metadata": [{
-        "name": "user_id",
-        "validator": "string"
-    }, {
-        "name": "period_id",
-        "validator": "string"
-    }, {
-        "name": "ru_name",
-        "validator": "string"
-    }, {
-        "name": "ref_p_start_date",
-        "validator": "date"
-    }, {
-        "name": "ref_p_end_date",
-        "validator": "date"
-    }, {
-        "name": "trad_as",
-        "validator": "optional_string"
-    }],
-    "sections": [{
-        "id": "section",
-        "groups": [{
-            "id": "group",
-            "title": "",
-            "blocks": [{
-                "type": "Introduction",
-                "id": "introduction",
-                "primary_content": [{
-                    "type": "Basic",
-                    "id": "use-of-information",
-                    "content": [{
-                        "list": ["Data should relate to all sites in England, Scotland, Wales and Northern Ireland unless otherwise stated.", "You can provide informed estimates if actual figures aren\u2019t available.", "We will treat your data securely and confidentially."]
-                    }]
-                }],
-                "preview_content": {
-                    "id": "preview",
-                    "title": "Information you need",
-                    "content": [{
-                        "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
-                    }],
-                    "questions": [{
-                        "question": "Total turnover",
-                        "content": [{
-                            "description": "Include:",
-                            "list": ["exports", "income from sub-contracted activities", "commission", "sales of goods purchased for resale", "transport, insurance and packaging charges", "revenue earned from other parts of the business not named at the top of this page (please supply at fair value)"]
-                        }, {
-                            "description": "Exclude:",
-                            "list": ["VAT", "income from the sale of fixed capital assets", "grants and subsidies", "insurance claims", "interest received"]
-                        }]
-                    }, {
-                        "question": "Value of exports",
-                        "content": [{
-                            "description": "Include:",
-                            "list": ["all countries outside of England, Scotland, Wales and Northern Ireland"]
-                        }]
-                    }, {
-                        "question": "Changes in total turnover",
-                        "content": [{
-                            "description": "Include:",
-                            "list": ["change in level of business activity", "maintenance/shutdowns", "special/calendar events", "weather", "price effects", "currency effects (increase/decrease in the currency value)"]
-                        }]
-                    }]
-                },
-                "secondary_content": [{
-                    "id": "how-we-use-your-data",
-                    "title": "How we use your data",
-                    "content": [{
-                        "list": ["You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.", "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"]
-                    }]
-                }]
-            }, {
-                "id": "reporting-period-block",
-                "type": "Question",
-                "questions": [{
-                    "answers": [{
-                        "options": [{
-                            "value": "Yes",
-                            "label": "Yes"
-                        }, {
-                            "value": "No",
-                            "label": "No"
-                        }],
+    {
+      "name": "period_id",
+      "validator": "string"
+    },
+    {
+      "name": "ru_name",
+      "validator": "string"
+    },
+    {
+      "name": "ref_p_start_date",
+      "validator": "date"
+    },
+    {
+      "name": "ref_p_end_date",
+      "validator": "date"
+    },
+    {
+      "name": "trad_as",
+      "validator": "optional_string"
+    }
+  ],
+  "sections": [
+    {
+      "id": "section",
+      "groups": [
+        {
+          "id": "group",
+          "title": "",
+          "blocks": [
+            {
+              "type": "Introduction",
+              "id": "introduction",
+              "primary_content": [
+                {
+                  "type": "Basic",
+                  "id": "use-of-information",
+                  "content": [
+                    {
+                      "list": [
+                        "Data should relate to all sites in England, Scotland, Wales and Northern Ireland unless otherwise stated.",
+                        "You can provide informed estimates if actual figures aren’t available.",
+                        "We will treat your data securely and confidentially."
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "preview_content": {
+                "id": "preview",
+                "title": "Information you need",
+                "content": [
+                  {
+                    "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
+                  }
+                ],
+                "questions": [
+                  {
+                    "question": "Total turnover",
+                    "content": [
+                      {
+                        "description": "Include:",
+                        "list": [
+                          "exports",
+                          "income from sub-contracted activities",
+                          "commission",
+                          "sales of goods purchased for resale",
+                          "transport, insurance and packaging charges",
+                          "revenue earned from other parts of the business not named at the top of this page (please supply at fair value)"
+                        ]
+                      },
+                      {
+                        "description": "Exclude:",
+                        "list": [
+                          "VAT",
+                          "income from the sale of fixed capital assets",
+                          "grants and subsidies",
+                          "insurance claims",
+                          "interest received"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "question": "Value of exports",
+                    "content": [
+                      {
+                        "description": "Include:",
+                        "list": [
+                          "all countries outside of England, Scotland, Wales and Northern Ireland"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "question": "Changes in total turnover",
+                    "content": [
+                      {
+                        "description": "Include:",
+                        "list": [
+                          "change in level of business activity",
+                          "maintenance/shutdowns",
+                          "special/calendar events",
+                          "weather",
+                          "price effects",
+                          "currency effects (increase/decrease in the currency value)"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              "secondary_content": [
+                {
+                  "id": "how-we-use-your-data",
+                  "title": "How we use your data",
+                  "content": [
+                    {
+                      "list": [
+                        "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
+                        "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "reporting-period-block",
+              "type": "Question",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "options": [
+                        {
+                          "value": "Yes",
+                          "label": "Yes"
+                        },
+                        {
+                          "value": "No",
+                          "label": "No"
+                        }
+                      ],
+                      "id": "reporting-period-answer",
+                      "type": "Radio",
+                      "q_code": "d12",
+                      "mandatory": true
+                    }
+                  ],
+                  "type": "General",
+                  "id": "reporting-period-question",
+                  "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "when": [
+                      {
                         "id": "reporting-period-answer",
-                        "type": "Radio",
-                        "q_code": "d12",
-                        "mandatory": true
-                    }],
-                    "type": "General",
-                    "id": "reporting-period-question",
-                    "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
-                }],
-                "routing_rules": [{
-                    "goto": {
-                        "when": [{
-                            "id": "reporting-period-answer",
-                            "value": "Yes",
-                            "condition": "equals"
-                        }],
-                        "block": "turnover-block"
-                    }
-                }, {
-                    "goto": {
-                        "block": "reporting-period-block-2"
-                    }
-                }],
-                "title": "Reporting period"
-            }, {
-                "type": "Question",
-                "id": "reporting-period-block-2",
-                "title": "Reporting period",
-                "questions": [{
-                    "type": "DateRange",
-                    "id": "reporting-period-question-2",
-                    "title": "What are the dates of the period that you will be reporting for?",
-                    "period_limits": {
-                        "minimum": {
-                            "days": 10
-                        },
-                        "maximum": {
-                            "days": 50
-                        }
+                        "value": "Yes",
+                        "condition": "equals"
+                      }
+                    ],
+                    "block": "turnover-block"
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "reporting-period-block-2"
+                  }
+                }
+              ],
+              "title": "Reporting period"
+            },
+            {
+              "type": "Question",
+              "id": "reporting-period-block-2",
+              "title": "Reporting period",
+              "questions": [
+                {
+                  "type": "DateRange",
+                  "id": "reporting-period-question-2",
+                  "title": "What are the dates of the period that you will be reporting for?",
+                  "period_limits": {
+                    "minimum": {
+                      "days": 10
                     },
-                    "answers": [{
-                        "type": "Date",
-                        "id": "period-from",
-                        "label": "From",
-                        "mandatory": true,
-                        "q_code": "11",
-                        "minimum": {
-                            "meta": "ref_p_start_date",
-                            "offset_by": {
-                                "days": -19
-                            }
+                    "maximum": {
+                      "days": 50
+                    }
+                  },
+                  "answers": [
+                    {
+                      "type": "Date",
+                      "id": "period-from",
+                      "label": "From",
+                      "mandatory": true,
+                      "q_code": "11",
+                      "minimum": {
+                        "meta": "ref_p_start_date",
+                        "offset_by": {
+                          "days": -19
                         }
-                    }, {
-                        "type": "Date",
-                        "id": "period-to",
-                        "label": "To",
-                        "mandatory": true,
-                        "q_code": "12",
-                        "maximum": {
-                            "meta": "ref_p_end_date",
-                            "offset_by": {
-                                "days": 20
-                            }
-                        }
-                    }]
-                }]
-            }, {
-                "id": "turnover-block",
-                "type": "Question",
-                "title": "Total turnover",
-                "questions": [{
-                    "guidance": {
-                        "content": [{
-                            "title": "Include:",
-                            "list": ["exports", "income from sub-contracted activities", "commission", "sales of goods purchased for resale", "transport, insurance and packaging charges", "revenue earned from other parts of the business not named at the top of this page (please supply at fair value)"]
-                        }, {
-                            "title": "Exclude:",
-                            "list": ["VAT", "income from the sale of fixed capital assets", "grants and subsidies", "insurance claims", "interest received"]
-                        }]
+                      }
                     },
-                    "id": "turnover-question",
-                    "answers": [{
+                    {
+                      "type": "Date",
+                      "id": "period-to",
+                      "label": "To",
+                      "mandatory": true,
+                      "q_code": "12",
+                      "maximum": {
+                        "meta": "ref_p_end_date",
+                        "offset_by": {
+                          "days": 20
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "turnover-block",
+              "type": "Question",
+              "title": "Total turnover",
+              "questions": [
+                {
+                  "guidance": {
+                    "content": [
+                      {
+                        "title": "Include:",
+                        "list": [
+                          "exports",
+                          "income from sub-contracted activities",
+                          "commission",
+                          "sales of goods purchased for resale",
+                          "transport, insurance and packaging charges",
+                          "revenue earned from other parts of the business not named at the top of this page (please supply at fair value)"
+                        ]
+                      },
+                      {
+                        "title": "Exclude:",
+                        "list": [
+                          "VAT",
+                          "income from the sale of fixed capital assets",
+                          "grants and subsidies",
+                          "insurance claims",
+                          "interest received"
+                        ]
+                      }
+                    ]
+                  },
+                  "id": "turnover-question",
+                  "answers": [
+                    {
+                      "id": "turnover-answer",
+                      "label": "Total turnover excluding VAT",
+                      "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                      "type": "Currency",
+                      "currency": "GBP",
+                      "decimal_places": 2,
+                      "q_code": "40",
+                      "mandatory": false,
+                      "default": 0
+                    }
+                  ],
+                  "type": "General",
+                  "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s <em>total turnover</em>, excluding VAT?"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "when": [
+                      {
                         "id": "turnover-answer",
-                        "label": "Total turnover excluding VAT",
-                        "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
-                        "type": "Currency",
-                        "currency": "GBP",
-                        "decimal_places": 2,
-                        "q_code": "40",
-                        "mandatory": false,
-                        "default": 0
-                    }],
-                    "type": "General",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>total turnover</em>, excluding VAT?"
-                }],
-                "routing_rules": [{
-                    "goto": {
-                        "when": [{
-                            "id": "turnover-answer",
-                            "condition": "greater than",
-                            "value": 0
-                        }],
-                        "block": "confirm-turnover-block"
-                    }
-                }, {
-                    "goto": {
-                        "block": "confirm-zero-turnover-block"
-                    }
-                }]
-            }, {
-                "type": "ConfirmationQuestion",
-                "title": "Total turnover",
-                "id": "confirm-turnover-block",
-                "questions": [{
-                    "type": "General",
-                    "answers": [{
-                        "type": "Radio",
-                        "id": "confirm-turnover-answer",
-                        "q_code": "d40",
-                        "options": [{
-                            "label": "Yes this is correct",
-                            "value": "Yes"
-                        }, {
-                            "label": "No I need to change this",
-                            "value": "No"
-                        }],
-                        "mandatory": true
-                    }],
-                    "id": "confirm-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
-                }],
-                "routing_rules": [{
-                    "goto": {
-                        "when": [{
-                            "value": "No",
-                            "id": "confirm-turnover-answer",
-                            "condition": "equals"
-                        }],
-                        "block": "turnover-block"
-                    }
-                }, {
-                    "goto": {
-                        "block": "exports-block"
-                    }
-                }]
-            }, {
-                "type": "ConfirmationQuestion",
-                "title": "Total turnover",
-                "id": "confirm-zero-turnover-block",
-                "questions": [{
-                    "type": "General",
-                    "answers": [{
-                        "type": "Radio",
-                        "id": "confirm-zero-turnover-answer",
-                        "q_code": "d49",
-                        "options": [{
-                            "label": "Yes this is correct",
-                            "value": "Yes"
-                        }, {
-                            "label": "No I need to change this",
-                            "value": "No"
-                        }],
-                        "mandatory": true
-                    }],
-                    "id": "confirm-zero-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
-                }],
-                "routing_rules": [{
-                    "goto": {
-                        "when": [{
-                            "value": "No",
-                            "id": "confirm-zero-turnover-answer",
-                            "condition": "equals"
-                        }],
-                        "block": "turnover-block"
-                    }
-                }, {
-                    "goto": {
-                        "block": "changes-in-turnover-block"
-                    }
-                }]
-            }, {
-                "id": "exports-block",
-                "type": "Question",
-                "questions": [{
-                    "id": "exports-question",
-                    "guidance": {
-                        "content": [{
-                            "title": "Include:",
-                            "list": ["All countries outside of England, Scotland, Wales and Northern Ireland"]
-                        }]
-                    },
-                    "answers": [{
-                        "id": "exports-answer",
-                        "label": "Exports",
-                        "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
-                        "type": "Currency",
-                        "currency": "GBP",
-                        "decimal_places": 2,
-                        "q_code": "49",
-                        "mandatory": true,
-                        "max_value": {
-                            "answer_id": "turnover-answer"
-                        }
-                    }],
-                    "type": "General",
-                    "title": "Of the <em>{{format_currency(answers['turnover-answer'])}}</em> total turnover, what was the value of <em>exports?</em>"
-                }],
-                "title": "Exports"
-            }, {
-                "id": "changes-in-turnover-block",
-                "type": "Question",
-                "questions": [{
-                    "title": "Did any significant changes occur to the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
-                    "id": "changes-in-turnover-question",
-                    "definitions": [{
-                        "title": "What constitutes a significant change?",
-                        "content": [{
-                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
-                        }, {
-                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
-                        }]
-                    }],
-                    "answers": [{
-                        "options": [{
-                            "value": "Yes",
-                            "label": "Yes"
-                        }, {
-                            "value": "No",
-                            "label": "No"
-                        }],
-                        "id": "changes-in-turnover-answer",
-                        "type": "Radio",
-                        "q_code": "146",
-                        "mandatory": true
-                    }],
-                    "guidance": {
-                        "content": [{
-                            "title": "Include",
-                            "list": ["change in level of business activity", "maintenance/shutdowns", "special/calendar events", "weather", "price effects", "currency effects (increase/decrease in the currency value)"]
-                        }]
-                    },
-                    "type": "General"
-                }],
-                "title": "Changes in total turnover",
-                "routing_rules": [{
-                    "goto": {
-                        "when": [{
-                            "id": "changes-in-turnover-answer",
-                            "value": "Yes",
-                            "condition": "equals"
-                        }],
-                        "block": "changes-in-turnover-block-2"
-                    }
-                }, {
-                    "goto": {
-                        "group": "summary-group"
-                    }
-                }]
-            }, {
-                "id": "changes-in-turnover-block-2",
-                "type": "Question",
-                "questions": [{
-                    "title": "Please indicate the reasons for any changes in the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
-                    "answers": [{
-                        "options": [{
-                            "q_code": "146a",
-                            "value": "Change in level of business activity",
-                            "label": "Change in level of business activity"
-                        }, {
-                            "q_code": "146b",
-                            "value": "Maintenance/shutdowns",
-                            "label": "Maintenance/shutdowns"
-                        }, {
-                            "q_code": "146c",
-                            "value": "Special/calendar events",
-                            "label": "Special/calendar events"
-                        }, {
-                            "q_code": "146d",
-                            "value": "Weather",
-                            "label": "Weather"
-                        }, {
-                            "q_code": "146e",
-                            "value": "Price effects",
-                            "label": "Price effects"
-                        }, {
-                            "q_code": "146f",
-                            "value": "Currency effects (increase/decrease in the currency value)",
-                            "label": "Currency effects (increase/decrease in the currency value)"
-                        }, {
-                            "q_code": "146g",
-                            "value": "Other",
-                            "label": "Other"
-                        }],
-                        "id": "changes-in-turnover-answer-2",
-                        "type": "Checkbox",
-                        "mandatory": true
-                    }],
-                    "type": "General",
-                    "id": "changes-in-turnover-question-2"
-                }],
-                "title": "Changes in total turnover"
-            }, {
-                "type": "Question",
-                "id": "changes-in-turnover-block-3",
-                "title": "Changes in total turnover",
-                "questions": [{
-                    "type": "General",
-                    "id": "changes-in-turnover-question-3",
-                    "title": "Please describe the changes in total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
-                    "answers": [{
-                        "guidance": {
-                            "hide_guidance": "Hide examples of commentary on changes to total turnover",
-                            "show_guidance": "Show examples of commentary on changes to total turnover",
-                            "content": [{
-                                "list": [],
-                                "title": "\u2018Change in level of business activity\u2019",
-                                "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
-                            }, {
-                                "list": [],
-                                "title": "\u2018Maintenance/shutdowns\u2019",
-                                "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
-                            }, {
-                                "list": [],
-                                "title": "\u2018Special/calendar events\u2019",
-                                "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
-                            }, {
-                                "list": [],
-                                "title": "\u2018Weather\u2019",
-                                "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
-                            }, {
-                                "list": [],
-                                "title": "\u2018Price effects\u2019",
-                                "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
-                            }, {
-                                "list": [],
-                                "title": "\u2018Currency effects (increase/decrease in the currency value)\u2019",
-                                "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
-                            }]
+                        "condition": "greater than",
+                        "value": 0
+                      }
+                    ],
+                    "block": "confirm-turnover-block"
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "confirm-zero-turnover-block"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "ConfirmationQuestion",
+              "title": "Total turnover",
+              "id": "confirm-turnover-block",
+              "questions": [
+                {
+                  "type": "General",
+                  "answers": [
+                    {
+                      "type": "Radio",
+                      "id": "confirm-turnover-answer",
+                      "q_code": "d40",
+                      "options": [
+                        {
+                          "label": "Yes this is correct",
+                          "value": "Yes"
                         },
-                        "type": "TextArea",
-                        "mandatory": true,
-                        "label": "Comments",
-                        "id": "changes-in-turnover-answer-3",
-                        "q_code": "146h"
-                    }],
-                    "description": "<p>We rely on your commentary to \u2018tell the story\u2019 behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
-                }]
-            }]
-        }]
-    }, {
-        "id": "summary-section",
-        "title": "Summary",
-        "groups": [{
-            "id": "summary-group",
-            "title": "Summary",
-            "blocks": [{
-                "type": "Summary",
-                "id": "summary"
-            }]
-        }]
-    }]
+                        {
+                          "label": "No I need to change this",
+                          "value": "No"
+                        }
+                      ],
+                      "mandatory": true
+                    }
+                  ],
+                  "id": "confirm-turnover-question",
+                  "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "when": [
+                      {
+                        "value": "No",
+                        "id": "confirm-turnover-answer",
+                        "condition": "equals"
+                      }
+                    ],
+                    "block": "turnover-block"
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "exports-block"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "ConfirmationQuestion",
+              "title": "Total turnover",
+              "id": "confirm-zero-turnover-block",
+              "questions": [
+                {
+                  "type": "General",
+                  "answers": [
+                    {
+                      "type": "Radio",
+                      "id": "confirm-zero-turnover-answer",
+                      "q_code": "d49",
+                      "options": [
+                        {
+                          "label": "Yes this is correct",
+                          "value": "Yes"
+                        },
+                        {
+                          "label": "No I need to change this",
+                          "value": "No"
+                        }
+                      ],
+                      "mandatory": true
+                    }
+                  ],
+                  "id": "confirm-zero-turnover-question",
+                  "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "when": [
+                      {
+                        "value": "No",
+                        "id": "confirm-zero-turnover-answer",
+                        "condition": "equals"
+                      }
+                    ],
+                    "block": "turnover-block"
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "changes-in-turnover-block"
+                  }
+                }
+              ]
+            },
+            {
+              "id": "exports-block",
+              "type": "Question",
+              "questions": [
+                {
+                  "id": "exports-question",
+                  "guidance": {
+                    "content": [
+                      {
+                        "title": "Include:",
+                        "list": [
+                          "All countries outside of England, Scotland, Wales and Northern Ireland"
+                        ]
+                      }
+                    ]
+                  },
+                  "answers": [
+                    {
+                      "id": "exports-answer",
+                      "label": "Exports",
+                      "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                      "type": "Currency",
+                      "currency": "GBP",
+                      "decimal_places": 2,
+                      "q_code": "49",
+                      "mandatory": true,
+                      "max_value": {
+                        "answer_id": "turnover-answer"
+                      }
+                    }
+                  ],
+                  "type": "General",
+                  "title": "Of the <em>{{format_currency(answers['turnover-answer'])}}</em> total turnover, what was the value of <em>exports?</em>"
+                }
+              ],
+              "title": "Exports"
+            },
+            {
+              "id": "changes-in-turnover-block",
+              "type": "Question",
+              "questions": [
+                {
+                  "title": "Did any significant changes occur to the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                  "id": "changes-in-turnover-question",
+                  "definitions": [
+                    {
+                      "title": "What constitutes a significant change?",
+                      "content": [
+                        {
+                          "description": "What constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s figures from the previous reporting period and the same reporting period last year."
+                        },
+                        {
+                          "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }
+                      ]
+                    }
+                  ],
+                  "answers": [
+                    {
+                      "options": [
+                        {
+                          "value": "Yes",
+                          "label": "Yes"
+                        },
+                        {
+                          "value": "No",
+                          "label": "No"
+                        }
+                      ],
+                      "id": "changes-in-turnover-answer",
+                      "type": "Radio",
+                      "q_code": "146",
+                      "mandatory": true
+                    }
+                  ],
+                  "guidance": {
+                    "content": [
+                      {
+                        "title": "Include",
+                        "list": [
+                          "change in level of business activity",
+                          "maintenance/shutdowns",
+                          "special/calendar events",
+                          "weather",
+                          "price effects",
+                          "currency effects (increase/decrease in the currency value)"
+                        ]
+                      }
+                    ]
+                  },
+                  "type": "General"
+                }
+              ],
+              "title": "Changes in total turnover",
+              "routing_rules": [
+                {
+                  "goto": {
+                    "when": [
+                      {
+                        "id": "changes-in-turnover-answer",
+                        "value": "Yes",
+                        "condition": "equals"
+                      }
+                    ],
+                    "block": "changes-in-turnover-block-2"
+                  }
+                },
+                {
+                  "goto": {
+                    "group": "summary-group"
+                  }
+                }
+              ]
+            },
+            {
+              "id": "changes-in-turnover-block-2",
+              "type": "Question",
+              "questions": [
+                {
+                  "title": "Please indicate the reasons for any changes in the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
+                  "answers": [
+                    {
+                      "options": [
+                        {
+                          "q_code": "146a",
+                          "value": "Change in level of business activity",
+                          "label": "Change in level of business activity"
+                        },
+                        {
+                          "q_code": "146b",
+                          "value": "Maintenance/shutdowns",
+                          "label": "Maintenance/shutdowns"
+                        },
+                        {
+                          "q_code": "146c",
+                          "value": "Special/calendar events",
+                          "label": "Special/calendar events"
+                        },
+                        {
+                          "q_code": "146d",
+                          "value": "Weather",
+                          "label": "Weather"
+                        },
+                        {
+                          "q_code": "146e",
+                          "value": "Price effects",
+                          "label": "Price effects"
+                        },
+                        {
+                          "q_code": "146f",
+                          "value": "Currency effects (increase/decrease in the currency value)",
+                          "label": "Currency effects (increase/decrease in the currency value)"
+                        },
+                        {
+                          "q_code": "146g",
+                          "value": "Other",
+                          "label": "Other"
+                        }
+                      ],
+                      "id": "changes-in-turnover-answer-2",
+                      "type": "Checkbox",
+                      "mandatory": true
+                    }
+                  ],
+                  "type": "General",
+                  "id": "changes-in-turnover-question-2"
+                }
+              ],
+              "title": "Changes in total turnover"
+            },
+            {
+              "type": "Question",
+              "id": "changes-in-turnover-block-3",
+              "title": "Changes in total turnover",
+              "questions": [
+                {
+                  "type": "General",
+                  "id": "changes-in-turnover-question-3",
+                  "title": "Please describe the changes in total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
+                  "answers": [
+                    {
+                      "guidance": {
+                        "hide_guidance": "Hide examples of commentary on changes to total turnover",
+                        "show_guidance": "Show examples of commentary on changes to total turnover",
+                        "content": [
+                          {
+                            "list": [
+                              
+                            ],
+                            "title": "‘Change in level of business activity’",
+                            "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
+                          },
+                          {
+                            "list": [
+                              
+                            ],
+                            "title": "‘Maintenance/shutdowns’",
+                            "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
+                          },
+                          {
+                            "list": [
+                              
+                            ],
+                            "title": "‘Special/calendar events’",
+                            "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
+                          },
+                          {
+                            "list": [
+                              
+                            ],
+                            "title": "‘Weather’",
+                            "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
+                          },
+                          {
+                            "list": [
+                              
+                            ],
+                            "title": "‘Price effects’",
+                            "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
+                          },
+                          {
+                            "list": [
+                              
+                            ],
+                            "title": "‘Currency effects (increase/decrease in the currency value)’",
+                            "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
+                          }
+                        ]
+                      },
+                      "type": "TextArea",
+                      "mandatory": true,
+                      "label": "Comments",
+                      "id": "changes-in-turnover-answer-3",
+                      "q_code": "146h"
+                    }
+                  ],
+                  "description": "<p>We rely on your commentary to ‘tell the story’ behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "summary-section",
+      "title": "Summary",
+      "groups": [
+        {
+          "id": "summary-group",
+          "title": "Summary",
+          "blocks": [
+            {
+              "type": "Summary",
+              "id": "summary"
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/data/en/mbs_0202_prototype.json
+++ b/data/en/mbs_0202_prototype.json
@@ -1,0 +1,459 @@
+{
+    "title": "Monthly Business Survey",
+    "survey_id": "009",
+    "mime_type": "application/json/ons/eq",
+    "theme": "northernireland",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.1",
+    "legal_basis": "Notice is given under article 5 of the Statistics of Trade and Employment (Northern Ireland) Order 1988.",
+    "description": "mbs",
+    "form_type": "0202",
+    "view_submitted_response": {
+        "enabled": true,
+        "duration": 900
+    },
+    "metadata": [{
+        "name": "user_id",
+        "validator": "string"
+    }, {
+        "name": "period_id",
+        "validator": "string"
+    }, {
+        "name": "ru_name",
+        "validator": "string"
+    }, {
+        "name": "ref_p_start_date",
+        "validator": "date"
+    }, {
+        "name": "ref_p_end_date",
+        "validator": "date"
+    }, {
+        "name": "trad_as",
+        "validator": "optional_string"
+    }],
+    "sections": [{
+        "id": "section",
+        "groups": [{
+            "id": "group",
+            "title": "",
+            "blocks": [{
+                "type": "Introduction",
+                "id": "introduction",
+                "primary_content": [{
+                    "type": "Basic",
+                    "id": "use-of-information",
+                    "content": [{
+                        "list": ["Data should relate to all sites in England, Scotland, Wales and Northern Ireland unless otherwise stated.", "You can provide informed estimates if actual figures aren\u2019t available.", "We will treat your data securely and confidentially."]
+                    }]
+                }],
+                "preview_content": {
+                    "id": "preview",
+                    "title": "Information you need",
+                    "content": [{
+                        "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
+                    }],
+                    "questions": [{
+                        "question": "Total turnover",
+                        "content": [{
+                            "description": "Include:",
+                            "list": ["exports", "income from sub-contracted activities", "commission", "sales of goods purchased for resale", "transport, insurance and packaging charges", "revenue earned from other parts of the business not named at the top of this page (please supply at fair value)"]
+                        }, {
+                            "description": "Exclude:",
+                            "list": ["VAT", "income from the sale of fixed capital assets", "grants and subsidies", "insurance claims", "interest received"]
+                        }]
+                    }, {
+                        "question": "Value of exports",
+                        "content": [{
+                            "description": "Include:",
+                            "list": ["all countries outside of England, Scotland, Wales and Northern Ireland"]
+                        }]
+                    }, {
+                        "question": "Changes in total turnover",
+                        "content": [{
+                            "description": "Include:",
+                            "list": ["change in level of business activity", "maintenance/shutdowns", "special/calendar events", "weather", "price effects", "currency effects (increase/decrease in the currency value)"]
+                        }]
+                    }]
+                },
+                "secondary_content": [{
+                    "id": "how-we-use-your-data",
+                    "title": "How we use your data",
+                    "content": [{
+                        "list": ["You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.", "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"]
+                    }]
+                }]
+            }, {
+                "id": "reporting-period-block",
+                "type": "Question",
+                "questions": [{
+                    "answers": [{
+                        "options": [{
+                            "value": "Yes",
+                            "label": "Yes"
+                        }, {
+                            "value": "No",
+                            "label": "No"
+                        }],
+                        "id": "reporting-period-answer",
+                        "type": "Radio",
+                        "q_code": "d12",
+                        "mandatory": true
+                    }],
+                    "type": "General",
+                    "id": "reporting-period-question",
+                    "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
+                }],
+                "routing_rules": [{
+                    "goto": {
+                        "when": [{
+                            "id": "reporting-period-answer",
+                            "value": "Yes",
+                            "condition": "equals"
+                        }],
+                        "block": "turnover-block"
+                    }
+                }, {
+                    "goto": {
+                        "block": "reporting-period-block-2"
+                    }
+                }],
+                "title": "Reporting period"
+            }, {
+                "type": "Question",
+                "id": "reporting-period-block-2",
+                "title": "Reporting period",
+                "questions": [{
+                    "type": "DateRange",
+                    "id": "reporting-period-question-2",
+                    "title": "What are the dates of the period that you will be reporting for?",
+                    "period_limits": {
+                        "minimum": {
+                            "days": 10
+                        },
+                        "maximum": {
+                            "days": 50
+                        }
+                    },
+                    "answers": [{
+                        "type": "Date",
+                        "id": "period-from",
+                        "label": "From",
+                        "mandatory": true,
+                        "q_code": "11",
+                        "minimum": {
+                            "meta": "ref_p_start_date",
+                            "offset_by": {
+                                "days": -19
+                            }
+                        }
+                    }, {
+                        "type": "Date",
+                        "id": "period-to",
+                        "label": "To",
+                        "mandatory": true,
+                        "q_code": "12",
+                        "maximum": {
+                            "meta": "ref_p_end_date",
+                            "offset_by": {
+                                "days": 20
+                            }
+                        }
+                    }]
+                }]
+            }, {
+                "id": "turnover-block",
+                "type": "Question",
+                "title": "Total turnover",
+                "questions": [{
+                    "guidance": {
+                        "content": [{
+                            "title": "Include:",
+                            "list": ["exports", "income from sub-contracted activities", "commission", "sales of goods purchased for resale", "transport, insurance and packaging charges", "revenue earned from other parts of the business not named at the top of this page (please supply at fair value)"]
+                        }, {
+                            "title": "Exclude:",
+                            "list": ["VAT", "income from the sale of fixed capital assets", "grants and subsidies", "insurance claims", "interest received"]
+                        }]
+                    },
+                    "id": "turnover-question",
+                    "answers": [{
+                        "id": "turnover-answer",
+                        "label": "Total turnover excluding VAT",
+                        "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                        "type": "Currency",
+                        "currency": "GBP",
+                        "decimal_places": 2,
+                        "q_code": "40",
+                        "mandatory": false,
+                        "default": 0
+                    }],
+                    "type": "General",
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>total turnover</em>, excluding VAT?"
+                }],
+                "routing_rules": [{
+                    "goto": {
+                        "when": [{
+                            "id": "turnover-answer",
+                            "condition": "greater than",
+                            "value": 0
+                        }],
+                        "block": "confirm-turnover-block"
+                    }
+                }, {
+                    "goto": {
+                        "block": "confirm-zero-turnover-block"
+                    }
+                }]
+            }, {
+                "type": "ConfirmationQuestion",
+                "title": "Total turnover",
+                "id": "confirm-turnover-block",
+                "questions": [{
+                    "type": "General",
+                    "answers": [{
+                        "type": "Radio",
+                        "id": "confirm-turnover-answer",
+                        "q_code": "d40",
+                        "options": [{
+                            "label": "Yes this is correct",
+                            "value": "Yes"
+                        }, {
+                            "label": "No I need to change this",
+                            "value": "No"
+                        }],
+                        "mandatory": true
+                    }],
+                    "id": "confirm-turnover-question",
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
+                }],
+                "routing_rules": [{
+                    "goto": {
+                        "when": [{
+                            "value": "No",
+                            "id": "confirm-turnover-answer",
+                            "condition": "equals"
+                        }],
+                        "block": "turnover-block"
+                    }
+                }, {
+                    "goto": {
+                        "block": "exports-block"
+                    }
+                }]
+            }, {
+                "type": "ConfirmationQuestion",
+                "title": "Total turnover",
+                "id": "confirm-zero-turnover-block",
+                "questions": [{
+                    "type": "General",
+                    "answers": [{
+                        "type": "Radio",
+                        "id": "confirm-zero-turnover-answer",
+                        "q_code": "d49",
+                        "options": [{
+                            "label": "Yes this is correct",
+                            "value": "Yes"
+                        }, {
+                            "label": "No I need to change this",
+                            "value": "No"
+                        }],
+                        "mandatory": true
+                    }],
+                    "id": "confirm-zero-turnover-question",
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
+                }],
+                "routing_rules": [{
+                    "goto": {
+                        "when": [{
+                            "value": "No",
+                            "id": "confirm-zero-turnover-answer",
+                            "condition": "equals"
+                        }],
+                        "block": "turnover-block"
+                    }
+                }, {
+                    "goto": {
+                        "block": "changes-in-turnover-block"
+                    }
+                }]
+            }, {
+                "id": "exports-block",
+                "type": "Question",
+                "questions": [{
+                    "id": "exports-question",
+                    "guidance": {
+                        "content": [{
+                            "title": "Include:",
+                            "list": ["All countries outside of England, Scotland, Wales and Northern Ireland"]
+                        }]
+                    },
+                    "answers": [{
+                        "id": "exports-answer",
+                        "label": "Exports",
+                        "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                        "type": "Currency",
+                        "currency": "GBP",
+                        "decimal_places": 2,
+                        "q_code": "49",
+                        "mandatory": true,
+                        "max_value": {
+                            "answer_id": "turnover-answer"
+                        }
+                    }],
+                    "type": "General",
+                    "title": "Of the <em>{{format_currency(answers['turnover-answer'])}}</em> total turnover, what was the value of <em>exports?</em>"
+                }],
+                "title": "Exports"
+            }, {
+                "id": "changes-in-turnover-block",
+                "type": "Question",
+                "questions": [{
+                    "title": "Did any significant changes occur to the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                    "id": "changes-in-turnover-question",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
+                        }, {
+                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }]
+                    }],
+                    "answers": [{
+                        "options": [{
+                            "value": "Yes",
+                            "label": "Yes"
+                        }, {
+                            "value": "No",
+                            "label": "No"
+                        }],
+                        "id": "changes-in-turnover-answer",
+                        "type": "Radio",
+                        "q_code": "146",
+                        "mandatory": true
+                    }],
+                    "guidance": {
+                        "content": [{
+                            "title": "Include",
+                            "list": ["change in level of business activity", "maintenance/shutdowns", "special/calendar events", "weather", "price effects", "currency effects (increase/decrease in the currency value)"]
+                        }]
+                    },
+                    "type": "General"
+                }],
+                "title": "Changes in total turnover",
+                "routing_rules": [{
+                    "goto": {
+                        "when": [{
+                            "id": "changes-in-turnover-answer",
+                            "value": "Yes",
+                            "condition": "equals"
+                        }],
+                        "block": "changes-in-turnover-block-2"
+                    }
+                }, {
+                    "goto": {
+                        "group": "summary-group"
+                    }
+                }]
+            }, {
+                "id": "changes-in-turnover-block-2",
+                "type": "Question",
+                "questions": [{
+                    "title": "Please indicate the reasons for any changes in the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
+                    "answers": [{
+                        "options": [{
+                            "q_code": "146a",
+                            "value": "Change in level of business activity",
+                            "label": "Change in level of business activity"
+                        }, {
+                            "q_code": "146b",
+                            "value": "Maintenance/shutdowns",
+                            "label": "Maintenance/shutdowns"
+                        }, {
+                            "q_code": "146c",
+                            "value": "Special/calendar events",
+                            "label": "Special/calendar events"
+                        }, {
+                            "q_code": "146d",
+                            "value": "Weather",
+                            "label": "Weather"
+                        }, {
+                            "q_code": "146e",
+                            "value": "Price effects",
+                            "label": "Price effects"
+                        }, {
+                            "q_code": "146f",
+                            "value": "Currency effects (increase/decrease in the currency value)",
+                            "label": "Currency effects (increase/decrease in the currency value)"
+                        }, {
+                            "q_code": "146g",
+                            "value": "Other",
+                            "label": "Other"
+                        }],
+                        "id": "changes-in-turnover-answer-2",
+                        "type": "Checkbox",
+                        "mandatory": true
+                    }],
+                    "type": "General",
+                    "id": "changes-in-turnover-question-2"
+                }],
+                "title": "Changes in total turnover"
+            }, {
+                "type": "Question",
+                "id": "changes-in-turnover-block-3",
+                "title": "Changes in total turnover",
+                "questions": [{
+                    "type": "General",
+                    "id": "changes-in-turnover-question-3",
+                    "title": "Please describe the changes in total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
+                    "answers": [{
+                        "guidance": {
+                            "hide_guidance": "Hide examples of commentary on changes to total turnover",
+                            "show_guidance": "Show examples of commentary on changes to total turnover",
+                            "content": [{
+                                "list": [],
+                                "title": "\u2018Change in level of business activity\u2019",
+                                "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
+                            }, {
+                                "list": [],
+                                "title": "\u2018Maintenance/shutdowns\u2019",
+                                "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
+                            }, {
+                                "list": [],
+                                "title": "\u2018Special/calendar events\u2019",
+                                "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
+                            }, {
+                                "list": [],
+                                "title": "\u2018Weather\u2019",
+                                "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
+                            }, {
+                                "list": [],
+                                "title": "\u2018Price effects\u2019",
+                                "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
+                            }, {
+                                "list": [],
+                                "title": "\u2018Currency effects (increase/decrease in the currency value)\u2019",
+                                "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
+                            }]
+                        },
+                        "type": "TextArea",
+                        "mandatory": true,
+                        "label": "Comments",
+                        "id": "changes-in-turnover-answer-3",
+                        "q_code": "146h"
+                    }],
+                    "description": "<p>We rely on your commentary to \u2018tell the story\u2019 behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
+                }]
+            }]
+        }]
+    }, {
+        "id": "summary-section",
+        "title": "Summary",
+        "groups": [{
+            "id": "summary-group",
+            "title": "Summary",
+            "blocks": [{
+                "type": "Summary",
+                "id": "summary"
+            }]
+        }]
+    }]
+}

--- a/data/en/mbs_0203.json
+++ b/data/en/mbs_0203.json
@@ -1,320 +1,271 @@
 {
-  "title": "Monthly Business Survey",
-  "survey_id": "009",
-  "mime_type": "application/json/ons/eq",
-  "theme": "default",
-  "schema_version": "0.0.1",
-  "data_version": "0.0.1",
-  "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
-  "description": "mbs",
-  "view_submitted_response": {
-    "enabled": true,
-    "duration": 900
-  },
-  "metadata": [
-    {
-      "name": "user_id",
-      "validator": "string"
+    "title": "Monthly Business Survey",
+    "survey_id": "009",
+    "mime_type": "application/json/ons/eq",
+    "theme": "default",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.1",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
+    "description": "mbs",
+    "view_submitted_response": {
+        "enabled": true,
+        "duration": 900
     },
-    {
-      "name": "period_id",
-      "validator": "string"
-    },
-    {
-      "name": "ru_name",
-      "validator": "string"
-    },
-    {
-      "name": "ref_p_start_date",
-      "validator": "date"
-    },
-    {
-      "name": "ref_p_end_date",
-      "validator": "date"
-    },
-    {
-      "name": "trad_as",
-      "validator": "optional_string"
-    }
-  ],
-  "sections": [
-    {
-      "id": "section",
-      "groups": [
+    "metadata": [{
+            "name": "user_id",
+            "validator": "string"
+        },
         {
-          "id": "msi",
-          "title": "",
-          "blocks": [
-            {
-              "type": "Introduction",
-              "id": "introduction",
-              "primary_content": [
-                {
-                  "type": "Basic",
-                  "id": "use-of-information",
-                  "content": [
+            "name": "period_id",
+            "validator": "string"
+        },
+        {
+            "name": "ru_name",
+            "validator": "string"
+        },
+        {
+            "name": "ref_p_start_date",
+            "validator": "date"
+        },
+        {
+            "name": "ref_p_end_date",
+            "validator": "date"
+        },
+        {
+            "name": "trad_as",
+            "validator": "optional_string"
+        }
+    ],
+    "sections": [{
+            "id": "section",
+            "groups": [{
+                "id": "msi",
+                "title": "",
+                "blocks": [{
+                        "type": "Introduction",
+                        "id": "introduction",
+                        "primary_content": [{
+                            "type": "Basic",
+                            "id": "use-of-information",
+                            "content": [{
+                                "list": [
+                                    "Data should relate to all sites in England, Scotland, Wales and Northern Ireland unless otherwise stated.",
+                                    "You can provide informed estimates if actual figures aren’t available.",
+                                    "We will treat your data securely and confidentially."
+                                ]
+                            }]
+                        }],
+                        "preview_content": {
+                            "id": "preview",
+                            "title": "Information you need",
+                            "content": [{
+                                "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate.",
+                                "list": [
+                                    "Total volume of potable water that was supplied to customers",
+                                    "Significant changes"
+                                ]
+                            }]
+                        },
+                        "secondary_content": [{
+                            "id": "how-we-use-your-data",
+                            "title": "How we use your data",
+                            "content": [{
+                                "list": [
+                                    "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
+                                    "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"
+                                ]
+                            }]
+                        }]
+                    },
                     {
-                      "list": [
-                        "Data should relate to all sites in England, Scotland, Wales and Northern Ireland unless otherwise stated.",
-                        "You can provide informed estimates if actual figures aren’t available.",
-                        "We will treat your data securely and confidentially."
-                      ]
+                        "id": "reporting-period-block",
+                        "type": "Question",
+                        "questions": [{
+                            "answers": [{
+                                "options": [{
+                                        "value": "Yes",
+                                        "label": "Yes"
+                                    },
+                                    {
+                                        "value": "No",
+                                        "label": "No"
+                                    }
+                                ],
+                                "id": "reporting-period-answer",
+                                "type": "Radio",
+                                "q_code": "d12",
+                                "mandatory": true
+                            }],
+                            "type": "General",
+                            "id": "reporting-period-question",
+                            "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "id": "reporting-period-answer",
+                                        "value": "Yes",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "water-volume-block"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "reporting-period-block-2"
+                                }
+                            }
+                        ],
+                        "title": "Reporting period"
+                    },
+                    {
+                        "type": "Question",
+                        "id": "reporting-period-block-2",
+                        "title": "Reporting period",
+                        "questions": [{
+                            "type": "DateRange",
+                            "id": "reporting-period-question-2",
+                            "title": "What are the dates of the period that you will be reporting for?",
+                            "period_limits": {
+                                "minimum": {
+                                    "days": 10
+                                },
+                                "maximum": {
+                                    "days": 50
+                                }
+                            },
+                            "answers": [{
+                                    "type": "Date",
+                                    "id": "period-from",
+                                    "label": "From",
+                                    "mandatory": true,
+                                    "q_code": "11",
+                                    "minimum": {
+                                        "meta": "ref_p_start_date",
+                                        "offset_by": {
+                                            "days": -19
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "Date",
+                                    "id": "period-to",
+                                    "label": "To",
+                                    "mandatory": true,
+                                    "q_code": "12",
+                                    "maximum": {
+                                        "meta": "ref_p_end_date",
+                                        "offset_by": {
+                                            "days": 20
+                                        }
+                                    }
+                                }
+                            ]
+                        }]
+                    },
+                    {
+                        "type": "Question",
+                        "id": "water-volume-block",
+                        "title": "Total volume of potable water that was supplied to customers",
+                        "questions": [{
+                            "id": "water-volume-question",
+                            "type": "General",
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the total volume of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s <em>potable water that was supplied to customers</em>, in megalitres?",
+                            "answers": [{
+                                "id": "water-volume",
+                                "mandatory": true,
+                                "q_code": "110",
+                                "type": "Unit",
+                                "unit_length": "short",
+                                "label": "Total volume of potable water that was supplied to customers, in megalitres",
+                                "unit": "volume-megaliter"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "significant-change",
+                        "title": "Significant changes",
+                        "type": "Question",
+                        "questions": [{
+                            "type": "General",
+                            "id": "significant-change-question",
+                            "title": "Did any significant changes occur to the figures provided for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                            "definitions": [{
+                                "title": "What constitutes a significant change?",
+                                "content": [{
+                                        "description": "What constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s figures from the previous reporting period and the same reporting period last year."
+                                    },
+                                    {
+                                        "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                                    }
+                                ]
+                            }],
+                            "answers": [{
+                                "id": "significant-change-established-answer",
+                                "label": "",
+                                "mandatory": true,
+                                "options": [{
+                                        "label": "Yes",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No",
+                                        "value": "No"
+                                    }
+                                ],
+                                "q_code": "146",
+                                "type": "Radio"
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "change-comment-block",
+                                    "when": [{
+                                        "id": "significant-change-established-answer",
+                                        "condition": "equals",
+                                        "value": "Yes"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "group": "summary-group"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "type": "Question",
+                        "id": "change-comment-block",
+                        "questions": [{
+                            "answers": [{
+                                "id": "change-comment",
+                                "label": "Comments",
+                                "mandatory": true,
+                                "q_code": "146h",
+                                "type": "TextArea"
+                            }],
+                            "description": "We rely on your commentary to ‘tell the story’ behind changes in figures. By commenting here it will reduce the need for us to call you.",
+                            "id": "change-comment-question",
+                            "title": "Please describe the changes for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
+                            "type": "General"
+                        }],
+                        "title": "Significant changes"
                     }
-                  ]
-                }
-              ],
-              "preview_content": {
-                "id": "preview",
-                "title": "Information you need",
-                "content": [
-                  {
-                    "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate.",
-                    "list": [
-                      "Total volume of potable water that was supplied to customers",
-                      "Significant changes"
-                    ]
-                  }
                 ]
-              },
-              "secondary_content": [
-                {
-                  "id": "how-we-use-your-data",
-                  "title": "How we use your data",
-                  "content": [
-                    {
-                      "list": [
-                        "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
-                        "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "id": "reporting-period-block",
-              "type": "Question",
-              "questions": [
-                {
-                  "answers": [
-                    {
-                      "options": [
-                        {
-                          "value": "Yes",
-                          "label": "Yes"
-                        },
-                        {
-                          "value": "No",
-                          "label": "No"
-                        }
-                      ],
-                      "id": "reporting-period-answer",
-                      "type": "Radio",
-                      "q_code": "d12",
-                      "mandatory": true
-                    }
-                  ],
-                  "type": "General",
-                  "id": "reporting-period-question",
-                  "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
-                }
-              ],
-              "routing_rules": [
-                {
-                  "goto": {
-                    "when": [
-                      {
-                        "id": "reporting-period-answer",
-                        "value": "Yes",
-                        "condition": "equals"
-                      }
-                    ],
-                    "block": "water-volume-block"
-                  }
-                },
-                {
-                  "goto": {
-                    "block": "reporting-period-block-2"
-                  }
-                }
-              ],
-              "title": "Reporting period"
-            },
-            {
-              "type": "Question",
-              "id": "reporting-period-block-2",
-              "title": "Reporting period",
-              "questions": [
-                {
-                  "type": "DateRange",
-                  "id": "reporting-period-question-2",
-                  "title": "What are the dates of the period that you will be reporting for?",
-                  "period_limits": {
-                    "minimum": {
-                      "days": 10
-                    },
-                    "maximum": {
-                      "days": 50
-                    }
-                  },
-                  "answers": [
-                    {
-                      "type": "Date",
-                      "id": "period-from",
-                      "label": "From",
-                      "mandatory": true,
-                      "q_code": "11",
-                      "minimum": {
-                        "meta": "ref_p_start_date",
-                        "offset_by": {
-                          "days": -19
-                        }
-                      }
-                    },
-                    {
-                      "type": "Date",
-                      "id": "period-to",
-                      "label": "To",
-                      "mandatory": true,
-                      "q_code": "12",
-                      "maximum": {
-                        "meta": "ref_p_end_date",
-                        "offset_by": {
-                          "days": 20
-                        }
-                      }
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "Question",
-              "id": "water-volume-block",
-              "title": "Total volume of potable water that was supplied to customers",
-              "questions": [
-                {
-                  "id": "water-volume-question",
-                  "type": "General",
-                  "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the total volume of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s <em>potable water that was supplied to customers</em>, in megalitres?",
-                  "answers": [
-                    {
-                      "id": "water-volume",
-                      "mandatory": true,
-                      "q_code": "110",
-                      "type": "Unit",
-                      "unit_length": "short",
-                      "label": "Total volume of potable water that was supplied to customers, in megalitres",
-                      "unit": "volume-megaliter"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "id": "significant-change",
-              "title": "Significant changes",
-              "type": "Question",
-              "questions": [
-                {
-                  "type": "General",
-                  "id": "significant-change-question",
-                  "title": "Did any significant changes occur to the figures provided for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
-                  "definitions": [
-                    {
-                      "title": "What constitutes a significant change?",
-                      "content": [
-                        {
-                          "description": "What constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s figures from the previous reporting period and the same reporting period last year."
-                        },
-                        {
-                          "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
-                        }
-                      ]
-                    }
-                  ],
-                  "answers": [
-                    {
-                      "id": "significant-change-established-answer",
-                      "label": "",
-                      "mandatory": true,
-                      "options": [
-                        {
-                          "label": "Yes",
-                          "value": "Yes"
-                        },
-                        {
-                          "label": "No",
-                          "value": "No"
-                        }
-                      ],
-                      "q_code": "146",
-                      "type": "Radio"
-                    }
-                  ]
-                }
-              ],
-              "routing_rules": [
-                {
-                  "goto": {
-                    "block": "change-comment-block",
-                    "when": [
-                      {
-                        "id": "significant-change-established-answer",
-                        "condition": "equals",
-                        "value": "Yes"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "goto": {
-                    "group": "summary-group"
-                  }
-                }
-              ]
-            },
-            {
-              "type": "Question",
-              "id": "change-comment-block",
-              "questions": [
-                {
-                  "answers": [
-                    {
-                      "id": "change-comment",
-                      "label": "Comments",
-                      "mandatory": true,
-                      "q_code": "146h",
-                      "type": "TextArea"
-                    }
-                  ],
-                  "description": "We rely on your commentary to ‘tell the story’ behind changes in figures. By commenting here it will reduce the need for us to call you.",
-                  "id": "change-comment-question",
-                  "title": "Please describe the changes for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
-                  "type": "General"
-                }
-              ],
-              "title": "Significant changes"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "summary-section",
-      "title": "Summary",
-      "groups": [
+            }]
+        },
         {
-          "id": "summary-group",
-          "title": "Summary",
-          "blocks": [
-            {
-              "type": "Summary",
-              "id": "summary"
-            }
-          ]
+            "id": "summary-section",
+            "title": "Summary",
+            "groups": [{
+                "id": "summary-group",
+                "title": "Summary",
+                "blocks": [{
+                    "type": "Summary",
+                    "id": "summary"
+                }]
+            }]
         }
-      ]
-    }
-  ]
+    ]
 }

--- a/data/en/mbs_0203.json
+++ b/data/en/mbs_0203.json
@@ -1,235 +1,320 @@
 {
-    "title": "Monthly Business Survey",
-    "survey_id": "009",
-    "mime_type": "application/json/ons/eq",
-    "theme": "default",
-    "schema_version": "0.0.1",
-    "data_version": "0.0.1",
-    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
-    "description": "mbs",
-    "view_submitted_response": {
-        "enabled": true,
-        "duration": 900
+  "title": "Monthly Business Survey",
+  "survey_id": "009",
+  "mime_type": "application/json/ons/eq",
+  "theme": "default",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.1",
+  "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
+  "description": "mbs",
+  "view_submitted_response": {
+    "enabled": true,
+    "duration": 900
+  },
+  "metadata": [
+    {
+      "name": "user_id",
+      "validator": "string"
     },
-    "metadata": [{
-        "name": "user_id",
-        "validator": "string"
-    }, {
-        "name": "period_id",
-        "validator": "string"
-    }, {
-        "name": "ru_name",
-        "validator": "string"
-    }, {
-        "name": "ref_p_start_date",
-        "validator": "date"
-    }, {
-        "name": "ref_p_end_date",
-        "validator": "date"
-    }, {
-        "name": "trad_as",
-        "validator": "optional_string"
-    }],
-    "sections": [{
-        "id": "section",
-        "groups": [{
-            "id": "msi",
-            "title": "",
-            "blocks": [{
-                "type": "Introduction",
-                "id": "introduction",
-                "primary_content": [{
-                    "type": "Basic",
-                    "id": "use-of-information",
-                    "content": [{
-                        "list": ["Data should relate to all sites in England, Scotland, Wales and Northern Ireland unless otherwise stated.", "You can provide informed estimates if actual figures aren\u2019t available.", "We will treat your data securely and confidentially."]
-                    }]
-                }],
-                "preview_content": {
-                    "id": "preview",
-                    "title": "Information you need",
-                    "content": [{
-                        "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate.",
-                        "list": ["Total volume of potable water that was supplied to customers", "Significant changes"]
-                    }]
-                },
-                "secondary_content": [{
-                    "id": "how-we-use-your-data",
-                    "title": "How we use your data",
-                    "content": [{
-                        "list": ["You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.", "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"]
-                    }]
-                }]
-            }, {
-                "id": "reporting-period-block",
-                "type": "Question",
-                "questions": [{
-                    "answers": [{
-                        "options": [{
-                            "value": "Yes",
-                            "label": "Yes"
-                        }, {
-                            "value": "No",
-                            "label": "No"
-                        }],
-                        "id": "reporting-period-answer",
-                        "type": "Radio",
-                        "q_code": "d12",
-                        "mandatory": true
-                    }],
-                    "type": "General",
-                    "id": "reporting-period-question",
-                    "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
-                }],
-                "routing_rules": [{
-                    "goto": {
-                        "when": [{
-                            "id": "reporting-period-answer",
-                            "value": "Yes",
-                            "condition": "equals"
-                        }],
-                        "block": "water-volume-block"
+    {
+      "name": "period_id",
+      "validator": "string"
+    },
+    {
+      "name": "ru_name",
+      "validator": "string"
+    },
+    {
+      "name": "ref_p_start_date",
+      "validator": "date"
+    },
+    {
+      "name": "ref_p_end_date",
+      "validator": "date"
+    },
+    {
+      "name": "trad_as",
+      "validator": "optional_string"
+    }
+  ],
+  "sections": [
+    {
+      "id": "section",
+      "groups": [
+        {
+          "id": "msi",
+          "title": "",
+          "blocks": [
+            {
+              "type": "Introduction",
+              "id": "introduction",
+              "primary_content": [
+                {
+                  "type": "Basic",
+                  "id": "use-of-information",
+                  "content": [
+                    {
+                      "list": [
+                        "Data should relate to all sites in England, Scotland, Wales and Northern Ireland unless otherwise stated.",
+                        "You can provide informed estimates if actual figures aren’t available.",
+                        "We will treat your data securely and confidentially."
+                      ]
                     }
-                }, {
-                    "goto": {
-                        "block": "reporting-period-block-2"
+                  ]
+                }
+              ],
+              "preview_content": {
+                "id": "preview",
+                "title": "Information you need",
+                "content": [
+                  {
+                    "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate.",
+                    "list": [
+                      "Total volume of potable water that was supplied to customers",
+                      "Significant changes"
+                    ]
+                  }
+                ]
+              },
+              "secondary_content": [
+                {
+                  "id": "how-we-use-your-data",
+                  "title": "How we use your data",
+                  "content": [
+                    {
+                      "list": [
+                        "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
+                        "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"
+                      ]
                     }
-                }],
-                "title": "Reporting period"
-            }, {
-                "type": "Question",
-                "id": "reporting-period-block-2",
-                "title": "Reporting period",
-                "questions": [{
-                    "type": "DateRange",
-                    "id": "reporting-period-question-2",
-                    "title": "What are the dates of the period that you will be reporting for?",
-                    "period_limits": {
-                        "minimum": {
-                            "days": 10
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "reporting-period-block",
+              "type": "Question",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "options": [
+                        {
+                          "value": "Yes",
+                          "label": "Yes"
                         },
-                        "maximum": {
-                            "days": 50
+                        {
+                          "value": "No",
+                          "label": "No"
                         }
+                      ],
+                      "id": "reporting-period-answer",
+                      "type": "Radio",
+                      "q_code": "d12",
+                      "mandatory": true
+                    }
+                  ],
+                  "type": "General",
+                  "id": "reporting-period-question",
+                  "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "when": [
+                      {
+                        "id": "reporting-period-answer",
+                        "value": "Yes",
+                        "condition": "equals"
+                      }
+                    ],
+                    "block": "water-volume-block"
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "reporting-period-block-2"
+                  }
+                }
+              ],
+              "title": "Reporting period"
+            },
+            {
+              "type": "Question",
+              "id": "reporting-period-block-2",
+              "title": "Reporting period",
+              "questions": [
+                {
+                  "type": "DateRange",
+                  "id": "reporting-period-question-2",
+                  "title": "What are the dates of the period that you will be reporting for?",
+                  "period_limits": {
+                    "minimum": {
+                      "days": 10
                     },
-                    "answers": [{
-                        "type": "Date",
-                        "id": "period-from",
-                        "label": "From",
-                        "mandatory": true,
-                        "q_code": "11",
-                        "minimum": {
-                            "meta": "ref_p_start_date",
-                            "offset_by": {
-                                "days": -19
-                            }
+                    "maximum": {
+                      "days": 50
+                    }
+                  },
+                  "answers": [
+                    {
+                      "type": "Date",
+                      "id": "period-from",
+                      "label": "From",
+                      "mandatory": true,
+                      "q_code": "11",
+                      "minimum": {
+                        "meta": "ref_p_start_date",
+                        "offset_by": {
+                          "days": -19
                         }
-                    }, {
-                        "type": "Date",
-                        "id": "period-to",
-                        "label": "To",
-                        "mandatory": true,
-                        "q_code": "12",
-                        "maximum": {
-                            "meta": "ref_p_end_date",
-                            "offset_by": {
-                                "days": 20
-                            }
+                      }
+                    },
+                    {
+                      "type": "Date",
+                      "id": "period-to",
+                      "label": "To",
+                      "mandatory": true,
+                      "q_code": "12",
+                      "maximum": {
+                        "meta": "ref_p_end_date",
+                        "offset_by": {
+                          "days": 20
                         }
-                    }]
-                }]
-            }, {
-                "type": "Question",
-                "id": "water-volume-block",
-                "title": "Total volume of potable water that was supplied to customers",
-                "questions": [{
-                    "id": "water-volume-question",
-                    "type": "General",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the total volume of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>potable water that was supplied to customers</em>, in megalitres?",
-                    "answers": [{
-                        "id": "water-volume",
-                        "mandatory": true,
-                        "q_code": "110",
-                        "type": "Unit",
-                        "unit_length": "short",
-                        "label": "Total volume of potable water that was supplied to customers, in megalitres",
-                        "unit": "volume-megaliter"
-                    }]
-                }]
-            }, {
-                "id": "significant-change",
-                "title": "Significant changes",
-                "type": "Question",
-                "questions": [{
-                    "type": "General",
-                    "id": "significant-change-question",
-                    "title": "Did any significant changes occur to the figures provided for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
-                    "definitions": [{
-                        "title": "What constitutes a significant change?",
-                        "content": [{
-                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
-                        }, {
-                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
-                        }]
-                    }],
-                    "answers": [{
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "Question",
+              "id": "water-volume-block",
+              "title": "Total volume of potable water that was supplied to customers",
+              "questions": [
+                {
+                  "id": "water-volume-question",
+                  "type": "General",
+                  "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the total volume of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s <em>potable water that was supplied to customers</em>, in megalitres?",
+                  "answers": [
+                    {
+                      "id": "water-volume",
+                      "mandatory": true,
+                      "q_code": "110",
+                      "type": "Unit",
+                      "unit_length": "short",
+                      "label": "Total volume of potable water that was supplied to customers, in megalitres",
+                      "unit": "volume-megaliter"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "significant-change",
+              "title": "Significant changes",
+              "type": "Question",
+              "questions": [
+                {
+                  "type": "General",
+                  "id": "significant-change-question",
+                  "title": "Did any significant changes occur to the figures provided for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                  "definitions": [
+                    {
+                      "title": "What constitutes a significant change?",
+                      "content": [
+                        {
+                          "description": "What constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s figures from the previous reporting period and the same reporting period last year."
+                        },
+                        {
+                          "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }
+                      ]
+                    }
+                  ],
+                  "answers": [
+                    {
+                      "id": "significant-change-established-answer",
+                      "label": "",
+                      "mandatory": true,
+                      "options": [
+                        {
+                          "label": "Yes",
+                          "value": "Yes"
+                        },
+                        {
+                          "label": "No",
+                          "value": "No"
+                        }
+                      ],
+                      "q_code": "146",
+                      "type": "Radio"
+                    }
+                  ]
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "change-comment-block",
+                    "when": [
+                      {
                         "id": "significant-change-established-answer",
-                        "label": "",
-                        "mandatory": true,
-                        "options": [{
-                            "label": "Yes",
-                            "value": "Yes"
-                        }, {
-                            "label": "No",
-                            "value": "No"
-                        }],
-                        "q_code": "146",
-                        "type": "Radio"
-                    }]
-                }],
-                "routing_rules": [{
-                    "goto": {
-                        "block": "change-comment-block",
-                        "when": [{
-                            "id": "significant-change-established-answer",
-                            "condition": "equals",
-                            "value": "Yes"
-                        }]
+                        "condition": "equals",
+                        "value": "Yes"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "group": "summary-group"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "Question",
+              "id": "change-comment-block",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "change-comment",
+                      "label": "Comments",
+                      "mandatory": true,
+                      "q_code": "146h",
+                      "type": "TextArea"
                     }
-                }, {
-                    "goto": {
-                        "group": "summary-group"
-                    }
-                }]
-            }, {
-                "type": "Question",
-                "id": "change-comment-block",
-                "questions": [{
-                    "answers": [{
-                        "id": "change-comment",
-                        "label": "Comments",
-                        "mandatory": true,
-                        "q_code": "146h",
-                        "type": "TextArea"
-                    }],
-                    "description": "We rely on your commentary to \u2018tell the story\u2019 behind changes in figures. By commenting here it will reduce the need for us to call you.",
-                    "id": "change-comment-question",
-                    "title": "Please describe the changes for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
-                    "type": "General"
-                }],
-                "title": "Significant changes"
-            }]
-        }]
-    }, {
-        "id": "summary-section",
-        "title": "Summary",
-        "groups": [{
-            "id": "summary-group",
-            "title": "Summary",
-            "blocks": [{
-                "type": "Summary",
-                "id": "summary"
-            }]
-        }]
-    }]
+                  ],
+                  "description": "We rely on your commentary to ‘tell the story’ behind changes in figures. By commenting here it will reduce the need for us to call you.",
+                  "id": "change-comment-question",
+                  "title": "Please describe the changes for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
+                  "type": "General"
+                }
+              ],
+              "title": "Significant changes"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "summary-section",
+      "title": "Summary",
+      "groups": [
+        {
+          "id": "summary-group",
+          "title": "Summary",
+          "blocks": [
+            {
+              "type": "Summary",
+              "id": "summary"
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/data/en/mbs_0203_prototype.json
+++ b/data/en/mbs_0203_prototype.json
@@ -1,0 +1,235 @@
+{
+    "title": "Monthly Business Survey",
+    "survey_id": "009",
+    "mime_type": "application/json/ons/eq",
+    "theme": "default",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.1",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
+    "description": "mbs",
+    "view_submitted_response": {
+        "enabled": true,
+        "duration": 900
+    },
+    "metadata": [{
+        "name": "user_id",
+        "validator": "string"
+    }, {
+        "name": "period_id",
+        "validator": "string"
+    }, {
+        "name": "ru_name",
+        "validator": "string"
+    }, {
+        "name": "ref_p_start_date",
+        "validator": "date"
+    }, {
+        "name": "ref_p_end_date",
+        "validator": "date"
+    }, {
+        "name": "trad_as",
+        "validator": "optional_string"
+    }],
+    "sections": [{
+        "id": "section",
+        "groups": [{
+            "id": "msi",
+            "title": "",
+            "blocks": [{
+                "type": "Introduction",
+                "id": "introduction",
+                "primary_content": [{
+                    "type": "Basic",
+                    "id": "use-of-information",
+                    "content": [{
+                        "list": ["Data should relate to all sites in England, Scotland, Wales and Northern Ireland unless otherwise stated.", "You can provide informed estimates if actual figures aren\u2019t available.", "We will treat your data securely and confidentially."]
+                    }]
+                }],
+                "preview_content": {
+                    "id": "preview",
+                    "title": "Information you need",
+                    "content": [{
+                        "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate.",
+                        "list": ["Total volume of potable water that was supplied to customers", "Significant changes"]
+                    }]
+                },
+                "secondary_content": [{
+                    "id": "how-we-use-your-data",
+                    "title": "How we use your data",
+                    "content": [{
+                        "list": ["You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.", "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"]
+                    }]
+                }]
+            }, {
+                "id": "reporting-period-block",
+                "type": "Question",
+                "questions": [{
+                    "answers": [{
+                        "options": [{
+                            "value": "Yes",
+                            "label": "Yes"
+                        }, {
+                            "value": "No",
+                            "label": "No"
+                        }],
+                        "id": "reporting-period-answer",
+                        "type": "Radio",
+                        "q_code": "d12",
+                        "mandatory": true
+                    }],
+                    "type": "General",
+                    "id": "reporting-period-question",
+                    "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
+                }],
+                "routing_rules": [{
+                    "goto": {
+                        "when": [{
+                            "id": "reporting-period-answer",
+                            "value": "Yes",
+                            "condition": "equals"
+                        }],
+                        "block": "water-volume-block"
+                    }
+                }, {
+                    "goto": {
+                        "block": "reporting-period-block-2"
+                    }
+                }],
+                "title": "Reporting period"
+            }, {
+                "type": "Question",
+                "id": "reporting-period-block-2",
+                "title": "Reporting period",
+                "questions": [{
+                    "type": "DateRange",
+                    "id": "reporting-period-question-2",
+                    "title": "What are the dates of the period that you will be reporting for?",
+                    "period_limits": {
+                        "minimum": {
+                            "days": 10
+                        },
+                        "maximum": {
+                            "days": 50
+                        }
+                    },
+                    "answers": [{
+                        "type": "Date",
+                        "id": "period-from",
+                        "label": "From",
+                        "mandatory": true,
+                        "q_code": "11",
+                        "minimum": {
+                            "meta": "ref_p_start_date",
+                            "offset_by": {
+                                "days": -19
+                            }
+                        }
+                    }, {
+                        "type": "Date",
+                        "id": "period-to",
+                        "label": "To",
+                        "mandatory": true,
+                        "q_code": "12",
+                        "maximum": {
+                            "meta": "ref_p_end_date",
+                            "offset_by": {
+                                "days": 20
+                            }
+                        }
+                    }]
+                }]
+            }, {
+                "type": "Question",
+                "id": "water-volume-block",
+                "title": "Total volume of potable water that was supplied to customers",
+                "questions": [{
+                    "id": "water-volume-question",
+                    "type": "General",
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the total volume of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>potable water that was supplied to customers</em>, in megalitres?",
+                    "answers": [{
+                        "id": "water-volume",
+                        "mandatory": true,
+                        "q_code": "110",
+                        "type": "Unit",
+                        "unit_length": "short",
+                        "label": "Total volume of potable water that was supplied to customers, in megalitres",
+                        "unit": "volume-megaliter"
+                    }]
+                }]
+            }, {
+                "id": "significant-change",
+                "title": "Significant changes",
+                "type": "Question",
+                "questions": [{
+                    "type": "General",
+                    "id": "significant-change-question",
+                    "title": "Did any significant changes occur to the figures provided for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
+                        }, {
+                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }]
+                    }],
+                    "answers": [{
+                        "id": "significant-change-established-answer",
+                        "label": "",
+                        "mandatory": true,
+                        "options": [{
+                            "label": "Yes",
+                            "value": "Yes"
+                        }, {
+                            "label": "No",
+                            "value": "No"
+                        }],
+                        "q_code": "146",
+                        "type": "Radio"
+                    }]
+                }],
+                "routing_rules": [{
+                    "goto": {
+                        "block": "change-comment-block",
+                        "when": [{
+                            "id": "significant-change-established-answer",
+                            "condition": "equals",
+                            "value": "Yes"
+                        }]
+                    }
+                }, {
+                    "goto": {
+                        "group": "summary-group"
+                    }
+                }]
+            }, {
+                "type": "Question",
+                "id": "change-comment-block",
+                "questions": [{
+                    "answers": [{
+                        "id": "change-comment",
+                        "label": "Comments",
+                        "mandatory": true,
+                        "q_code": "146h",
+                        "type": "TextArea"
+                    }],
+                    "description": "We rely on your commentary to \u2018tell the story\u2019 behind changes in figures. By commenting here it will reduce the need for us to call you.",
+                    "id": "change-comment-question",
+                    "title": "Please describe the changes for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
+                    "type": "General"
+                }],
+                "title": "Significant changes"
+            }]
+        }]
+    }, {
+        "id": "summary-section",
+        "title": "Summary",
+        "groups": [{
+            "id": "summary-group",
+            "title": "Summary",
+            "blocks": [{
+                "type": "Summary",
+                "id": "summary"
+            }]
+        }]
+    }]
+}

--- a/data/en/mbs_0204.json
+++ b/data/en/mbs_0204.json
@@ -1,235 +1,320 @@
 {
-    "title": "Monthly Business Survey",
-    "survey_id": "009",
-    "mime_type": "application/json/ons/eq",
-    "theme": "northernireland",
-    "schema_version": "0.0.1",
-    "data_version": "0.0.1",
-    "legal_basis": "Notice is given under article 5 of the Statistics of Trade and Employment (Northern Ireland) Order 1988.",
-    "description": "mbs",
-    "view_submitted_response": {
-        "enabled": true,
-        "duration": 900
+  "title": "Monthly Business Survey",
+  "survey_id": "009",
+  "mime_type": "application/json/ons/eq",
+  "theme": "northernireland",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.1",
+  "legal_basis": "Notice is given under article 5 of the Statistics of Trade and Employment (Northern Ireland) Order 1988.",
+  "description": "mbs",
+  "view_submitted_response": {
+    "enabled": true,
+    "duration": 900
+  },
+  "metadata": [
+    {
+      "name": "user_id",
+      "validator": "string"
     },
-    "metadata": [{
-        "name": "user_id",
-        "validator": "string"
-    }, {
-        "name": "period_id",
-        "validator": "string"
-    }, {
-        "name": "ru_name",
-        "validator": "string"
-    }, {
-        "name": "ref_p_start_date",
-        "validator": "date"
-    }, {
-        "name": "ref_p_end_date",
-        "validator": "date"
-    }, {
-        "name": "trad_as",
-        "validator": "optional_string"
-    }],
-    "sections": [{
-        "id": "section",
-        "groups": [{
-            "id": "msi",
-            "title": "",
-            "blocks": [{
-                "type": "Introduction",
-                "id": "introduction",
-                "primary_content": [{
-                    "type": "Basic",
-                    "id": "use-of-information",
-                    "content": [{
-                        "list": ["Data should relate to all sites in England, Scotland, Wales and Northern Ireland unless otherwise stated.", "You can provide informed estimates if actual figures aren\u2019t available.", "We will treat your data securely and confidentially."]
-                    }]
-                }],
-                "preview_content": {
-                    "id": "preview",
-                    "title": "Information you need",
-                    "content": [{
-                        "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate.",
-                        "list": ["Total volume of potable water that was supplied to customers", "Significant changes"]
-                    }]
-                },
-                "secondary_content": [{
-                    "id": "how-we-use-your-data",
-                    "title": "How we use your data",
-                    "content": [{
-                        "list": ["You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.", "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"]
-                    }]
-                }]
-            }, {
-                "id": "reporting-period-block",
-                "type": "Question",
-                "questions": [{
-                    "answers": [{
-                        "options": [{
-                            "value": "Yes",
-                            "label": "Yes"
-                        }, {
-                            "value": "No",
-                            "label": "No"
-                        }],
-                        "id": "reporting-period-answer",
-                        "type": "Radio",
-                        "q_code": "d12",
-                        "mandatory": true
-                    }],
-                    "type": "General",
-                    "id": "reporting-period-question",
-                    "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
-                }],
-                "routing_rules": [{
-                    "goto": {
-                        "when": [{
-                            "id": "reporting-period-answer",
-                            "value": "Yes",
-                            "condition": "equals"
-                        }],
-                        "block": "water-volume-block"
+    {
+      "name": "period_id",
+      "validator": "string"
+    },
+    {
+      "name": "ru_name",
+      "validator": "string"
+    },
+    {
+      "name": "ref_p_start_date",
+      "validator": "date"
+    },
+    {
+      "name": "ref_p_end_date",
+      "validator": "date"
+    },
+    {
+      "name": "trad_as",
+      "validator": "optional_string"
+    }
+  ],
+  "sections": [
+    {
+      "id": "section",
+      "groups": [
+        {
+          "id": "msi",
+          "title": "",
+          "blocks": [
+            {
+              "type": "Introduction",
+              "id": "introduction",
+              "primary_content": [
+                {
+                  "type": "Basic",
+                  "id": "use-of-information",
+                  "content": [
+                    {
+                      "list": [
+                        "Data should relate to all sites in England, Scotland, Wales and Northern Ireland unless otherwise stated.",
+                        "You can provide informed estimates if actual figures aren’t available.",
+                        "We will treat your data securely and confidentially."
+                      ]
                     }
-                }, {
-                    "goto": {
-                        "block": "reporting-period-block-2"
+                  ]
+                }
+              ],
+              "preview_content": {
+                "id": "preview",
+                "title": "Information you need",
+                "content": [
+                  {
+                    "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate.",
+                    "list": [
+                      "Total volume of potable water that was supplied to customers",
+                      "Significant changes"
+                    ]
+                  }
+                ]
+              },
+              "secondary_content": [
+                {
+                  "id": "how-we-use-your-data",
+                  "title": "How we use your data",
+                  "content": [
+                    {
+                      "list": [
+                        "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
+                        "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"
+                      ]
                     }
-                }],
-                "title": "Reporting period"
-            }, {
-                "type": "Question",
-                "id": "reporting-period-block-2",
-                "title": "Reporting period",
-                "questions": [{
-                    "type": "DateRange",
-                    "id": "reporting-period-question-2",
-                    "title": "What are the dates of the period that you will be reporting for?",
-                    "period_limits": {
-                        "minimum": {
-                            "days": 10
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "reporting-period-block",
+              "type": "Question",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "options": [
+                        {
+                          "value": "Yes",
+                          "label": "Yes"
                         },
-                        "maximum": {
-                            "days": 50
+                        {
+                          "value": "No",
+                          "label": "No"
                         }
+                      ],
+                      "id": "reporting-period-answer",
+                      "type": "Radio",
+                      "q_code": "d12",
+                      "mandatory": true
+                    }
+                  ],
+                  "type": "General",
+                  "id": "reporting-period-question",
+                  "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "when": [
+                      {
+                        "id": "reporting-period-answer",
+                        "value": "Yes",
+                        "condition": "equals"
+                      }
+                    ],
+                    "block": "water-volume-block"
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "reporting-period-block-2"
+                  }
+                }
+              ],
+              "title": "Reporting period"
+            },
+            {
+              "type": "Question",
+              "id": "reporting-period-block-2",
+              "title": "Reporting period",
+              "questions": [
+                {
+                  "type": "DateRange",
+                  "id": "reporting-period-question-2",
+                  "title": "What are the dates of the period that you will be reporting for?",
+                  "period_limits": {
+                    "minimum": {
+                      "days": 10
                     },
-                    "answers": [{
-                        "type": "Date",
-                        "id": "period-from",
-                        "label": "From",
-                        "mandatory": true,
-                        "q_code": "11",
-                        "minimum": {
-                            "meta": "ref_p_start_date",
-                            "offset_by": {
-                                "days": -19
-                            }
+                    "maximum": {
+                      "days": 50
+                    }
+                  },
+                  "answers": [
+                    {
+                      "type": "Date",
+                      "id": "period-from",
+                      "label": "From",
+                      "mandatory": true,
+                      "q_code": "11",
+                      "minimum": {
+                        "meta": "ref_p_start_date",
+                        "offset_by": {
+                          "days": -19
                         }
-                    }, {
-                        "type": "Date",
-                        "id": "period-to",
-                        "label": "To",
-                        "mandatory": true,
-                        "q_code": "12",
-                        "maximum": {
-                            "meta": "ref_p_end_date",
-                            "offset_by": {
-                                "days": 20
-                            }
+                      }
+                    },
+                    {
+                      "type": "Date",
+                      "id": "period-to",
+                      "label": "To",
+                      "mandatory": true,
+                      "q_code": "12",
+                      "maximum": {
+                        "meta": "ref_p_end_date",
+                        "offset_by": {
+                          "days": 20
                         }
-                    }]
-                }]
-            }, {
-                "type": "Question",
-                "id": "water-volume-block",
-                "title": "Total volume of potable water that was supplied to customers",
-                "questions": [{
-                    "id": "water-volume-question",
-                    "type": "General",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the total volume of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>potable water that was supplied to customers</em>, in megalitres?",
-                    "answers": [{
-                        "id": "water-volume",
-                        "mandatory": true,
-                        "q_code": "110",
-                        "type": "Unit",
-                        "unit_length": "short",
-                        "label": "Total volume of potable water that was supplied to customers, in megalitres",
-                        "unit": "volume-megaliter"
-                    }]
-                }]
-            }, {
-                "id": "significant-change",
-                "title": "Significant changes",
-                "type": "Question",
-                "questions": [{
-                    "type": "General",
-                    "id": "significant-change-question",
-                    "title": "Did any significant changes occur to the figures provided for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
-                    "definitions": [{
-                        "title": "What constitutes a significant change?",
-                        "content": [{
-                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
-                        }, {
-                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
-                        }]
-                    }],
-                    "answers": [{
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "Question",
+              "id": "water-volume-block",
+              "title": "Total volume of potable water that was supplied to customers",
+              "questions": [
+                {
+                  "id": "water-volume-question",
+                  "type": "General",
+                  "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the total volume of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s <em>potable water that was supplied to customers</em>, in megalitres?",
+                  "answers": [
+                    {
+                      "id": "water-volume",
+                      "mandatory": true,
+                      "q_code": "110",
+                      "type": "Unit",
+                      "unit_length": "short",
+                      "label": "Total volume of potable water that was supplied to customers, in megalitres",
+                      "unit": "volume-megaliter"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "significant-change",
+              "title": "Significant changes",
+              "type": "Question",
+              "questions": [
+                {
+                  "type": "General",
+                  "id": "significant-change-question",
+                  "title": "Did any significant changes occur to the figures provided for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                  "definitions": [
+                    {
+                      "title": "What constitutes a significant change?",
+                      "content": [
+                        {
+                          "description": "What constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s figures from the previous reporting period and the same reporting period last year."
+                        },
+                        {
+                          "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }
+                      ]
+                    }
+                  ],
+                  "answers": [
+                    {
+                      "id": "significant-change-established-answer",
+                      "label": "",
+                      "mandatory": true,
+                      "options": [
+                        {
+                          "label": "Yes",
+                          "value": "Yes"
+                        },
+                        {
+                          "label": "No",
+                          "value": "No"
+                        }
+                      ],
+                      "q_code": "146",
+                      "type": "Radio"
+                    }
+                  ]
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "block": "change-comment-block",
+                    "when": [
+                      {
                         "id": "significant-change-established-answer",
-                        "label": "",
-                        "mandatory": true,
-                        "options": [{
-                            "label": "Yes",
-                            "value": "Yes"
-                        }, {
-                            "label": "No",
-                            "value": "No"
-                        }],
-                        "q_code": "146",
-                        "type": "Radio"
-                    }]
-                }],
-                "routing_rules": [{
-                    "goto": {
-                        "block": "change-comment-block",
-                        "when": [{
-                            "id": "significant-change-established-answer",
-                            "condition": "equals",
-                            "value": "Yes"
-                        }]
+                        "condition": "equals",
+                        "value": "Yes"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "goto": {
+                    "group": "summary-group"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "Question",
+              "id": "change-comment-block",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "id": "change-comment",
+                      "label": "Comments",
+                      "mandatory": true,
+                      "q_code": "146h",
+                      "type": "TextArea"
                     }
-                }, {
-                    "goto": {
-                        "group": "summary-group"
-                    }
-                }]
-            }, {
-                "type": "Question",
-                "id": "change-comment-block",
-                "questions": [{
-                    "answers": [{
-                        "id": "change-comment",
-                        "label": "Comments",
-                        "mandatory": true,
-                        "q_code": "146h",
-                        "type": "TextArea"
-                    }],
-                    "description": "We rely on your commentary to \u2018tell the story\u2019 behind changes in figures. By commenting here it will reduce the need for us to call you.",
-                    "id": "change-comment-question",
-                    "title": "Please describe the changes for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
-                    "type": "General"
-                }],
-                "title": "Significant changes"
-            }]
-        }]
-    }, {
-        "id": "summary-section",
-        "title": "Summary",
-        "groups": [{
-            "id": "summary-group",
-            "title": "Summary",
-            "blocks": [{
-                "type": "Summary",
-                "id": "summary"
-            }]
-        }]
-    }]
+                  ],
+                  "description": "We rely on your commentary to ‘tell the story’ behind changes in figures. By commenting here it will reduce the need for us to call you.",
+                  "id": "change-comment-question",
+                  "title": "Please describe the changes for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
+                  "type": "General"
+                }
+              ],
+              "title": "Significant changes"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "summary-section",
+      "title": "Summary",
+      "groups": [
+        {
+          "id": "summary-group",
+          "title": "Summary",
+          "blocks": [
+            {
+              "type": "Summary",
+              "id": "summary"
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/data/en/mbs_0204.json
+++ b/data/en/mbs_0204.json
@@ -1,320 +1,271 @@
 {
-  "title": "Monthly Business Survey",
-  "survey_id": "009",
-  "mime_type": "application/json/ons/eq",
-  "theme": "northernireland",
-  "schema_version": "0.0.1",
-  "data_version": "0.0.1",
-  "legal_basis": "Notice is given under article 5 of the Statistics of Trade and Employment (Northern Ireland) Order 1988.",
-  "description": "mbs",
-  "view_submitted_response": {
-    "enabled": true,
-    "duration": 900
-  },
-  "metadata": [
-    {
-      "name": "user_id",
-      "validator": "string"
+    "title": "Monthly Business Survey",
+    "survey_id": "009",
+    "mime_type": "application/json/ons/eq",
+    "theme": "northernireland",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.1",
+    "legal_basis": "Notice is given under article 5 of the Statistics of Trade and Employment (Northern Ireland) Order 1988.",
+    "description": "mbs",
+    "view_submitted_response": {
+        "enabled": true,
+        "duration": 900
     },
-    {
-      "name": "period_id",
-      "validator": "string"
-    },
-    {
-      "name": "ru_name",
-      "validator": "string"
-    },
-    {
-      "name": "ref_p_start_date",
-      "validator": "date"
-    },
-    {
-      "name": "ref_p_end_date",
-      "validator": "date"
-    },
-    {
-      "name": "trad_as",
-      "validator": "optional_string"
-    }
-  ],
-  "sections": [
-    {
-      "id": "section",
-      "groups": [
+    "metadata": [{
+            "name": "user_id",
+            "validator": "string"
+        },
         {
-          "id": "msi",
-          "title": "",
-          "blocks": [
-            {
-              "type": "Introduction",
-              "id": "introduction",
-              "primary_content": [
-                {
-                  "type": "Basic",
-                  "id": "use-of-information",
-                  "content": [
+            "name": "period_id",
+            "validator": "string"
+        },
+        {
+            "name": "ru_name",
+            "validator": "string"
+        },
+        {
+            "name": "ref_p_start_date",
+            "validator": "date"
+        },
+        {
+            "name": "ref_p_end_date",
+            "validator": "date"
+        },
+        {
+            "name": "trad_as",
+            "validator": "optional_string"
+        }
+    ],
+    "sections": [{
+            "id": "section",
+            "groups": [{
+                "id": "msi",
+                "title": "",
+                "blocks": [{
+                        "type": "Introduction",
+                        "id": "introduction",
+                        "primary_content": [{
+                            "type": "Basic",
+                            "id": "use-of-information",
+                            "content": [{
+                                "list": [
+                                    "Data should relate to all sites in England, Scotland, Wales and Northern Ireland unless otherwise stated.",
+                                    "You can provide informed estimates if actual figures aren’t available.",
+                                    "We will treat your data securely and confidentially."
+                                ]
+                            }]
+                        }],
+                        "preview_content": {
+                            "id": "preview",
+                            "title": "Information you need",
+                            "content": [{
+                                "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate.",
+                                "list": [
+                                    "Total volume of potable water that was supplied to customers",
+                                    "Significant changes"
+                                ]
+                            }]
+                        },
+                        "secondary_content": [{
+                            "id": "how-we-use-your-data",
+                            "title": "How we use your data",
+                            "content": [{
+                                "list": [
+                                    "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
+                                    "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"
+                                ]
+                            }]
+                        }]
+                    },
                     {
-                      "list": [
-                        "Data should relate to all sites in England, Scotland, Wales and Northern Ireland unless otherwise stated.",
-                        "You can provide informed estimates if actual figures aren’t available.",
-                        "We will treat your data securely and confidentially."
-                      ]
+                        "id": "reporting-period-block",
+                        "type": "Question",
+                        "questions": [{
+                            "answers": [{
+                                "options": [{
+                                        "value": "Yes",
+                                        "label": "Yes"
+                                    },
+                                    {
+                                        "value": "No",
+                                        "label": "No"
+                                    }
+                                ],
+                                "id": "reporting-period-answer",
+                                "type": "Radio",
+                                "q_code": "d12",
+                                "mandatory": true
+                            }],
+                            "type": "General",
+                            "id": "reporting-period-question",
+                            "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "id": "reporting-period-answer",
+                                        "value": "Yes",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "water-volume-block"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "reporting-period-block-2"
+                                }
+                            }
+                        ],
+                        "title": "Reporting period"
+                    },
+                    {
+                        "type": "Question",
+                        "id": "reporting-period-block-2",
+                        "title": "Reporting period",
+                        "questions": [{
+                            "type": "DateRange",
+                            "id": "reporting-period-question-2",
+                            "title": "What are the dates of the period that you will be reporting for?",
+                            "period_limits": {
+                                "minimum": {
+                                    "days": 10
+                                },
+                                "maximum": {
+                                    "days": 50
+                                }
+                            },
+                            "answers": [{
+                                    "type": "Date",
+                                    "id": "period-from",
+                                    "label": "From",
+                                    "mandatory": true,
+                                    "q_code": "11",
+                                    "minimum": {
+                                        "meta": "ref_p_start_date",
+                                        "offset_by": {
+                                            "days": -19
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "Date",
+                                    "id": "period-to",
+                                    "label": "To",
+                                    "mandatory": true,
+                                    "q_code": "12",
+                                    "maximum": {
+                                        "meta": "ref_p_end_date",
+                                        "offset_by": {
+                                            "days": 20
+                                        }
+                                    }
+                                }
+                            ]
+                        }]
+                    },
+                    {
+                        "type": "Question",
+                        "id": "water-volume-block",
+                        "title": "Total volume of potable water that was supplied to customers",
+                        "questions": [{
+                            "id": "water-volume-question",
+                            "type": "General",
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the total volume of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s <em>potable water that was supplied to customers</em>, in megalitres?",
+                            "answers": [{
+                                "id": "water-volume",
+                                "mandatory": true,
+                                "q_code": "110",
+                                "type": "Unit",
+                                "unit_length": "short",
+                                "label": "Total volume of potable water that was supplied to customers, in megalitres",
+                                "unit": "volume-megaliter"
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "significant-change",
+                        "title": "Significant changes",
+                        "type": "Question",
+                        "questions": [{
+                            "type": "General",
+                            "id": "significant-change-question",
+                            "title": "Did any significant changes occur to the figures provided for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                            "definitions": [{
+                                "title": "What constitutes a significant change?",
+                                "content": [{
+                                        "description": "What constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s figures from the previous reporting period and the same reporting period last year."
+                                    },
+                                    {
+                                        "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                                    }
+                                ]
+                            }],
+                            "answers": [{
+                                "id": "significant-change-established-answer",
+                                "label": "",
+                                "mandatory": true,
+                                "options": [{
+                                        "label": "Yes",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No",
+                                        "value": "No"
+                                    }
+                                ],
+                                "q_code": "146",
+                                "type": "Radio"
+                            }]
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "block": "change-comment-block",
+                                    "when": [{
+                                        "id": "significant-change-established-answer",
+                                        "condition": "equals",
+                                        "value": "Yes"
+                                    }]
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "group": "summary-group"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "type": "Question",
+                        "id": "change-comment-block",
+                        "questions": [{
+                            "answers": [{
+                                "id": "change-comment",
+                                "label": "Comments",
+                                "mandatory": true,
+                                "q_code": "146h",
+                                "type": "TextArea"
+                            }],
+                            "description": "We rely on your commentary to ‘tell the story’ behind changes in figures. By commenting here it will reduce the need for us to call you.",
+                            "id": "change-comment-question",
+                            "title": "Please describe the changes for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
+                            "type": "General"
+                        }],
+                        "title": "Significant changes"
                     }
-                  ]
-                }
-              ],
-              "preview_content": {
-                "id": "preview",
-                "title": "Information you need",
-                "content": [
-                  {
-                    "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate.",
-                    "list": [
-                      "Total volume of potable water that was supplied to customers",
-                      "Significant changes"
-                    ]
-                  }
                 ]
-              },
-              "secondary_content": [
-                {
-                  "id": "how-we-use-your-data",
-                  "title": "How we use your data",
-                  "content": [
-                    {
-                      "list": [
-                        "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
-                        "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "id": "reporting-period-block",
-              "type": "Question",
-              "questions": [
-                {
-                  "answers": [
-                    {
-                      "options": [
-                        {
-                          "value": "Yes",
-                          "label": "Yes"
-                        },
-                        {
-                          "value": "No",
-                          "label": "No"
-                        }
-                      ],
-                      "id": "reporting-period-answer",
-                      "type": "Radio",
-                      "q_code": "d12",
-                      "mandatory": true
-                    }
-                  ],
-                  "type": "General",
-                  "id": "reporting-period-question",
-                  "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
-                }
-              ],
-              "routing_rules": [
-                {
-                  "goto": {
-                    "when": [
-                      {
-                        "id": "reporting-period-answer",
-                        "value": "Yes",
-                        "condition": "equals"
-                      }
-                    ],
-                    "block": "water-volume-block"
-                  }
-                },
-                {
-                  "goto": {
-                    "block": "reporting-period-block-2"
-                  }
-                }
-              ],
-              "title": "Reporting period"
-            },
-            {
-              "type": "Question",
-              "id": "reporting-period-block-2",
-              "title": "Reporting period",
-              "questions": [
-                {
-                  "type": "DateRange",
-                  "id": "reporting-period-question-2",
-                  "title": "What are the dates of the period that you will be reporting for?",
-                  "period_limits": {
-                    "minimum": {
-                      "days": 10
-                    },
-                    "maximum": {
-                      "days": 50
-                    }
-                  },
-                  "answers": [
-                    {
-                      "type": "Date",
-                      "id": "period-from",
-                      "label": "From",
-                      "mandatory": true,
-                      "q_code": "11",
-                      "minimum": {
-                        "meta": "ref_p_start_date",
-                        "offset_by": {
-                          "days": -19
-                        }
-                      }
-                    },
-                    {
-                      "type": "Date",
-                      "id": "period-to",
-                      "label": "To",
-                      "mandatory": true,
-                      "q_code": "12",
-                      "maximum": {
-                        "meta": "ref_p_end_date",
-                        "offset_by": {
-                          "days": 20
-                        }
-                      }
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "Question",
-              "id": "water-volume-block",
-              "title": "Total volume of potable water that was supplied to customers",
-              "questions": [
-                {
-                  "id": "water-volume-question",
-                  "type": "General",
-                  "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the total volume of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s <em>potable water that was supplied to customers</em>, in megalitres?",
-                  "answers": [
-                    {
-                      "id": "water-volume",
-                      "mandatory": true,
-                      "q_code": "110",
-                      "type": "Unit",
-                      "unit_length": "short",
-                      "label": "Total volume of potable water that was supplied to customers, in megalitres",
-                      "unit": "volume-megaliter"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "id": "significant-change",
-              "title": "Significant changes",
-              "type": "Question",
-              "questions": [
-                {
-                  "type": "General",
-                  "id": "significant-change-question",
-                  "title": "Did any significant changes occur to the figures provided for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
-                  "definitions": [
-                    {
-                      "title": "What constitutes a significant change?",
-                      "content": [
-                        {
-                          "description": "What constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s figures from the previous reporting period and the same reporting period last year."
-                        },
-                        {
-                          "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
-                        }
-                      ]
-                    }
-                  ],
-                  "answers": [
-                    {
-                      "id": "significant-change-established-answer",
-                      "label": "",
-                      "mandatory": true,
-                      "options": [
-                        {
-                          "label": "Yes",
-                          "value": "Yes"
-                        },
-                        {
-                          "label": "No",
-                          "value": "No"
-                        }
-                      ],
-                      "q_code": "146",
-                      "type": "Radio"
-                    }
-                  ]
-                }
-              ],
-              "routing_rules": [
-                {
-                  "goto": {
-                    "block": "change-comment-block",
-                    "when": [
-                      {
-                        "id": "significant-change-established-answer",
-                        "condition": "equals",
-                        "value": "Yes"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "goto": {
-                    "group": "summary-group"
-                  }
-                }
-              ]
-            },
-            {
-              "type": "Question",
-              "id": "change-comment-block",
-              "questions": [
-                {
-                  "answers": [
-                    {
-                      "id": "change-comment",
-                      "label": "Comments",
-                      "mandatory": true,
-                      "q_code": "146h",
-                      "type": "TextArea"
-                    }
-                  ],
-                  "description": "We rely on your commentary to ‘tell the story’ behind changes in figures. By commenting here it will reduce the need for us to call you.",
-                  "id": "change-comment-question",
-                  "title": "Please describe the changes for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
-                  "type": "General"
-                }
-              ],
-              "title": "Significant changes"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "summary-section",
-      "title": "Summary",
-      "groups": [
+            }]
+        },
         {
-          "id": "summary-group",
-          "title": "Summary",
-          "blocks": [
-            {
-              "type": "Summary",
-              "id": "summary"
-            }
-          ]
+            "id": "summary-section",
+            "title": "Summary",
+            "groups": [{
+                "id": "summary-group",
+                "title": "Summary",
+                "blocks": [{
+                    "type": "Summary",
+                    "id": "summary"
+                }]
+            }]
         }
-      ]
-    }
-  ]
+    ]
 }

--- a/data/en/mbs_0204_prototype.json
+++ b/data/en/mbs_0204_prototype.json
@@ -1,0 +1,235 @@
+{
+    "title": "Monthly Business Survey",
+    "survey_id": "009",
+    "mime_type": "application/json/ons/eq",
+    "theme": "northernireland",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.1",
+    "legal_basis": "Notice is given under article 5 of the Statistics of Trade and Employment (Northern Ireland) Order 1988.",
+    "description": "mbs",
+    "view_submitted_response": {
+        "enabled": true,
+        "duration": 900
+    },
+    "metadata": [{
+        "name": "user_id",
+        "validator": "string"
+    }, {
+        "name": "period_id",
+        "validator": "string"
+    }, {
+        "name": "ru_name",
+        "validator": "string"
+    }, {
+        "name": "ref_p_start_date",
+        "validator": "date"
+    }, {
+        "name": "ref_p_end_date",
+        "validator": "date"
+    }, {
+        "name": "trad_as",
+        "validator": "optional_string"
+    }],
+    "sections": [{
+        "id": "section",
+        "groups": [{
+            "id": "msi",
+            "title": "",
+            "blocks": [{
+                "type": "Introduction",
+                "id": "introduction",
+                "primary_content": [{
+                    "type": "Basic",
+                    "id": "use-of-information",
+                    "content": [{
+                        "list": ["Data should relate to all sites in England, Scotland, Wales and Northern Ireland unless otherwise stated.", "You can provide informed estimates if actual figures aren\u2019t available.", "We will treat your data securely and confidentially."]
+                    }]
+                }],
+                "preview_content": {
+                    "id": "preview",
+                    "title": "Information you need",
+                    "content": [{
+                        "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate.",
+                        "list": ["Total volume of potable water that was supplied to customers", "Significant changes"]
+                    }]
+                },
+                "secondary_content": [{
+                    "id": "how-we-use-your-data",
+                    "title": "How we use your data",
+                    "content": [{
+                        "list": ["You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.", "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"]
+                    }]
+                }]
+            }, {
+                "id": "reporting-period-block",
+                "type": "Question",
+                "questions": [{
+                    "answers": [{
+                        "options": [{
+                            "value": "Yes",
+                            "label": "Yes"
+                        }, {
+                            "value": "No",
+                            "label": "No"
+                        }],
+                        "id": "reporting-period-answer",
+                        "type": "Radio",
+                        "q_code": "d12",
+                        "mandatory": true
+                    }],
+                    "type": "General",
+                    "id": "reporting-period-question",
+                    "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
+                }],
+                "routing_rules": [{
+                    "goto": {
+                        "when": [{
+                            "id": "reporting-period-answer",
+                            "value": "Yes",
+                            "condition": "equals"
+                        }],
+                        "block": "water-volume-block"
+                    }
+                }, {
+                    "goto": {
+                        "block": "reporting-period-block-2"
+                    }
+                }],
+                "title": "Reporting period"
+            }, {
+                "type": "Question",
+                "id": "reporting-period-block-2",
+                "title": "Reporting period",
+                "questions": [{
+                    "type": "DateRange",
+                    "id": "reporting-period-question-2",
+                    "title": "What are the dates of the period that you will be reporting for?",
+                    "period_limits": {
+                        "minimum": {
+                            "days": 10
+                        },
+                        "maximum": {
+                            "days": 50
+                        }
+                    },
+                    "answers": [{
+                        "type": "Date",
+                        "id": "period-from",
+                        "label": "From",
+                        "mandatory": true,
+                        "q_code": "11",
+                        "minimum": {
+                            "meta": "ref_p_start_date",
+                            "offset_by": {
+                                "days": -19
+                            }
+                        }
+                    }, {
+                        "type": "Date",
+                        "id": "period-to",
+                        "label": "To",
+                        "mandatory": true,
+                        "q_code": "12",
+                        "maximum": {
+                            "meta": "ref_p_end_date",
+                            "offset_by": {
+                                "days": 20
+                            }
+                        }
+                    }]
+                }]
+            }, {
+                "type": "Question",
+                "id": "water-volume-block",
+                "title": "Total volume of potable water that was supplied to customers",
+                "questions": [{
+                    "id": "water-volume-question",
+                    "type": "General",
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the total volume of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>potable water that was supplied to customers</em>, in megalitres?",
+                    "answers": [{
+                        "id": "water-volume",
+                        "mandatory": true,
+                        "q_code": "110",
+                        "type": "Unit",
+                        "unit_length": "short",
+                        "label": "Total volume of potable water that was supplied to customers, in megalitres",
+                        "unit": "volume-megaliter"
+                    }]
+                }]
+            }, {
+                "id": "significant-change",
+                "title": "Significant changes",
+                "type": "Question",
+                "questions": [{
+                    "type": "General",
+                    "id": "significant-change-question",
+                    "title": "Did any significant changes occur to the figures provided for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
+                        }, {
+                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }]
+                    }],
+                    "answers": [{
+                        "id": "significant-change-established-answer",
+                        "label": "",
+                        "mandatory": true,
+                        "options": [{
+                            "label": "Yes",
+                            "value": "Yes"
+                        }, {
+                            "label": "No",
+                            "value": "No"
+                        }],
+                        "q_code": "146",
+                        "type": "Radio"
+                    }]
+                }],
+                "routing_rules": [{
+                    "goto": {
+                        "block": "change-comment-block",
+                        "when": [{
+                            "id": "significant-change-established-answer",
+                            "condition": "equals",
+                            "value": "Yes"
+                        }]
+                    }
+                }, {
+                    "goto": {
+                        "group": "summary-group"
+                    }
+                }]
+            }, {
+                "type": "Question",
+                "id": "change-comment-block",
+                "questions": [{
+                    "answers": [{
+                        "id": "change-comment",
+                        "label": "Comments",
+                        "mandatory": true,
+                        "q_code": "146h",
+                        "type": "TextArea"
+                    }],
+                    "description": "We rely on your commentary to \u2018tell the story\u2019 behind changes in figures. By commenting here it will reduce the need for us to call you.",
+                    "id": "change-comment-question",
+                    "title": "Please describe the changes for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
+                    "type": "General"
+                }],
+                "title": "Significant changes"
+            }]
+        }]
+    }, {
+        "id": "summary-section",
+        "title": "Summary",
+        "groups": [{
+            "id": "summary-group",
+            "title": "Summary",
+            "blocks": [{
+                "type": "Summary",
+                "id": "summary"
+            }]
+        }]
+    }]
+}

--- a/data/en/mbs_0205.json
+++ b/data/en/mbs_0205.json
@@ -1,419 +1,605 @@
 {
-    "title": "Monthly Business Survey",
-    "survey_id": "009",
-    "mime_type": "application/json/ons/eq",
-    "theme": "default",
-    "schema_version": "0.0.1",
-    "data_version": "0.0.1",
-    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
-    "description": "mbs",
-    "view_submitted_response": {
-        "enabled": true,
-        "duration": 900
+  "title": "Monthly Business Survey",
+  "survey_id": "009",
+  "mime_type": "application/json/ons/eq",
+  "theme": "default",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.1",
+  "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
+  "description": "mbs",
+  "view_submitted_response": {
+    "enabled": true,
+    "duration": 900
+  },
+  "metadata": [
+    {
+      "name": "user_id",
+      "validator": "string"
     },
-    "metadata": [{
-        "name": "user_id",
-        "validator": "string"
-    }, {
-        "name": "period_id",
-        "validator": "string"
-    }, {
-        "name": "ru_name",
-        "validator": "string"
-    }, {
-        "name": "ref_p_start_date",
-        "validator": "date"
-    }, {
-        "name": "ref_p_end_date",
-        "validator": "date"
-    }, {
-        "name": "trad_as",
-        "validator": "optional_string"
-    }],
-    "sections": [{
-        "id": "section",
-        "groups": [{
-            "id": "group",
-            "title": "",
-            "blocks": [{
-                "type": "Introduction",
-                "id": "introduction",
-                "primary_content": [{
-                    "type": "Basic",
-                    "id": "use-of-information",
-                    "content": [{
-                        "list": ["Data should relate to all sites in England, Scotland, Wales and Northern Ireland unless otherwise stated.", "You can provide informed estimates if actual figures aren\u2019t available.", "We will treat your data securely and confidentially."]
-                    }]
-                }],
-                "preview_content": {
-                    "id": "preview",
-                    "title": "Information you need",
-                    "content": [{
-                        "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
-                    }],
-                    "questions": [{
-                        "question": "Turnover",
-                        "content": [{
-                            "description": "Include:",
-                            "list": ["income from sub-contracted activities", "commission", "sales of goods purchased for resale", "transport, insurance and packaging charges", "revenue earned from other parts of the business, not named at the top of this page (please supply at fair value)"]
-                        }, {
-                            "description": "Exclude:",
-                            "list": ["VAT", "income from the sale of fixed capital assets", "grants and subsidies", "insurance claims", "interest received"]
-                        }]
-                    }, {
-                        "question": "Value of exports",
-                        "content": [{
-                            "description": "Include:",
-                            "list": ["all countries outside of England, Scotland, Wales and Northern Ireland"]
-                        }]
-                    }, {
-                        "question": "Value of excise duty"
-                    }, {
-                        "question": "Changes in turnover",
-                        "content": [{
-                            "description": "Include:",
-                            "list": ["change in level of business activity", "maintenance/shutdowns", "special/calendar events", "weather", "price effects", "currency effects (increase/decrease in the currency value)"]
-                        }]
-                    }]
-                },
-                "secondary_content": [{
-                    "id": "how-we-use-your-data",
-                    "title": "How we use your data",
-                    "content": [{
-                        "list": ["You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.", "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"]
-                    }]
-                }]
-            }, {
-                "id": "reporting-period-block",
-                "type": "Question",
-                "questions": [{
-                    "answers": [{
-                        "options": [{
-                            "value": "Yes",
-                            "label": "Yes"
-                        }, {
-                            "value": "No",
-                            "label": "No"
-                        }],
+    {
+      "name": "period_id",
+      "validator": "string"
+    },
+    {
+      "name": "ru_name",
+      "validator": "string"
+    },
+    {
+      "name": "ref_p_start_date",
+      "validator": "date"
+    },
+    {
+      "name": "ref_p_end_date",
+      "validator": "date"
+    },
+    {
+      "name": "trad_as",
+      "validator": "optional_string"
+    }
+  ],
+  "sections": [
+    {
+      "id": "section",
+      "groups": [
+        {
+          "id": "group",
+          "title": "",
+          "blocks": [
+            {
+              "type": "Introduction",
+              "id": "introduction",
+              "primary_content": [
+                {
+                  "type": "Basic",
+                  "id": "use-of-information",
+                  "content": [
+                    {
+                      "list": [
+                        "Data should relate to all sites in England, Scotland, Wales and Northern Ireland unless otherwise stated.",
+                        "You can provide informed estimates if actual figures aren’t available.",
+                        "We will treat your data securely and confidentially."
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "preview_content": {
+                "id": "preview",
+                "title": "Information you need",
+                "content": [
+                  {
+                    "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
+                  }
+                ],
+                "questions": [
+                  {
+                    "question": "Turnover",
+                    "content": [
+                      {
+                        "description": "Include:",
+                        "list": [
+                          "income from sub-contracted activities",
+                          "commission",
+                          "sales of goods purchased for resale",
+                          "transport, insurance and packaging charges",
+                          "revenue earned from other parts of the business, not named at the top of this page (please supply at fair value)"
+                        ]
+                      },
+                      {
+                        "description": "Exclude:",
+                        "list": [
+                          "VAT",
+                          "income from the sale of fixed capital assets",
+                          "grants and subsidies",
+                          "insurance claims",
+                          "interest received"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "question": "Value of exports",
+                    "content": [
+                      {
+                        "description": "Include:",
+                        "list": [
+                          "all countries outside of England, Scotland, Wales and Northern Ireland"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "question": "Value of excise duty"
+                  },
+                  {
+                    "question": "Changes in turnover",
+                    "content": [
+                      {
+                        "description": "Include:",
+                        "list": [
+                          "change in level of business activity",
+                          "maintenance/shutdowns",
+                          "special/calendar events",
+                          "weather",
+                          "price effects",
+                          "currency effects (increase/decrease in the currency value)"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              "secondary_content": [
+                {
+                  "id": "how-we-use-your-data",
+                  "title": "How we use your data",
+                  "content": [
+                    {
+                      "list": [
+                        "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
+                        "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "reporting-period-block",
+              "type": "Question",
+              "questions": [
+                {
+                  "answers": [
+                    {
+                      "options": [
+                        {
+                          "value": "Yes",
+                          "label": "Yes"
+                        },
+                        {
+                          "value": "No",
+                          "label": "No"
+                        }
+                      ],
+                      "id": "reporting-period-answer",
+                      "type": "Radio",
+                      "q_code": "d12",
+                      "mandatory": true
+                    }
+                  ],
+                  "type": "General",
+                  "id": "reporting-period-question",
+                  "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "when": [
+                      {
                         "id": "reporting-period-answer",
-                        "type": "Radio",
-                        "q_code": "d12",
-                        "mandatory": true
-                    }],
-                    "type": "General",
-                    "id": "reporting-period-question",
-                    "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
-                }],
-                "routing_rules": [{
-                    "goto": {
-                        "when": [{
-                            "id": "reporting-period-answer",
-                            "value": "Yes",
-                            "condition": "equals"
-                        }],
-                        "block": "turnover-block"
+                        "value": "Yes",
+                        "condition": "equals"
+                      }
+                    ],
+                    "block": "turnover-block"
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "reporting-period-block-2"
+                  }
+                }
+              ],
+              "title": "Reporting period"
+            },
+            {
+              "type": "Question",
+              "id": "reporting-period-block-2",
+              "title": "Reporting period",
+              "questions": [
+                {
+                  "type": "DateRange",
+                  "id": "reporting-period-question-2",
+                  "title": "What are the dates of the period that you will be reporting for?",
+                  "period_limits": {
+                    "minimum": {
+                      "days": 10
+                    },
+                    "maximum": {
+                      "days": 50
                     }
-                }, {
-                    "goto": {
-                        "block": "reporting-period-block-2"
+                  },
+                  "answers": [
+                    {
+                      "type": "Date",
+                      "id": "period-from",
+                      "label": "From",
+                      "mandatory": true,
+                      "q_code": "11",
+                      "minimum": {
+                        "meta": "ref_p_start_date",
+                        "offset_by": {
+                          "days": -19
+                        }
+                      }
+                    },
+                    {
+                      "type": "Date",
+                      "id": "period-to",
+                      "label": "To",
+                      "mandatory": true,
+                      "q_code": "12",
+                      "maximum": {
+                        "meta": "ref_p_end_date",
+                        "offset_by": {
+                          "days": 20
+                        }
+                      }
                     }
-                }],
-                "title": "Reporting period"
-            }, {
-                "type": "Question",
-                "id": "reporting-period-block-2",
-                "title": "Reporting period",
-                "questions": [{
-                    "type": "DateRange",
-                    "id": "reporting-period-question-2",
-                    "title": "What are the dates of the period that you will be reporting for?",
-                    "period_limits": {
-                        "minimum": {
-                            "days": 10
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "turnover-block",
+              "type": "Question",
+              "questions": [
+                {
+                  "guidance": {
+                    "content": [
+                      {
+                        "title": "Include:",
+                        "list": [
+                          "income from sub-contracted activities",
+                          "commission",
+                          "sales of goods purchased for resale",
+                          "transport, insurance and packaging charges",
+                          "revenue earned from other parts of the business, not named at the top of this page (please supply at fair value)"
+                        ]
+                      },
+                      {
+                        "title": "Exclude:",
+                        "list": [
+                          "VAT",
+                          "income from the sale of fixed capital assets",
+                          "grants and subsidies",
+                          "insurance claims",
+                          "interest received"
+                        ]
+                      }
+                    ]
+                  },
+                  "id": "turnover-question",
+                  "answers": [
+                    {
+                      "id": "turnover-answer",
+                      "label": "Turnover excluding VAT",
+                      "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                      "type": "Currency",
+                      "currency": "GBP",
+                      "decimal_places": 2,
+                      "q_code": "40",
+                      "mandatory": true
+                    }
+                  ],
+                  "type": "General",
+                  "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s <em>turnover</em>, excluding VAT?"
+                }
+              ],
+              "title": "Turnover"
+            },
+            {
+              "type": "ConfirmationQuestion",
+              "title": "Turnover",
+              "id": "confirm-turnover-block",
+              "questions": [
+                {
+                  "type": "General",
+                  "answers": [
+                    {
+                      "type": "Radio",
+                      "id": "confirm-turnover-answer",
+                      "q_code": "d40",
+                      "options": [
+                        {
+                          "label": "Yes this is correct",
+                          "value": "Yes"
                         },
-                        "maximum": {
-                            "days": 50
+                        {
+                          "label": "No I need to change this",
+                          "value": "No"
                         }
-                    },
-                    "answers": [{
-                        "type": "Date",
-                        "id": "period-from",
-                        "label": "From",
-                        "mandatory": true,
-                        "q_code": "11",
-                        "minimum": {
-                            "meta": "ref_p_start_date",
-                            "offset_by": {
-                                "days": -19
-                            }
-                        }
-                    }, {
-                        "type": "Date",
-                        "id": "period-to",
-                        "label": "To",
-                        "mandatory": true,
-                        "q_code": "12",
-                        "maximum": {
-                            "meta": "ref_p_end_date",
-                            "offset_by": {
-                                "days": 20
-                            }
-                        }
-                    }]
-                }]
-            }, {
-                "id": "turnover-block",
-                "type": "Question",
-                "questions": [{
-                    "guidance": {
-                        "content": [{
-                            "title": "Include:",
-                            "list": ["income from sub-contracted activities", "commission", "sales of goods purchased for resale", "transport, insurance and packaging charges", "revenue earned from other parts of the business, not named at the top of this page (please supply at fair value)"]
-                        }, {
-                            "title": "Exclude:",
-                            "list": ["VAT", "income from the sale of fixed capital assets", "grants and subsidies", "insurance claims", "interest received"]
-                        }]
-                    },
-                    "id": "turnover-question",
-                    "answers": [{
-                        "id": "turnover-answer",
-                        "label": "Turnover excluding VAT",
-                        "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
-                        "type": "Currency",
-                        "currency": "GBP",
-                        "decimal_places": 2,
-                        "q_code": "40",
-                        "mandatory": true
-                    }],
-                    "type": "General",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>turnover</em>, excluding VAT?"
-                }],
-                "title": "Turnover"
-            }, {
-                "type": "ConfirmationQuestion",
-                "title": "Turnover",
-                "id": "confirm-turnover-block",
-                "questions": [{
-                    "type": "General",
-                    "answers": [{
-                        "type": "Radio",
+                      ],
+                      "mandatory": true
+                    }
+                  ],
+                  "id": "confirm-turnover-question",
+                  "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
+                }
+              ],
+              "routing_rules": [
+                {
+                  "goto": {
+                    "when": [
+                      {
+                        "value": "No",
                         "id": "confirm-turnover-answer",
-                        "q_code": "d40",
-                        "options": [{
-                            "label": "Yes this is correct",
-                            "value": "Yes"
-                        }, {
-                            "label": "No I need to change this",
-                            "value": "No"
-                        }],
-                        "mandatory": true
-                    }],
-                    "id": "confirm-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
-                }],
-                "routing_rules": [{
-                    "goto": {
-                        "when": [{
-                            "value": "No",
-                            "id": "confirm-turnover-answer",
-                            "condition": "equals"
-                        }],
-                        "block": "turnover-block"
+                        "condition": "equals"
+                      }
+                    ],
+                    "block": "turnover-block"
+                  }
+                },
+                {
+                  "goto": {
+                    "block": "exports-block"
+                  }
+                }
+              ]
+            },
+            {
+              "id": "exports-block",
+              "type": "Question",
+              "questions": [
+                {
+                  "guidance": {
+                    "content": [
+                      {
+                        "list": [
+                          "All countries outside of England, Scotland, Wales and Northern Ireland"
+                        ],
+                        "title": "Include:"
+                      }
+                    ]
+                  },
+                  "id": "exports-question",
+                  "answers": [
+                    {
+                      "id": "exports-answer",
+                      "label": "Exports",
+                      "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                      "type": "Currency",
+                      "currency": "GBP",
+                      "decimal_places": 2,
+                      "q_code": "49",
+                      "mandatory": true
                     }
-                }, {
-                    "goto": {
-                        "block": "exports-block"
+                  ],
+                  "type": "General",
+                  "title": "What was the value of <em>exports</em>?"
+                }
+              ],
+              "title": "Exports"
+            },
+            {
+              "id": "excise-duty-block",
+              "type": "Question",
+              "questions": [
+                {
+                  "id": "excise-duty-question",
+                  "answers": [
+                    {
+                      "id": "excise-duty-answer",
+                      "label": "Excise duty",
+                      "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                      "type": "Currency",
+                      "currency": "GBP",
+                      "decimal_places": 2,
+                      "q_code": "90",
+                      "mandatory": true
                     }
-                }]
-            }, {
-                "id": "exports-block",
-                "type": "Question",
-                "questions": [{
-                    "guidance": {
-                        "content": [{
-                            "list": ["All countries outside of England, Scotland, Wales and Northern Ireland"],
-                            "title": "Include:"
-                        }]
-                    },
-                    "id": "exports-question",
-                    "answers": [{
-                        "id": "exports-answer",
-                        "label": "Exports",
-                        "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
-                        "type": "Currency",
-                        "currency": "GBP",
-                        "decimal_places": 2,
-                        "q_code": "49",
-                        "mandatory": true
-                    }],
-                    "type": "General",
-                    "title": "What was the value of <em>exports</em>?"
-                }],
-                "title": "Exports"
-            }, {
-                "id": "excise-duty-block",
-                "type": "Question",
-                "questions": [{
-                    "id": "excise-duty-question",
-                    "answers": [{
-                        "id": "excise-duty-answer",
-                        "label": "Excise duty",
-                        "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
-                        "type": "Currency",
-                        "currency": "GBP",
-                        "decimal_places": 2,
-                        "q_code": "90",
-                        "mandatory": true
-                    }],
-                    "type": "General",
-                    "title": "What was the value of <em>excise duty</em>?"
-                }],
-                "title": "Excise duty"
-            }, {
-                "id": "changes-in-turnover-block",
-                "type": "Question",
-                "questions": [{
-                    "title": "Did any significant changes occur to the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
-                    "id": "changes-in-turnover-question",
-                    "definitions": [{
-                        "title": "What constitutes a significant change?",
-                        "content": [{
-                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
-                        }, {
-                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
-                        }]
-                    }],
-                    "answers": [{
-                        "options": [{
-                            "value": "Yes",
-                            "label": "Yes"
-                        }, {
-                            "value": "No",
-                            "label": "No"
-                        }],
-                        "id": "changes-in-turnover-answer",
-                        "type": "Radio",
-                        "q_code": "146",
-                        "mandatory": false
-                    }],
-                    "guidance": {
-                        "content": [{
-                            "title": "Include",
-                            "list": ["change in level of business activity", "maintenance/shutdowns", "special/calendar events", "weather", "price effects", "currency effects (increase/decrease in the currency value)"]
-                        }]
-                    },
-                    "type": "General"
-                }],
-                "title": "Changes in turnover",
-                "routing_rules": [{
-                    "goto": {
-                        "when": [{
-                            "id": "changes-in-turnover-answer",
-                            "value": "Yes",
-                            "condition": "equals"
-                        }],
-                        "block": "changes-in-turnover-block-2"
-                    }
-                }, {
-                    "goto": {
-                        "group": "summary-group"
-                    }
-                }]
-            }, {
-                "id": "changes-in-turnover-block-2",
-                "type": "Question",
-                "questions": [{
-                    "title": "Please indicate the reasons for any changes in the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
-                    "answers": [{
-                        "options": [{
-                            "q_code": "146a",
-                            "value": "Change in level of business activity",
-                            "label": "Change in level of business activity"
-                        }, {
-                            "q_code": "146b",
-                            "value": "Maintenance/shutdowns",
-                            "label": "Maintenance/shutdowns"
-                        }, {
-                            "q_code": "146c",
-                            "value": "Special/calendar events",
-                            "label": "Special/calendar events"
-                        }, {
-                            "q_code": "146d",
-                            "value": "Weather",
-                            "label": "Weather"
-                        }, {
-                            "q_code": "146e",
-                            "value": "Price effects",
-                            "label": "Price effects"
-                        }, {
-                            "q_code": "146f",
-                            "value": "Currency effects (increase/decrease in the currency value)",
-                            "label": "Currency effects (increase/decrease in the currency value)"
-                        }, {
-                            "q_code": "146g",
-                            "value": "Other",
-                            "label": "Other"
-                        }],
-                        "id": "changes-in-turnover-answer-2",
-                        "type": "Checkbox",
-                        "mandatory": true
-                    }],
-                    "type": "General",
-                    "id": "changes-in-turnover-question-2"
-                }],
-                "title": "Changes in turnover"
-            }, {
-                "type": "Question",
-                "id": "changes-in-turnover-block-3",
-                "title": "Changes in turnover",
-                "questions": [{
-                    "type": "General",
-                    "id": "changes-in-turnover-question-3",
-                    "title": "Please describe the changes in turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
-                    "answers": [{
-                        "guidance": {
-                            "hide_guidance": "Hide examples of commentary on changes to turnover",
-                            "show_guidance": "Show examples of commentary on changes to turnover",
-                            "content": [{
-                                "title": "\u2018Change in level of business activity\u2019",
-                                "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
-                            }, {
-                                "title": "\u2018Maintenance/shutdowns\u2019",
-                                "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
-                            }, {
-                                "title": "\u2018Special/calendar events\u2019",
-                                "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
-                            }, {
-                                "title": "\u2018Weather\u2019",
-                                "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
-                            }, {
-                                "title": "\u2018Price effects\u2019",
-                                "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
-                            }, {
-                                "title": "\u2018Currency effects (increase/decrease in the currency value)\u2019",
-                                "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
-                            }]
+                  ],
+                  "type": "General",
+                  "title": "What was the value of <em>excise duty</em>?"
+                }
+              ],
+              "title": "Excise duty"
+            },
+            {
+              "id": "changes-in-turnover-block",
+              "type": "Question",
+              "questions": [
+                {
+                  "title": "Did any significant changes occur to the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                  "id": "changes-in-turnover-question",
+                  "definitions": [
+                    {
+                      "title": "What constitutes a significant change?",
+                      "content": [
+                        {
+                          "description": "What constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s figures from the previous reporting period and the same reporting period last year."
                         },
-                        "type": "TextArea",
-                        "mandatory": true,
-                        "label": "Comments",
-                        "id": "changes-in-turnover-answer-3",
-                        "q_code": "146h"
-                    }],
-                    "description": "<p>We rely on your commentary to \u2018tell the story\u2019 behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
-                }]
-            }]
-        }]
-    }, {
-        "id": "summary-section",
-        "title": "Summary",
-        "groups": [{
-            "id": "summary-group",
-            "title": "Summary",
-            "blocks": [{
-                "type": "Summary",
-                "id": "summary"
-            }]
-        }]
-    }]
+                        {
+                          "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }
+                      ]
+                    }
+                  ],
+                  "answers": [
+                    {
+                      "options": [
+                        {
+                          "value": "Yes",
+                          "label": "Yes"
+                        },
+                        {
+                          "value": "No",
+                          "label": "No"
+                        }
+                      ],
+                      "id": "changes-in-turnover-answer",
+                      "type": "Radio",
+                      "q_code": "146",
+                      "mandatory": false
+                    }
+                  ],
+                  "guidance": {
+                    "content": [
+                      {
+                        "title": "Include",
+                        "list": [
+                          "change in level of business activity",
+                          "maintenance/shutdowns",
+                          "special/calendar events",
+                          "weather",
+                          "price effects",
+                          "currency effects (increase/decrease in the currency value)"
+                        ]
+                      }
+                    ]
+                  },
+                  "type": "General"
+                }
+              ],
+              "title": "Changes in turnover",
+              "routing_rules": [
+                {
+                  "goto": {
+                    "when": [
+                      {
+                        "id": "changes-in-turnover-answer",
+                        "value": "Yes",
+                        "condition": "equals"
+                      }
+                    ],
+                    "block": "changes-in-turnover-block-2"
+                  }
+                },
+                {
+                  "goto": {
+                    "group": "summary-group"
+                  }
+                }
+              ]
+            },
+            {
+              "id": "changes-in-turnover-block-2",
+              "type": "Question",
+              "questions": [
+                {
+                  "title": "Please indicate the reasons for any changes in the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
+                  "answers": [
+                    {
+                      "options": [
+                        {
+                          "q_code": "146a",
+                          "value": "Change in level of business activity",
+                          "label": "Change in level of business activity"
+                        },
+                        {
+                          "q_code": "146b",
+                          "value": "Maintenance/shutdowns",
+                          "label": "Maintenance/shutdowns"
+                        },
+                        {
+                          "q_code": "146c",
+                          "value": "Special/calendar events",
+                          "label": "Special/calendar events"
+                        },
+                        {
+                          "q_code": "146d",
+                          "value": "Weather",
+                          "label": "Weather"
+                        },
+                        {
+                          "q_code": "146e",
+                          "value": "Price effects",
+                          "label": "Price effects"
+                        },
+                        {
+                          "q_code": "146f",
+                          "value": "Currency effects (increase/decrease in the currency value)",
+                          "label": "Currency effects (increase/decrease in the currency value)"
+                        },
+                        {
+                          "q_code": "146g",
+                          "value": "Other",
+                          "label": "Other"
+                        }
+                      ],
+                      "id": "changes-in-turnover-answer-2",
+                      "type": "Checkbox",
+                      "mandatory": true
+                    }
+                  ],
+                  "type": "General",
+                  "id": "changes-in-turnover-question-2"
+                }
+              ],
+              "title": "Changes in turnover"
+            },
+            {
+              "type": "Question",
+              "id": "changes-in-turnover-block-3",
+              "title": "Changes in turnover",
+              "questions": [
+                {
+                  "type": "General",
+                  "id": "changes-in-turnover-question-3",
+                  "title": "Please describe the changes in turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
+                  "answers": [
+                    {
+                      "guidance": {
+                        "hide_guidance": "Hide examples of commentary on changes to turnover",
+                        "show_guidance": "Show examples of commentary on changes to turnover",
+                        "content": [
+                          {
+                            "title": "‘Change in level of business activity’",
+                            "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
+                          },
+                          {
+                            "title": "‘Maintenance/shutdowns’",
+                            "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
+                          },
+                          {
+                            "title": "‘Special/calendar events’",
+                            "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
+                          },
+                          {
+                            "title": "‘Weather’",
+                            "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
+                          },
+                          {
+                            "title": "‘Price effects’",
+                            "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
+                          },
+                          {
+                            "title": "‘Currency effects (increase/decrease in the currency value)’",
+                            "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
+                          }
+                        ]
+                      },
+                      "type": "TextArea",
+                      "mandatory": true,
+                      "label": "Comments",
+                      "id": "changes-in-turnover-answer-3",
+                      "q_code": "146h"
+                    }
+                  ],
+                  "description": "<p>We rely on your commentary to ‘tell the story’ behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "summary-section",
+      "title": "Summary",
+      "groups": [
+        {
+          "id": "summary-group",
+          "title": "Summary",
+          "blocks": [
+            {
+              "type": "Summary",
+              "id": "summary"
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/data/en/mbs_0205.json
+++ b/data/en/mbs_0205.json
@@ -1,605 +1,523 @@
 {
-  "title": "Monthly Business Survey",
-  "survey_id": "009",
-  "mime_type": "application/json/ons/eq",
-  "theme": "default",
-  "schema_version": "0.0.1",
-  "data_version": "0.0.1",
-  "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
-  "description": "mbs",
-  "view_submitted_response": {
-    "enabled": true,
-    "duration": 900
-  },
-  "metadata": [
-    {
-      "name": "user_id",
-      "validator": "string"
+    "title": "Monthly Business Survey",
+    "survey_id": "009",
+    "mime_type": "application/json/ons/eq",
+    "theme": "default",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.1",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
+    "description": "mbs",
+    "view_submitted_response": {
+        "enabled": true,
+        "duration": 900
     },
-    {
-      "name": "period_id",
-      "validator": "string"
-    },
-    {
-      "name": "ru_name",
-      "validator": "string"
-    },
-    {
-      "name": "ref_p_start_date",
-      "validator": "date"
-    },
-    {
-      "name": "ref_p_end_date",
-      "validator": "date"
-    },
-    {
-      "name": "trad_as",
-      "validator": "optional_string"
-    }
-  ],
-  "sections": [
-    {
-      "id": "section",
-      "groups": [
+    "metadata": [{
+            "name": "user_id",
+            "validator": "string"
+        },
         {
-          "id": "group",
-          "title": "",
-          "blocks": [
-            {
-              "type": "Introduction",
-              "id": "introduction",
-              "primary_content": [
-                {
-                  "type": "Basic",
-                  "id": "use-of-information",
-                  "content": [
-                    {
-                      "list": [
-                        "Data should relate to all sites in England, Scotland, Wales and Northern Ireland unless otherwise stated.",
-                        "You can provide informed estimates if actual figures aren’t available.",
-                        "We will treat your data securely and confidentially."
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "preview_content": {
-                "id": "preview",
-                "title": "Information you need",
-                "content": [
-                  {
-                    "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
-                  }
-                ],
-                "questions": [
-                  {
-                    "question": "Turnover",
-                    "content": [
-                      {
-                        "description": "Include:",
-                        "list": [
-                          "income from sub-contracted activities",
-                          "commission",
-                          "sales of goods purchased for resale",
-                          "transport, insurance and packaging charges",
-                          "revenue earned from other parts of the business, not named at the top of this page (please supply at fair value)"
-                        ]
-                      },
-                      {
-                        "description": "Exclude:",
-                        "list": [
-                          "VAT",
-                          "income from the sale of fixed capital assets",
-                          "grants and subsidies",
-                          "insurance claims",
-                          "interest received"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "question": "Value of exports",
-                    "content": [
-                      {
-                        "description": "Include:",
-                        "list": [
-                          "all countries outside of England, Scotland, Wales and Northern Ireland"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "question": "Value of excise duty"
-                  },
-                  {
-                    "question": "Changes in turnover",
-                    "content": [
-                      {
-                        "description": "Include:",
-                        "list": [
-                          "change in level of business activity",
-                          "maintenance/shutdowns",
-                          "special/calendar events",
-                          "weather",
-                          "price effects",
-                          "currency effects (increase/decrease in the currency value)"
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              },
-              "secondary_content": [
-                {
-                  "id": "how-we-use-your-data",
-                  "title": "How we use your data",
-                  "content": [
-                    {
-                      "list": [
-                        "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
-                        "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "id": "reporting-period-block",
-              "type": "Question",
-              "questions": [
-                {
-                  "answers": [
-                    {
-                      "options": [
-                        {
-                          "value": "Yes",
-                          "label": "Yes"
+            "name": "period_id",
+            "validator": "string"
+        },
+        {
+            "name": "ru_name",
+            "validator": "string"
+        },
+        {
+            "name": "ref_p_start_date",
+            "validator": "date"
+        },
+        {
+            "name": "ref_p_end_date",
+            "validator": "date"
+        },
+        {
+            "name": "trad_as",
+            "validator": "optional_string"
+        }
+    ],
+    "sections": [{
+            "id": "section",
+            "groups": [{
+                "id": "group",
+                "title": "",
+                "blocks": [{
+                        "type": "Introduction",
+                        "id": "introduction",
+                        "primary_content": [{
+                            "type": "Basic",
+                            "id": "use-of-information",
+                            "content": [{
+                                "list": [
+                                    "Data should relate to all sites in England, Scotland, Wales and Northern Ireland unless otherwise stated.",
+                                    "You can provide informed estimates if actual figures aren’t available.",
+                                    "We will treat your data securely and confidentially."
+                                ]
+                            }]
+                        }],
+                        "preview_content": {
+                            "id": "preview",
+                            "title": "Information you need",
+                            "content": [{
+                                "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
+                            }],
+                            "questions": [{
+                                    "question": "Turnover",
+                                    "content": [{
+                                            "description": "Include:",
+                                            "list": [
+                                                "income from sub-contracted activities",
+                                                "commission",
+                                                "sales of goods purchased for resale",
+                                                "transport, insurance and packaging charges",
+                                                "revenue earned from other parts of the business, not named at the top of this page (please supply at fair value)"
+                                            ]
+                                        },
+                                        {
+                                            "description": "Exclude:",
+                                            "list": [
+                                                "VAT",
+                                                "income from the sale of fixed capital assets",
+                                                "grants and subsidies",
+                                                "insurance claims",
+                                                "interest received"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "question": "Value of exports",
+                                    "content": [{
+                                        "description": "Include:",
+                                        "list": [
+                                            "all countries outside of England, Scotland, Wales and Northern Ireland"
+                                        ]
+                                    }]
+                                },
+                                {
+                                    "question": "Value of excise duty"
+                                },
+                                {
+                                    "question": "Changes in turnover",
+                                    "content": [{
+                                        "description": "Include:",
+                                        "list": [
+                                            "change in level of business activity",
+                                            "maintenance/shutdowns",
+                                            "special/calendar events",
+                                            "weather",
+                                            "price effects",
+                                            "currency effects (increase/decrease in the currency value)"
+                                        ]
+                                    }]
+                                }
+                            ]
                         },
-                        {
-                          "value": "No",
-                          "label": "No"
-                        }
-                      ],
-                      "id": "reporting-period-answer",
-                      "type": "Radio",
-                      "q_code": "d12",
-                      "mandatory": true
-                    }
-                  ],
-                  "type": "General",
-                  "id": "reporting-period-question",
-                  "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
-                }
-              ],
-              "routing_rules": [
-                {
-                  "goto": {
-                    "when": [
-                      {
-                        "id": "reporting-period-answer",
-                        "value": "Yes",
-                        "condition": "equals"
-                      }
-                    ],
-                    "block": "turnover-block"
-                  }
-                },
-                {
-                  "goto": {
-                    "block": "reporting-period-block-2"
-                  }
-                }
-              ],
-              "title": "Reporting period"
-            },
-            {
-              "type": "Question",
-              "id": "reporting-period-block-2",
-              "title": "Reporting period",
-              "questions": [
-                {
-                  "type": "DateRange",
-                  "id": "reporting-period-question-2",
-                  "title": "What are the dates of the period that you will be reporting for?",
-                  "period_limits": {
-                    "minimum": {
-                      "days": 10
-                    },
-                    "maximum": {
-                      "days": 50
-                    }
-                  },
-                  "answers": [
-                    {
-                      "type": "Date",
-                      "id": "period-from",
-                      "label": "From",
-                      "mandatory": true,
-                      "q_code": "11",
-                      "minimum": {
-                        "meta": "ref_p_start_date",
-                        "offset_by": {
-                          "days": -19
-                        }
-                      }
+                        "secondary_content": [{
+                            "id": "how-we-use-your-data",
+                            "title": "How we use your data",
+                            "content": [{
+                                "list": [
+                                    "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
+                                    "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"
+                                ]
+                            }]
+                        }]
                     },
                     {
-                      "type": "Date",
-                      "id": "period-to",
-                      "label": "To",
-                      "mandatory": true,
-                      "q_code": "12",
-                      "maximum": {
-                        "meta": "ref_p_end_date",
-                        "offset_by": {
-                          "days": 20
-                        }
-                      }
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "id": "turnover-block",
-              "type": "Question",
-              "questions": [
-                {
-                  "guidance": {
-                    "content": [
-                      {
-                        "title": "Include:",
-                        "list": [
-                          "income from sub-contracted activities",
-                          "commission",
-                          "sales of goods purchased for resale",
-                          "transport, insurance and packaging charges",
-                          "revenue earned from other parts of the business, not named at the top of this page (please supply at fair value)"
-                        ]
-                      },
-                      {
-                        "title": "Exclude:",
-                        "list": [
-                          "VAT",
-                          "income from the sale of fixed capital assets",
-                          "grants and subsidies",
-                          "insurance claims",
-                          "interest received"
-                        ]
-                      }
-                    ]
-                  },
-                  "id": "turnover-question",
-                  "answers": [
-                    {
-                      "id": "turnover-answer",
-                      "label": "Turnover excluding VAT",
-                      "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
-                      "type": "Currency",
-                      "currency": "GBP",
-                      "decimal_places": 2,
-                      "q_code": "40",
-                      "mandatory": true
-                    }
-                  ],
-                  "type": "General",
-                  "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s <em>turnover</em>, excluding VAT?"
-                }
-              ],
-              "title": "Turnover"
-            },
-            {
-              "type": "ConfirmationQuestion",
-              "title": "Turnover",
-              "id": "confirm-turnover-block",
-              "questions": [
-                {
-                  "type": "General",
-                  "answers": [
-                    {
-                      "type": "Radio",
-                      "id": "confirm-turnover-answer",
-                      "q_code": "d40",
-                      "options": [
-                        {
-                          "label": "Yes this is correct",
-                          "value": "Yes"
-                        },
-                        {
-                          "label": "No I need to change this",
-                          "value": "No"
-                        }
-                      ],
-                      "mandatory": true
-                    }
-                  ],
-                  "id": "confirm-turnover-question",
-                  "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
-                }
-              ],
-              "routing_rules": [
-                {
-                  "goto": {
-                    "when": [
-                      {
-                        "value": "No",
-                        "id": "confirm-turnover-answer",
-                        "condition": "equals"
-                      }
-                    ],
-                    "block": "turnover-block"
-                  }
-                },
-                {
-                  "goto": {
-                    "block": "exports-block"
-                  }
-                }
-              ]
-            },
-            {
-              "id": "exports-block",
-              "type": "Question",
-              "questions": [
-                {
-                  "guidance": {
-                    "content": [
-                      {
-                        "list": [
-                          "All countries outside of England, Scotland, Wales and Northern Ireland"
+                        "id": "reporting-period-block",
+                        "type": "Question",
+                        "questions": [{
+                            "answers": [{
+                                "options": [{
+                                        "value": "Yes",
+                                        "label": "Yes"
+                                    },
+                                    {
+                                        "value": "No",
+                                        "label": "No"
+                                    }
+                                ],
+                                "id": "reporting-period-answer",
+                                "type": "Radio",
+                                "q_code": "d12",
+                                "mandatory": true
+                            }],
+                            "type": "General",
+                            "id": "reporting-period-question",
+                            "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "id": "reporting-period-answer",
+                                        "value": "Yes",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "turnover-block"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "reporting-period-block-2"
+                                }
+                            }
                         ],
-                        "title": "Include:"
-                      }
-                    ]
-                  },
-                  "id": "exports-question",
-                  "answers": [
+                        "title": "Reporting period"
+                    },
                     {
-                      "id": "exports-answer",
-                      "label": "Exports",
-                      "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
-                      "type": "Currency",
-                      "currency": "GBP",
-                      "decimal_places": 2,
-                      "q_code": "49",
-                      "mandatory": true
-                    }
-                  ],
-                  "type": "General",
-                  "title": "What was the value of <em>exports</em>?"
-                }
-              ],
-              "title": "Exports"
-            },
-            {
-              "id": "excise-duty-block",
-              "type": "Question",
-              "questions": [
-                {
-                  "id": "excise-duty-question",
-                  "answers": [
+                        "type": "Question",
+                        "id": "reporting-period-block-2",
+                        "title": "Reporting period",
+                        "questions": [{
+                            "type": "DateRange",
+                            "id": "reporting-period-question-2",
+                            "title": "What are the dates of the period that you will be reporting for?",
+                            "period_limits": {
+                                "minimum": {
+                                    "days": 10
+                                },
+                                "maximum": {
+                                    "days": 50
+                                }
+                            },
+                            "answers": [{
+                                    "type": "Date",
+                                    "id": "period-from",
+                                    "label": "From",
+                                    "mandatory": true,
+                                    "q_code": "11",
+                                    "minimum": {
+                                        "meta": "ref_p_start_date",
+                                        "offset_by": {
+                                            "days": -19
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "Date",
+                                    "id": "period-to",
+                                    "label": "To",
+                                    "mandatory": true,
+                                    "q_code": "12",
+                                    "maximum": {
+                                        "meta": "ref_p_end_date",
+                                        "offset_by": {
+                                            "days": 20
+                                        }
+                                    }
+                                }
+                            ]
+                        }]
+                    },
                     {
-                      "id": "excise-duty-answer",
-                      "label": "Excise duty",
-                      "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
-                      "type": "Currency",
-                      "currency": "GBP",
-                      "decimal_places": 2,
-                      "q_code": "90",
-                      "mandatory": true
-                    }
-                  ],
-                  "type": "General",
-                  "title": "What was the value of <em>excise duty</em>?"
-                }
-              ],
-              "title": "Excise duty"
-            },
-            {
-              "id": "changes-in-turnover-block",
-              "type": "Question",
-              "questions": [
-                {
-                  "title": "Did any significant changes occur to the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
-                  "id": "changes-in-turnover-question",
-                  "definitions": [
+                        "id": "turnover-block",
+                        "type": "Question",
+                        "questions": [{
+                            "guidance": {
+                                "content": [{
+                                        "title": "Include:",
+                                        "list": [
+                                            "income from sub-contracted activities",
+                                            "commission",
+                                            "sales of goods purchased for resale",
+                                            "transport, insurance and packaging charges",
+                                            "revenue earned from other parts of the business, not named at the top of this page (please supply at fair value)"
+                                        ]
+                                    },
+                                    {
+                                        "title": "Exclude:",
+                                        "list": [
+                                            "VAT",
+                                            "income from the sale of fixed capital assets",
+                                            "grants and subsidies",
+                                            "insurance claims",
+                                            "interest received"
+                                        ]
+                                    }
+                                ]
+                            },
+                            "id": "turnover-question",
+                            "answers": [{
+                                "id": "turnover-answer",
+                                "label": "Turnover excluding VAT",
+                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                                "type": "Currency",
+                                "currency": "GBP",
+                                "decimal_places": 2,
+                                "q_code": "40",
+                                "mandatory": true
+                            }],
+                            "type": "General",
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s <em>turnover</em>, excluding VAT?"
+                        }],
+                        "title": "Turnover"
+                    },
                     {
-                      "title": "What constitutes a significant change?",
-                      "content": [
-                        {
-                          "description": "What constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s figures from the previous reporting period and the same reporting period last year."
-                        },
-                        {
-                          "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
-                        }
-                      ]
-                    }
-                  ],
-                  "answers": [
-                    {
-                      "options": [
-                        {
-                          "value": "Yes",
-                          "label": "Yes"
-                        },
-                        {
-                          "value": "No",
-                          "label": "No"
-                        }
-                      ],
-                      "id": "changes-in-turnover-answer",
-                      "type": "Radio",
-                      "q_code": "146",
-                      "mandatory": false
-                    }
-                  ],
-                  "guidance": {
-                    "content": [
-                      {
-                        "title": "Include",
-                        "list": [
-                          "change in level of business activity",
-                          "maintenance/shutdowns",
-                          "special/calendar events",
-                          "weather",
-                          "price effects",
-                          "currency effects (increase/decrease in the currency value)"
+                        "type": "ConfirmationQuestion",
+                        "title": "Turnover",
+                        "id": "confirm-turnover-block",
+                        "questions": [{
+                            "type": "General",
+                            "answers": [{
+                                "type": "Radio",
+                                "id": "confirm-turnover-answer",
+                                "q_code": "d40",
+                                "options": [{
+                                        "label": "Yes this is correct",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No I need to change this",
+                                        "value": "No"
+                                    }
+                                ],
+                                "mandatory": true
+                            }],
+                            "id": "confirm-turnover-question",
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "value": "No",
+                                        "id": "confirm-turnover-answer",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "turnover-block"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "exports-block"
+                                }
+                            }
                         ]
-                      }
-                    ]
-                  },
-                  "type": "General"
-                }
-              ],
-              "title": "Changes in turnover",
-              "routing_rules": [
-                {
-                  "goto": {
-                    "when": [
-                      {
-                        "id": "changes-in-turnover-answer",
-                        "value": "Yes",
-                        "condition": "equals"
-                      }
-                    ],
-                    "block": "changes-in-turnover-block-2"
-                  }
-                },
-                {
-                  "goto": {
-                    "group": "summary-group"
-                  }
-                }
-              ]
-            },
-            {
-              "id": "changes-in-turnover-block-2",
-              "type": "Question",
-              "questions": [
-                {
-                  "title": "Please indicate the reasons for any changes in the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
-                  "answers": [
+                    },
                     {
-                      "options": [
-                        {
-                          "q_code": "146a",
-                          "value": "Change in level of business activity",
-                          "label": "Change in level of business activity"
-                        },
-                        {
-                          "q_code": "146b",
-                          "value": "Maintenance/shutdowns",
-                          "label": "Maintenance/shutdowns"
-                        },
-                        {
-                          "q_code": "146c",
-                          "value": "Special/calendar events",
-                          "label": "Special/calendar events"
-                        },
-                        {
-                          "q_code": "146d",
-                          "value": "Weather",
-                          "label": "Weather"
-                        },
-                        {
-                          "q_code": "146e",
-                          "value": "Price effects",
-                          "label": "Price effects"
-                        },
-                        {
-                          "q_code": "146f",
-                          "value": "Currency effects (increase/decrease in the currency value)",
-                          "label": "Currency effects (increase/decrease in the currency value)"
-                        },
-                        {
-                          "q_code": "146g",
-                          "value": "Other",
-                          "label": "Other"
-                        }
-                      ],
-                      "id": "changes-in-turnover-answer-2",
-                      "type": "Checkbox",
-                      "mandatory": true
-                    }
-                  ],
-                  "type": "General",
-                  "id": "changes-in-turnover-question-2"
-                }
-              ],
-              "title": "Changes in turnover"
-            },
-            {
-              "type": "Question",
-              "id": "changes-in-turnover-block-3",
-              "title": "Changes in turnover",
-              "questions": [
-                {
-                  "type": "General",
-                  "id": "changes-in-turnover-question-3",
-                  "title": "Please describe the changes in turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
-                  "answers": [
+                        "id": "exports-block",
+                        "type": "Question",
+                        "questions": [{
+                            "guidance": {
+                                "content": [{
+                                    "list": [
+                                        "All countries outside of England, Scotland, Wales and Northern Ireland"
+                                    ],
+                                    "title": "Include:"
+                                }]
+                            },
+                            "id": "exports-question",
+                            "answers": [{
+                                "id": "exports-answer",
+                                "label": "Exports",
+                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                                "type": "Currency",
+                                "currency": "GBP",
+                                "decimal_places": 2,
+                                "q_code": "49",
+                                "mandatory": true
+                            }],
+                            "type": "General",
+                            "title": "What was the value of <em>exports</em>?"
+                        }],
+                        "title": "Exports"
+                    },
                     {
-                      "guidance": {
-                        "hide_guidance": "Hide examples of commentary on changes to turnover",
-                        "show_guidance": "Show examples of commentary on changes to turnover",
-                        "content": [
-                          {
-                            "title": "‘Change in level of business activity’",
-                            "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
-                          },
-                          {
-                            "title": "‘Maintenance/shutdowns’",
-                            "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
-                          },
-                          {
-                            "title": "‘Special/calendar events’",
-                            "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
-                          },
-                          {
-                            "title": "‘Weather’",
-                            "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
-                          },
-                          {
-                            "title": "‘Price effects’",
-                            "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
-                          },
-                          {
-                            "title": "‘Currency effects (increase/decrease in the currency value)’",
-                            "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
-                          }
+                        "id": "excise-duty-block",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "excise-duty-question",
+                            "answers": [{
+                                "id": "excise-duty-answer",
+                                "label": "Excise duty",
+                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                                "type": "Currency",
+                                "currency": "GBP",
+                                "decimal_places": 2,
+                                "q_code": "90",
+                                "mandatory": true
+                            }],
+                            "type": "General",
+                            "title": "What was the value of <em>excise duty</em>?"
+                        }],
+                        "title": "Excise duty"
+                    },
+                    {
+                        "id": "changes-in-turnover-block",
+                        "type": "Question",
+                        "questions": [{
+                            "title": "Did any significant changes occur to the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                            "id": "changes-in-turnover-question",
+                            "definitions": [{
+                                "title": "What constitutes a significant change?",
+                                "content": [{
+                                        "description": "What constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s figures from the previous reporting period and the same reporting period last year."
+                                    },
+                                    {
+                                        "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                                    }
+                                ]
+                            }],
+                            "answers": [{
+                                "options": [{
+                                        "value": "Yes",
+                                        "label": "Yes"
+                                    },
+                                    {
+                                        "value": "No",
+                                        "label": "No"
+                                    }
+                                ],
+                                "id": "changes-in-turnover-answer",
+                                "type": "Radio",
+                                "q_code": "146",
+                                "mandatory": false
+                            }],
+                            "guidance": {
+                                "content": [{
+                                    "title": "Include",
+                                    "list": [
+                                        "change in level of business activity",
+                                        "maintenance/shutdowns",
+                                        "special/calendar events",
+                                        "weather",
+                                        "price effects",
+                                        "currency effects (increase/decrease in the currency value)"
+                                    ]
+                                }]
+                            },
+                            "type": "General"
+                        }],
+                        "title": "Changes in turnover",
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "id": "changes-in-turnover-answer",
+                                        "value": "Yes",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "changes-in-turnover-block-2"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "group": "summary-group"
+                                }
+                            }
                         ]
-                      },
-                      "type": "TextArea",
-                      "mandatory": true,
-                      "label": "Comments",
-                      "id": "changes-in-turnover-answer-3",
-                      "q_code": "146h"
+                    },
+                    {
+                        "id": "changes-in-turnover-block-2",
+                        "type": "Question",
+                        "questions": [{
+                            "title": "Please indicate the reasons for any changes in the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
+                            "answers": [{
+                                "options": [{
+                                        "q_code": "146a",
+                                        "value": "Change in level of business activity",
+                                        "label": "Change in level of business activity"
+                                    },
+                                    {
+                                        "q_code": "146b",
+                                        "value": "Maintenance/shutdowns",
+                                        "label": "Maintenance/shutdowns"
+                                    },
+                                    {
+                                        "q_code": "146c",
+                                        "value": "Special/calendar events",
+                                        "label": "Special/calendar events"
+                                    },
+                                    {
+                                        "q_code": "146d",
+                                        "value": "Weather",
+                                        "label": "Weather"
+                                    },
+                                    {
+                                        "q_code": "146e",
+                                        "value": "Price effects",
+                                        "label": "Price effects"
+                                    },
+                                    {
+                                        "q_code": "146f",
+                                        "value": "Currency effects (increase/decrease in the currency value)",
+                                        "label": "Currency effects (increase/decrease in the currency value)"
+                                    },
+                                    {
+                                        "q_code": "146g",
+                                        "value": "Other",
+                                        "label": "Other"
+                                    }
+                                ],
+                                "id": "changes-in-turnover-answer-2",
+                                "type": "Checkbox",
+                                "mandatory": true
+                            }],
+                            "type": "General",
+                            "id": "changes-in-turnover-question-2"
+                        }],
+                        "title": "Changes in turnover"
+                    },
+                    {
+                        "type": "Question",
+                        "id": "changes-in-turnover-block-3",
+                        "title": "Changes in turnover",
+                        "questions": [{
+                            "type": "General",
+                            "id": "changes-in-turnover-question-3",
+                            "title": "Please describe the changes in turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
+                            "answers": [{
+                                "guidance": {
+                                    "hide_guidance": "Hide examples of commentary on changes to turnover",
+                                    "show_guidance": "Show examples of commentary on changes to turnover",
+                                    "content": [{
+                                            "title": "‘Change in level of business activity’",
+                                            "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
+                                        },
+                                        {
+                                            "title": "‘Maintenance/shutdowns’",
+                                            "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
+                                        },
+                                        {
+                                            "title": "‘Special/calendar events’",
+                                            "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
+                                        },
+                                        {
+                                            "title": "‘Weather’",
+                                            "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
+                                        },
+                                        {
+                                            "title": "‘Price effects’",
+                                            "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
+                                        },
+                                        {
+                                            "title": "‘Currency effects (increase/decrease in the currency value)’",
+                                            "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
+                                        }
+                                    ]
+                                },
+                                "type": "TextArea",
+                                "mandatory": true,
+                                "label": "Comments",
+                                "id": "changes-in-turnover-answer-3",
+                                "q_code": "146h"
+                            }],
+                            "description": "<p>We rely on your commentary to ‘tell the story’ behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
+                        }]
                     }
-                  ],
-                  "description": "<p>We rely on your commentary to ‘tell the story’ behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "summary-section",
-      "title": "Summary",
-      "groups": [
+                ]
+            }]
+        },
         {
-          "id": "summary-group",
-          "title": "Summary",
-          "blocks": [
-            {
-              "type": "Summary",
-              "id": "summary"
-            }
-          ]
+            "id": "summary-section",
+            "title": "Summary",
+            "groups": [{
+                "id": "summary-group",
+                "title": "Summary",
+                "blocks": [{
+                    "type": "Summary",
+                    "id": "summary"
+                }]
+            }]
         }
-      ]
-    }
-  ]
+    ]
 }

--- a/data/en/mbs_0205_prototype.json
+++ b/data/en/mbs_0205_prototype.json
@@ -1,0 +1,419 @@
+{
+    "title": "Monthly Business Survey",
+    "survey_id": "009",
+    "mime_type": "application/json/ons/eq",
+    "theme": "default",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.1",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
+    "description": "mbs",
+    "view_submitted_response": {
+        "enabled": true,
+        "duration": 900
+    },
+    "metadata": [{
+        "name": "user_id",
+        "validator": "string"
+    }, {
+        "name": "period_id",
+        "validator": "string"
+    }, {
+        "name": "ru_name",
+        "validator": "string"
+    }, {
+        "name": "ref_p_start_date",
+        "validator": "date"
+    }, {
+        "name": "ref_p_end_date",
+        "validator": "date"
+    }, {
+        "name": "trad_as",
+        "validator": "optional_string"
+    }],
+    "sections": [{
+        "id": "section",
+        "groups": [{
+            "id": "group",
+            "title": "",
+            "blocks": [{
+                "type": "Introduction",
+                "id": "introduction",
+                "primary_content": [{
+                    "type": "Basic",
+                    "id": "use-of-information",
+                    "content": [{
+                        "list": ["Data should relate to all sites in England, Scotland, Wales and Northern Ireland unless otherwise stated.", "You can provide informed estimates if actual figures aren\u2019t available.", "We will treat your data securely and confidentially."]
+                    }]
+                }],
+                "preview_content": {
+                    "id": "preview",
+                    "title": "Information you need",
+                    "content": [{
+                        "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
+                    }],
+                    "questions": [{
+                        "question": "Turnover",
+                        "content": [{
+                            "description": "Include:",
+                            "list": ["income from sub-contracted activities", "commission", "sales of goods purchased for resale", "transport, insurance and packaging charges", "revenue earned from other parts of the business, not named at the top of this page (please supply at fair value)"]
+                        }, {
+                            "description": "Exclude:",
+                            "list": ["VAT", "income from the sale of fixed capital assets", "grants and subsidies", "insurance claims", "interest received"]
+                        }]
+                    }, {
+                        "question": "Value of exports",
+                        "content": [{
+                            "description": "Include:",
+                            "list": ["all countries outside of England, Scotland, Wales and Northern Ireland"]
+                        }]
+                    }, {
+                        "question": "Value of excise duty"
+                    }, {
+                        "question": "Changes in turnover",
+                        "content": [{
+                            "description": "Include:",
+                            "list": ["change in level of business activity", "maintenance/shutdowns", "special/calendar events", "weather", "price effects", "currency effects (increase/decrease in the currency value)"]
+                        }]
+                    }]
+                },
+                "secondary_content": [{
+                    "id": "how-we-use-your-data",
+                    "title": "How we use your data",
+                    "content": [{
+                        "list": ["You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.", "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"]
+                    }]
+                }]
+            }, {
+                "id": "reporting-period-block",
+                "type": "Question",
+                "questions": [{
+                    "answers": [{
+                        "options": [{
+                            "value": "Yes",
+                            "label": "Yes"
+                        }, {
+                            "value": "No",
+                            "label": "No"
+                        }],
+                        "id": "reporting-period-answer",
+                        "type": "Radio",
+                        "q_code": "d12",
+                        "mandatory": true
+                    }],
+                    "type": "General",
+                    "id": "reporting-period-question",
+                    "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
+                }],
+                "routing_rules": [{
+                    "goto": {
+                        "when": [{
+                            "id": "reporting-period-answer",
+                            "value": "Yes",
+                            "condition": "equals"
+                        }],
+                        "block": "turnover-block"
+                    }
+                }, {
+                    "goto": {
+                        "block": "reporting-period-block-2"
+                    }
+                }],
+                "title": "Reporting period"
+            }, {
+                "type": "Question",
+                "id": "reporting-period-block-2",
+                "title": "Reporting period",
+                "questions": [{
+                    "type": "DateRange",
+                    "id": "reporting-period-question-2",
+                    "title": "What are the dates of the period that you will be reporting for?",
+                    "period_limits": {
+                        "minimum": {
+                            "days": 10
+                        },
+                        "maximum": {
+                            "days": 50
+                        }
+                    },
+                    "answers": [{
+                        "type": "Date",
+                        "id": "period-from",
+                        "label": "From",
+                        "mandatory": true,
+                        "q_code": "11",
+                        "minimum": {
+                            "meta": "ref_p_start_date",
+                            "offset_by": {
+                                "days": -19
+                            }
+                        }
+                    }, {
+                        "type": "Date",
+                        "id": "period-to",
+                        "label": "To",
+                        "mandatory": true,
+                        "q_code": "12",
+                        "maximum": {
+                            "meta": "ref_p_end_date",
+                            "offset_by": {
+                                "days": 20
+                            }
+                        }
+                    }]
+                }]
+            }, {
+                "id": "turnover-block",
+                "type": "Question",
+                "questions": [{
+                    "guidance": {
+                        "content": [{
+                            "title": "Include:",
+                            "list": ["income from sub-contracted activities", "commission", "sales of goods purchased for resale", "transport, insurance and packaging charges", "revenue earned from other parts of the business, not named at the top of this page (please supply at fair value)"]
+                        }, {
+                            "title": "Exclude:",
+                            "list": ["VAT", "income from the sale of fixed capital assets", "grants and subsidies", "insurance claims", "interest received"]
+                        }]
+                    },
+                    "id": "turnover-question",
+                    "answers": [{
+                        "id": "turnover-answer",
+                        "label": "Turnover excluding VAT",
+                        "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                        "type": "Currency",
+                        "currency": "GBP",
+                        "decimal_places": 2,
+                        "q_code": "40",
+                        "mandatory": true
+                    }],
+                    "type": "General",
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>turnover</em>, excluding VAT?"
+                }],
+                "title": "Turnover"
+            }, {
+                "type": "ConfirmationQuestion",
+                "title": "Turnover",
+                "id": "confirm-turnover-block",
+                "questions": [{
+                    "type": "General",
+                    "answers": [{
+                        "type": "Radio",
+                        "id": "confirm-turnover-answer",
+                        "q_code": "d40",
+                        "options": [{
+                            "label": "Yes this is correct",
+                            "value": "Yes"
+                        }, {
+                            "label": "No I need to change this",
+                            "value": "No"
+                        }],
+                        "mandatory": true
+                    }],
+                    "id": "confirm-turnover-question",
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
+                }],
+                "routing_rules": [{
+                    "goto": {
+                        "when": [{
+                            "value": "No",
+                            "id": "confirm-turnover-answer",
+                            "condition": "equals"
+                        }],
+                        "block": "turnover-block"
+                    }
+                }, {
+                    "goto": {
+                        "block": "exports-block"
+                    }
+                }]
+            }, {
+                "id": "exports-block",
+                "type": "Question",
+                "questions": [{
+                    "guidance": {
+                        "content": [{
+                            "list": ["All countries outside of England, Scotland, Wales and Northern Ireland"],
+                            "title": "Include:"
+                        }]
+                    },
+                    "id": "exports-question",
+                    "answers": [{
+                        "id": "exports-answer",
+                        "label": "Exports",
+                        "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                        "type": "Currency",
+                        "currency": "GBP",
+                        "decimal_places": 2,
+                        "q_code": "49",
+                        "mandatory": true
+                    }],
+                    "type": "General",
+                    "title": "What was the value of <em>exports</em>?"
+                }],
+                "title": "Exports"
+            }, {
+                "id": "excise-duty-block",
+                "type": "Question",
+                "questions": [{
+                    "id": "excise-duty-question",
+                    "answers": [{
+                        "id": "excise-duty-answer",
+                        "label": "Excise duty",
+                        "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                        "type": "Currency",
+                        "currency": "GBP",
+                        "decimal_places": 2,
+                        "q_code": "90",
+                        "mandatory": true
+                    }],
+                    "type": "General",
+                    "title": "What was the value of <em>excise duty</em>?"
+                }],
+                "title": "Excise duty"
+            }, {
+                "id": "changes-in-turnover-block",
+                "type": "Question",
+                "questions": [{
+                    "title": "Did any significant changes occur to the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                    "id": "changes-in-turnover-question",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
+                        }, {
+                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }]
+                    }],
+                    "answers": [{
+                        "options": [{
+                            "value": "Yes",
+                            "label": "Yes"
+                        }, {
+                            "value": "No",
+                            "label": "No"
+                        }],
+                        "id": "changes-in-turnover-answer",
+                        "type": "Radio",
+                        "q_code": "146",
+                        "mandatory": false
+                    }],
+                    "guidance": {
+                        "content": [{
+                            "title": "Include",
+                            "list": ["change in level of business activity", "maintenance/shutdowns", "special/calendar events", "weather", "price effects", "currency effects (increase/decrease in the currency value)"]
+                        }]
+                    },
+                    "type": "General"
+                }],
+                "title": "Changes in turnover",
+                "routing_rules": [{
+                    "goto": {
+                        "when": [{
+                            "id": "changes-in-turnover-answer",
+                            "value": "Yes",
+                            "condition": "equals"
+                        }],
+                        "block": "changes-in-turnover-block-2"
+                    }
+                }, {
+                    "goto": {
+                        "group": "summary-group"
+                    }
+                }]
+            }, {
+                "id": "changes-in-turnover-block-2",
+                "type": "Question",
+                "questions": [{
+                    "title": "Please indicate the reasons for any changes in the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
+                    "answers": [{
+                        "options": [{
+                            "q_code": "146a",
+                            "value": "Change in level of business activity",
+                            "label": "Change in level of business activity"
+                        }, {
+                            "q_code": "146b",
+                            "value": "Maintenance/shutdowns",
+                            "label": "Maintenance/shutdowns"
+                        }, {
+                            "q_code": "146c",
+                            "value": "Special/calendar events",
+                            "label": "Special/calendar events"
+                        }, {
+                            "q_code": "146d",
+                            "value": "Weather",
+                            "label": "Weather"
+                        }, {
+                            "q_code": "146e",
+                            "value": "Price effects",
+                            "label": "Price effects"
+                        }, {
+                            "q_code": "146f",
+                            "value": "Currency effects (increase/decrease in the currency value)",
+                            "label": "Currency effects (increase/decrease in the currency value)"
+                        }, {
+                            "q_code": "146g",
+                            "value": "Other",
+                            "label": "Other"
+                        }],
+                        "id": "changes-in-turnover-answer-2",
+                        "type": "Checkbox",
+                        "mandatory": true
+                    }],
+                    "type": "General",
+                    "id": "changes-in-turnover-question-2"
+                }],
+                "title": "Changes in turnover"
+            }, {
+                "type": "Question",
+                "id": "changes-in-turnover-block-3",
+                "title": "Changes in turnover",
+                "questions": [{
+                    "type": "General",
+                    "id": "changes-in-turnover-question-3",
+                    "title": "Please describe the changes in turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
+                    "answers": [{
+                        "guidance": {
+                            "hide_guidance": "Hide examples of commentary on changes to turnover",
+                            "show_guidance": "Show examples of commentary on changes to turnover",
+                            "content": [{
+                                "title": "\u2018Change in level of business activity\u2019",
+                                "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
+                            }, {
+                                "title": "\u2018Maintenance/shutdowns\u2019",
+                                "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
+                            }, {
+                                "title": "\u2018Special/calendar events\u2019",
+                                "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
+                            }, {
+                                "title": "\u2018Weather\u2019",
+                                "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
+                            }, {
+                                "title": "\u2018Price effects\u2019",
+                                "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
+                            }, {
+                                "title": "\u2018Currency effects (increase/decrease in the currency value)\u2019",
+                                "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
+                            }]
+                        },
+                        "type": "TextArea",
+                        "mandatory": true,
+                        "label": "Comments",
+                        "id": "changes-in-turnover-answer-3",
+                        "q_code": "146h"
+                    }],
+                    "description": "<p>We rely on your commentary to \u2018tell the story\u2019 behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
+                }]
+            }]
+        }]
+    }, {
+        "id": "summary-section",
+        "title": "Summary",
+        "groups": [{
+            "id": "summary-group",
+            "title": "Summary",
+            "blocks": [{
+                "type": "Summary",
+                "id": "summary"
+            }]
+        }]
+    }]
+}

--- a/data/en/mbs_0216.json
+++ b/data/en/mbs_0216.json
@@ -11,415 +11,597 @@
         "enabled": true,
         "duration": 900
     },
-    "metadata": [{
-        "name": "user_id",
-        "validator": "string"
-    }, {
-        "name": "period_id",
-        "validator": "string"
-    }, {
-        "name": "ru_name",
-        "validator": "string"
-    }, {
-        "name": "ref_p_start_date",
-        "validator": "date"
-    }, {
-        "name": "ref_p_end_date",
-        "validator": "date"
-    }, {
-        "name": "trad_as",
-        "validator": "optional_string"
-    }],
-    "sections": [{
-        "id": "section",
-        "groups": [{
-            "id": "group",
-            "title": "",
-            "blocks": [{
-                "type": "Introduction",
-                "id": "introduction",
-                "primary_content": [{
-                    "type": "Basic",
-                    "id": "use-of-information",
-                    "content": [{
-                        "list": ["Data should relate to all sites in England, Scotland, Wales and Northern Ireland unless otherwise stated.", "You can provide informed estimates if actual figures aren\u2019t available.", "We will treat your data securely and confidentially."]
-                    }]
-                }],
-                "preview_content": {
-                    "id": "preview",
-                    "title": "Information you need",
-                    "content": [{
-                        "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
-                    }],
-                    "questions": [{
-                        "question": "Turnover",
-                        "content": [{
-                            "description": "Include:",
-                            "list": ["income from sub-contracted activities", "commission", "sales of goods purchased for resale", "transport, insurance and packaging charges", "revenue earned from other parts of the business, not named at the top of this page (please supply at fair value)"]
-                        }, {
-                            "description": "Exclude:",
-                            "list": ["VAT", "income from the sale of fixed capital assets", "grants and subsidies", "insurance claims", "interest received"]
-                        }]
-                    }, {
-                        "question": "Value of exports",
-                        "content": [{
-                            "description": "Include:",
-                            "list": ["all countries outside of England, Scotland, Wales and Northern Ireland"]
-                        }]
-                    }, {
-                        "question": "Value of excise duty"
-                    }, {
-                        "question": "Changes in turnover",
-                        "content": [{
-                            "description": "Include:",
-                            "list": ["change in level of business activity", "maintenance/shutdowns", "special/calendar events", "weather", "price effects", "currency effects (increase/decrease in the currency value)"]
-                        }]
-                    }]
-                },
-                "secondary_content": [{
-                    "id": "how-we-use-your-data",
-                    "title": "How we use your data",
-                    "content": [{
-                        "list": ["You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.", "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"]
-                    }]
-                }]
-            }, {
-                "id": "reporting-period-block",
-                "type": "Question",
-                "questions": [{
-                    "answers": [{
-                        "options": [{
-                            "value": "Yes",
-                            "label": "Yes"
-                        }, {
-                            "value": "No",
-                            "label": "No"
-                        }],
-                        "id": "reporting-period-answer",
-                        "type": "Radio",
-                        "q_code": "d12",
-                        "mandatory": true
-                    }],
-                    "type": "General",
-                    "id": "reporting-period-question",
-                    "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
-                }],
-                "routing_rules": [{
-                    "goto": {
-                        "when": [{
-                            "id": "reporting-period-answer",
-                            "value": "Yes",
-                            "condition": "equals"
-                        }],
-                        "block": "turnover-block"
-                    }
-                }, {
-                    "goto": {
-                        "block": "reporting-period-block-2"
-                    }
-                }],
-                "title": "Reporting period"
-            }, {
-                "type": "Question",
-                "id": "reporting-period-block-2",
-                "title": "Reporting period",
-                "questions": [{
-                    "type": "DateRange",
-                    "id": "reporting-period-question-2",
-                    "title": "What are the dates of the period that you will be reporting for?",
-                    "period_limits": {
-                        "minimum": {
-                            "days": 10
+    "metadata": [
+        {
+            "name": "user_id",
+            "validator": "string"
+        },
+        {
+            "name": "period_id",
+            "validator": "string"
+        },
+        {
+            "name": "ru_name",
+            "validator": "string"
+        },
+        {
+            "name": "ref_p_start_date",
+            "validator": "date"
+        },
+        {
+            "name": "ref_p_end_date",
+            "validator": "date"
+        },
+        {
+            "name": "trad_as",
+            "validator": "optional_string"
+        }
+    ],
+    "sections": [
+        {
+            "id": "section",
+            "groups": [
+                {
+                    "id": "group",
+                    "title": "",
+                    "blocks": [
+                        {
+                            "type": "Introduction",
+                            "id": "introduction",
+                            "primary_content": [
+                                {
+                                    "type": "Basic",
+                                    "id": "use-of-information",
+                                    "content": [
+                                        {
+                                            "list": [
+                                                "Data should relate to all sites in England, Scotland, Wales and Northern Ireland unless otherwise stated.",
+                                                "You can provide informed estimates if actual figures aren’t available.",
+                                                "We will treat your data securely and confidentially."
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "preview_content": {
+                                "id": "preview",
+                                "title": "Information you need",
+                                "content": [
+                                    {
+                                        "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
+                                    }
+                                ],
+                                "questions": [
+                                    {
+                                        "question": "Turnover",
+                                        "content": [
+                                            {
+                                                "description": "Include:",
+                                                "list": [
+                                                    "income from sub-contracted activities",
+                                                    "commission",
+                                                    "sales of goods purchased for resale",
+                                                    "transport, insurance and packaging charges",
+                                                    "revenue earned from other parts of the business, not named at the top of this page (please supply at fair value)"
+                                                ]
+                                            },
+                                            {
+                                                "description": "Exclude:",
+                                                "list": [
+                                                    "VAT",
+                                                    "income from the sale of fixed capital assets",
+                                                    "grants and subsidies",
+                                                    "insurance claims",
+                                                    "interest received"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "question": "Value of exports",
+                                        "content": [
+                                            {
+                                                "description": "Include:",
+                                                "list": ["all countries outside of England, Scotland, Wales and Northern Ireland"]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "question": "Value of excise duty"
+                                    },
+                                    {
+                                        "question": "Changes in turnover",
+                                        "content": [
+                                            {
+                                                "description": "Include:",
+                                                "list": [
+                                                    "change in level of business activity",
+                                                    "maintenance/shutdowns",
+                                                    "special/calendar events",
+                                                    "weather",
+                                                    "price effects",
+                                                    "currency effects (increase/decrease in the currency value)"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "secondary_content": [
+                                {
+                                    "id": "how-we-use-your-data",
+                                    "title": "How we use your data",
+                                    "content": [
+                                        {
+                                            "list": [
+                                                "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
+                                                "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
                         },
-                        "maximum": {
-                            "days": 50
-                        }
-                    },
-                    "answers": [{
-                        "type": "Date",
-                        "id": "period-from",
-                        "label": "From",
-                        "mandatory": true,
-                        "q_code": "11",
-                        "minimum": {
-                            "meta": "ref_p_start_date",
-                            "offset_by": {
-                                "days": -19
-                            }
-                        }
-                    }, {
-                        "type": "Date",
-                        "id": "period-to",
-                        "label": "To",
-                        "mandatory": true,
-                        "q_code": "12",
-                        "maximum": {
-                            "meta": "ref_p_end_date",
-                            "offset_by": {
-                                "days": 20
-                            }
-                        }
-                    }]
-                }]
-            }, {
-                "id": "turnover-block",
-                "type": "Question",
-                "questions": [{
-                    "guidance": {
-                        "content": [{
-                            "title": "Include:",
-                            "list": ["income from sub-contracted activities", "commission", "sales of goods purchased for resale", "transport, insurance and packaging charges", "revenue earned from other parts of the business, not named at the top of this page (please supply at fair value)"]
-                        }, {
-                            "title": "Exclude:",
-                            "list": ["VAT", "income from the sale of fixed capital assets", "grants and subsidies", "insurance claims", "interest received"]
-                        }]
-                    },
-                    "id": "turnover-question",
-                    "answers": [{
-                        "id": "turnover-answer",
-                        "label": "Turnover excluding VAT",
-                        "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
-                        "type": "Currency",
-                        "currency": "GBP",
-                        "decimal_places": 2,
-                        "q_code": "40",
-                        "mandatory": true
-                    }],
-                    "type": "General",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>turnover</em>, excluding VAT?"
-                }],
-                "title": "Turnover"
-            }, {
-                "type": "ConfirmationQuestion",
-                "title": "Turnover",
-                "id": "confirm-turnover-block",
-                "questions": [{
-                    "type": "General",
-                    "answers": [{
-                        "type": "Radio",
-                        "id": "confirm-turnover-answer",
-                        "q_code": "d40",
-                        "options": [{
-                            "label": "Yes this is correct",
-                            "value": "Yes"
-                        }, {
-                            "label": "No I need to change this",
-                            "value": "No"
-                        }],
-                        "mandatory": true
-                    }],
-                    "id": "confirm-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
-                }],
-                "routing_rules": [{
-                    "goto": {
-                        "when": [{
-                            "value": "No",
-                            "id": "confirm-turnover-answer",
-                            "condition": "equals"
-                        }],
-                        "block": "turnover-block"
-                    }
-                }, {
-                    "goto": {
-                        "block": "exports-block"
-                    }
-                }]
-            }, {
-                "id": "exports-block",
-                "type": "Question",
-                "questions": [{
-                    "guidance": {
-                        "content": [{
-                            "list": ["All countries outside of England, Scotland, Wales and Northern Ireland"],
-                            "title": "Include:"
-                        }]
-                    },
-                    "id": "exports-question",
-                    "answers": [{
-                        "id": "exports-answer",
-                        "label": "Exports",
-                        "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
-                        "type": "Currency",
-                        "currency": "GBP",
-                        "decimal_places": 2,
-                        "q_code": "49",
-                        "mandatory": true
-                    }],
-                    "type": "General",
-                    "title": "What was the value of <em>exports</em>?"
-                }],
-                "title": "Exports"
-            }, {
-                "id": "excise-duty-block",
-                "type": "Question",
-                "questions": [{
-                    "id": "excise-duty-question",
-                    "answers": [{
-                        "id": "excise-duty-answer",
-                        "label": "Excise duty",
-                        "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
-                        "type": "Currency",
-                        "currency": "GBP",
-                        "decimal_places": 2,
-                        "q_code": "90",
-                        "mandatory": true
-                    }],
-                    "type": "General",
-                    "title": "What was the value of <em>excise duty</em>?"
-                }],
-                "title": "Excise duty"
-            }, {
-                "id": "changes-in-turnover-block",
-                "type": "Question",
-                "questions": [{
-                    "title": "Did any significant changes occur to the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
-                    "id": "changes-in-turnover-question",
-                    "definitions": [{
-                        "title": "What constitutes a significant change?",
-                        "content": [{
-                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
-                        }, {
-                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
-                        }]
-                    }],
-                    "answers": [{
-                        "options": [{
-                            "value": "Yes",
-                            "label": "Yes"
-                        }, {
-                            "value": "No",
-                            "label": "No"
-                        }],
-                        "id": "changes-in-turnover-answer",
-                        "type": "Radio",
-                        "q_code": "146",
-                        "mandatory": false
-                    }],
-                    "guidance": {
-                        "content": [{
-                            "title": "Include",
-                            "list": ["change in level of business activity", "maintenance/shutdowns", "special/calendar events", "weather", "price effects", "currency effects (increase/decrease in the currency value)"]
-                        }]
-                    },
-                    "type": "General"
-                }],
-                "title": "Changes in turnover",
-                "routing_rules": [{
-                    "goto": {
-                        "when": [{
-                            "id": "changes-in-turnover-answer",
-                            "value": "Yes",
-                            "condition": "equals"
-                        }],
-                        "block": "changes-in-turnover-block-2"
-                    }
-                }, {
-                    "goto": {
-                        "group": "summary-group"
-                    }
-                }]
-            }, {
-                "id": "changes-in-turnover-block-2",
-                "type": "Question",
-                "questions": [{
-                    "title": "Please indicate the reasons for any changes in the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
-                    "answers": [{
-                        "options": [{
-                            "q_code": "146a",
-                            "value": "Change in level of business activity",
-                            "label": "Change in level of business activity"
-                        }, {
-                            "q_code": "146b",
-                            "value": "Maintenance/shutdowns",
-                            "label": "Maintenance/shutdowns"
-                        }, {
-                            "q_code": "146c",
-                            "value": "Special/calendar events",
-                            "label": "Special/calendar events"
-                        }, {
-                            "q_code": "146d",
-                            "value": "Weather",
-                            "label": "Weather"
-                        }, {
-                            "q_code": "146e",
-                            "value": "Price effects",
-                            "label": "Price effects"
-                        }, {
-                            "q_code": "146f",
-                            "value": "Currency effects (increase/decrease in the currency value)",
-                            "label": "Currency effects (increase/decrease in the currency value)"
-                        }, {
-                            "q_code": "146g",
-                            "value": "Other",
-                            "label": "Other"
-                        }],
-                        "id": "changes-in-turnover-answer-2",
-                        "type": "Checkbox",
-                        "mandatory": true
-                    }],
-                    "type": "General",
-                    "id": "changes-in-turnover-question-2"
-                }],
-                "title": "Changes in turnover"
-            }, {
-                "type": "Question",
-                "id": "changes-in-turnover-block-3",
-                "title": "Changes in turnover",
-                "questions": [{
-                    "type": "General",
-                    "id": "changes-in-turnover-question-3",
-                    "title": "Please describe the changes in turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
-                    "answers": [{
-                        "guidance": {
-                            "hide_guidance": "Hide examples of commentary on changes to turnover",
-                            "show_guidance": "Show examples of commentary on changes to turnover",
-                            "content": [{
-                                "list": [],
-                                "title": "\u2018Change in level of business activity\u2019",
-                                "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
-                            }, {
-                                "list": [],
-                                "title": "\u2018Maintenance/shutdowns\u2019",
-                                "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
-                            }, {
-                                "list": [],
-                                "title": "\u2018Special/calendar events\u2019",
-                                "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
-                            }, {
-                                "list": [],
-                                "title": "\u2018Weather\u2019",
-                                "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
-                            }, {
-                                "list": [],
-                                "title": "\u2018Price effects\u2019",
-                                "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
-                            }, {
-                                "list": [],
-                                "title": "\u2018Currency effects (increase/decrease in the currency value)\u2019",
-                                "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
-                            }]
+                        {
+                            "id": "reporting-period-block",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "options": [
+                                                {
+                                                    "value": "Yes",
+                                                    "label": "Yes"
+                                                },
+                                                {
+                                                    "value": "No",
+                                                    "label": "No"
+                                                }
+                                            ],
+                                            "id": "reporting-period-answer",
+                                            "type": "Radio",
+                                            "q_code": "d12",
+                                            "mandatory": true
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "id": "reporting-period-question",
+                                    "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "when": [
+                                            {
+                                                "id": "reporting-period-answer",
+                                                "value": "Yes",
+                                                "condition": "equals"
+                                            }
+                                        ],
+                                        "block": "turnover-block"
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "reporting-period-block-2"
+                                    }
+                                }
+                            ],
+                            "title": "Reporting period"
                         },
-                        "type": "TextArea",
-                        "mandatory": true,
-                        "label": "Comments",
-                        "id": "changes-in-turnover-answer-3",
-                        "q_code": "146h"
-                    }],
-                    "description": "<p>We rely on your commentary to \u2018tell the story\u2019 behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
-                }]
-            }]
-        }]
-    }, {
-        "id": "summary-section",
-        "title": "Summary",
-        "groups": [{
-            "id": "summary-group",
+                        {
+                            "type": "Question",
+                            "id": "reporting-period-block-2",
+                            "title": "Reporting period",
+                            "questions": [
+                                {
+                                    "type": "DateRange",
+                                    "id": "reporting-period-question-2",
+                                    "title": "What are the dates of the period that you will be reporting for?",
+                                    "period_limits": {
+                                        "minimum": {
+                                            "days": 10
+                                        },
+                                        "maximum": {
+                                            "days": 50
+                                        }
+                                    },
+                                    "answers": [
+                                        {
+                                            "type": "Date",
+                                            "id": "period-from",
+                                            "label": "From",
+                                            "mandatory": true,
+                                            "q_code": "11",
+                                            "minimum": {
+                                                "meta": "ref_p_start_date",
+                                                "offset_by": {
+                                                    "days": -19
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "type": "Date",
+                                            "id": "period-to",
+                                            "label": "To",
+                                            "mandatory": true,
+                                            "q_code": "12",
+                                            "maximum": {
+                                                "meta": "ref_p_end_date",
+                                                "offset_by": {
+                                                    "days": 20
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "turnover-block",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "guidance": {
+                                        "content": [
+                                            {
+                                                "title": "Include:",
+                                                "list": [
+                                                    "income from sub-contracted activities",
+                                                    "commission",
+                                                    "sales of goods purchased for resale",
+                                                    "transport, insurance and packaging charges",
+                                                    "revenue earned from other parts of the business, not named at the top of this page (please supply at fair value)"
+                                                ]
+                                            },
+                                            {
+                                                "title": "Exclude:",
+                                                "list": [
+                                                    "VAT",
+                                                    "income from the sale of fixed capital assets",
+                                                    "grants and subsidies",
+                                                    "insurance claims",
+                                                    "interest received"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "id": "turnover-question",
+                                    "answers": [
+                                        {
+                                            "id": "turnover-answer",
+                                            "label": "Turnover excluding VAT",
+                                            "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                                            "type": "Currency",
+                                            "currency": "GBP",
+                                            "decimal_places": 2,
+                                            "q_code": "40",
+                                            "mandatory": true
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s <em>turnover</em>, excluding VAT?"
+                                }
+                            ],
+                            "title": "Turnover"
+                        },
+                        {
+                            "type": "ConfirmationQuestion",
+                            "title": "Turnover",
+                            "id": "confirm-turnover-block",
+                            "questions": [
+                                {
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "type": "Radio",
+                                            "id": "confirm-turnover-answer",
+                                            "q_code": "d40",
+                                            "options": [
+                                                {
+                                                    "label": "Yes this is correct",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No I need to change this",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "mandatory": true
+                                        }
+                                    ],
+                                    "id": "confirm-turnover-question",
+                                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "when": [
+                                            {
+                                                "value": "No",
+                                                "id": "confirm-turnover-answer",
+                                                "condition": "equals"
+                                            }
+                                        ],
+                                        "block": "turnover-block"
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "exports-block"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "id": "exports-block",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "guidance": {
+                                        "content": [
+                                            {
+                                                "list": ["All countries outside of England, Scotland, Wales and Northern Ireland"],
+                                                "title": "Include:"
+                                            }
+                                        ]
+                                    },
+                                    "id": "exports-question",
+                                    "answers": [
+                                        {
+                                            "id": "exports-answer",
+                                            "label": "Exports",
+                                            "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                                            "type": "Currency",
+                                            "currency": "GBP",
+                                            "decimal_places": 2,
+                                            "q_code": "49",
+                                            "mandatory": true
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "title": "What was the value of <em>exports</em>?"
+                                }
+                            ],
+                            "title": "Exports"
+                        },
+                        {
+                            "id": "excise-duty-block",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "id": "excise-duty-question",
+                                    "answers": [
+                                        {
+                                            "id": "excise-duty-answer",
+                                            "label": "Excise duty",
+                                            "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                                            "type": "Currency",
+                                            "currency": "GBP",
+                                            "decimal_places": 2,
+                                            "q_code": "90",
+                                            "mandatory": true
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "title": "What was the value of <em>excise duty</em>?"
+                                }
+                            ],
+                            "title": "Excise duty"
+                        },
+                        {
+                            "id": "changes-in-turnover-block",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "title": "Did any significant changes occur to the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                                    "id": "changes-in-turnover-question",
+                                    "definitions": [
+                                        {
+                                            "title": "What constitutes a significant change?",
+                                            "content": [
+                                                {
+                                                    "description": "What constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s figures from the previous reporting period and the same reporting period last year."
+                                                },
+                                                {
+                                                    "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "answers": [
+                                        {
+                                            "options": [
+                                                {
+                                                    "value": "Yes",
+                                                    "label": "Yes"
+                                                },
+                                                {
+                                                    "value": "No",
+                                                    "label": "No"
+                                                }
+                                            ],
+                                            "id": "changes-in-turnover-answer",
+                                            "type": "Radio",
+                                            "q_code": "146",
+                                            "mandatory": false
+                                        }
+                                    ],
+                                    "guidance": {
+                                        "content": [
+                                            {
+                                                "title": "Include",
+                                                "list": [
+                                                    "change in level of business activity",
+                                                    "maintenance/shutdowns",
+                                                    "special/calendar events",
+                                                    "weather",
+                                                    "price effects",
+                                                    "currency effects (increase/decrease in the currency value)"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Changes in turnover",
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "when": [
+                                            {
+                                                "id": "changes-in-turnover-answer",
+                                                "value": "Yes",
+                                                "condition": "equals"
+                                            }
+                                        ],
+                                        "block": "changes-in-turnover-block-2"
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "group": "summary-group"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "id": "changes-in-turnover-block-2",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "title": "Please indicate the reasons for any changes in the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
+                                    "answers": [
+                                        {
+                                            "options": [
+                                                {
+                                                    "q_code": "146a",
+                                                    "value": "Change in level of business activity",
+                                                    "label": "Change in level of business activity"
+                                                },
+                                                {
+                                                    "q_code": "146b",
+                                                    "value": "Maintenance/shutdowns",
+                                                    "label": "Maintenance/shutdowns"
+                                                },
+                                                {
+                                                    "q_code": "146c",
+                                                    "value": "Special/calendar events",
+                                                    "label": "Special/calendar events"
+                                                },
+                                                {
+                                                    "q_code": "146d",
+                                                    "value": "Weather",
+                                                    "label": "Weather"
+                                                },
+                                                {
+                                                    "q_code": "146e",
+                                                    "value": "Price effects",
+                                                    "label": "Price effects"
+                                                },
+                                                {
+                                                    "q_code": "146f",
+                                                    "value": "Currency effects (increase/decrease in the currency value)",
+                                                    "label": "Currency effects (increase/decrease in the currency value)"
+                                                },
+                                                {
+                                                    "q_code": "146g",
+                                                    "value": "Other",
+                                                    "label": "Other"
+                                                }
+                                            ],
+                                            "id": "changes-in-turnover-answer-2",
+                                            "type": "Checkbox",
+                                            "mandatory": true
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "id": "changes-in-turnover-question-2"
+                                }
+                            ],
+                            "title": "Changes in turnover"
+                        },
+                        {
+                            "type": "Question",
+                            "id": "changes-in-turnover-block-3",
+                            "title": "Changes in turnover",
+                            "questions": [
+                                {
+                                    "type": "General",
+                                    "id": "changes-in-turnover-question-3",
+                                    "title": "Please describe the changes in turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
+                                    "answers": [
+                                        {
+                                            "guidance": {
+                                                "hide_guidance": "Hide examples of commentary on changes to turnover",
+                                                "show_guidance": "Show examples of commentary on changes to turnover",
+                                                "content": [
+                                                    {
+                                                        "list": [],
+                                                        "title": "‘Change in level of business activity’",
+                                                        "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
+                                                    },
+                                                    {
+                                                        "list": [],
+                                                        "title": "‘Maintenance/shutdowns’",
+                                                        "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
+                                                    },
+                                                    {
+                                                        "list": [],
+                                                        "title": "‘Special/calendar events’",
+                                                        "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
+                                                    },
+                                                    {
+                                                        "list": [],
+                                                        "title": "‘Weather’",
+                                                        "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
+                                                    },
+                                                    {
+                                                        "list": [],
+                                                        "title": "‘Price effects’",
+                                                        "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
+                                                    },
+                                                    {
+                                                        "list": [],
+                                                        "title": "‘Currency effects (increase/decrease in the currency value)’",
+                                                        "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
+                                                    }
+                                                ]
+                                            },
+                                            "type": "TextArea",
+                                            "mandatory": true,
+                                            "label": "Comments",
+                                            "id": "changes-in-turnover-answer-3",
+                                            "q_code": "146h"
+                                        }
+                                    ],
+                                    "description": "<p>We rely on your commentary to ‘tell the story’ behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "summary-section",
             "title": "Summary",
-            "blocks": [{
-                "type": "Summary",
-                "id": "summary"
-            }]
-        }]
-    }]
+            "groups": [
+                {
+                    "id": "summary-group",
+                    "title": "Summary",
+                    "blocks": [
+                        {
+                            "type": "Summary",
+                            "id": "summary"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
 }

--- a/data/en/mbs_0216.json
+++ b/data/en/mbs_0216.json
@@ -11,8 +11,7 @@
         "enabled": true,
         "duration": 900
     },
-    "metadata": [
-        {
+    "metadata": [{
             "name": "user_id",
             "validator": "string"
         },
@@ -37,571 +36,490 @@
             "validator": "optional_string"
         }
     ],
-    "sections": [
-        {
+    "sections": [{
             "id": "section",
-            "groups": [
-                {
-                    "id": "group",
-                    "title": "",
-                    "blocks": [
-                        {
-                            "type": "Introduction",
-                            "id": "introduction",
-                            "primary_content": [
-                                {
-                                    "type": "Basic",
-                                    "id": "use-of-information",
-                                    "content": [
-                                        {
+            "groups": [{
+                "id": "group",
+                "title": "",
+                "blocks": [{
+                        "type": "Introduction",
+                        "id": "introduction",
+                        "primary_content": [{
+                            "type": "Basic",
+                            "id": "use-of-information",
+                            "content": [{
+                                "list": [
+                                    "Data should relate to all sites in England, Scotland, Wales and Northern Ireland unless otherwise stated.",
+                                    "You can provide informed estimates if actual figures aren’t available.",
+                                    "We will treat your data securely and confidentially."
+                                ]
+                            }]
+                        }],
+                        "preview_content": {
+                            "id": "preview",
+                            "title": "Information you need",
+                            "content": [{
+                                "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
+                            }],
+                            "questions": [{
+                                    "question": "Turnover",
+                                    "content": [{
+                                            "description": "Include:",
                                             "list": [
-                                                "Data should relate to all sites in England, Scotland, Wales and Northern Ireland unless otherwise stated.",
-                                                "You can provide informed estimates if actual figures aren’t available.",
-                                                "We will treat your data securely and confidentially."
+                                                "income from sub-contracted activities",
+                                                "commission",
+                                                "sales of goods purchased for resale",
+                                                "transport, insurance and packaging charges",
+                                                "revenue earned from other parts of the business, not named at the top of this page (please supply at fair value)"
+                                            ]
+                                        },
+                                        {
+                                            "description": "Exclude:",
+                                            "list": [
+                                                "VAT",
+                                                "income from the sale of fixed capital assets",
+                                                "grants and subsidies",
+                                                "insurance claims",
+                                                "interest received"
                                             ]
                                         }
                                     ]
+                                },
+                                {
+                                    "question": "Value of exports",
+                                    "content": [{
+                                        "description": "Include:",
+                                        "list": ["all countries outside of England, Scotland, Wales and Northern Ireland"]
+                                    }]
+                                },
+                                {
+                                    "question": "Value of excise duty"
+                                },
+                                {
+                                    "question": "Changes in turnover",
+                                    "content": [{
+                                        "description": "Include:",
+                                        "list": [
+                                            "change in level of business activity",
+                                            "maintenance/shutdowns",
+                                            "special/calendar events",
+                                            "weather",
+                                            "price effects",
+                                            "currency effects (increase/decrease in the currency value)"
+                                        ]
+                                    }]
                                 }
-                            ],
-                            "preview_content": {
-                                "id": "preview",
-                                "title": "Information you need",
-                                "content": [
+                            ]
+                        },
+                        "secondary_content": [{
+                            "id": "how-we-use-your-data",
+                            "title": "How we use your data",
+                            "content": [{
+                                "list": [
+                                    "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
+                                    "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"
+                                ]
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "reporting-period-block",
+                        "type": "Question",
+                        "questions": [{
+                            "answers": [{
+                                "options": [{
+                                        "value": "Yes",
+                                        "label": "Yes"
+                                    },
                                     {
-                                        "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
+                                        "value": "No",
+                                        "label": "No"
                                     }
                                 ],
-                                "questions": [
-                                    {
-                                        "question": "Turnover",
-                                        "content": [
-                                            {
-                                                "description": "Include:",
-                                                "list": [
-                                                    "income from sub-contracted activities",
-                                                    "commission",
-                                                    "sales of goods purchased for resale",
-                                                    "transport, insurance and packaging charges",
-                                                    "revenue earned from other parts of the business, not named at the top of this page (please supply at fair value)"
-                                                ]
-                                            },
-                                            {
-                                                "description": "Exclude:",
-                                                "list": [
-                                                    "VAT",
-                                                    "income from the sale of fixed capital assets",
-                                                    "grants and subsidies",
-                                                    "insurance claims",
-                                                    "interest received"
-                                                ]
-                                            }
+                                "id": "reporting-period-answer",
+                                "type": "Radio",
+                                "q_code": "d12",
+                                "mandatory": true
+                            }],
+                            "type": "General",
+                            "id": "reporting-period-question",
+                            "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "id": "reporting-period-answer",
+                                        "value": "Yes",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "turnover-block"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "reporting-period-block-2"
+                                }
+                            }
+                        ],
+                        "title": "Reporting period"
+                    },
+                    {
+                        "type": "Question",
+                        "id": "reporting-period-block-2",
+                        "title": "Reporting period",
+                        "questions": [{
+                            "type": "DateRange",
+                            "id": "reporting-period-question-2",
+                            "title": "What are the dates of the period that you will be reporting for?",
+                            "period_limits": {
+                                "minimum": {
+                                    "days": 10
+                                },
+                                "maximum": {
+                                    "days": 50
+                                }
+                            },
+                            "answers": [{
+                                    "type": "Date",
+                                    "id": "period-from",
+                                    "label": "From",
+                                    "mandatory": true,
+                                    "q_code": "11",
+                                    "minimum": {
+                                        "meta": "ref_p_start_date",
+                                        "offset_by": {
+                                            "days": -19
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "Date",
+                                    "id": "period-to",
+                                    "label": "To",
+                                    "mandatory": true,
+                                    "q_code": "12",
+                                    "maximum": {
+                                        "meta": "ref_p_end_date",
+                                        "offset_by": {
+                                            "days": 20
+                                        }
+                                    }
+                                }
+                            ]
+                        }]
+                    },
+                    {
+                        "id": "turnover-block",
+                        "type": "Question",
+                        "questions": [{
+                            "guidance": {
+                                "content": [{
+                                        "title": "Include:",
+                                        "list": [
+                                            "income from sub-contracted activities",
+                                            "commission",
+                                            "sales of goods purchased for resale",
+                                            "transport, insurance and packaging charges",
+                                            "revenue earned from other parts of the business, not named at the top of this page (please supply at fair value)"
                                         ]
                                     },
                                     {
-                                        "question": "Value of exports",
-                                        "content": [
-                                            {
-                                                "description": "Include:",
-                                                "list": ["all countries outside of England, Scotland, Wales and Northern Ireland"]
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "question": "Value of excise duty"
-                                    },
-                                    {
-                                        "question": "Changes in turnover",
-                                        "content": [
-                                            {
-                                                "description": "Include:",
-                                                "list": [
-                                                    "change in level of business activity",
-                                                    "maintenance/shutdowns",
-                                                    "special/calendar events",
-                                                    "weather",
-                                                    "price effects",
-                                                    "currency effects (increase/decrease in the currency value)"
-                                                ]
-                                            }
+                                        "title": "Exclude:",
+                                        "list": [
+                                            "VAT",
+                                            "income from the sale of fixed capital assets",
+                                            "grants and subsidies",
+                                            "insurance claims",
+                                            "interest received"
                                         ]
                                     }
                                 ]
                             },
-                            "secondary_content": [
-                                {
-                                    "id": "how-we-use-your-data",
-                                    "title": "How we use your data",
-                                    "content": [
+                            "id": "turnover-question",
+                            "answers": [{
+                                "id": "turnover-answer",
+                                "label": "Turnover excluding VAT",
+                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                                "type": "Currency",
+                                "currency": "GBP",
+                                "decimal_places": 2,
+                                "q_code": "40",
+                                "mandatory": true
+                            }],
+                            "type": "General",
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s <em>turnover</em>, excluding VAT?"
+                        }],
+                        "title": "Turnover"
+                    },
+                    {
+                        "type": "ConfirmationQuestion",
+                        "title": "Turnover",
+                        "id": "confirm-turnover-block",
+                        "questions": [{
+                            "type": "General",
+                            "answers": [{
+                                "type": "Radio",
+                                "id": "confirm-turnover-answer",
+                                "q_code": "d40",
+                                "options": [{
+                                        "label": "Yes this is correct",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No I need to change this",
+                                        "value": "No"
+                                    }
+                                ],
+                                "mandatory": true
+                            }],
+                            "id": "confirm-turnover-question",
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "value": "No",
+                                        "id": "confirm-turnover-answer",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "turnover-block"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "exports-block"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "exports-block",
+                        "type": "Question",
+                        "questions": [{
+                            "guidance": {
+                                "content": [{
+                                    "list": ["All countries outside of England, Scotland, Wales and Northern Ireland"],
+                                    "title": "Include:"
+                                }]
+                            },
+                            "id": "exports-question",
+                            "answers": [{
+                                "id": "exports-answer",
+                                "label": "Exports",
+                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                                "type": "Currency",
+                                "currency": "GBP",
+                                "decimal_places": 2,
+                                "q_code": "49",
+                                "mandatory": true
+                            }],
+                            "type": "General",
+                            "title": "What was the value of <em>exports</em>?"
+                        }],
+                        "title": "Exports"
+                    },
+                    {
+                        "id": "excise-duty-block",
+                        "type": "Question",
+                        "questions": [{
+                            "id": "excise-duty-question",
+                            "answers": [{
+                                "id": "excise-duty-answer",
+                                "label": "Excise duty",
+                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                                "type": "Currency",
+                                "currency": "GBP",
+                                "decimal_places": 2,
+                                "q_code": "90",
+                                "mandatory": true
+                            }],
+                            "type": "General",
+                            "title": "What was the value of <em>excise duty</em>?"
+                        }],
+                        "title": "Excise duty"
+                    },
+                    {
+                        "id": "changes-in-turnover-block",
+                        "type": "Question",
+                        "questions": [{
+                            "title": "Did any significant changes occur to the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                            "id": "changes-in-turnover-question",
+                            "definitions": [{
+                                "title": "What constitutes a significant change?",
+                                "content": [{
+                                        "description": "What constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s figures from the previous reporting period and the same reporting period last year."
+                                    },
+                                    {
+                                        "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                                    }
+                                ]
+                            }],
+                            "answers": [{
+                                "options": [{
+                                        "value": "Yes",
+                                        "label": "Yes"
+                                    },
+                                    {
+                                        "value": "No",
+                                        "label": "No"
+                                    }
+                                ],
+                                "id": "changes-in-turnover-answer",
+                                "type": "Radio",
+                                "q_code": "146",
+                                "mandatory": false
+                            }],
+                            "guidance": {
+                                "content": [{
+                                    "title": "Include",
+                                    "list": [
+                                        "change in level of business activity",
+                                        "maintenance/shutdowns",
+                                        "special/calendar events",
+                                        "weather",
+                                        "price effects",
+                                        "currency effects (increase/decrease in the currency value)"
+                                    ]
+                                }]
+                            },
+                            "type": "General"
+                        }],
+                        "title": "Changes in turnover",
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "id": "changes-in-turnover-answer",
+                                        "value": "Yes",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "changes-in-turnover-block-2"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "group": "summary-group"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "changes-in-turnover-block-2",
+                        "type": "Question",
+                        "questions": [{
+                            "title": "Please indicate the reasons for any changes in the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
+                            "answers": [{
+                                "options": [{
+                                        "q_code": "146a",
+                                        "value": "Change in level of business activity",
+                                        "label": "Change in level of business activity"
+                                    },
+                                    {
+                                        "q_code": "146b",
+                                        "value": "Maintenance/shutdowns",
+                                        "label": "Maintenance/shutdowns"
+                                    },
+                                    {
+                                        "q_code": "146c",
+                                        "value": "Special/calendar events",
+                                        "label": "Special/calendar events"
+                                    },
+                                    {
+                                        "q_code": "146d",
+                                        "value": "Weather",
+                                        "label": "Weather"
+                                    },
+                                    {
+                                        "q_code": "146e",
+                                        "value": "Price effects",
+                                        "label": "Price effects"
+                                    },
+                                    {
+                                        "q_code": "146f",
+                                        "value": "Currency effects (increase/decrease in the currency value)",
+                                        "label": "Currency effects (increase/decrease in the currency value)"
+                                    },
+                                    {
+                                        "q_code": "146g",
+                                        "value": "Other",
+                                        "label": "Other"
+                                    }
+                                ],
+                                "id": "changes-in-turnover-answer-2",
+                                "type": "Checkbox",
+                                "mandatory": true
+                            }],
+                            "type": "General",
+                            "id": "changes-in-turnover-question-2"
+                        }],
+                        "title": "Changes in turnover"
+                    },
+                    {
+                        "type": "Question",
+                        "id": "changes-in-turnover-block-3",
+                        "title": "Changes in turnover",
+                        "questions": [{
+                            "type": "General",
+                            "id": "changes-in-turnover-question-3",
+                            "title": "Please describe the changes in turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
+                            "answers": [{
+                                "guidance": {
+                                    "hide_guidance": "Hide examples of commentary on changes to turnover",
+                                    "show_guidance": "Show examples of commentary on changes to turnover",
+                                    "content": [{
+                                            "list": [],
+                                            "title": "‘Change in level of business activity’",
+                                            "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
+                                        },
                                         {
-                                            "list": [
-                                                "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
-                                                "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"
-                                            ]
+                                            "list": [],
+                                            "title": "‘Maintenance/shutdowns’",
+                                            "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
+                                        },
+                                        {
+                                            "list": [],
+                                            "title": "‘Special/calendar events’",
+                                            "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
+                                        },
+                                        {
+                                            "list": [],
+                                            "title": "‘Weather’",
+                                            "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
+                                        },
+                                        {
+                                            "list": [],
+                                            "title": "‘Price effects’",
+                                            "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
+                                        },
+                                        {
+                                            "list": [],
+                                            "title": "‘Currency effects (increase/decrease in the currency value)’",
+                                            "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
                                         }
                                     ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "reporting-period-block",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "answers": [
-                                        {
-                                            "options": [
-                                                {
-                                                    "value": "Yes",
-                                                    "label": "Yes"
-                                                },
-                                                {
-                                                    "value": "No",
-                                                    "label": "No"
-                                                }
-                                            ],
-                                            "id": "reporting-period-answer",
-                                            "type": "Radio",
-                                            "q_code": "d12",
-                                            "mandatory": true
-                                        }
-                                    ],
-                                    "type": "General",
-                                    "id": "reporting-period-question",
-                                    "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "when": [
-                                            {
-                                                "id": "reporting-period-answer",
-                                                "value": "Yes",
-                                                "condition": "equals"
-                                            }
-                                        ],
-                                        "block": "turnover-block"
-                                    }
                                 },
-                                {
-                                    "goto": {
-                                        "block": "reporting-period-block-2"
-                                    }
-                                }
-                            ],
-                            "title": "Reporting period"
-                        },
-                        {
-                            "type": "Question",
-                            "id": "reporting-period-block-2",
-                            "title": "Reporting period",
-                            "questions": [
-                                {
-                                    "type": "DateRange",
-                                    "id": "reporting-period-question-2",
-                                    "title": "What are the dates of the period that you will be reporting for?",
-                                    "period_limits": {
-                                        "minimum": {
-                                            "days": 10
-                                        },
-                                        "maximum": {
-                                            "days": 50
-                                        }
-                                    },
-                                    "answers": [
-                                        {
-                                            "type": "Date",
-                                            "id": "period-from",
-                                            "label": "From",
-                                            "mandatory": true,
-                                            "q_code": "11",
-                                            "minimum": {
-                                                "meta": "ref_p_start_date",
-                                                "offset_by": {
-                                                    "days": -19
-                                                }
-                                            }
-                                        },
-                                        {
-                                            "type": "Date",
-                                            "id": "period-to",
-                                            "label": "To",
-                                            "mandatory": true,
-                                            "q_code": "12",
-                                            "maximum": {
-                                                "meta": "ref_p_end_date",
-                                                "offset_by": {
-                                                    "days": 20
-                                                }
-                                            }
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "turnover-block",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "guidance": {
-                                        "content": [
-                                            {
-                                                "title": "Include:",
-                                                "list": [
-                                                    "income from sub-contracted activities",
-                                                    "commission",
-                                                    "sales of goods purchased for resale",
-                                                    "transport, insurance and packaging charges",
-                                                    "revenue earned from other parts of the business, not named at the top of this page (please supply at fair value)"
-                                                ]
-                                            },
-                                            {
-                                                "title": "Exclude:",
-                                                "list": [
-                                                    "VAT",
-                                                    "income from the sale of fixed capital assets",
-                                                    "grants and subsidies",
-                                                    "insurance claims",
-                                                    "interest received"
-                                                ]
-                                            }
-                                        ]
-                                    },
-                                    "id": "turnover-question",
-                                    "answers": [
-                                        {
-                                            "id": "turnover-answer",
-                                            "label": "Turnover excluding VAT",
-                                            "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
-                                            "type": "Currency",
-                                            "currency": "GBP",
-                                            "decimal_places": 2,
-                                            "q_code": "40",
-                                            "mandatory": true
-                                        }
-                                    ],
-                                    "type": "General",
-                                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s <em>turnover</em>, excluding VAT?"
-                                }
-                            ],
-                            "title": "Turnover"
-                        },
-                        {
-                            "type": "ConfirmationQuestion",
-                            "title": "Turnover",
-                            "id": "confirm-turnover-block",
-                            "questions": [
-                                {
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "type": "Radio",
-                                            "id": "confirm-turnover-answer",
-                                            "q_code": "d40",
-                                            "options": [
-                                                {
-                                                    "label": "Yes this is correct",
-                                                    "value": "Yes"
-                                                },
-                                                {
-                                                    "label": "No I need to change this",
-                                                    "value": "No"
-                                                }
-                                            ],
-                                            "mandatory": true
-                                        }
-                                    ],
-                                    "id": "confirm-turnover-question",
-                                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "when": [
-                                            {
-                                                "value": "No",
-                                                "id": "confirm-turnover-answer",
-                                                "condition": "equals"
-                                            }
-                                        ],
-                                        "block": "turnover-block"
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "exports-block"
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "id": "exports-block",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "guidance": {
-                                        "content": [
-                                            {
-                                                "list": ["All countries outside of England, Scotland, Wales and Northern Ireland"],
-                                                "title": "Include:"
-                                            }
-                                        ]
-                                    },
-                                    "id": "exports-question",
-                                    "answers": [
-                                        {
-                                            "id": "exports-answer",
-                                            "label": "Exports",
-                                            "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
-                                            "type": "Currency",
-                                            "currency": "GBP",
-                                            "decimal_places": 2,
-                                            "q_code": "49",
-                                            "mandatory": true
-                                        }
-                                    ],
-                                    "type": "General",
-                                    "title": "What was the value of <em>exports</em>?"
-                                }
-                            ],
-                            "title": "Exports"
-                        },
-                        {
-                            "id": "excise-duty-block",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "id": "excise-duty-question",
-                                    "answers": [
-                                        {
-                                            "id": "excise-duty-answer",
-                                            "label": "Excise duty",
-                                            "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
-                                            "type": "Currency",
-                                            "currency": "GBP",
-                                            "decimal_places": 2,
-                                            "q_code": "90",
-                                            "mandatory": true
-                                        }
-                                    ],
-                                    "type": "General",
-                                    "title": "What was the value of <em>excise duty</em>?"
-                                }
-                            ],
-                            "title": "Excise duty"
-                        },
-                        {
-                            "id": "changes-in-turnover-block",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "title": "Did any significant changes occur to the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
-                                    "id": "changes-in-turnover-question",
-                                    "definitions": [
-                                        {
-                                            "title": "What constitutes a significant change?",
-                                            "content": [
-                                                {
-                                                    "description": "What constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s figures from the previous reporting period and the same reporting period last year."
-                                                },
-                                                {
-                                                    "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
-                                                }
-                                            ]
-                                        }
-                                    ],
-                                    "answers": [
-                                        {
-                                            "options": [
-                                                {
-                                                    "value": "Yes",
-                                                    "label": "Yes"
-                                                },
-                                                {
-                                                    "value": "No",
-                                                    "label": "No"
-                                                }
-                                            ],
-                                            "id": "changes-in-turnover-answer",
-                                            "type": "Radio",
-                                            "q_code": "146",
-                                            "mandatory": false
-                                        }
-                                    ],
-                                    "guidance": {
-                                        "content": [
-                                            {
-                                                "title": "Include",
-                                                "list": [
-                                                    "change in level of business activity",
-                                                    "maintenance/shutdowns",
-                                                    "special/calendar events",
-                                                    "weather",
-                                                    "price effects",
-                                                    "currency effects (increase/decrease in the currency value)"
-                                                ]
-                                            }
-                                        ]
-                                    },
-                                    "type": "General"
-                                }
-                            ],
-                            "title": "Changes in turnover",
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "when": [
-                                            {
-                                                "id": "changes-in-turnover-answer",
-                                                "value": "Yes",
-                                                "condition": "equals"
-                                            }
-                                        ],
-                                        "block": "changes-in-turnover-block-2"
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "group": "summary-group"
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "id": "changes-in-turnover-block-2",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "title": "Please indicate the reasons for any changes in the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
-                                    "answers": [
-                                        {
-                                            "options": [
-                                                {
-                                                    "q_code": "146a",
-                                                    "value": "Change in level of business activity",
-                                                    "label": "Change in level of business activity"
-                                                },
-                                                {
-                                                    "q_code": "146b",
-                                                    "value": "Maintenance/shutdowns",
-                                                    "label": "Maintenance/shutdowns"
-                                                },
-                                                {
-                                                    "q_code": "146c",
-                                                    "value": "Special/calendar events",
-                                                    "label": "Special/calendar events"
-                                                },
-                                                {
-                                                    "q_code": "146d",
-                                                    "value": "Weather",
-                                                    "label": "Weather"
-                                                },
-                                                {
-                                                    "q_code": "146e",
-                                                    "value": "Price effects",
-                                                    "label": "Price effects"
-                                                },
-                                                {
-                                                    "q_code": "146f",
-                                                    "value": "Currency effects (increase/decrease in the currency value)",
-                                                    "label": "Currency effects (increase/decrease in the currency value)"
-                                                },
-                                                {
-                                                    "q_code": "146g",
-                                                    "value": "Other",
-                                                    "label": "Other"
-                                                }
-                                            ],
-                                            "id": "changes-in-turnover-answer-2",
-                                            "type": "Checkbox",
-                                            "mandatory": true
-                                        }
-                                    ],
-                                    "type": "General",
-                                    "id": "changes-in-turnover-question-2"
-                                }
-                            ],
-                            "title": "Changes in turnover"
-                        },
-                        {
-                            "type": "Question",
-                            "id": "changes-in-turnover-block-3",
-                            "title": "Changes in turnover",
-                            "questions": [
-                                {
-                                    "type": "General",
-                                    "id": "changes-in-turnover-question-3",
-                                    "title": "Please describe the changes in turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
-                                    "answers": [
-                                        {
-                                            "guidance": {
-                                                "hide_guidance": "Hide examples of commentary on changes to turnover",
-                                                "show_guidance": "Show examples of commentary on changes to turnover",
-                                                "content": [
-                                                    {
-                                                        "list": [],
-                                                        "title": "‘Change in level of business activity’",
-                                                        "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
-                                                    },
-                                                    {
-                                                        "list": [],
-                                                        "title": "‘Maintenance/shutdowns’",
-                                                        "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
-                                                    },
-                                                    {
-                                                        "list": [],
-                                                        "title": "‘Special/calendar events’",
-                                                        "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
-                                                    },
-                                                    {
-                                                        "list": [],
-                                                        "title": "‘Weather’",
-                                                        "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
-                                                    },
-                                                    {
-                                                        "list": [],
-                                                        "title": "‘Price effects’",
-                                                        "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
-                                                    },
-                                                    {
-                                                        "list": [],
-                                                        "title": "‘Currency effects (increase/decrease in the currency value)’",
-                                                        "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
-                                                    }
-                                                ]
-                                            },
-                                            "type": "TextArea",
-                                            "mandatory": true,
-                                            "label": "Comments",
-                                            "id": "changes-in-turnover-answer-3",
-                                            "q_code": "146h"
-                                        }
-                                    ],
-                                    "description": "<p>We rely on your commentary to ‘tell the story’ behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ]
+                                "type": "TextArea",
+                                "mandatory": true,
+                                "label": "Comments",
+                                "id": "changes-in-turnover-answer-3",
+                                "q_code": "146h"
+                            }],
+                            "description": "<p>We rely on your commentary to ‘tell the story’ behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
+                        }]
+                    }
+                ]
+            }]
         },
         {
             "id": "summary-section",
             "title": "Summary",
-            "groups": [
-                {
-                    "id": "summary-group",
-                    "title": "Summary",
-                    "blocks": [
-                        {
-                            "type": "Summary",
-                            "id": "summary"
-                        }
-                    ]
-                }
-            ]
+            "groups": [{
+                "id": "summary-group",
+                "title": "Summary",
+                "blocks": [{
+                    "type": "Summary",
+                    "id": "summary"
+                }]
+            }]
         }
     ]
 }

--- a/data/en/mbs_0216_prototype.json
+++ b/data/en/mbs_0216_prototype.json
@@ -1,0 +1,425 @@
+{
+    "title": "Monthly Business Survey",
+    "survey_id": "009",
+    "mime_type": "application/json/ons/eq",
+    "theme": "northernireland",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.1",
+    "legal_basis": "Notice is given under article 5 of the Statistics of Trade and Employment (Northern Ireland) Order 1988.",
+    "description": "mbs",
+    "view_submitted_response": {
+        "enabled": true,
+        "duration": 900
+    },
+    "metadata": [{
+        "name": "user_id",
+        "validator": "string"
+    }, {
+        "name": "period_id",
+        "validator": "string"
+    }, {
+        "name": "ru_name",
+        "validator": "string"
+    }, {
+        "name": "ref_p_start_date",
+        "validator": "date"
+    }, {
+        "name": "ref_p_end_date",
+        "validator": "date"
+    }, {
+        "name": "trad_as",
+        "validator": "optional_string"
+    }],
+    "sections": [{
+        "id": "section",
+        "groups": [{
+            "id": "group",
+            "title": "",
+            "blocks": [{
+                "type": "Introduction",
+                "id": "introduction",
+                "primary_content": [{
+                    "type": "Basic",
+                    "id": "use-of-information",
+                    "content": [{
+                        "list": ["Data should relate to all sites in England, Scotland, Wales and Northern Ireland unless otherwise stated.", "You can provide informed estimates if actual figures aren\u2019t available.", "We will treat your data securely and confidentially."]
+                    }]
+                }],
+                "preview_content": {
+                    "id": "preview",
+                    "title": "Information you need",
+                    "content": [{
+                        "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
+                    }],
+                    "questions": [{
+                        "question": "Turnover",
+                        "content": [{
+                            "description": "Include:",
+                            "list": ["income from sub-contracted activities", "commission", "sales of goods purchased for resale", "transport, insurance and packaging charges", "revenue earned from other parts of the business, not named at the top of this page (please supply at fair value)"]
+                        }, {
+                            "description": "Exclude:",
+                            "list": ["VAT", "income from the sale of fixed capital assets", "grants and subsidies", "insurance claims", "interest received"]
+                        }]
+                    }, {
+                        "question": "Value of exports",
+                        "content": [{
+                            "description": "Include:",
+                            "list": ["all countries outside of England, Scotland, Wales and Northern Ireland"]
+                        }]
+                    }, {
+                        "question": "Value of excise duty"
+                    }, {
+                        "question": "Changes in turnover",
+                        "content": [{
+                            "description": "Include:",
+                            "list": ["change in level of business activity", "maintenance/shutdowns", "special/calendar events", "weather", "price effects", "currency effects (increase/decrease in the currency value)"]
+                        }]
+                    }]
+                },
+                "secondary_content": [{
+                    "id": "how-we-use-your-data",
+                    "title": "How we use your data",
+                    "content": [{
+                        "list": ["You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.", "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"]
+                    }]
+                }]
+            }, {
+                "id": "reporting-period-block",
+                "type": "Question",
+                "questions": [{
+                    "answers": [{
+                        "options": [{
+                            "value": "Yes",
+                            "label": "Yes"
+                        }, {
+                            "value": "No",
+                            "label": "No"
+                        }],
+                        "id": "reporting-period-answer",
+                        "type": "Radio",
+                        "q_code": "d12",
+                        "mandatory": true
+                    }],
+                    "type": "General",
+                    "id": "reporting-period-question",
+                    "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
+                }],
+                "routing_rules": [{
+                    "goto": {
+                        "when": [{
+                            "id": "reporting-period-answer",
+                            "value": "Yes",
+                            "condition": "equals"
+                        }],
+                        "block": "turnover-block"
+                    }
+                }, {
+                    "goto": {
+                        "block": "reporting-period-block-2"
+                    }
+                }],
+                "title": "Reporting period"
+            }, {
+                "type": "Question",
+                "id": "reporting-period-block-2",
+                "title": "Reporting period",
+                "questions": [{
+                    "type": "DateRange",
+                    "id": "reporting-period-question-2",
+                    "title": "What are the dates of the period that you will be reporting for?",
+                    "period_limits": {
+                        "minimum": {
+                            "days": 10
+                        },
+                        "maximum": {
+                            "days": 50
+                        }
+                    },
+                    "answers": [{
+                        "type": "Date",
+                        "id": "period-from",
+                        "label": "From",
+                        "mandatory": true,
+                        "q_code": "11",
+                        "minimum": {
+                            "meta": "ref_p_start_date",
+                            "offset_by": {
+                                "days": -19
+                            }
+                        }
+                    }, {
+                        "type": "Date",
+                        "id": "period-to",
+                        "label": "To",
+                        "mandatory": true,
+                        "q_code": "12",
+                        "maximum": {
+                            "meta": "ref_p_end_date",
+                            "offset_by": {
+                                "days": 20
+                            }
+                        }
+                    }]
+                }]
+            }, {
+                "id": "turnover-block",
+                "type": "Question",
+                "questions": [{
+                    "guidance": {
+                        "content": [{
+                            "title": "Include:",
+                            "list": ["income from sub-contracted activities", "commission", "sales of goods purchased for resale", "transport, insurance and packaging charges", "revenue earned from other parts of the business, not named at the top of this page (please supply at fair value)"]
+                        }, {
+                            "title": "Exclude:",
+                            "list": ["VAT", "income from the sale of fixed capital assets", "grants and subsidies", "insurance claims", "interest received"]
+                        }]
+                    },
+                    "id": "turnover-question",
+                    "answers": [{
+                        "id": "turnover-answer",
+                        "label": "Turnover excluding VAT",
+                        "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                        "type": "Currency",
+                        "currency": "GBP",
+                        "decimal_places": 2,
+                        "q_code": "40",
+                        "mandatory": true
+                    }],
+                    "type": "General",
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>turnover</em>, excluding VAT?"
+                }],
+                "title": "Turnover"
+            }, {
+                "type": "ConfirmationQuestion",
+                "title": "Turnover",
+                "id": "confirm-turnover-block",
+                "questions": [{
+                    "type": "General",
+                    "answers": [{
+                        "type": "Radio",
+                        "id": "confirm-turnover-answer",
+                        "q_code": "d40",
+                        "options": [{
+                            "label": "Yes this is correct",
+                            "value": "Yes"
+                        }, {
+                            "label": "No I need to change this",
+                            "value": "No"
+                        }],
+                        "mandatory": true
+                    }],
+                    "id": "confirm-turnover-question",
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
+                }],
+                "routing_rules": [{
+                    "goto": {
+                        "when": [{
+                            "value": "No",
+                            "id": "confirm-turnover-answer",
+                            "condition": "equals"
+                        }],
+                        "block": "turnover-block"
+                    }
+                }, {
+                    "goto": {
+                        "block": "exports-block"
+                    }
+                }]
+            }, {
+                "id": "exports-block",
+                "type": "Question",
+                "questions": [{
+                    "guidance": {
+                        "content": [{
+                            "list": ["All countries outside of England, Scotland, Wales and Northern Ireland"],
+                            "title": "Include:"
+                        }]
+                    },
+                    "id": "exports-question",
+                    "answers": [{
+                        "id": "exports-answer",
+                        "label": "Exports",
+                        "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                        "type": "Currency",
+                        "currency": "GBP",
+                        "decimal_places": 2,
+                        "q_code": "49",
+                        "mandatory": true
+                    }],
+                    "type": "General",
+                    "title": "What was the value of <em>exports</em>?"
+                }],
+                "title": "Exports"
+            }, {
+                "id": "excise-duty-block",
+                "type": "Question",
+                "questions": [{
+                    "id": "excise-duty-question",
+                    "answers": [{
+                        "id": "excise-duty-answer",
+                        "label": "Excise duty",
+                        "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                        "type": "Currency",
+                        "currency": "GBP",
+                        "decimal_places": 2,
+                        "q_code": "90",
+                        "mandatory": true
+                    }],
+                    "type": "General",
+                    "title": "What was the value of <em>excise duty</em>?"
+                }],
+                "title": "Excise duty"
+            }, {
+                "id": "changes-in-turnover-block",
+                "type": "Question",
+                "questions": [{
+                    "title": "Did any significant changes occur to the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                    "id": "changes-in-turnover-question",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
+                        }, {
+                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }]
+                    }],
+                    "answers": [{
+                        "options": [{
+                            "value": "Yes",
+                            "label": "Yes"
+                        }, {
+                            "value": "No",
+                            "label": "No"
+                        }],
+                        "id": "changes-in-turnover-answer",
+                        "type": "Radio",
+                        "q_code": "146",
+                        "mandatory": false
+                    }],
+                    "guidance": {
+                        "content": [{
+                            "title": "Include",
+                            "list": ["change in level of business activity", "maintenance/shutdowns", "special/calendar events", "weather", "price effects", "currency effects (increase/decrease in the currency value)"]
+                        }]
+                    },
+                    "type": "General"
+                }],
+                "title": "Changes in turnover",
+                "routing_rules": [{
+                    "goto": {
+                        "when": [{
+                            "id": "changes-in-turnover-answer",
+                            "value": "Yes",
+                            "condition": "equals"
+                        }],
+                        "block": "changes-in-turnover-block-2"
+                    }
+                }, {
+                    "goto": {
+                        "group": "summary-group"
+                    }
+                }]
+            }, {
+                "id": "changes-in-turnover-block-2",
+                "type": "Question",
+                "questions": [{
+                    "title": "Please indicate the reasons for any changes in the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
+                    "answers": [{
+                        "options": [{
+                            "q_code": "146a",
+                            "value": "Change in level of business activity",
+                            "label": "Change in level of business activity"
+                        }, {
+                            "q_code": "146b",
+                            "value": "Maintenance/shutdowns",
+                            "label": "Maintenance/shutdowns"
+                        }, {
+                            "q_code": "146c",
+                            "value": "Special/calendar events",
+                            "label": "Special/calendar events"
+                        }, {
+                            "q_code": "146d",
+                            "value": "Weather",
+                            "label": "Weather"
+                        }, {
+                            "q_code": "146e",
+                            "value": "Price effects",
+                            "label": "Price effects"
+                        }, {
+                            "q_code": "146f",
+                            "value": "Currency effects (increase/decrease in the currency value)",
+                            "label": "Currency effects (increase/decrease in the currency value)"
+                        }, {
+                            "q_code": "146g",
+                            "value": "Other",
+                            "label": "Other"
+                        }],
+                        "id": "changes-in-turnover-answer-2",
+                        "type": "Checkbox",
+                        "mandatory": true
+                    }],
+                    "type": "General",
+                    "id": "changes-in-turnover-question-2"
+                }],
+                "title": "Changes in turnover"
+            }, {
+                "type": "Question",
+                "id": "changes-in-turnover-block-3",
+                "title": "Changes in turnover",
+                "questions": [{
+                    "type": "General",
+                    "id": "changes-in-turnover-question-3",
+                    "title": "Please describe the changes in turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
+                    "answers": [{
+                        "guidance": {
+                            "hide_guidance": "Hide examples of commentary on changes to turnover",
+                            "show_guidance": "Show examples of commentary on changes to turnover",
+                            "content": [{
+                                "list": [],
+                                "title": "\u2018Change in level of business activity\u2019",
+                                "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
+                            }, {
+                                "list": [],
+                                "title": "\u2018Maintenance/shutdowns\u2019",
+                                "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
+                            }, {
+                                "list": [],
+                                "title": "\u2018Special/calendar events\u2019",
+                                "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
+                            }, {
+                                "list": [],
+                                "title": "\u2018Weather\u2019",
+                                "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
+                            }, {
+                                "list": [],
+                                "title": "\u2018Price effects\u2019",
+                                "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
+                            }, {
+                                "list": [],
+                                "title": "\u2018Currency effects (increase/decrease in the currency value)\u2019",
+                                "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
+                            }]
+                        },
+                        "type": "TextArea",
+                        "mandatory": true,
+                        "label": "Comments",
+                        "id": "changes-in-turnover-answer-3",
+                        "q_code": "146h"
+                    }],
+                    "description": "<p>We rely on your commentary to \u2018tell the story\u2019 behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
+                }]
+            }]
+        }]
+    }, {
+        "id": "summary-section",
+        "title": "Summary",
+        "groups": [{
+            "id": "summary-group",
+            "title": "Summary",
+            "blocks": [{
+                "type": "Summary",
+                "id": "summary"
+            }]
+        }]
+    }]
+}

--- a/data/en/mbs_0817.json
+++ b/data/en/mbs_0817.json
@@ -11,363 +11,531 @@
         "enabled": true,
         "duration": 900
     },
-    "metadata": [{
-        "name": "user_id",
-        "validator": "string"
-    }, {
-        "name": "period_id",
-        "validator": "string"
-    }, {
-        "name": "ru_name",
-        "validator": "string"
-    }, {
-        "name": "ref_p_start_date",
-        "validator": "date"
-    }, {
-        "name": "ref_p_end_date",
-        "validator": "date"
-    }, {
-        "name": "trad_as",
-        "validator": "optional_string"
-    }],
-    "sections": [{
-        "id": "section",
-        "groups": [{
-            "id": "group",
-            "title": "",
-            "blocks": [{
-                "type": "Introduction",
-                "id": "introduction",
-                "primary_content": [{
-                    "type": "Basic",
-                    "id": "use-of-information",
-                    "content": [{
-                        "list": ["Data should relate to all sites in England, Scotland and Wales unless otherwise stated.", "You can provide informed estimates if actual figures aren\u2019t available.", "We will treat your data securely and confidentially."]
-                    }]
-                }],
-                "preview_content": {
-                    "id": "preview",
-                    "title": "Information you need",
-                    "content": [{
-                        "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
-                    }],
-                    "questions": [{
-                        "question": "Total turnover",
-                        "content": [{
-                            "description": "Include:",
-                            "list": ["exports", "costs incurred and passed on to customers", "income from sub-contracted activities", "commission", "sales of goods purchased for resale", "revenue earned from other parts of the business, not named at the top of this page (please supply at fair value)"]
-                        }, {
-                            "description": "Exclude:",
-                            "list": ["VAT", "income from the sale of fixed capital assets", "grants and subsidies", "insurance claims", "interest received"]
-                        }]
-                    }, {
-                        "question": "Changes in turnover",
-                        "content": [{
-                            "description": "Include:",
-                            "list": ["change in level of business activity", "maintenance/shutdowns", "special/calendar events", "weather", "price effects", "currency effects (increase/decrease in the currency value)"]
-                        }]
-                    }]
-                },
-                "secondary_content": [{
-                    "id": "how-we-use-your-data",
-                    "title": "How we use your data",
-                    "content": [{
-                        "list": ["You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.", "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"]
-                    }]
-                }]
-            }, {
-                "id": "reporting-period-block",
-                "type": "Question",
-                "questions": [{
-                    "answers": [{
-                        "options": [{
-                            "value": "Yes",
-                            "label": "Yes"
-                        }, {
-                            "value": "No",
-                            "label": "No"
-                        }],
-                        "id": "reporting-period-answer",
-                        "type": "Radio",
-                        "q_code": "d12",
-                        "mandatory": true
-                    }],
-                    "type": "General",
-                    "id": "reporting-period-question",
-                    "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
-                }],
-                "routing_rules": [{
-                    "goto": {
-                        "when": [{
-                            "id": "reporting-period-answer",
-                            "value": "Yes",
-                            "condition": "equals"
-                        }],
-                        "block": "turnover-block"
-                    }
-                }, {
-                    "goto": {
-                        "block": "reporting-period-block-2"
-                    }
-                }],
-                "title": "Reporting period"
-            }, {
-                "type": "Question",
-                "id": "reporting-period-block-2",
-                "title": "Reporting period",
-                "questions": [{
-                    "type": "DateRange",
-                    "id": "reporting-period-question-2",
-                    "title": "What are the dates of the period that you will be reporting for?",
-                    "period_limits": {
-                        "minimum": {
-                            "days": 10
+    "metadata": [
+        {
+            "name": "user_id",
+            "validator": "string"
+        },
+        {
+            "name": "period_id",
+            "validator": "string"
+        },
+        {
+            "name": "ru_name",
+            "validator": "string"
+        },
+        {
+            "name": "ref_p_start_date",
+            "validator": "date"
+        },
+        {
+            "name": "ref_p_end_date",
+            "validator": "date"
+        },
+        {
+            "name": "trad_as",
+            "validator": "optional_string"
+        }
+    ],
+    "sections": [
+        {
+            "id": "section",
+            "groups": [
+                {
+                    "id": "group",
+                    "title": "",
+                    "blocks": [
+                        {
+                            "type": "Introduction",
+                            "id": "introduction",
+                            "primary_content": [
+                                {
+                                    "type": "Basic",
+                                    "id": "use-of-information",
+                                    "content": [
+                                        {
+                                            "list": [
+                                                "Data should relate to all sites in England, Scotland and Wales unless otherwise stated.",
+                                                "You can provide informed estimates if actual figures aren’t available.",
+                                                "We will treat your data securely and confidentially."
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "preview_content": {
+                                "id": "preview",
+                                "title": "Information you need",
+                                "content": [
+                                    {
+                                        "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
+                                    }
+                                ],
+                                "questions": [
+                                    {
+                                        "question": "Total turnover",
+                                        "content": [
+                                            {
+                                                "description": "Include:",
+                                                "list": [
+                                                    "exports",
+                                                    "costs incurred and passed on to customers",
+                                                    "income from sub-contracted activities",
+                                                    "commission",
+                                                    "sales of goods purchased for resale",
+                                                    "revenue earned from other parts of the business, not named at the top of this page (please supply at fair value)"
+                                                ]
+                                            },
+                                            {
+                                                "description": "Exclude:",
+                                                "list": [
+                                                    "VAT",
+                                                    "income from the sale of fixed capital assets",
+                                                    "grants and subsidies",
+                                                    "insurance claims",
+                                                    "interest received"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "question": "Changes in turnover",
+                                        "content": [
+                                            {
+                                                "description": "Include:",
+                                                "list": [
+                                                    "change in level of business activity",
+                                                    "maintenance/shutdowns",
+                                                    "special/calendar events",
+                                                    "weather",
+                                                    "price effects",
+                                                    "currency effects (increase/decrease in the currency value)"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "secondary_content": [
+                                {
+                                    "id": "how-we-use-your-data",
+                                    "title": "How we use your data",
+                                    "content": [
+                                        {
+                                            "list": [
+                                                "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
+                                                "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
                         },
-                        "maximum": {
-                            "days": 50
-                        }
-                    },
-                    "answers": [{
-                        "type": "Date",
-                        "id": "period-from",
-                        "label": "From",
-                        "mandatory": true,
-                        "q_code": "11",
-                        "minimum": {
-                            "meta": "ref_p_start_date",
-                            "offset_by": {
-                                "days": -19
-                            }
-                        }
-                    }, {
-                        "type": "Date",
-                        "id": "period-to",
-                        "label": "To",
-                        "mandatory": true,
-                        "q_code": "12",
-                        "maximum": {
-                            "meta": "ref_p_end_date",
-                            "offset_by": {
-                                "days": 20
-                            }
-                        }
-                    }]
-                }]
-            }, {
-                "id": "turnover-block",
-                "type": "Question",
-                "questions": [{
-                    "guidance": {
-                        "content": [{
-                            "title": "Include:",
-                            "list": ["exports", "costs incurred and passed on to customers", "income from sub-contracted activities", "commission", "sales of goods purchased for resale", "revenue earned from other parts of the business not named (please supply at fair value)"]
-                        }, {
-                            "title": "Exclude:",
-                            "list": ["VAT", "income from the sale of fixed capital assets", "grants and subsidies", "insurance claims", "interest received"]
-                        }]
-                    },
-                    "id": "turnover-question",
-                    "answers": [{
-                        "id": "turnover-answer",
-                        "label": "Total turnover excluding VAT",
-                        "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
-                        "type": "Currency",
-                        "currency": "GBP",
-                        "decimal_places": 2,
-                        "q_code": "40",
-                        "mandatory": true
-                    }],
-                    "type": "General",
-                    "title": "For the period {{format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>total turnover</em>, excluding VAT?"
-                }],
-                "title": "Total turnover"
-            }, {
-                "type": "ConfirmationQuestion",
-                "title": "Total turnover",
-                "id": "confirm-turnover-block",
-                "questions": [{
-                    "type": "General",
-                    "answers": [{
-                        "type": "Radio",
-                        "id": "confirm-turnover-answer",
-                        "q_code": "d40",
-                        "options": [{
-                            "label": "Yes this is correct",
-                            "value": "Yes"
-                        }, {
-                            "label": "No I need to change this",
-                            "value": "No"
-                        }],
-                        "mandatory": true
-                    }],
-                    "id": "confirm-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
-                }],
-                "routing_rules": [{
-                    "goto": {
-                        "when": [{
-                            "value": "No",
-                            "id": "confirm-turnover-answer",
-                            "condition": "equals"
-                        }],
-                        "block": "turnover-block"
-                    }
-                }, {
-                    "goto": {
-                        "block": "changes-in-turnover-block"
-                    }
-                }]
-            }, {
-                "id": "changes-in-turnover-block",
-                "type": "Question",
-                "questions": [{
-                    "title": "Did any significant changes occur to the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
-                    "id": "changes-in-turnover-question",
-                    "definitions": [{
-                        "title": "What constitutes a significant change?",
-                        "content": [{
-                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
-                        }, {
-                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
-                        }]
-                    }],
-                    "answers": [{
-                        "options": [{
-                            "value": "Yes",
-                            "label": "Yes"
-                        }, {
-                            "value": "No",
-                            "label": "No"
-                        }],
-                        "id": "changes-in-turnover-answer",
-                        "type": "Radio",
-                        "q_code": "146",
-                        "mandatory": true
-                    }],
-                    "guidance": {
-                        "content": [{
-                            "title": "Include:",
-                            "list": ["change in level of business activity", "maintenance/shutdowns", "special/calendar events", "weather", "price effects", "currency effects (increase/decrease in the currency value)"]
-                        }]
-                    },
-                    "type": "General"
-                }],
-                "title": "Changes in turnover",
-                "routing_rules": [{
-                    "goto": {
-                        "when": [{
-                            "id": "changes-in-turnover-answer",
-                            "value": "Yes",
-                            "condition": "equals"
-                        }],
-                        "block": "changes-in-turnover-block-2"
-                    }
-                }, {
-                    "goto": {
-                        "group": "summary-group"
-                    }
-                }]
-            }, {
-                "id": "changes-in-turnover-block-2",
-                "type": "Question",
-                "questions": [{
-                    "title": "Please indicate the reasons for any changes in the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
-                    "answers": [{
-                        "options": [{
-                            "q_code": "146a",
-                            "value": "Change in level of business activity",
-                            "label": "Change in level of business activity"
-                        }, {
-                            "q_code": "146b",
-                            "value": "Maintenance/shutdowns",
-                            "label": "Maintenance/shutdowns"
-                        }, {
-                            "q_code": "146c",
-                            "value": "Special/calendar events",
-                            "label": "Special/calendar events"
-                        }, {
-                            "q_code": "146d",
-                            "value": "Weather",
-                            "label": "Weather"
-                        }, {
-                            "q_code": "146e",
-                            "value": "Price effects",
-                            "label": "Price effects"
-                        }, {
-                            "q_code": "146f",
-                            "value": "Currency effects (increase/decrease in the currency value)",
-                            "label": "Currency effects (increase/decrease in the currency value)"
-                        }, {
-                            "q_code": "146g",
-                            "value": "Other",
-                            "label": "Other"
-                        }],
-                        "id": "changes-in-turnover-answer-2",
-                        "type": "Checkbox",
-                        "mandatory": true
-                    }],
-                    "type": "General",
-                    "id": "changes-in-turnover-question-2"
-                }],
-                "title": "Changes in turnover"
-            }, {
-                "type": "Question",
-                "id": "changes-in-turnover-block-3",
-                "title": "Changes in turnover",
-                "questions": [{
-                    "type": "General",
-                    "id": "changes-in-turnover-question-3",
-                    "title": "Please describe the changes in turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
-                    "answers": [{
-                        "guidance": {
-                            "hide_guidance": "Hide examples of commentary on changes to turnover",
-                            "show_guidance": "Show examples of commentary on changes to turnover",
-                            "content": [{
-                                "list": [],
-                                "title": "\u2018Change in level of business activity\u2019",
-                                "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
-                            }, {
-                                "list": [],
-                                "title": "\u2018Maintenance/shutdowns\u2019",
-                                "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
-                            }, {
-                                "list": [],
-                                "title": "\u2018Special/calendar events\u2019",
-                                "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
-                            }, {
-                                "list": [],
-                                "title": "\u2018Weather\u2019",
-                                "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
-                            }, {
-                                "list": [],
-                                "title": "\u2018Price effects\u2019",
-                                "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
-                            }, {
-                                "list": [],
-                                "title": "\u2018Currency effects (increase/decrease in the currency value)\u2019",
-                                "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
-                            }]
+                        {
+                            "id": "reporting-period-block",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "options": [
+                                                {
+                                                    "value": "Yes",
+                                                    "label": "Yes"
+                                                },
+                                                {
+                                                    "value": "No",
+                                                    "label": "No"
+                                                }
+                                            ],
+                                            "id": "reporting-period-answer",
+                                            "type": "Radio",
+                                            "q_code": "d12",
+                                            "mandatory": true
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "id": "reporting-period-question",
+                                    "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "when": [
+                                            {
+                                                "id": "reporting-period-answer",
+                                                "value": "Yes",
+                                                "condition": "equals"
+                                            }
+                                        ],
+                                        "block": "turnover-block"
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "reporting-period-block-2"
+                                    }
+                                }
+                            ],
+                            "title": "Reporting period"
                         },
-                        "type": "TextArea",
-                        "mandatory": true,
-                        "label": "Comments",
-                        "id": "changes-in-turnover-answer-3",
-                        "q_code": "146h"
-                    }],
-                    "description": "<p>We rely on your commentary to \u2018tell the story\u2019 behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
-                }]
-            }]
-        }]
-    }, {
-        "id": "summary-section",
-        "title": "Summary",
-        "groups": [{
-            "id": "summary-group",
+                        {
+                            "type": "Question",
+                            "id": "reporting-period-block-2",
+                            "title": "Reporting period",
+                            "questions": [
+                                {
+                                    "type": "DateRange",
+                                    "id": "reporting-period-question-2",
+                                    "title": "What are the dates of the period that you will be reporting for?",
+                                    "period_limits": {
+                                        "minimum": {
+                                            "days": 10
+                                        },
+                                        "maximum": {
+                                            "days": 50
+                                        }
+                                    },
+                                    "answers": [
+                                        {
+                                            "type": "Date",
+                                            "id": "period-from",
+                                            "label": "From",
+                                            "mandatory": true,
+                                            "q_code": "11",
+                                            "minimum": {
+                                                "meta": "ref_p_start_date",
+                                                "offset_by": {
+                                                    "days": -19
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "type": "Date",
+                                            "id": "period-to",
+                                            "label": "To",
+                                            "mandatory": true,
+                                            "q_code": "12",
+                                            "maximum": {
+                                                "meta": "ref_p_end_date",
+                                                "offset_by": {
+                                                    "days": 20
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "turnover-block",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "guidance": {
+                                        "content": [
+                                            {
+                                                "title": "Include:",
+                                                "list": [
+                                                    "exports",
+                                                    "costs incurred and passed on to customers",
+                                                    "income from sub-contracted activities",
+                                                    "commission",
+                                                    "sales of goods purchased for resale",
+                                                    "revenue earned from other parts of the business not named (please supply at fair value)"
+                                                ]
+                                            },
+                                            {
+                                                "title": "Exclude:",
+                                                "list": [
+                                                    "VAT",
+                                                    "income from the sale of fixed capital assets",
+                                                    "grants and subsidies",
+                                                    "insurance claims",
+                                                    "interest received"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "id": "turnover-question",
+                                    "answers": [
+                                        {
+                                            "id": "turnover-answer",
+                                            "label": "Total turnover excluding VAT",
+                                            "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                                            "type": "Currency",
+                                            "currency": "GBP",
+                                            "decimal_places": 2,
+                                            "q_code": "40",
+                                            "mandatory": true
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "title": "For the period {{format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s <em>total turnover</em>, excluding VAT?"
+                                }
+                            ],
+                            "title": "Total turnover"
+                        },
+                        {
+                            "type": "ConfirmationQuestion",
+                            "title": "Total turnover",
+                            "id": "confirm-turnover-block",
+                            "questions": [
+                                {
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "type": "Radio",
+                                            "id": "confirm-turnover-answer",
+                                            "q_code": "d40",
+                                            "options": [
+                                                {
+                                                    "label": "Yes this is correct",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No I need to change this",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "mandatory": true
+                                        }
+                                    ],
+                                    "id": "confirm-turnover-question",
+                                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "when": [
+                                            {
+                                                "value": "No",
+                                                "id": "confirm-turnover-answer",
+                                                "condition": "equals"
+                                            }
+                                        ],
+                                        "block": "turnover-block"
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "changes-in-turnover-block"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "id": "changes-in-turnover-block",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "title": "Did any significant changes occur to the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                                    "id": "changes-in-turnover-question",
+                                    "definitions": [
+                                        {
+                                            "title": "What constitutes a significant change?",
+                                            "content": [
+                                                {
+                                                    "description": "What constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s figures from the previous reporting period and the same reporting period last year."
+                                                },
+                                                {
+                                                    "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "answers": [
+                                        {
+                                            "options": [
+                                                {
+                                                    "value": "Yes",
+                                                    "label": "Yes"
+                                                },
+                                                {
+                                                    "value": "No",
+                                                    "label": "No"
+                                                }
+                                            ],
+                                            "id": "changes-in-turnover-answer",
+                                            "type": "Radio",
+                                            "q_code": "146",
+                                            "mandatory": true
+                                        }
+                                    ],
+                                    "guidance": {
+                                        "content": [
+                                            {
+                                                "title": "Include:",
+                                                "list": [
+                                                    "change in level of business activity",
+                                                    "maintenance/shutdowns",
+                                                    "special/calendar events",
+                                                    "weather",
+                                                    "price effects",
+                                                    "currency effects (increase/decrease in the currency value)"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Changes in turnover",
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "when": [
+                                            {
+                                                "id": "changes-in-turnover-answer",
+                                                "value": "Yes",
+                                                "condition": "equals"
+                                            }
+                                        ],
+                                        "block": "changes-in-turnover-block-2"
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "group": "summary-group"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "id": "changes-in-turnover-block-2",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "title": "Please indicate the reasons for any changes in the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
+                                    "answers": [
+                                        {
+                                            "options": [
+                                                {
+                                                    "q_code": "146a",
+                                                    "value": "Change in level of business activity",
+                                                    "label": "Change in level of business activity"
+                                                },
+                                                {
+                                                    "q_code": "146b",
+                                                    "value": "Maintenance/shutdowns",
+                                                    "label": "Maintenance/shutdowns"
+                                                },
+                                                {
+                                                    "q_code": "146c",
+                                                    "value": "Special/calendar events",
+                                                    "label": "Special/calendar events"
+                                                },
+                                                {
+                                                    "q_code": "146d",
+                                                    "value": "Weather",
+                                                    "label": "Weather"
+                                                },
+                                                {
+                                                    "q_code": "146e",
+                                                    "value": "Price effects",
+                                                    "label": "Price effects"
+                                                },
+                                                {
+                                                    "q_code": "146f",
+                                                    "value": "Currency effects (increase/decrease in the currency value)",
+                                                    "label": "Currency effects (increase/decrease in the currency value)"
+                                                },
+                                                {
+                                                    "q_code": "146g",
+                                                    "value": "Other",
+                                                    "label": "Other"
+                                                }
+                                            ],
+                                            "id": "changes-in-turnover-answer-2",
+                                            "type": "Checkbox",
+                                            "mandatory": true
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "id": "changes-in-turnover-question-2"
+                                }
+                            ],
+                            "title": "Changes in turnover"
+                        },
+                        {
+                            "type": "Question",
+                            "id": "changes-in-turnover-block-3",
+                            "title": "Changes in turnover",
+                            "questions": [
+                                {
+                                    "type": "General",
+                                    "id": "changes-in-turnover-question-3",
+                                    "title": "Please describe the changes in turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
+                                    "answers": [
+                                        {
+                                            "guidance": {
+                                                "hide_guidance": "Hide examples of commentary on changes to turnover",
+                                                "show_guidance": "Show examples of commentary on changes to turnover",
+                                                "content": [
+                                                    {
+                                                        "list": [],
+                                                        "title": "‘Change in level of business activity’",
+                                                        "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
+                                                    },
+                                                    {
+                                                        "list": [],
+                                                        "title": "‘Maintenance/shutdowns’",
+                                                        "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
+                                                    },
+                                                    {
+                                                        "list": [],
+                                                        "title": "‘Special/calendar events’",
+                                                        "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
+                                                    },
+                                                    {
+                                                        "list": [],
+                                                        "title": "‘Weather’",
+                                                        "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
+                                                    },
+                                                    {
+                                                        "list": [],
+                                                        "title": "‘Price effects’",
+                                                        "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
+                                                    },
+                                                    {
+                                                        "list": [],
+                                                        "title": "‘Currency effects (increase/decrease in the currency value)’",
+                                                        "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
+                                                    }
+                                                ]
+                                            },
+                                            "type": "TextArea",
+                                            "mandatory": true,
+                                            "label": "Comments",
+                                            "id": "changes-in-turnover-answer-3",
+                                            "q_code": "146h"
+                                        }
+                                    ],
+                                    "description": "<p>We rely on your commentary to ‘tell the story’ behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "summary-section",
             "title": "Summary",
-            "blocks": [{
-                "type": "Summary",
-                "id": "summary"
-            }]
-        }]
-    }]
+            "groups": [
+                {
+                    "id": "summary-group",
+                    "title": "Summary",
+                    "blocks": [
+                        {
+                            "type": "Summary",
+                            "id": "summary"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
 }

--- a/data/en/mbs_0817.json
+++ b/data/en/mbs_0817.json
@@ -11,8 +11,7 @@
         "enabled": true,
         "duration": 900
     },
-    "metadata": [
-        {
+    "metadata": [{
             "name": "user_id",
             "validator": "string"
         },
@@ -37,505 +36,436 @@
             "validator": "optional_string"
         }
     ],
-    "sections": [
-        {
+    "sections": [{
             "id": "section",
-            "groups": [
-                {
-                    "id": "group",
-                    "title": "",
-                    "blocks": [
-                        {
-                            "type": "Introduction",
-                            "id": "introduction",
-                            "primary_content": [
-                                {
-                                    "type": "Basic",
-                                    "id": "use-of-information",
-                                    "content": [
-                                        {
+            "groups": [{
+                "id": "group",
+                "title": "",
+                "blocks": [{
+                        "type": "Introduction",
+                        "id": "introduction",
+                        "primary_content": [{
+                            "type": "Basic",
+                            "id": "use-of-information",
+                            "content": [{
+                                "list": [
+                                    "Data should relate to all sites in England, Scotland and Wales unless otherwise stated.",
+                                    "You can provide informed estimates if actual figures aren’t available.",
+                                    "We will treat your data securely and confidentially."
+                                ]
+                            }]
+                        }],
+                        "preview_content": {
+                            "id": "preview",
+                            "title": "Information you need",
+                            "content": [{
+                                "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
+                            }],
+                            "questions": [{
+                                    "question": "Total turnover",
+                                    "content": [{
+                                            "description": "Include:",
                                             "list": [
-                                                "Data should relate to all sites in England, Scotland and Wales unless otherwise stated.",
-                                                "You can provide informed estimates if actual figures aren’t available.",
-                                                "We will treat your data securely and confidentially."
+                                                "exports",
+                                                "costs incurred and passed on to customers",
+                                                "income from sub-contracted activities",
+                                                "commission",
+                                                "sales of goods purchased for resale",
+                                                "revenue earned from other parts of the business, not named at the top of this page (please supply at fair value)"
+                                            ]
+                                        },
+                                        {
+                                            "description": "Exclude:",
+                                            "list": [
+                                                "VAT",
+                                                "income from the sale of fixed capital assets",
+                                                "grants and subsidies",
+                                                "insurance claims",
+                                                "interest received"
                                             ]
                                         }
                                     ]
+                                },
+                                {
+                                    "question": "Changes in turnover",
+                                    "content": [{
+                                        "description": "Include:",
+                                        "list": [
+                                            "change in level of business activity",
+                                            "maintenance/shutdowns",
+                                            "special/calendar events",
+                                            "weather",
+                                            "price effects",
+                                            "currency effects (increase/decrease in the currency value)"
+                                        ]
+                                    }]
                                 }
-                            ],
-                            "preview_content": {
-                                "id": "preview",
-                                "title": "Information you need",
-                                "content": [
+                            ]
+                        },
+                        "secondary_content": [{
+                            "id": "how-we-use-your-data",
+                            "title": "How we use your data",
+                            "content": [{
+                                "list": [
+                                    "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
+                                    "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"
+                                ]
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "reporting-period-block",
+                        "type": "Question",
+                        "questions": [{
+                            "answers": [{
+                                "options": [{
+                                        "value": "Yes",
+                                        "label": "Yes"
+                                    },
                                     {
-                                        "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
+                                        "value": "No",
+                                        "label": "No"
                                     }
                                 ],
-                                "questions": [
-                                    {
-                                        "question": "Total turnover",
-                                        "content": [
-                                            {
-                                                "description": "Include:",
-                                                "list": [
-                                                    "exports",
-                                                    "costs incurred and passed on to customers",
-                                                    "income from sub-contracted activities",
-                                                    "commission",
-                                                    "sales of goods purchased for resale",
-                                                    "revenue earned from other parts of the business, not named at the top of this page (please supply at fair value)"
-                                                ]
-                                            },
-                                            {
-                                                "description": "Exclude:",
-                                                "list": [
-                                                    "VAT",
-                                                    "income from the sale of fixed capital assets",
-                                                    "grants and subsidies",
-                                                    "insurance claims",
-                                                    "interest received"
-                                                ]
-                                            }
+                                "id": "reporting-period-answer",
+                                "type": "Radio",
+                                "q_code": "d12",
+                                "mandatory": true
+                            }],
+                            "type": "General",
+                            "id": "reporting-period-question",
+                            "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "id": "reporting-period-answer",
+                                        "value": "Yes",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "turnover-block"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "reporting-period-block-2"
+                                }
+                            }
+                        ],
+                        "title": "Reporting period"
+                    },
+                    {
+                        "type": "Question",
+                        "id": "reporting-period-block-2",
+                        "title": "Reporting period",
+                        "questions": [{
+                            "type": "DateRange",
+                            "id": "reporting-period-question-2",
+                            "title": "What are the dates of the period that you will be reporting for?",
+                            "period_limits": {
+                                "minimum": {
+                                    "days": 10
+                                },
+                                "maximum": {
+                                    "days": 50
+                                }
+                            },
+                            "answers": [{
+                                    "type": "Date",
+                                    "id": "period-from",
+                                    "label": "From",
+                                    "mandatory": true,
+                                    "q_code": "11",
+                                    "minimum": {
+                                        "meta": "ref_p_start_date",
+                                        "offset_by": {
+                                            "days": -19
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "Date",
+                                    "id": "period-to",
+                                    "label": "To",
+                                    "mandatory": true,
+                                    "q_code": "12",
+                                    "maximum": {
+                                        "meta": "ref_p_end_date",
+                                        "offset_by": {
+                                            "days": 20
+                                        }
+                                    }
+                                }
+                            ]
+                        }]
+                    },
+                    {
+                        "id": "turnover-block",
+                        "type": "Question",
+                        "questions": [{
+                            "guidance": {
+                                "content": [{
+                                        "title": "Include:",
+                                        "list": [
+                                            "exports",
+                                            "costs incurred and passed on to customers",
+                                            "income from sub-contracted activities",
+                                            "commission",
+                                            "sales of goods purchased for resale",
+                                            "revenue earned from other parts of the business not named (please supply at fair value)"
                                         ]
                                     },
                                     {
-                                        "question": "Changes in turnover",
-                                        "content": [
-                                            {
-                                                "description": "Include:",
-                                                "list": [
-                                                    "change in level of business activity",
-                                                    "maintenance/shutdowns",
-                                                    "special/calendar events",
-                                                    "weather",
-                                                    "price effects",
-                                                    "currency effects (increase/decrease in the currency value)"
-                                                ]
-                                            }
+                                        "title": "Exclude:",
+                                        "list": [
+                                            "VAT",
+                                            "income from the sale of fixed capital assets",
+                                            "grants and subsidies",
+                                            "insurance claims",
+                                            "interest received"
                                         ]
                                     }
                                 ]
                             },
-                            "secondary_content": [
-                                {
-                                    "id": "how-we-use-your-data",
-                                    "title": "How we use your data",
-                                    "content": [
+                            "id": "turnover-question",
+                            "answers": [{
+                                "id": "turnover-answer",
+                                "label": "Total turnover excluding VAT",
+                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                                "type": "Currency",
+                                "currency": "GBP",
+                                "decimal_places": 2,
+                                "q_code": "40",
+                                "mandatory": true
+                            }],
+                            "type": "General",
+                            "title": "For the period {{format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s <em>total turnover</em>, excluding VAT?"
+                        }],
+                        "title": "Total turnover"
+                    },
+                    {
+                        "type": "ConfirmationQuestion",
+                        "title": "Total turnover",
+                        "id": "confirm-turnover-block",
+                        "questions": [{
+                            "type": "General",
+                            "answers": [{
+                                "type": "Radio",
+                                "id": "confirm-turnover-answer",
+                                "q_code": "d40",
+                                "options": [{
+                                        "label": "Yes this is correct",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No I need to change this",
+                                        "value": "No"
+                                    }
+                                ],
+                                "mandatory": true
+                            }],
+                            "id": "confirm-turnover-question",
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "value": "No",
+                                        "id": "confirm-turnover-answer",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "turnover-block"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "changes-in-turnover-block"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "changes-in-turnover-block",
+                        "type": "Question",
+                        "questions": [{
+                            "title": "Did any significant changes occur to the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                            "id": "changes-in-turnover-question",
+                            "definitions": [{
+                                "title": "What constitutes a significant change?",
+                                "content": [{
+                                        "description": "What constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s figures from the previous reporting period and the same reporting period last year."
+                                    },
+                                    {
+                                        "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                                    }
+                                ]
+                            }],
+                            "answers": [{
+                                "options": [{
+                                        "value": "Yes",
+                                        "label": "Yes"
+                                    },
+                                    {
+                                        "value": "No",
+                                        "label": "No"
+                                    }
+                                ],
+                                "id": "changes-in-turnover-answer",
+                                "type": "Radio",
+                                "q_code": "146",
+                                "mandatory": true
+                            }],
+                            "guidance": {
+                                "content": [{
+                                    "title": "Include:",
+                                    "list": [
+                                        "change in level of business activity",
+                                        "maintenance/shutdowns",
+                                        "special/calendar events",
+                                        "weather",
+                                        "price effects",
+                                        "currency effects (increase/decrease in the currency value)"
+                                    ]
+                                }]
+                            },
+                            "type": "General"
+                        }],
+                        "title": "Changes in turnover",
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "id": "changes-in-turnover-answer",
+                                        "value": "Yes",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "changes-in-turnover-block-2"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "group": "summary-group"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "changes-in-turnover-block-2",
+                        "type": "Question",
+                        "questions": [{
+                            "title": "Please indicate the reasons for any changes in the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
+                            "answers": [{
+                                "options": [{
+                                        "q_code": "146a",
+                                        "value": "Change in level of business activity",
+                                        "label": "Change in level of business activity"
+                                    },
+                                    {
+                                        "q_code": "146b",
+                                        "value": "Maintenance/shutdowns",
+                                        "label": "Maintenance/shutdowns"
+                                    },
+                                    {
+                                        "q_code": "146c",
+                                        "value": "Special/calendar events",
+                                        "label": "Special/calendar events"
+                                    },
+                                    {
+                                        "q_code": "146d",
+                                        "value": "Weather",
+                                        "label": "Weather"
+                                    },
+                                    {
+                                        "q_code": "146e",
+                                        "value": "Price effects",
+                                        "label": "Price effects"
+                                    },
+                                    {
+                                        "q_code": "146f",
+                                        "value": "Currency effects (increase/decrease in the currency value)",
+                                        "label": "Currency effects (increase/decrease in the currency value)"
+                                    },
+                                    {
+                                        "q_code": "146g",
+                                        "value": "Other",
+                                        "label": "Other"
+                                    }
+                                ],
+                                "id": "changes-in-turnover-answer-2",
+                                "type": "Checkbox",
+                                "mandatory": true
+                            }],
+                            "type": "General",
+                            "id": "changes-in-turnover-question-2"
+                        }],
+                        "title": "Changes in turnover"
+                    },
+                    {
+                        "type": "Question",
+                        "id": "changes-in-turnover-block-3",
+                        "title": "Changes in turnover",
+                        "questions": [{
+                            "type": "General",
+                            "id": "changes-in-turnover-question-3",
+                            "title": "Please describe the changes in turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
+                            "answers": [{
+                                "guidance": {
+                                    "hide_guidance": "Hide examples of commentary on changes to turnover",
+                                    "show_guidance": "Show examples of commentary on changes to turnover",
+                                    "content": [{
+                                            "list": [],
+                                            "title": "‘Change in level of business activity’",
+                                            "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
+                                        },
                                         {
-                                            "list": [
-                                                "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
-                                                "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"
-                                            ]
+                                            "list": [],
+                                            "title": "‘Maintenance/shutdowns’",
+                                            "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
+                                        },
+                                        {
+                                            "list": [],
+                                            "title": "‘Special/calendar events’",
+                                            "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
+                                        },
+                                        {
+                                            "list": [],
+                                            "title": "‘Weather’",
+                                            "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
+                                        },
+                                        {
+                                            "list": [],
+                                            "title": "‘Price effects’",
+                                            "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
+                                        },
+                                        {
+                                            "list": [],
+                                            "title": "‘Currency effects (increase/decrease in the currency value)’",
+                                            "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
                                         }
                                     ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "reporting-period-block",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "answers": [
-                                        {
-                                            "options": [
-                                                {
-                                                    "value": "Yes",
-                                                    "label": "Yes"
-                                                },
-                                                {
-                                                    "value": "No",
-                                                    "label": "No"
-                                                }
-                                            ],
-                                            "id": "reporting-period-answer",
-                                            "type": "Radio",
-                                            "q_code": "d12",
-                                            "mandatory": true
-                                        }
-                                    ],
-                                    "type": "General",
-                                    "id": "reporting-period-question",
-                                    "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "when": [
-                                            {
-                                                "id": "reporting-period-answer",
-                                                "value": "Yes",
-                                                "condition": "equals"
-                                            }
-                                        ],
-                                        "block": "turnover-block"
-                                    }
                                 },
-                                {
-                                    "goto": {
-                                        "block": "reporting-period-block-2"
-                                    }
-                                }
-                            ],
-                            "title": "Reporting period"
-                        },
-                        {
-                            "type": "Question",
-                            "id": "reporting-period-block-2",
-                            "title": "Reporting period",
-                            "questions": [
-                                {
-                                    "type": "DateRange",
-                                    "id": "reporting-period-question-2",
-                                    "title": "What are the dates of the period that you will be reporting for?",
-                                    "period_limits": {
-                                        "minimum": {
-                                            "days": 10
-                                        },
-                                        "maximum": {
-                                            "days": 50
-                                        }
-                                    },
-                                    "answers": [
-                                        {
-                                            "type": "Date",
-                                            "id": "period-from",
-                                            "label": "From",
-                                            "mandatory": true,
-                                            "q_code": "11",
-                                            "minimum": {
-                                                "meta": "ref_p_start_date",
-                                                "offset_by": {
-                                                    "days": -19
-                                                }
-                                            }
-                                        },
-                                        {
-                                            "type": "Date",
-                                            "id": "period-to",
-                                            "label": "To",
-                                            "mandatory": true,
-                                            "q_code": "12",
-                                            "maximum": {
-                                                "meta": "ref_p_end_date",
-                                                "offset_by": {
-                                                    "days": 20
-                                                }
-                                            }
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "turnover-block",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "guidance": {
-                                        "content": [
-                                            {
-                                                "title": "Include:",
-                                                "list": [
-                                                    "exports",
-                                                    "costs incurred and passed on to customers",
-                                                    "income from sub-contracted activities",
-                                                    "commission",
-                                                    "sales of goods purchased for resale",
-                                                    "revenue earned from other parts of the business not named (please supply at fair value)"
-                                                ]
-                                            },
-                                            {
-                                                "title": "Exclude:",
-                                                "list": [
-                                                    "VAT",
-                                                    "income from the sale of fixed capital assets",
-                                                    "grants and subsidies",
-                                                    "insurance claims",
-                                                    "interest received"
-                                                ]
-                                            }
-                                        ]
-                                    },
-                                    "id": "turnover-question",
-                                    "answers": [
-                                        {
-                                            "id": "turnover-answer",
-                                            "label": "Total turnover excluding VAT",
-                                            "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
-                                            "type": "Currency",
-                                            "currency": "GBP",
-                                            "decimal_places": 2,
-                                            "q_code": "40",
-                                            "mandatory": true
-                                        }
-                                    ],
-                                    "type": "General",
-                                    "title": "For the period {{format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s <em>total turnover</em>, excluding VAT?"
-                                }
-                            ],
-                            "title": "Total turnover"
-                        },
-                        {
-                            "type": "ConfirmationQuestion",
-                            "title": "Total turnover",
-                            "id": "confirm-turnover-block",
-                            "questions": [
-                                {
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "type": "Radio",
-                                            "id": "confirm-turnover-answer",
-                                            "q_code": "d40",
-                                            "options": [
-                                                {
-                                                    "label": "Yes this is correct",
-                                                    "value": "Yes"
-                                                },
-                                                {
-                                                    "label": "No I need to change this",
-                                                    "value": "No"
-                                                }
-                                            ],
-                                            "mandatory": true
-                                        }
-                                    ],
-                                    "id": "confirm-turnover-question",
-                                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "when": [
-                                            {
-                                                "value": "No",
-                                                "id": "confirm-turnover-answer",
-                                                "condition": "equals"
-                                            }
-                                        ],
-                                        "block": "turnover-block"
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "changes-in-turnover-block"
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "id": "changes-in-turnover-block",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "title": "Did any significant changes occur to the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
-                                    "id": "changes-in-turnover-question",
-                                    "definitions": [
-                                        {
-                                            "title": "What constitutes a significant change?",
-                                            "content": [
-                                                {
-                                                    "description": "What constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s figures from the previous reporting period and the same reporting period last year."
-                                                },
-                                                {
-                                                    "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
-                                                }
-                                            ]
-                                        }
-                                    ],
-                                    "answers": [
-                                        {
-                                            "options": [
-                                                {
-                                                    "value": "Yes",
-                                                    "label": "Yes"
-                                                },
-                                                {
-                                                    "value": "No",
-                                                    "label": "No"
-                                                }
-                                            ],
-                                            "id": "changes-in-turnover-answer",
-                                            "type": "Radio",
-                                            "q_code": "146",
-                                            "mandatory": true
-                                        }
-                                    ],
-                                    "guidance": {
-                                        "content": [
-                                            {
-                                                "title": "Include:",
-                                                "list": [
-                                                    "change in level of business activity",
-                                                    "maintenance/shutdowns",
-                                                    "special/calendar events",
-                                                    "weather",
-                                                    "price effects",
-                                                    "currency effects (increase/decrease in the currency value)"
-                                                ]
-                                            }
-                                        ]
-                                    },
-                                    "type": "General"
-                                }
-                            ],
-                            "title": "Changes in turnover",
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "when": [
-                                            {
-                                                "id": "changes-in-turnover-answer",
-                                                "value": "Yes",
-                                                "condition": "equals"
-                                            }
-                                        ],
-                                        "block": "changes-in-turnover-block-2"
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "group": "summary-group"
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "id": "changes-in-turnover-block-2",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "title": "Please indicate the reasons for any changes in the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
-                                    "answers": [
-                                        {
-                                            "options": [
-                                                {
-                                                    "q_code": "146a",
-                                                    "value": "Change in level of business activity",
-                                                    "label": "Change in level of business activity"
-                                                },
-                                                {
-                                                    "q_code": "146b",
-                                                    "value": "Maintenance/shutdowns",
-                                                    "label": "Maintenance/shutdowns"
-                                                },
-                                                {
-                                                    "q_code": "146c",
-                                                    "value": "Special/calendar events",
-                                                    "label": "Special/calendar events"
-                                                },
-                                                {
-                                                    "q_code": "146d",
-                                                    "value": "Weather",
-                                                    "label": "Weather"
-                                                },
-                                                {
-                                                    "q_code": "146e",
-                                                    "value": "Price effects",
-                                                    "label": "Price effects"
-                                                },
-                                                {
-                                                    "q_code": "146f",
-                                                    "value": "Currency effects (increase/decrease in the currency value)",
-                                                    "label": "Currency effects (increase/decrease in the currency value)"
-                                                },
-                                                {
-                                                    "q_code": "146g",
-                                                    "value": "Other",
-                                                    "label": "Other"
-                                                }
-                                            ],
-                                            "id": "changes-in-turnover-answer-2",
-                                            "type": "Checkbox",
-                                            "mandatory": true
-                                        }
-                                    ],
-                                    "type": "General",
-                                    "id": "changes-in-turnover-question-2"
-                                }
-                            ],
-                            "title": "Changes in turnover"
-                        },
-                        {
-                            "type": "Question",
-                            "id": "changes-in-turnover-block-3",
-                            "title": "Changes in turnover",
-                            "questions": [
-                                {
-                                    "type": "General",
-                                    "id": "changes-in-turnover-question-3",
-                                    "title": "Please describe the changes in turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
-                                    "answers": [
-                                        {
-                                            "guidance": {
-                                                "hide_guidance": "Hide examples of commentary on changes to turnover",
-                                                "show_guidance": "Show examples of commentary on changes to turnover",
-                                                "content": [
-                                                    {
-                                                        "list": [],
-                                                        "title": "‘Change in level of business activity’",
-                                                        "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
-                                                    },
-                                                    {
-                                                        "list": [],
-                                                        "title": "‘Maintenance/shutdowns’",
-                                                        "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
-                                                    },
-                                                    {
-                                                        "list": [],
-                                                        "title": "‘Special/calendar events’",
-                                                        "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
-                                                    },
-                                                    {
-                                                        "list": [],
-                                                        "title": "‘Weather’",
-                                                        "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
-                                                    },
-                                                    {
-                                                        "list": [],
-                                                        "title": "‘Price effects’",
-                                                        "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
-                                                    },
-                                                    {
-                                                        "list": [],
-                                                        "title": "‘Currency effects (increase/decrease in the currency value)’",
-                                                        "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
-                                                    }
-                                                ]
-                                            },
-                                            "type": "TextArea",
-                                            "mandatory": true,
-                                            "label": "Comments",
-                                            "id": "changes-in-turnover-answer-3",
-                                            "q_code": "146h"
-                                        }
-                                    ],
-                                    "description": "<p>We rely on your commentary to ‘tell the story’ behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ]
+                                "type": "TextArea",
+                                "mandatory": true,
+                                "label": "Comments",
+                                "id": "changes-in-turnover-answer-3",
+                                "q_code": "146h"
+                            }],
+                            "description": "<p>We rely on your commentary to ‘tell the story’ behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
+                        }]
+                    }
+                ]
+            }]
         },
         {
             "id": "summary-section",
             "title": "Summary",
-            "groups": [
-                {
-                    "id": "summary-group",
-                    "title": "Summary",
-                    "blocks": [
-                        {
-                            "type": "Summary",
-                            "id": "summary"
-                        }
-                    ]
-                }
-            ]
+            "groups": [{
+                "id": "summary-group",
+                "title": "Summary",
+                "blocks": [{
+                    "type": "Summary",
+                    "id": "summary"
+                }]
+            }]
         }
     ]
 }

--- a/data/en/mbs_0817_prototype.json
+++ b/data/en/mbs_0817_prototype.json
@@ -1,0 +1,373 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "survey_id": "009",
+    "theme": "default",
+    "data_version": "0.0.1",
+    "title": "Monthly Business Survey",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
+    "description": "mbs",
+    "view_submitted_response": {
+        "enabled": true,
+        "duration": 900
+    },
+    "metadata": [{
+        "name": "user_id",
+        "validator": "string"
+    }, {
+        "name": "period_id",
+        "validator": "string"
+    }, {
+        "name": "ru_name",
+        "validator": "string"
+    }, {
+        "name": "ref_p_start_date",
+        "validator": "date"
+    }, {
+        "name": "ref_p_end_date",
+        "validator": "date"
+    }, {
+        "name": "trad_as",
+        "validator": "optional_string"
+    }],
+    "sections": [{
+        "id": "section",
+        "groups": [{
+            "id": "group",
+            "title": "",
+            "blocks": [{
+                "type": "Introduction",
+                "id": "introduction",
+                "primary_content": [{
+                    "type": "Basic",
+                    "id": "use-of-information",
+                    "content": [{
+                        "list": ["Data should relate to all sites in England, Scotland and Wales unless otherwise stated.", "You can provide informed estimates if actual figures aren\u2019t available.", "We will treat your data securely and confidentially."]
+                    }]
+                }],
+                "preview_content": {
+                    "id": "preview",
+                    "title": "Information you need",
+                    "content": [{
+                        "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
+                    }],
+                    "questions": [{
+                        "question": "Total turnover",
+                        "content": [{
+                            "description": "Include:",
+                            "list": ["exports", "costs incurred and passed on to customers", "income from sub-contracted activities", "commission", "sales of goods purchased for resale", "revenue earned from other parts of the business, not named at the top of this page (please supply at fair value)"]
+                        }, {
+                            "description": "Exclude:",
+                            "list": ["VAT", "income from the sale of fixed capital assets", "grants and subsidies", "insurance claims", "interest received"]
+                        }]
+                    }, {
+                        "question": "Changes in turnover",
+                        "content": [{
+                            "description": "Include:",
+                            "list": ["change in level of business activity", "maintenance/shutdowns", "special/calendar events", "weather", "price effects", "currency effects (increase/decrease in the currency value)"]
+                        }]
+                    }]
+                },
+                "secondary_content": [{
+                    "id": "how-we-use-your-data",
+                    "title": "How we use your data",
+                    "content": [{
+                        "list": ["You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.", "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"]
+                    }]
+                }]
+            }, {
+                "id": "reporting-period-block",
+                "type": "Question",
+                "questions": [{
+                    "answers": [{
+                        "options": [{
+                            "value": "Yes",
+                            "label": "Yes"
+                        }, {
+                            "value": "No",
+                            "label": "No"
+                        }],
+                        "id": "reporting-period-answer",
+                        "type": "Radio",
+                        "q_code": "d12",
+                        "mandatory": true
+                    }],
+                    "type": "General",
+                    "id": "reporting-period-question",
+                    "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
+                }],
+                "routing_rules": [{
+                    "goto": {
+                        "when": [{
+                            "id": "reporting-period-answer",
+                            "value": "Yes",
+                            "condition": "equals"
+                        }],
+                        "block": "turnover-block"
+                    }
+                }, {
+                    "goto": {
+                        "block": "reporting-period-block-2"
+                    }
+                }],
+                "title": "Reporting period"
+            }, {
+                "type": "Question",
+                "id": "reporting-period-block-2",
+                "title": "Reporting period",
+                "questions": [{
+                    "type": "DateRange",
+                    "id": "reporting-period-question-2",
+                    "title": "What are the dates of the period that you will be reporting for?",
+                    "period_limits": {
+                        "minimum": {
+                            "days": 10
+                        },
+                        "maximum": {
+                            "days": 50
+                        }
+                    },
+                    "answers": [{
+                        "type": "Date",
+                        "id": "period-from",
+                        "label": "From",
+                        "mandatory": true,
+                        "q_code": "11",
+                        "minimum": {
+                            "meta": "ref_p_start_date",
+                            "offset_by": {
+                                "days": -19
+                            }
+                        }
+                    }, {
+                        "type": "Date",
+                        "id": "period-to",
+                        "label": "To",
+                        "mandatory": true,
+                        "q_code": "12",
+                        "maximum": {
+                            "meta": "ref_p_end_date",
+                            "offset_by": {
+                                "days": 20
+                            }
+                        }
+                    }]
+                }]
+            }, {
+                "id": "turnover-block",
+                "type": "Question",
+                "questions": [{
+                    "guidance": {
+                        "content": [{
+                            "title": "Include:",
+                            "list": ["exports", "costs incurred and passed on to customers", "income from sub-contracted activities", "commission", "sales of goods purchased for resale", "revenue earned from other parts of the business not named (please supply at fair value)"]
+                        }, {
+                            "title": "Exclude:",
+                            "list": ["VAT", "income from the sale of fixed capital assets", "grants and subsidies", "insurance claims", "interest received"]
+                        }]
+                    },
+                    "id": "turnover-question",
+                    "answers": [{
+                        "id": "turnover-answer",
+                        "label": "Total turnover excluding VAT",
+                        "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                        "type": "Currency",
+                        "currency": "GBP",
+                        "decimal_places": 2,
+                        "q_code": "40",
+                        "mandatory": true
+                    }],
+                    "type": "General",
+                    "title": "For the period {{format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>total turnover</em>, excluding VAT?"
+                }],
+                "title": "Total turnover"
+            }, {
+                "type": "ConfirmationQuestion",
+                "title": "Total turnover",
+                "id": "confirm-turnover-block",
+                "questions": [{
+                    "type": "General",
+                    "answers": [{
+                        "type": "Radio",
+                        "id": "confirm-turnover-answer",
+                        "q_code": "d40",
+                        "options": [{
+                            "label": "Yes this is correct",
+                            "value": "Yes"
+                        }, {
+                            "label": "No I need to change this",
+                            "value": "No"
+                        }],
+                        "mandatory": true
+                    }],
+                    "id": "confirm-turnover-question",
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
+                }],
+                "routing_rules": [{
+                    "goto": {
+                        "when": [{
+                            "value": "No",
+                            "id": "confirm-turnover-answer",
+                            "condition": "equals"
+                        }],
+                        "block": "turnover-block"
+                    }
+                }, {
+                    "goto": {
+                        "block": "changes-in-turnover-block"
+                    }
+                }]
+            }, {
+                "id": "changes-in-turnover-block",
+                "type": "Question",
+                "questions": [{
+                    "title": "Did any significant changes occur to the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                    "id": "changes-in-turnover-question",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
+                        }, {
+                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }]
+                    }],
+                    "answers": [{
+                        "options": [{
+                            "value": "Yes",
+                            "label": "Yes"
+                        }, {
+                            "value": "No",
+                            "label": "No"
+                        }],
+                        "id": "changes-in-turnover-answer",
+                        "type": "Radio",
+                        "q_code": "146",
+                        "mandatory": true
+                    }],
+                    "guidance": {
+                        "content": [{
+                            "title": "Include:",
+                            "list": ["change in level of business activity", "maintenance/shutdowns", "special/calendar events", "weather", "price effects", "currency effects (increase/decrease in the currency value)"]
+                        }]
+                    },
+                    "type": "General"
+                }],
+                "title": "Changes in turnover",
+                "routing_rules": [{
+                    "goto": {
+                        "when": [{
+                            "id": "changes-in-turnover-answer",
+                            "value": "Yes",
+                            "condition": "equals"
+                        }],
+                        "block": "changes-in-turnover-block-2"
+                    }
+                }, {
+                    "goto": {
+                        "group": "summary-group"
+                    }
+                }]
+            }, {
+                "id": "changes-in-turnover-block-2",
+                "type": "Question",
+                "questions": [{
+                    "title": "Please indicate the reasons for any changes in the turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
+                    "answers": [{
+                        "options": [{
+                            "q_code": "146a",
+                            "value": "Change in level of business activity",
+                            "label": "Change in level of business activity"
+                        }, {
+                            "q_code": "146b",
+                            "value": "Maintenance/shutdowns",
+                            "label": "Maintenance/shutdowns"
+                        }, {
+                            "q_code": "146c",
+                            "value": "Special/calendar events",
+                            "label": "Special/calendar events"
+                        }, {
+                            "q_code": "146d",
+                            "value": "Weather",
+                            "label": "Weather"
+                        }, {
+                            "q_code": "146e",
+                            "value": "Price effects",
+                            "label": "Price effects"
+                        }, {
+                            "q_code": "146f",
+                            "value": "Currency effects (increase/decrease in the currency value)",
+                            "label": "Currency effects (increase/decrease in the currency value)"
+                        }, {
+                            "q_code": "146g",
+                            "value": "Other",
+                            "label": "Other"
+                        }],
+                        "id": "changes-in-turnover-answer-2",
+                        "type": "Checkbox",
+                        "mandatory": true
+                    }],
+                    "type": "General",
+                    "id": "changes-in-turnover-question-2"
+                }],
+                "title": "Changes in turnover"
+            }, {
+                "type": "Question",
+                "id": "changes-in-turnover-block-3",
+                "title": "Changes in turnover",
+                "questions": [{
+                    "type": "General",
+                    "id": "changes-in-turnover-question-3",
+                    "title": "Please describe the changes in turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
+                    "answers": [{
+                        "guidance": {
+                            "hide_guidance": "Hide examples of commentary on changes to turnover",
+                            "show_guidance": "Show examples of commentary on changes to turnover",
+                            "content": [{
+                                "list": [],
+                                "title": "\u2018Change in level of business activity\u2019",
+                                "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
+                            }, {
+                                "list": [],
+                                "title": "\u2018Maintenance/shutdowns\u2019",
+                                "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
+                            }, {
+                                "list": [],
+                                "title": "\u2018Special/calendar events\u2019",
+                                "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
+                            }, {
+                                "list": [],
+                                "title": "\u2018Weather\u2019",
+                                "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
+                            }, {
+                                "list": [],
+                                "title": "\u2018Price effects\u2019",
+                                "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
+                            }, {
+                                "list": [],
+                                "title": "\u2018Currency effects (increase/decrease in the currency value)\u2019",
+                                "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
+                            }]
+                        },
+                        "type": "TextArea",
+                        "mandatory": true,
+                        "label": "Comments",
+                        "id": "changes-in-turnover-answer-3",
+                        "q_code": "146h"
+                    }],
+                    "description": "<p>We rely on your commentary to \u2018tell the story\u2019 behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
+                }]
+            }]
+        }]
+    }, {
+        "id": "summary-section",
+        "title": "Summary",
+        "groups": [{
+            "id": "summary-group",
+            "title": "Summary",
+            "blocks": [{
+                "type": "Summary",
+                "id": "summary"
+            }]
+        }]
+    }]
+}

--- a/data/en/mbs_0823.json
+++ b/data/en/mbs_0823.json
@@ -11,8 +11,7 @@
         "enabled": true,
         "duration": 900
     },
-    "metadata": [
-        {
+    "metadata": [{
             "name": "user_id",
             "validator": "string"
         },
@@ -37,505 +36,436 @@
             "validator": "optional_string"
         }
     ],
-    "sections": [
-        {
+    "sections": [{
             "id": "section",
-            "groups": [
-                {
-                    "id": "group",
-                    "title": "",
-                    "blocks": [
-                        {
-                            "type": "Introduction",
-                            "id": "introduction",
-                            "primary_content": [
-                                {
-                                    "type": "Basic",
-                                    "id": "use-of-information",
-                                    "content": [
-                                        {
+            "groups": [{
+                "id": "group",
+                "title": "",
+                "blocks": [{
+                        "type": "Introduction",
+                        "id": "introduction",
+                        "primary_content": [{
+                            "type": "Basic",
+                            "id": "use-of-information",
+                            "content": [{
+                                "list": [
+                                    "Data should relate to all sites in England, Scotland and Wales unless otherwise stated.",
+                                    "You can provide informed estimates if actual figures aren’t available.",
+                                    "We will treat your data securely and confidentially."
+                                ]
+                            }]
+                        }],
+                        "preview_content": {
+                            "id": "preview",
+                            "title": "Information you need",
+                            "content": [{
+                                "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
+                            }],
+                            "questions": [{
+                                    "question": "Total turnover",
+                                    "content": [{
+                                            "description": "Include:",
                                             "list": [
-                                                "Data should relate to all sites in England, Scotland and Wales unless otherwise stated.",
-                                                "You can provide informed estimates if actual figures aren’t available.",
-                                                "We will treat your data securely and confidentially."
+                                                "exports",
+                                                "costs incurred and passed on to customers",
+                                                "income from sub-contracted activities",
+                                                "commission",
+                                                "sales of goods purchased for resale",
+                                                "revenue earned from other parts of the business, not named at the top of this page (please supply at fair value)"
+                                            ]
+                                        },
+                                        {
+                                            "description": "Exclude:",
+                                            "list": [
+                                                "VAT",
+                                                "income from the sale of fixed capital assets",
+                                                "grants and subsidies",
+                                                "insurance claims",
+                                                "interest received"
                                             ]
                                         }
                                     ]
+                                },
+                                {
+                                    "question": "Changes in turnover",
+                                    "content": [{
+                                        "description": "Include:",
+                                        "list": [
+                                            "change in level of business activity",
+                                            "maintenance/shutdowns",
+                                            "special/calendar events",
+                                            "weather",
+                                            "price effects",
+                                            "currency effects (increase/decrease in the currency value)"
+                                        ]
+                                    }]
                                 }
-                            ],
-                            "preview_content": {
-                                "id": "preview",
-                                "title": "Information you need",
-                                "content": [
+                            ]
+                        },
+                        "secondary_content": [{
+                            "id": "how-we-use-your-data",
+                            "title": "How we use your data",
+                            "content": [{
+                                "list": [
+                                    "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
+                                    "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"
+                                ]
+                            }]
+                        }]
+                    },
+                    {
+                        "id": "reporting-period-block",
+                        "type": "Question",
+                        "questions": [{
+                            "answers": [{
+                                "options": [{
+                                        "value": "Yes",
+                                        "label": "Yes"
+                                    },
                                     {
-                                        "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
+                                        "value": "No",
+                                        "label": "No"
                                     }
                                 ],
-                                "questions": [
-                                    {
-                                        "question": "Total turnover",
-                                        "content": [
-                                            {
-                                                "description": "Include:",
-                                                "list": [
-                                                    "exports",
-                                                    "costs incurred and passed on to customers",
-                                                    "income from sub-contracted activities",
-                                                    "commission",
-                                                    "sales of goods purchased for resale",
-                                                    "revenue earned from other parts of the business, not named at the top of this page (please supply at fair value)"
-                                                ]
-                                            },
-                                            {
-                                                "description": "Exclude:",
-                                                "list": [
-                                                    "VAT",
-                                                    "income from the sale of fixed capital assets",
-                                                    "grants and subsidies",
-                                                    "insurance claims",
-                                                    "interest received"
-                                                ]
-                                            }
+                                "id": "reporting-period-answer",
+                                "type": "Radio",
+                                "q_code": "d12",
+                                "mandatory": true
+                            }],
+                            "type": "General",
+                            "id": "reporting-period-question",
+                            "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "id": "reporting-period-answer",
+                                        "value": "Yes",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "turnover-block"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "reporting-period-block-2"
+                                }
+                            }
+                        ],
+                        "title": "Reporting period"
+                    },
+                    {
+                        "type": "Question",
+                        "id": "reporting-period-block-2",
+                        "title": "Reporting period",
+                        "questions": [{
+                            "type": "DateRange",
+                            "id": "reporting-period-question-2",
+                            "title": "What are the dates of the period that you will be reporting for?",
+                            "period_limits": {
+                                "minimum": {
+                                    "days": 10
+                                },
+                                "maximum": {
+                                    "days": 50
+                                }
+                            },
+                            "answers": [{
+                                    "type": "Date",
+                                    "id": "period-from",
+                                    "label": "From",
+                                    "mandatory": true,
+                                    "q_code": "11",
+                                    "minimum": {
+                                        "meta": "ref_p_start_date",
+                                        "offset_by": {
+                                            "days": -19
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "Date",
+                                    "id": "period-to",
+                                    "label": "To",
+                                    "mandatory": true,
+                                    "q_code": "12",
+                                    "maximum": {
+                                        "meta": "ref_p_end_date",
+                                        "offset_by": {
+                                            "days": 20
+                                        }
+                                    }
+                                }
+                            ]
+                        }]
+                    },
+                    {
+                        "id": "turnover-block",
+                        "type": "Question",
+                        "questions": [{
+                            "guidance": {
+                                "content": [{
+                                        "title": "Include:",
+                                        "list": [
+                                            "exports",
+                                            "costs incurred and passed on to customers",
+                                            "income from sub-contracted activities",
+                                            "commission",
+                                            "sales of goods purchased for resale",
+                                            "revenue earned from other parts of the business, not named at the top of this page (please supply at fair value)"
                                         ]
                                     },
                                     {
-                                        "question": "Changes in turnover",
-                                        "content": [
-                                            {
-                                                "description": "Include:",
-                                                "list": [
-                                                    "change in level of business activity",
-                                                    "maintenance/shutdowns",
-                                                    "special/calendar events",
-                                                    "weather",
-                                                    "price effects",
-                                                    "currency effects (increase/decrease in the currency value)"
-                                                ]
-                                            }
+                                        "title": "Exclude:",
+                                        "list": [
+                                            "VAT",
+                                            "income from the sale of fixed capital assets",
+                                            "grants and subsidies",
+                                            "insurance claims",
+                                            "interest received"
                                         ]
                                     }
                                 ]
                             },
-                            "secondary_content": [
-                                {
-                                    "id": "how-we-use-your-data",
-                                    "title": "How we use your data",
-                                    "content": [
+                            "id": "turnover-question",
+                            "answers": [{
+                                "id": "turnover-answer",
+                                "label": "Total turnover excluding VAT",
+                                "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                                "type": "Currency",
+                                "currency": "GBP",
+                                "decimal_places": 2,
+                                "q_code": "40",
+                                "mandatory": true
+                            }],
+                            "type": "General",
+                            "title": "For the period {{format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s <em>total turnover</em>, excluding VAT?"
+                        }],
+                        "title": "Total Turnover"
+                    },
+                    {
+                        "type": "ConfirmationQuestion",
+                        "title": "Total turnover",
+                        "id": "confirm-turnover-block",
+                        "questions": [{
+                            "type": "General",
+                            "answers": [{
+                                "type": "Radio",
+                                "id": "confirm-turnover-answer",
+                                "q_code": "d40",
+                                "options": [{
+                                        "label": "Yes this is correct",
+                                        "value": "Yes"
+                                    },
+                                    {
+                                        "label": "No I need to change this",
+                                        "value": "No"
+                                    }
+                                ],
+                                "mandatory": true
+                            }],
+                            "id": "confirm-turnover-question",
+                            "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
+                        }],
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "value": "No",
+                                        "id": "confirm-turnover-answer",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "turnover-block"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "block": "changes-in-turnover-block"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "changes-in-turnover-block",
+                        "type": "Question",
+                        "questions": [{
+                            "title": "Did any significant changes occur to the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                            "id": "changes-in-turnover-question",
+                            "definitions": [{
+                                "title": "What constitutes a significant change?",
+                                "content": [{
+                                        "description": "What constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s figures from the previous reporting period and the same reporting period last year."
+                                    },
+                                    {
+                                        "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                                    }
+                                ]
+                            }],
+                            "answers": [{
+                                "options": [{
+                                        "value": "Yes",
+                                        "label": "Yes"
+                                    },
+                                    {
+                                        "value": "No",
+                                        "label": "No"
+                                    }
+                                ],
+                                "id": "changes-in-turnover-answer",
+                                "type": "Radio",
+                                "q_code": "146",
+                                "mandatory": true
+                            }],
+                            "guidance": {
+                                "content": [{
+                                    "title": "Include:",
+                                    "list": [
+                                        "change in level of business activity",
+                                        "maintenance/shutdowns",
+                                        "special/calendar events",
+                                        "weather",
+                                        "price effects",
+                                        "currency effects (increase/decrease in the currency value)"
+                                    ]
+                                }]
+                            },
+                            "type": "General"
+                        }],
+                        "title": "Changes in total turnover",
+                        "routing_rules": [{
+                                "goto": {
+                                    "when": [{
+                                        "id": "changes-in-turnover-answer",
+                                        "value": "Yes",
+                                        "condition": "equals"
+                                    }],
+                                    "block": "changes-in-turnover-block-2"
+                                }
+                            },
+                            {
+                                "goto": {
+                                    "group": "summary-group"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "changes-in-turnover-block-2",
+                        "type": "Question",
+                        "questions": [{
+                            "title": "Please indicate the reasons for any changes in the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
+                            "answers": [{
+                                "options": [{
+                                        "q_code": "146a",
+                                        "value": "Change in level of business activity",
+                                        "label": "Change in level of business activity"
+                                    },
+                                    {
+                                        "q_code": "146b",
+                                        "value": "Maintenance/shutdowns",
+                                        "label": "Maintenance/shutdowns"
+                                    },
+                                    {
+                                        "q_code": "146c",
+                                        "value": "Special/calendar events",
+                                        "label": "Special/calendar events"
+                                    },
+                                    {
+                                        "q_code": "146d",
+                                        "value": "Weather",
+                                        "label": "Weather"
+                                    },
+                                    {
+                                        "q_code": "146e",
+                                        "value": "Price effects",
+                                        "label": "Price effects"
+                                    },
+                                    {
+                                        "q_code": "146f",
+                                        "value": "Currency effects (increase/decrease in the currency value)",
+                                        "label": "Currency effects (increase/decrease in the currency value)"
+                                    },
+                                    {
+                                        "q_code": "146g",
+                                        "value": "Other",
+                                        "label": "Other"
+                                    }
+                                ],
+                                "id": "changes-in-turnover-answer-2",
+                                "type": "Checkbox",
+                                "mandatory": true
+                            }],
+                            "type": "General",
+                            "id": "changes-in-turnover-question-2"
+                        }],
+                        "title": "Changes in total turnover"
+                    },
+                    {
+                        "type": "Question",
+                        "id": "changes-in-turnover-block-3",
+                        "title": "Changes in total turnover",
+                        "questions": [{
+                            "type": "General",
+                            "id": "changes-in-turnover-question-3",
+                            "title": "Please describe the changes in total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
+                            "answers": [{
+                                "guidance": {
+                                    "hide_guidance": "Hide examples of commentary on changes to total turnover",
+                                    "show_guidance": "Show examples of commentary on changes to total turnover",
+                                    "content": [{
+                                            "list": [],
+                                            "title": "‘Change in level of business activity’",
+                                            "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
+                                        },
                                         {
-                                            "list": [
-                                                "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
-                                                "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"
-                                            ]
+                                            "list": [],
+                                            "title": "‘Maintenance/shutdowns’",
+                                            "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
+                                        },
+                                        {
+                                            "list": [],
+                                            "title": "‘Special/calendar events’",
+                                            "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
+                                        },
+                                        {
+                                            "list": [],
+                                            "title": "‘Weather’",
+                                            "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
+                                        },
+                                        {
+                                            "list": [],
+                                            "title": "‘Price effects’",
+                                            "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
+                                        },
+                                        {
+                                            "list": [],
+                                            "title": "‘Currency effects (increase/decrease in the currency value)’",
+                                            "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
                                         }
                                     ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "reporting-period-block",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "answers": [
-                                        {
-                                            "options": [
-                                                {
-                                                    "value": "Yes",
-                                                    "label": "Yes"
-                                                },
-                                                {
-                                                    "value": "No",
-                                                    "label": "No"
-                                                }
-                                            ],
-                                            "id": "reporting-period-answer",
-                                            "type": "Radio",
-                                            "q_code": "d12",
-                                            "mandatory": true
-                                        }
-                                    ],
-                                    "type": "General",
-                                    "id": "reporting-period-question",
-                                    "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "when": [
-                                            {
-                                                "id": "reporting-period-answer",
-                                                "value": "Yes",
-                                                "condition": "equals"
-                                            }
-                                        ],
-                                        "block": "turnover-block"
-                                    }
                                 },
-                                {
-                                    "goto": {
-                                        "block": "reporting-period-block-2"
-                                    }
-                                }
-                            ],
-                            "title": "Reporting period"
-                        },
-                        {
-                            "type": "Question",
-                            "id": "reporting-period-block-2",
-                            "title": "Reporting period",
-                            "questions": [
-                                {
-                                    "type": "DateRange",
-                                    "id": "reporting-period-question-2",
-                                    "title": "What are the dates of the period that you will be reporting for?",
-                                    "period_limits": {
-                                        "minimum": {
-                                            "days": 10
-                                        },
-                                        "maximum": {
-                                            "days": 50
-                                        }
-                                    },
-                                    "answers": [
-                                        {
-                                            "type": "Date",
-                                            "id": "period-from",
-                                            "label": "From",
-                                            "mandatory": true,
-                                            "q_code": "11",
-                                            "minimum": {
-                                                "meta": "ref_p_start_date",
-                                                "offset_by": {
-                                                    "days": -19
-                                                }
-                                            }
-                                        },
-                                        {
-                                            "type": "Date",
-                                            "id": "period-to",
-                                            "label": "To",
-                                            "mandatory": true,
-                                            "q_code": "12",
-                                            "maximum": {
-                                                "meta": "ref_p_end_date",
-                                                "offset_by": {
-                                                    "days": 20
-                                                }
-                                            }
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "turnover-block",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "guidance": {
-                                        "content": [
-                                            {
-                                                "title": "Include:",
-                                                "list": [
-                                                    "exports",
-                                                    "costs incurred and passed on to customers",
-                                                    "income from sub-contracted activities",
-                                                    "commission",
-                                                    "sales of goods purchased for resale",
-                                                    "revenue earned from other parts of the business, not named at the top of this page (please supply at fair value)"
-                                                ]
-                                            },
-                                            {
-                                                "title": "Exclude:",
-                                                "list": [
-                                                    "VAT",
-                                                    "income from the sale of fixed capital assets",
-                                                    "grants and subsidies",
-                                                    "insurance claims",
-                                                    "interest received"
-                                                ]
-                                            }
-                                        ]
-                                    },
-                                    "id": "turnover-question",
-                                    "answers": [
-                                        {
-                                            "id": "turnover-answer",
-                                            "label": "Total turnover excluding VAT",
-                                            "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
-                                            "type": "Currency",
-                                            "currency": "GBP",
-                                            "decimal_places": 2,
-                                            "q_code": "40",
-                                            "mandatory": true
-                                        }
-                                    ],
-                                    "type": "General",
-                                    "title": "For the period {{format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s <em>total turnover</em>, excluding VAT?"
-                                }
-                            ],
-                            "title": "Total Turnover"
-                        },
-                        {
-                            "type": "ConfirmationQuestion",
-                            "title": "Total turnover",
-                            "id": "confirm-turnover-block",
-                            "questions": [
-                                {
-                                    "type": "General",
-                                    "answers": [
-                                        {
-                                            "type": "Radio",
-                                            "id": "confirm-turnover-answer",
-                                            "q_code": "d40",
-                                            "options": [
-                                                {
-                                                    "label": "Yes this is correct",
-                                                    "value": "Yes"
-                                                },
-                                                {
-                                                    "label": "No I need to change this",
-                                                    "value": "No"
-                                                }
-                                            ],
-                                            "mandatory": true
-                                        }
-                                    ],
-                                    "id": "confirm-turnover-question",
-                                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
-                                }
-                            ],
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "when": [
-                                            {
-                                                "value": "No",
-                                                "id": "confirm-turnover-answer",
-                                                "condition": "equals"
-                                            }
-                                        ],
-                                        "block": "turnover-block"
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "block": "changes-in-turnover-block"
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "id": "changes-in-turnover-block",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "title": "Did any significant changes occur to the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
-                                    "id": "changes-in-turnover-question",
-                                    "definitions": [
-                                        {
-                                            "title": "What constitutes a significant change?",
-                                            "content": [
-                                                {
-                                                    "description": "What constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s figures from the previous reporting period and the same reporting period last year."
-                                                },
-                                                {
-                                                    "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
-                                                }
-                                            ]
-                                        }
-                                    ],
-                                    "answers": [
-                                        {
-                                            "options": [
-                                                {
-                                                    "value": "Yes",
-                                                    "label": "Yes"
-                                                },
-                                                {
-                                                    "value": "No",
-                                                    "label": "No"
-                                                }
-                                            ],
-                                            "id": "changes-in-turnover-answer",
-                                            "type": "Radio",
-                                            "q_code": "146",
-                                            "mandatory": true
-                                        }
-                                    ],
-                                    "guidance": {
-                                        "content": [
-                                            {
-                                                "title": "Include:",
-                                                "list": [
-                                                    "change in level of business activity",
-                                                    "maintenance/shutdowns",
-                                                    "special/calendar events",
-                                                    "weather",
-                                                    "price effects",
-                                                    "currency effects (increase/decrease in the currency value)"
-                                                ]
-                                            }
-                                        ]
-                                    },
-                                    "type": "General"
-                                }
-                            ],
-                            "title": "Changes in total turnover",
-                            "routing_rules": [
-                                {
-                                    "goto": {
-                                        "when": [
-                                            {
-                                                "id": "changes-in-turnover-answer",
-                                                "value": "Yes",
-                                                "condition": "equals"
-                                            }
-                                        ],
-                                        "block": "changes-in-turnover-block-2"
-                                    }
-                                },
-                                {
-                                    "goto": {
-                                        "group": "summary-group"
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "id": "changes-in-turnover-block-2",
-                            "type": "Question",
-                            "questions": [
-                                {
-                                    "title": "Please indicate the reasons for any changes in the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
-                                    "answers": [
-                                        {
-                                            "options": [
-                                                {
-                                                    "q_code": "146a",
-                                                    "value": "Change in level of business activity",
-                                                    "label": "Change in level of business activity"
-                                                },
-                                                {
-                                                    "q_code": "146b",
-                                                    "value": "Maintenance/shutdowns",
-                                                    "label": "Maintenance/shutdowns"
-                                                },
-                                                {
-                                                    "q_code": "146c",
-                                                    "value": "Special/calendar events",
-                                                    "label": "Special/calendar events"
-                                                },
-                                                {
-                                                    "q_code": "146d",
-                                                    "value": "Weather",
-                                                    "label": "Weather"
-                                                },
-                                                {
-                                                    "q_code": "146e",
-                                                    "value": "Price effects",
-                                                    "label": "Price effects"
-                                                },
-                                                {
-                                                    "q_code": "146f",
-                                                    "value": "Currency effects (increase/decrease in the currency value)",
-                                                    "label": "Currency effects (increase/decrease in the currency value)"
-                                                },
-                                                {
-                                                    "q_code": "146g",
-                                                    "value": "Other",
-                                                    "label": "Other"
-                                                }
-                                            ],
-                                            "id": "changes-in-turnover-answer-2",
-                                            "type": "Checkbox",
-                                            "mandatory": true
-                                        }
-                                    ],
-                                    "type": "General",
-                                    "id": "changes-in-turnover-question-2"
-                                }
-                            ],
-                            "title": "Changes in total turnover"
-                        },
-                        {
-                            "type": "Question",
-                            "id": "changes-in-turnover-block-3",
-                            "title": "Changes in total turnover",
-                            "questions": [
-                                {
-                                    "type": "General",
-                                    "id": "changes-in-turnover-question-3",
-                                    "title": "Please describe the changes in total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
-                                    "answers": [
-                                        {
-                                            "guidance": {
-                                                "hide_guidance": "Hide examples of commentary on changes to total turnover",
-                                                "show_guidance": "Show examples of commentary on changes to total turnover",
-                                                "content": [
-                                                    {
-                                                        "list": [],
-                                                        "title": "‘Change in level of business activity’",
-                                                        "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
-                                                    },
-                                                    {
-                                                        "list": [],
-                                                        "title": "‘Maintenance/shutdowns’",
-                                                        "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
-                                                    },
-                                                    {
-                                                        "list": [],
-                                                        "title": "‘Special/calendar events’",
-                                                        "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
-                                                    },
-                                                    {
-                                                        "list": [],
-                                                        "title": "‘Weather’",
-                                                        "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
-                                                    },
-                                                    {
-                                                        "list": [],
-                                                        "title": "‘Price effects’",
-                                                        "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
-                                                    },
-                                                    {
-                                                        "list": [],
-                                                        "title": "‘Currency effects (increase/decrease in the currency value)’",
-                                                        "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
-                                                    }
-                                                ]
-                                            },
-                                            "type": "TextArea",
-                                            "mandatory": true,
-                                            "label": "Comments",
-                                            "id": "changes-in-turnover-answer-3",
-                                            "q_code": "146h"
-                                        }
-                                    ],
-                                    "description": "<p>We rely on your commentary to ‘tell the story’ behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ]
+                                "type": "TextArea",
+                                "mandatory": true,
+                                "label": "Comments",
+                                "id": "changes-in-turnover-answer-3",
+                                "q_code": "146h"
+                            }],
+                            "description": "<p>We rely on your commentary to ‘tell the story’ behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
+                        }]
+                    }
+                ]
+            }]
         },
         {
             "id": "summary-section",
             "title": "Summary",
-            "groups": [
-                {
-                    "id": "summary-group",
-                    "title": "Summary",
-                    "blocks": [
-                        {
-                            "type": "Summary",
-                            "id": "summary"
-                        }
-                    ]
-                }
-            ]
+            "groups": [{
+                "id": "summary-group",
+                "title": "Summary",
+                "blocks": [{
+                    "type": "Summary",
+                    "id": "summary"
+                }]
+            }]
         }
     ]
 }

--- a/data/en/mbs_0823.json
+++ b/data/en/mbs_0823.json
@@ -11,363 +11,531 @@
         "enabled": true,
         "duration": 900
     },
-    "metadata": [{
-        "name": "user_id",
-        "validator": "string"
-    }, {
-        "name": "period_id",
-        "validator": "string"
-    }, {
-        "name": "ru_name",
-        "validator": "string"
-    }, {
-        "name": "ref_p_start_date",
-        "validator": "date"
-    }, {
-        "name": "ref_p_end_date",
-        "validator": "date"
-    }, {
-        "name": "trad_as",
-        "validator": "optional_string"
-    }],
-    "sections": [{
-        "id": "section",
-        "groups": [{
-            "id": "group",
-            "title": "",
-            "blocks": [{
-                "type": "Introduction",
-                "id": "introduction",
-                "primary_content": [{
-                    "type": "Basic",
-                    "id": "use-of-information",
-                    "content": [{
-                        "list": ["Data should relate to all sites in England, Scotland and Wales unless otherwise stated.", "You can provide informed estimates if actual figures aren\u2019t available.", "We will treat your data securely and confidentially."]
-                    }]
-                }],
-                "preview_content": {
-                    "id": "preview",
-                    "title": "Information you need",
-                    "content": [{
-                        "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
-                    }],
-                    "questions": [{
-                        "question": "Total turnover",
-                        "content": [{
-                            "description": "Include:",
-                            "list": ["exports", "costs incurred and passed on to customers", "income from sub-contracted activities", "commission", "sales of goods purchased for resale", "revenue earned from other parts of the business, not named at the top of this page (please supply at fair value)"]
-                        }, {
-                            "description": "Exclude:",
-                            "list": ["VAT", "income from the sale of fixed capital assets", "grants and subsidies", "insurance claims", "interest received"]
-                        }]
-                    }, {
-                        "question": "Changes in turnover",
-                        "content": [{
-                            "description": "Include:",
-                            "list": ["change in level of business activity", "maintenance/shutdowns", "special/calendar events", "weather", "price effects", "currency effects (increase/decrease in the currency value)"]
-                        }]
-                    }]
-                },
-                "secondary_content": [{
-                    "id": "how-we-use-your-data",
-                    "title": "How we use your data",
-                    "content": [{
-                        "list": ["You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.", "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"]
-                    }]
-                }]
-            }, {
-                "id": "reporting-period-block",
-                "type": "Question",
-                "questions": [{
-                    "answers": [{
-                        "options": [{
-                            "value": "Yes",
-                            "label": "Yes"
-                        }, {
-                            "value": "No",
-                            "label": "No"
-                        }],
-                        "id": "reporting-period-answer",
-                        "type": "Radio",
-                        "q_code": "d12",
-                        "mandatory": true
-                    }],
-                    "type": "General",
-                    "id": "reporting-period-question",
-                    "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
-                }],
-                "routing_rules": [{
-                    "goto": {
-                        "when": [{
-                            "id": "reporting-period-answer",
-                            "value": "Yes",
-                            "condition": "equals"
-                        }],
-                        "block": "turnover-block"
-                    }
-                }, {
-                    "goto": {
-                        "block": "reporting-period-block-2"
-                    }
-                }],
-                "title": "Reporting period"
-            }, {
-                "type": "Question",
-                "id": "reporting-period-block-2",
-                "title": "Reporting period",
-                "questions": [{
-                    "type": "DateRange",
-                    "id": "reporting-period-question-2",
-                    "title": "What are the dates of the period that you will be reporting for?",
-                    "period_limits": {
-                        "minimum": {
-                            "days": 10
+    "metadata": [
+        {
+            "name": "user_id",
+            "validator": "string"
+        },
+        {
+            "name": "period_id",
+            "validator": "string"
+        },
+        {
+            "name": "ru_name",
+            "validator": "string"
+        },
+        {
+            "name": "ref_p_start_date",
+            "validator": "date"
+        },
+        {
+            "name": "ref_p_end_date",
+            "validator": "date"
+        },
+        {
+            "name": "trad_as",
+            "validator": "optional_string"
+        }
+    ],
+    "sections": [
+        {
+            "id": "section",
+            "groups": [
+                {
+                    "id": "group",
+                    "title": "",
+                    "blocks": [
+                        {
+                            "type": "Introduction",
+                            "id": "introduction",
+                            "primary_content": [
+                                {
+                                    "type": "Basic",
+                                    "id": "use-of-information",
+                                    "content": [
+                                        {
+                                            "list": [
+                                                "Data should relate to all sites in England, Scotland and Wales unless otherwise stated.",
+                                                "You can provide informed estimates if actual figures aren’t available.",
+                                                "We will treat your data securely and confidentially."
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "preview_content": {
+                                "id": "preview",
+                                "title": "Information you need",
+                                "content": [
+                                    {
+                                        "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
+                                    }
+                                ],
+                                "questions": [
+                                    {
+                                        "question": "Total turnover",
+                                        "content": [
+                                            {
+                                                "description": "Include:",
+                                                "list": [
+                                                    "exports",
+                                                    "costs incurred and passed on to customers",
+                                                    "income from sub-contracted activities",
+                                                    "commission",
+                                                    "sales of goods purchased for resale",
+                                                    "revenue earned from other parts of the business, not named at the top of this page (please supply at fair value)"
+                                                ]
+                                            },
+                                            {
+                                                "description": "Exclude:",
+                                                "list": [
+                                                    "VAT",
+                                                    "income from the sale of fixed capital assets",
+                                                    "grants and subsidies",
+                                                    "insurance claims",
+                                                    "interest received"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "question": "Changes in turnover",
+                                        "content": [
+                                            {
+                                                "description": "Include:",
+                                                "list": [
+                                                    "change in level of business activity",
+                                                    "maintenance/shutdowns",
+                                                    "special/calendar events",
+                                                    "weather",
+                                                    "price effects",
+                                                    "currency effects (increase/decrease in the currency value)"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "secondary_content": [
+                                {
+                                    "id": "how-we-use-your-data",
+                                    "title": "How we use your data",
+                                    "content": [
+                                        {
+                                            "list": [
+                                                "You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.",
+                                                "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
                         },
-                        "maximum": {
-                            "days": 50
-                        }
-                    },
-                    "answers": [{
-                        "type": "Date",
-                        "id": "period-from",
-                        "label": "From",
-                        "mandatory": true,
-                        "q_code": "11",
-                        "minimum": {
-                            "meta": "ref_p_start_date",
-                            "offset_by": {
-                                "days": -19
-                            }
-                        }
-                    }, {
-                        "type": "Date",
-                        "id": "period-to",
-                        "label": "To",
-                        "mandatory": true,
-                        "q_code": "12",
-                        "maximum": {
-                            "meta": "ref_p_end_date",
-                            "offset_by": {
-                                "days": 20
-                            }
-                        }
-                    }]
-                }]
-            }, {
-                "id": "turnover-block",
-                "type": "Question",
-                "questions": [{
-                    "guidance": {
-                        "content": [{
-                            "title": "Include:",
-                            "list": ["exports", "costs incurred and passed on to customers", "income from sub-contracted activities", "commission", "sales of goods purchased for resale", "revenue earned from other parts of the business, not named at the top of this page (please supply at fair value)"]
-                        }, {
-                            "title": "Exclude:",
-                            "list": ["VAT", "income from the sale of fixed capital assets", "grants and subsidies", "insurance claims", "interest received"]
-                        }]
-                    },
-                    "id": "turnover-question",
-                    "answers": [{
-                        "id": "turnover-answer",
-                        "label": "Total turnover excluding VAT",
-                        "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
-                        "type": "Currency",
-                        "currency": "GBP",
-                        "decimal_places": 2,
-                        "q_code": "40",
-                        "mandatory": true
-                    }],
-                    "type": "General",
-                    "title": "For the period {{format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>total turnover</em>, excluding VAT?"
-                }],
-                "title": "Total Turnover"
-            }, {
-                "type": "ConfirmationQuestion",
-                "title": "Total turnover",
-                "id": "confirm-turnover-block",
-                "questions": [{
-                    "type": "General",
-                    "answers": [{
-                        "type": "Radio",
-                        "id": "confirm-turnover-answer",
-                        "q_code": "d40",
-                        "options": [{
-                            "label": "Yes this is correct",
-                            "value": "Yes"
-                        }, {
-                            "label": "No I need to change this",
-                            "value": "No"
-                        }],
-                        "mandatory": true
-                    }],
-                    "id": "confirm-turnover-question",
-                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
-                }],
-                "routing_rules": [{
-                    "goto": {
-                        "when": [{
-                            "value": "No",
-                            "id": "confirm-turnover-answer",
-                            "condition": "equals"
-                        }],
-                        "block": "turnover-block"
-                    }
-                }, {
-                    "goto": {
-                        "block": "changes-in-turnover-block"
-                    }
-                }]
-            }, {
-                "id": "changes-in-turnover-block",
-                "type": "Question",
-                "questions": [{
-                    "title": "Did any significant changes occur to the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
-                    "id": "changes-in-turnover-question",
-                    "definitions": [{
-                        "title": "What constitutes a significant change?",
-                        "content": [{
-                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
-                        }, {
-                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
-                        }]
-                    }],
-                    "answers": [{
-                        "options": [{
-                            "value": "Yes",
-                            "label": "Yes"
-                        }, {
-                            "value": "No",
-                            "label": "No"
-                        }],
-                        "id": "changes-in-turnover-answer",
-                        "type": "Radio",
-                        "q_code": "146",
-                        "mandatory": true
-                    }],
-                    "guidance": {
-                        "content": [{
-                            "title": "Include:",
-                            "list": ["change in level of business activity", "maintenance/shutdowns", "special/calendar events", "weather", "price effects", "currency effects (increase/decrease in the currency value)"]
-                        }]
-                    },
-                    "type": "General"
-                }],
-                "title": "Changes in total turnover",
-                "routing_rules": [{
-                    "goto": {
-                        "when": [{
-                            "id": "changes-in-turnover-answer",
-                            "value": "Yes",
-                            "condition": "equals"
-                        }],
-                        "block": "changes-in-turnover-block-2"
-                    }
-                }, {
-                    "goto": {
-                        "group": "summary-group"
-                    }
-                }]
-            }, {
-                "id": "changes-in-turnover-block-2",
-                "type": "Question",
-                "questions": [{
-                    "title": "Please indicate the reasons for any changes in the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
-                    "answers": [{
-                        "options": [{
-                            "q_code": "146a",
-                            "value": "Change in level of business activity",
-                            "label": "Change in level of business activity"
-                        }, {
-                            "q_code": "146b",
-                            "value": "Maintenance/shutdowns",
-                            "label": "Maintenance/shutdowns"
-                        }, {
-                            "q_code": "146c",
-                            "value": "Special/calendar events",
-                            "label": "Special/calendar events"
-                        }, {
-                            "q_code": "146d",
-                            "value": "Weather",
-                            "label": "Weather"
-                        }, {
-                            "q_code": "146e",
-                            "value": "Price effects",
-                            "label": "Price effects"
-                        }, {
-                            "q_code": "146f",
-                            "value": "Currency effects (increase/decrease in the currency value)",
-                            "label": "Currency effects (increase/decrease in the currency value)"
-                        }, {
-                            "q_code": "146g",
-                            "value": "Other",
-                            "label": "Other"
-                        }],
-                        "id": "changes-in-turnover-answer-2",
-                        "type": "Checkbox",
-                        "mandatory": true
-                    }],
-                    "type": "General",
-                    "id": "changes-in-turnover-question-2"
-                }],
-                "title": "Changes in total turnover"
-            }, {
-                "type": "Question",
-                "id": "changes-in-turnover-block-3",
-                "title": "Changes in total turnover",
-                "questions": [{
-                    "type": "General",
-                    "id": "changes-in-turnover-question-3",
-                    "title": "Please describe the changes in total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
-                    "answers": [{
-                        "guidance": {
-                            "hide_guidance": "Hide examples of commentary on changes to total turnover",
-                            "show_guidance": "Show examples of commentary on changes to total turnover",
-                            "content": [{
-                                "list": [],
-                                "title": "\u2018Change in level of business activity\u2019",
-                                "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
-                            }, {
-                                "list": [],
-                                "title": "\u2018Maintenance/shutdowns\u2019",
-                                "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
-                            }, {
-                                "list": [],
-                                "title": "\u2018Special/calendar events\u2019",
-                                "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
-                            }, {
-                                "list": [],
-                                "title": "\u2018Weather\u2019",
-                                "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
-                            }, {
-                                "list": [],
-                                "title": "\u2018Price effects\u2019",
-                                "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
-                            }, {
-                                "list": [],
-                                "title": "\u2018Currency effects (increase/decrease in the currency value)\u2019",
-                                "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
-                            }]
+                        {
+                            "id": "reporting-period-block",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "answers": [
+                                        {
+                                            "options": [
+                                                {
+                                                    "value": "Yes",
+                                                    "label": "Yes"
+                                                },
+                                                {
+                                                    "value": "No",
+                                                    "label": "No"
+                                                }
+                                            ],
+                                            "id": "reporting-period-answer",
+                                            "type": "Radio",
+                                            "q_code": "d12",
+                                            "mandatory": true
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "id": "reporting-period-question",
+                                    "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "when": [
+                                            {
+                                                "id": "reporting-period-answer",
+                                                "value": "Yes",
+                                                "condition": "equals"
+                                            }
+                                        ],
+                                        "block": "turnover-block"
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "reporting-period-block-2"
+                                    }
+                                }
+                            ],
+                            "title": "Reporting period"
                         },
-                        "type": "TextArea",
-                        "mandatory": true,
-                        "label": "Comments",
-                        "id": "changes-in-turnover-answer-3",
-                        "q_code": "146h"
-                    }],
-                    "description": "<p>We rely on your commentary to \u2018tell the story\u2019 behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
-                }]
-            }]
-        }]
-    }, {
-        "id": "summary-section",
-        "title": "Summary",
-        "groups": [{
-            "id": "summary-group",
+                        {
+                            "type": "Question",
+                            "id": "reporting-period-block-2",
+                            "title": "Reporting period",
+                            "questions": [
+                                {
+                                    "type": "DateRange",
+                                    "id": "reporting-period-question-2",
+                                    "title": "What are the dates of the period that you will be reporting for?",
+                                    "period_limits": {
+                                        "minimum": {
+                                            "days": 10
+                                        },
+                                        "maximum": {
+                                            "days": 50
+                                        }
+                                    },
+                                    "answers": [
+                                        {
+                                            "type": "Date",
+                                            "id": "period-from",
+                                            "label": "From",
+                                            "mandatory": true,
+                                            "q_code": "11",
+                                            "minimum": {
+                                                "meta": "ref_p_start_date",
+                                                "offset_by": {
+                                                    "days": -19
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "type": "Date",
+                                            "id": "period-to",
+                                            "label": "To",
+                                            "mandatory": true,
+                                            "q_code": "12",
+                                            "maximum": {
+                                                "meta": "ref_p_end_date",
+                                                "offset_by": {
+                                                    "days": 20
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "turnover-block",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "guidance": {
+                                        "content": [
+                                            {
+                                                "title": "Include:",
+                                                "list": [
+                                                    "exports",
+                                                    "costs incurred and passed on to customers",
+                                                    "income from sub-contracted activities",
+                                                    "commission",
+                                                    "sales of goods purchased for resale",
+                                                    "revenue earned from other parts of the business, not named at the top of this page (please supply at fair value)"
+                                                ]
+                                            },
+                                            {
+                                                "title": "Exclude:",
+                                                "list": [
+                                                    "VAT",
+                                                    "income from the sale of fixed capital assets",
+                                                    "grants and subsidies",
+                                                    "insurance claims",
+                                                    "interest received"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "id": "turnover-question",
+                                    "answers": [
+                                        {
+                                            "id": "turnover-answer",
+                                            "label": "Total turnover excluding VAT",
+                                            "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                                            "type": "Currency",
+                                            "currency": "GBP",
+                                            "decimal_places": 2,
+                                            "q_code": "40",
+                                            "mandatory": true
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "title": "For the period {{format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s <em>total turnover</em>, excluding VAT?"
+                                }
+                            ],
+                            "title": "Total Turnover"
+                        },
+                        {
+                            "type": "ConfirmationQuestion",
+                            "title": "Total turnover",
+                            "id": "confirm-turnover-block",
+                            "questions": [
+                                {
+                                    "type": "General",
+                                    "answers": [
+                                        {
+                                            "type": "Radio",
+                                            "id": "confirm-turnover-answer",
+                                            "q_code": "d40",
+                                            "options": [
+                                                {
+                                                    "label": "Yes this is correct",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No I need to change this",
+                                                    "value": "No"
+                                                }
+                                            ],
+                                            "mandatory": true
+                                        }
+                                    ],
+                                    "id": "confirm-turnover-question",
+                                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
+                                }
+                            ],
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "when": [
+                                            {
+                                                "value": "No",
+                                                "id": "confirm-turnover-answer",
+                                                "condition": "equals"
+                                            }
+                                        ],
+                                        "block": "turnover-block"
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "changes-in-turnover-block"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "id": "changes-in-turnover-block",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "title": "Did any significant changes occur to the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                                    "id": "changes-in-turnover-question",
+                                    "definitions": [
+                                        {
+                                            "title": "What constitutes a significant change?",
+                                            "content": [
+                                                {
+                                                    "description": "What constitutes a ‘significant change’ is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}’s figures from the previous reporting period and the same reporting period last year."
+                                                },
+                                                {
+                                                    "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "answers": [
+                                        {
+                                            "options": [
+                                                {
+                                                    "value": "Yes",
+                                                    "label": "Yes"
+                                                },
+                                                {
+                                                    "value": "No",
+                                                    "label": "No"
+                                                }
+                                            ],
+                                            "id": "changes-in-turnover-answer",
+                                            "type": "Radio",
+                                            "q_code": "146",
+                                            "mandatory": true
+                                        }
+                                    ],
+                                    "guidance": {
+                                        "content": [
+                                            {
+                                                "title": "Include:",
+                                                "list": [
+                                                    "change in level of business activity",
+                                                    "maintenance/shutdowns",
+                                                    "special/calendar events",
+                                                    "weather",
+                                                    "price effects",
+                                                    "currency effects (increase/decrease in the currency value)"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "type": "General"
+                                }
+                            ],
+                            "title": "Changes in total turnover",
+                            "routing_rules": [
+                                {
+                                    "goto": {
+                                        "when": [
+                                            {
+                                                "id": "changes-in-turnover-answer",
+                                                "value": "Yes",
+                                                "condition": "equals"
+                                            }
+                                        ],
+                                        "block": "changes-in-turnover-block-2"
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "group": "summary-group"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "id": "changes-in-turnover-block-2",
+                            "type": "Question",
+                            "questions": [
+                                {
+                                    "title": "Please indicate the reasons for any changes in the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
+                                    "answers": [
+                                        {
+                                            "options": [
+                                                {
+                                                    "q_code": "146a",
+                                                    "value": "Change in level of business activity",
+                                                    "label": "Change in level of business activity"
+                                                },
+                                                {
+                                                    "q_code": "146b",
+                                                    "value": "Maintenance/shutdowns",
+                                                    "label": "Maintenance/shutdowns"
+                                                },
+                                                {
+                                                    "q_code": "146c",
+                                                    "value": "Special/calendar events",
+                                                    "label": "Special/calendar events"
+                                                },
+                                                {
+                                                    "q_code": "146d",
+                                                    "value": "Weather",
+                                                    "label": "Weather"
+                                                },
+                                                {
+                                                    "q_code": "146e",
+                                                    "value": "Price effects",
+                                                    "label": "Price effects"
+                                                },
+                                                {
+                                                    "q_code": "146f",
+                                                    "value": "Currency effects (increase/decrease in the currency value)",
+                                                    "label": "Currency effects (increase/decrease in the currency value)"
+                                                },
+                                                {
+                                                    "q_code": "146g",
+                                                    "value": "Other",
+                                                    "label": "Other"
+                                                }
+                                            ],
+                                            "id": "changes-in-turnover-answer-2",
+                                            "type": "Checkbox",
+                                            "mandatory": true
+                                        }
+                                    ],
+                                    "type": "General",
+                                    "id": "changes-in-turnover-question-2"
+                                }
+                            ],
+                            "title": "Changes in total turnover"
+                        },
+                        {
+                            "type": "Question",
+                            "id": "changes-in-turnover-block-3",
+                            "title": "Changes in total turnover",
+                            "questions": [
+                                {
+                                    "type": "General",
+                                    "id": "changes-in-turnover-question-3",
+                                    "title": "Please describe the changes in total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
+                                    "answers": [
+                                        {
+                                            "guidance": {
+                                                "hide_guidance": "Hide examples of commentary on changes to total turnover",
+                                                "show_guidance": "Show examples of commentary on changes to total turnover",
+                                                "content": [
+                                                    {
+                                                        "list": [],
+                                                        "title": "‘Change in level of business activity’",
+                                                        "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
+                                                    },
+                                                    {
+                                                        "list": [],
+                                                        "title": "‘Maintenance/shutdowns’",
+                                                        "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
+                                                    },
+                                                    {
+                                                        "list": [],
+                                                        "title": "‘Special/calendar events’",
+                                                        "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
+                                                    },
+                                                    {
+                                                        "list": [],
+                                                        "title": "‘Weather’",
+                                                        "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
+                                                    },
+                                                    {
+                                                        "list": [],
+                                                        "title": "‘Price effects’",
+                                                        "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
+                                                    },
+                                                    {
+                                                        "list": [],
+                                                        "title": "‘Currency effects (increase/decrease in the currency value)’",
+                                                        "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
+                                                    }
+                                                ]
+                                            },
+                                            "type": "TextArea",
+                                            "mandatory": true,
+                                            "label": "Comments",
+                                            "id": "changes-in-turnover-answer-3",
+                                            "q_code": "146h"
+                                        }
+                                    ],
+                                    "description": "<p>We rely on your commentary to ‘tell the story’ behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "summary-section",
             "title": "Summary",
-            "blocks": [{
-                "type": "Summary",
-                "id": "summary"
-            }]
-        }]
-    }]
+            "groups": [
+                {
+                    "id": "summary-group",
+                    "title": "Summary",
+                    "blocks": [
+                        {
+                            "type": "Summary",
+                            "id": "summary"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
 }

--- a/data/en/mbs_0823_prototype.json
+++ b/data/en/mbs_0823_prototype.json
@@ -1,0 +1,373 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "schema_version": "0.0.1",
+    "survey_id": "009",
+    "theme": "default",
+    "data_version": "0.0.1",
+    "title": "Monthly Business Survey",
+    "legal_basis": "Notice is given under section 1 of the Statistics of Trade Act 1947.",
+    "description": "mbs",
+    "view_submitted_response": {
+        "enabled": true,
+        "duration": 900
+    },
+    "metadata": [{
+        "name": "user_id",
+        "validator": "string"
+    }, {
+        "name": "period_id",
+        "validator": "string"
+    }, {
+        "name": "ru_name",
+        "validator": "string"
+    }, {
+        "name": "ref_p_start_date",
+        "validator": "date"
+    }, {
+        "name": "ref_p_end_date",
+        "validator": "date"
+    }, {
+        "name": "trad_as",
+        "validator": "optional_string"
+    }],
+    "sections": [{
+        "id": "section",
+        "groups": [{
+            "id": "group",
+            "title": "",
+            "blocks": [{
+                "type": "Introduction",
+                "id": "introduction",
+                "primary_content": [{
+                    "type": "Basic",
+                    "id": "use-of-information",
+                    "content": [{
+                        "list": ["Data should relate to all sites in England, Scotland and Wales unless otherwise stated.", "You can provide informed estimates if actual figures aren\u2019t available.", "We will treat your data securely and confidentially."]
+                    }]
+                }],
+                "preview_content": {
+                    "id": "preview",
+                    "title": "Information you need",
+                    "content": [{
+                        "description": "You can select the dates of the period you are reporting for, if the given dates are not appropriate."
+                    }],
+                    "questions": [{
+                        "question": "Total turnover",
+                        "content": [{
+                            "description": "Include:",
+                            "list": ["exports", "costs incurred and passed on to customers", "income from sub-contracted activities", "commission", "sales of goods purchased for resale", "revenue earned from other parts of the business, not named at the top of this page (please supply at fair value)"]
+                        }, {
+                            "description": "Exclude:",
+                            "list": ["VAT", "income from the sale of fixed capital assets", "grants and subsidies", "insurance claims", "interest received"]
+                        }]
+                    }, {
+                        "question": "Changes in turnover",
+                        "content": [{
+                            "description": "Include:",
+                            "list": ["change in level of business activity", "maintenance/shutdowns", "special/calendar events", "weather", "price effects", "currency effects (increase/decrease in the currency value)"]
+                        }]
+                    }]
+                },
+                "secondary_content": [{
+                    "id": "how-we-use-your-data",
+                    "title": "How we use your data",
+                    "content": [{
+                        "list": ["You cannot appeal your selection. Your business was selected to give us a comprehensive view of the UK economy.", "The information you provide contributes to <a rel='noopener noreferrer' target='_blank' href='https://www.ons.gov.uk/economy/grossdomesticproductgdp'>Gross Domestic Product (GDP).</a>"]
+                    }]
+                }]
+            }, {
+                "id": "reporting-period-block",
+                "type": "Question",
+                "questions": [{
+                    "answers": [{
+                        "options": [{
+                            "value": "Yes",
+                            "label": "Yes"
+                        }, {
+                            "value": "No",
+                            "label": "No"
+                        }],
+                        "id": "reporting-period-answer",
+                        "type": "Radio",
+                        "q_code": "d12",
+                        "mandatory": true
+                    }],
+                    "type": "General",
+                    "id": "reporting-period-question",
+                    "title": "Are you able to report for the period from {{metadata['ref_p_start_date']|format_date}} to {{metadata['ref_p_end_date']|format_date}}?"
+                }],
+                "routing_rules": [{
+                    "goto": {
+                        "when": [{
+                            "id": "reporting-period-answer",
+                            "value": "Yes",
+                            "condition": "equals"
+                        }],
+                        "block": "turnover-block"
+                    }
+                }, {
+                    "goto": {
+                        "block": "reporting-period-block-2"
+                    }
+                }],
+                "title": "Reporting period"
+            }, {
+                "type": "Question",
+                "id": "reporting-period-block-2",
+                "title": "Reporting period",
+                "questions": [{
+                    "type": "DateRange",
+                    "id": "reporting-period-question-2",
+                    "title": "What are the dates of the period that you will be reporting for?",
+                    "period_limits": {
+                        "minimum": {
+                            "days": 10
+                        },
+                        "maximum": {
+                            "days": 50
+                        }
+                    },
+                    "answers": [{
+                        "type": "Date",
+                        "id": "period-from",
+                        "label": "From",
+                        "mandatory": true,
+                        "q_code": "11",
+                        "minimum": {
+                            "meta": "ref_p_start_date",
+                            "offset_by": {
+                                "days": -19
+                            }
+                        }
+                    }, {
+                        "type": "Date",
+                        "id": "period-to",
+                        "label": "To",
+                        "mandatory": true,
+                        "q_code": "12",
+                        "maximum": {
+                            "meta": "ref_p_end_date",
+                            "offset_by": {
+                                "days": 20
+                            }
+                        }
+                    }]
+                }]
+            }, {
+                "id": "turnover-block",
+                "type": "Question",
+                "questions": [{
+                    "guidance": {
+                        "content": [{
+                            "title": "Include:",
+                            "list": ["exports", "costs incurred and passed on to customers", "income from sub-contracted activities", "commission", "sales of goods purchased for resale", "revenue earned from other parts of the business, not named at the top of this page (please supply at fair value)"]
+                        }, {
+                            "title": "Exclude:",
+                            "list": ["VAT", "income from the sale of fixed capital assets", "grants and subsidies", "insurance claims", "interest received"]
+                        }]
+                    },
+                    "id": "turnover-question",
+                    "answers": [{
+                        "id": "turnover-answer",
+                        "label": "Total turnover excluding VAT",
+                        "description": "Enter the full value (e.g. 56,234.33) or a value to the nearest £thousand (e.g. 56,000). Do not enter ‘56’ for £56,000.",
+                        "type": "Currency",
+                        "currency": "GBP",
+                        "decimal_places": 2,
+                        "q_code": "40",
+                        "mandatory": true
+                    }],
+                    "type": "General",
+                    "title": "For the period {{format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, what was the value of {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s <em>total turnover</em>, excluding VAT?"
+                }],
+                "title": "Total Turnover"
+            }, {
+                "type": "ConfirmationQuestion",
+                "title": "Total turnover",
+                "id": "confirm-turnover-block",
+                "questions": [{
+                    "type": "General",
+                    "answers": [{
+                        "type": "Radio",
+                        "id": "confirm-turnover-answer",
+                        "q_code": "d40",
+                        "options": [{
+                            "label": "Yes this is correct",
+                            "value": "Yes"
+                        }, {
+                            "label": "No I need to change this",
+                            "value": "No"
+                        }],
+                        "mandatory": true
+                    }],
+                    "id": "confirm-turnover-question",
+                    "title": "For the period {{ format_conditional_date (answers['period-from'], metadata['ref_p_start_date'])}} to {{ format_conditional_date (answers['period-to'], metadata['ref_p_end_date'])}}, the value of the total turnover was <em>{{format_currency(answers['turnover-answer'])}}</em>, is this correct?"
+                }],
+                "routing_rules": [{
+                    "goto": {
+                        "when": [{
+                            "value": "No",
+                            "id": "confirm-turnover-answer",
+                            "condition": "equals"
+                        }],
+                        "block": "turnover-block"
+                    }
+                }, {
+                    "goto": {
+                        "block": "changes-in-turnover-block"
+                    }
+                }]
+            }, {
+                "id": "changes-in-turnover-block",
+                "type": "Question",
+                "questions": [{
+                    "title": "Did any significant changes occur to the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}?",
+                    "id": "changes-in-turnover-question",
+                    "definitions": [{
+                        "title": "What constitutes a significant change?",
+                        "content": [{
+                            "description": "What constitutes a \u2018significant change\u2019 is dependent on your own interpretation in relation to {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}\u2019s figures from the previous reporting period and the same reporting period last year."
+                        }, {
+                            "description": "This information will help us to validate your data and should reduce the need to query any figures with you."
+                        }]
+                    }],
+                    "answers": [{
+                        "options": [{
+                            "value": "Yes",
+                            "label": "Yes"
+                        }, {
+                            "value": "No",
+                            "label": "No"
+                        }],
+                        "id": "changes-in-turnover-answer",
+                        "type": "Radio",
+                        "q_code": "146",
+                        "mandatory": true
+                    }],
+                    "guidance": {
+                        "content": [{
+                            "title": "Include:",
+                            "list": ["change in level of business activity", "maintenance/shutdowns", "special/calendar events", "weather", "price effects", "currency effects (increase/decrease in the currency value)"]
+                        }]
+                    },
+                    "type": "General"
+                }],
+                "title": "Changes in total turnover",
+                "routing_rules": [{
+                    "goto": {
+                        "when": [{
+                            "id": "changes-in-turnover-answer",
+                            "value": "Yes",
+                            "condition": "equals"
+                        }],
+                        "block": "changes-in-turnover-block-2"
+                    }
+                }, {
+                    "goto": {
+                        "group": "summary-group"
+                    }
+                }]
+            }, {
+                "id": "changes-in-turnover-block-2",
+                "type": "Question",
+                "questions": [{
+                    "title": "Please indicate the reasons for any changes in the total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }}",
+                    "answers": [{
+                        "options": [{
+                            "q_code": "146a",
+                            "value": "Change in level of business activity",
+                            "label": "Change in level of business activity"
+                        }, {
+                            "q_code": "146b",
+                            "value": "Maintenance/shutdowns",
+                            "label": "Maintenance/shutdowns"
+                        }, {
+                            "q_code": "146c",
+                            "value": "Special/calendar events",
+                            "label": "Special/calendar events"
+                        }, {
+                            "q_code": "146d",
+                            "value": "Weather",
+                            "label": "Weather"
+                        }, {
+                            "q_code": "146e",
+                            "value": "Price effects",
+                            "label": "Price effects"
+                        }, {
+                            "q_code": "146f",
+                            "value": "Currency effects (increase/decrease in the currency value)",
+                            "label": "Currency effects (increase/decrease in the currency value)"
+                        }, {
+                            "q_code": "146g",
+                            "value": "Other",
+                            "label": "Other"
+                        }],
+                        "id": "changes-in-turnover-answer-2",
+                        "type": "Checkbox",
+                        "mandatory": true
+                    }],
+                    "type": "General",
+                    "id": "changes-in-turnover-question-2"
+                }],
+                "title": "Changes in total turnover"
+            }, {
+                "type": "Question",
+                "id": "changes-in-turnover-block-3",
+                "title": "Changes in total turnover",
+                "questions": [{
+                    "type": "General",
+                    "id": "changes-in-turnover-question-3",
+                    "title": "Please describe the changes in total turnover for {{ first_non_empty_item(metadata['trad_as'], metadata['ru_name']) }} in more detail",
+                    "answers": [{
+                        "guidance": {
+                            "hide_guidance": "Hide examples of commentary on changes to total turnover",
+                            "show_guidance": "Show examples of commentary on changes to total turnover",
+                            "content": [{
+                                "list": [],
+                                "title": "\u2018Change in level of business activity\u2019",
+                                "description": "\"We gained a new two year overseas contract, which increased our exports this month.\""
+                            }, {
+                                "list": [],
+                                "title": "\u2018Maintenance/shutdowns\u2019",
+                                "description": "\"Our activity is significantly lower this month as we had a two week planned maintenance shutdown.\""
+                            }, {
+                                "list": [],
+                                "title": "\u2018Special/calendar events\u2019",
+                                "description": "\"We manufacture school uniforms so the increase this month is a typical seasonal peak for our business.\""
+                            }, {
+                                "list": [],
+                                "title": "\u2018Weather\u2019",
+                                "description": "\"Bad weather caused a flood at one of our sites, this reduced the amount of work we could undertake and affected sales.\""
+                            }, {
+                                "list": [],
+                                "title": "\u2018Price effects\u2019",
+                                "description": "\"We have increased the prices of our products/services. We do this every January, hence our sales figures appear higher.\""
+                            }, {
+                                "list": [],
+                                "title": "\u2018Currency effects (increase/decrease in the currency value)\u2019",
+                                "description": "\"The depreciation of sterling has resulted in more overseas sales.\""
+                            }]
+                        },
+                        "type": "TextArea",
+                        "mandatory": true,
+                        "label": "Comments",
+                        "id": "changes-in-turnover-answer-3",
+                        "q_code": "146h"
+                    }],
+                    "description": "<p>We rely on your commentary to \u2018tell the story\u2019 behind changes in figures.  By commenting here it will reduce the need for us to call you.</p>"
+                }]
+            }]
+        }]
+    }, {
+        "id": "summary-section",
+        "title": "Summary",
+        "groups": [{
+            "id": "summary-group",
+            "title": "Summary",
+            "blocks": [{
+                "type": "Summary",
+                "id": "summary"
+            }]
+        }]
+    }]
+}


### PR DESCRIPTION
### What is the context of this PR?
The business accidentally entered a QCode for `covid_0001` incorrectly. This pull request fixes that. Additionally, to avoid putting MBS and Construction live, I have rolled back those changes and added `mbs_xxxx_prototype.json` and `construction_0001_prototype.json` which are the updated versions so that the business can test these.

When we are ready to make the mbs and construction surveys live, we just need to remove the `_prototype` suffix and remove the old version. 

### How to review 
Make sure `_prototype` files are the updated versions. You can use the information on their Jira tickets to do this.
Make sure the following QCode fix is applied: 

> there were 2 "116" codes, they changed one to 125: Please give more details about how [Ru Name] has diversified to produce or provide new goods or services

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
