### PR TITLE
EAR 1041 - Make DateRange question on MBS0111 required

### DIFF
--- a/data/en/mbs_0111.json
+++ b/data/en/mbs_0111.json
@@ -132,7 +132,7 @@
                             "answers": [{
                                     "id": "answer568d0c90-e364-4b11-a831-ef09a5840784from",
                                     "type": "Date",
-                                    "mandatory": false,
+                                    "mandatory": true,
                                     "label": "From",
                                     "q_code": "11",
                                     "minimum": {
@@ -145,7 +145,7 @@
                                 {
                                     "id": "answer568d0c90-e364-4b11-a831-ef09a5840784to",
                                     "type": "Date",
-                                    "mandatory": false,
+                                    "mandatory": true,
                                     "label": "To",
                                     "q_code": "12",
                                     "maximum": {


### PR DESCRIPTION
### What is the context of this PR?
[JIRA Ticket](https://collaborate2.ons.gov.uk/jira/browse/EAR-1041)

Makes the "What are the dates of the period you will be reporting for?" DateRange question mandatory as per the other form types.

### How to review 
Check that q1a on `mbs_0111` is now mandatory (as per the other form types).

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
