### PR TITLE
Change to single quotes

### DIFF
--- a/app/assets/js/app/modules/cookies/cookiesbanner.js
+++ b/app/assets/js/app/modules/cookies/cookiesbanner.js
@@ -1,4 +1,4 @@
-import { cookie, setDefaultConsentCookie, approveAllCookieTypes, setConsentCookie } from './cookiesfunctions'
+import { cookie, setDefaultConsentCookie, approveAllCookieTypes, setConsentCookie, parseCookie } from './cookiesfunctions'
 
 export default class CookiesBanner {
   constructor(component) {
@@ -21,7 +21,7 @@ export default class CookiesBanner {
     const displayCookiesBanner = this.component && cookie('ons_cookie_message_displayed') !== 'true'
     let policy = cookie('ons_cookie_policy')
     if (policy) {
-      setConsentCookie(JSON.parse(policy.replace(/'/g, '"')))
+      setConsentCookie(parseCookie(policy))
     }
     if (displayCookiesBanner) {
       this.component.style.display = 'block'

--- a/app/assets/js/app/modules/cookies/cookiesfunctions.js
+++ b/app/assets/js/app/modules/cookies/cookiesfunctions.js
@@ -37,8 +37,7 @@ export function cookie(name, value, options) {
 }
 
 export function setDefaultConsentCookie() {
-  const defaultConsentCookie = JSON.stringify(DEFAULT_COOKIE_CONSENT).replace(/"/g, '"')
-  setCookie('ons_cookie_policy', defaultConsentCookie, { days: 365 })
+  setCookie('ons_cookie_policy', JSON.stringify(DEFAULT_COOKIE_CONSENT), { days: 365 })
 }
 
 export function approveAllCookieTypes() {
@@ -55,10 +54,10 @@ export function getConsentCookie() {
   let consentCookieObj
 
   if (consentCookie) {
-    consentCookieObj = JSON.parse(consentCookie.replace(/'/g, '"'))
+    consentCookieObj = parseCookie(consentCookie)
 
     if (typeof consentCookieObj !== 'object' && consentCookieObj !== null) {
-      consentCookieObj = JSON.parse(consentCookieObj.replace(/'/g, '"'))
+      consentCookieObj = parseCookie(consentCookieObj)
     }
   } else {
     return null
@@ -69,10 +68,8 @@ export function getConsentCookie() {
 export function setConsentCookie(options) {
   const domain = getDomain(document.domain)
 
-  let cookieConsent = getConsentCookie()
-  if (!cookieConsent) {
-    cookieConsent = JSON.parse(JSON.stringify(DEFAULT_COOKIE_CONSENT).replace(/'/g, '"'))
-  }
+  let cookieConsent = getConsentCookie() || DEFAULT_COOKIE_CONSENT
+
   for (let cookieType in options) {
     cookieConsent[cookieType] = options[cookieType]
     if (!options[cookieType]) {
@@ -87,7 +84,8 @@ export function setConsentCookie(options) {
       }
     }
   }
-  setCookie('ons_cookie_policy', JSON.stringify(cookieConsent).replace(/"/g, '"'), { days: 365 })
+
+  setCookie('ons_cookie_policy', JSON.stringify(cookieConsent), { days: 365 })
 }
 
 export function checkConsentCookieCategory(cookieName, cookieCategory) {
@@ -142,8 +140,13 @@ export function setCookie(name, value, options) {
       cookieString = cookieString + '; Secure'
     }
 
-    document.cookie = cookieString
+    // Use lowercase quotes as standard - incoming cookies use them
+    document.cookie = cookieString.replace(/"/g, '\'')
   }
+}
+
+export function parseCookie(cookieString) {
+  return JSON.parse(cookieString.replace(/'/g, '"'))
 }
 
 export function getCookie(name) {

--- a/app/assets/js/app/modules/cookies/cookiessettings.js
+++ b/app/assets/js/app/modules/cookies/cookiessettings.js
@@ -1,5 +1,5 @@
 import { unset } from 'lodash'
-import { cookie, setDefaultConsentCookie, setConsentCookie, setCookie } from './cookiesfunctions'
+import { cookie, setDefaultConsentCookie, setConsentCookie, setCookie, parseCookie } from './cookiesfunctions'
 
 export default class CookiesSettings {
   constructor(component) {
@@ -14,7 +14,7 @@ export default class CookiesSettings {
     }
 
     const currentConsentCookie = cookie('ons_cookie_policy')
-    let currentConsentCookieJSON = JSON.parse(currentConsentCookie.replace(/'/g, '"'))
+    let currentConsentCookieJSON = parseCookie(currentConsentCookie)
 
     unset(currentConsentCookieJSON, 'essential')
 

--- a/app/utilities/cookies.py
+++ b/app/utilities/cookies.py
@@ -5,6 +5,6 @@ def analytics_allowed(request):
     cookie_policy = request.cookies.get('ons_cookie_policy')
 
     if cookie_policy:
-        return json.loads(cookie_policy.replace('\'', '\"'))['usage']
+        return json.loads(cookie_policy.replace("'", '"'))['usage']
 
     return False

--- a/app/utilities/cookies.py
+++ b/app/utilities/cookies.py
@@ -1,6 +1,5 @@
-#!/usr/bin/env python3
-
 import json
+
 
 def analytics_allowed(request):
     cookie_policy = request.cookies.get('ons_cookie_policy')

--- a/app/utilities/cookies.py
+++ b/app/utilities/cookies.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+
+import json
+
+def analytics_allowed(request):
+    cookie_policy = request.cookies.get('ons_cookie_policy')
+
+    if cookie_policy:
+        return json.loads(cookie_policy.replace("'", "\""))["usage"]
+    else:
+        return False

--- a/app/utilities/cookies.py
+++ b/app/utilities/cookies.py
@@ -5,6 +5,6 @@ def analytics_allowed(request):
     cookie_policy = request.cookies.get('ons_cookie_policy')
 
     if cookie_policy:
-        return json.loads(cookie_policy.replace("'", "\""))["usage"]
-    else:
-        return False
+        return json.loads(cookie_policy.replace('\'', '\"'))['usage']
+
+    return False

--- a/app/views/errors.py
+++ b/app/views/errors.py
@@ -13,6 +13,8 @@ from app.libs.utils import convert_tx_id_for_boxes
 from app.submitter.submission_failed import SubmissionFailedException
 from app.templating.template_renderer import TemplateRenderer
 
+from app.utilities.cookies import analytics_allowed
+
 logger = get_logger()
 
 errors_blueprint = Blueprint('errors', __name__)
@@ -84,8 +86,7 @@ def _render_error_page(status_code):
     user_agent = user_agent_parser.Parse(request.headers.get('User-Agent', ''))
 
     cookie_message = request.cookies.get('ons_cookie_message_displayed')
-    cookie_policy = request.cookies.get('ons_cookie_policy')
-    allow_analytics = cookie_policy and "'usage':true" in cookie_policy
+    allow_analytics = analytics_allowed(request)
     return render_theme_template('default', 'errors/error.html',
                                  status_code=status_code,
                                  analytics_gtm_id=current_app.config['EQ_GTM_ID'],
@@ -109,8 +110,7 @@ def render_template(template_name):
     user_agent = user_agent_parser.Parse(request.headers.get('User-Agent', ''))
 
     cookie_message = request.cookies.get('ons_cookie_message_displayed')
-    cookie_policy = request.cookies.get('ons_cookie_policy')
-    allow_analytics = cookie_policy and "'usage':true" in cookie_policy
+    allow_analytics = analytics_allowed(request)
     return render_theme_template(cookie_session.get('theme', 'default'),
                                  template_name=template_name,
                                  analytics_gtm_id=current_app.config['EQ_GTM_ID'],

--- a/app/views/errors.py
+++ b/app/views/errors.py
@@ -85,7 +85,7 @@ def _render_error_page(status_code):
 
     cookie_message = request.cookies.get('ons_cookie_message_displayed')
     cookie_policy = request.cookies.get('ons_cookie_policy')
-    allow_analytics = cookie_policy and '"usage":true' in cookie_policy
+    allow_analytics = cookie_policy and "'usage':true" in cookie_policy
     return render_theme_template('default', 'errors/error.html',
                                  status_code=status_code,
                                  analytics_gtm_id=current_app.config['EQ_GTM_ID'],
@@ -110,7 +110,7 @@ def render_template(template_name):
 
     cookie_message = request.cookies.get('ons_cookie_message_displayed')
     cookie_policy = request.cookies.get('ons_cookie_policy')
-    allow_analytics = cookie_policy and '"usage":true' in cookie_policy
+    allow_analytics = cookie_policy and "'usage':true" in cookie_policy
     return render_theme_template(cookie_session.get('theme', 'default'),
                                  template_name=template_name,
                                  analytics_gtm_id=current_app.config['EQ_GTM_ID'],

--- a/app/views/feedback.py
+++ b/app/views/feedback.py
@@ -105,5 +105,5 @@ def post_thank_you():
 def _render_template(template, **kwargs):
     cookie_message = request.cookies.get('ons_cookie_message_displayed')
     cookie_policy = request.cookies.get('ons_cookie_policy')
-    allow_analytics = cookie_policy and '"usage":true' in cookie_policy
+    allow_analytics = cookie_policy and "'usage':true" in cookie_policy
     return template_helper.render_template(template, cookie_message=cookie_message, allow_analytics=allow_analytics, **kwargs)

--- a/app/views/feedback.py
+++ b/app/views/feedback.py
@@ -14,6 +14,8 @@ from app.submitter.converter import convert_feedback
 from app.utilities.schema import load_schema_from_session_data
 from app.authentication.no_token_exception import NoTokenException
 
+from app.utilities.cookies import analytics_allowed
+
 logger = get_logger()
 
 feedback_blueprint = Blueprint(name='feedback',
@@ -104,6 +106,5 @@ def post_thank_you():
 @template_helper.with_metadata_context
 def _render_template(template, **kwargs):
     cookie_message = request.cookies.get('ons_cookie_message_displayed')
-    cookie_policy = request.cookies.get('ons_cookie_policy')
-    allow_analytics = cookie_policy and "'usage':true" in cookie_policy
+    allow_analytics = analytics_allowed(request)
     return template_helper.render_template(template, cookie_message=cookie_message, allow_analytics=allow_analytics, **kwargs)

--- a/app/views/questionnaire.py
+++ b/app/views/questionnaire.py
@@ -251,7 +251,7 @@ def get_thank_you(schema, metadata, eq_id, form_type):
 
         cookie_message = request.cookies.get('ons_cookie_message_displayed')
         cookie_policy = request.cookies.get('ons_cookie_policy')
-        allow_analytics = cookie_policy and '"usage":true' in cookie_policy
+        allow_analytics = cookie_policy and "'usage':true" in cookie_policy
 
         return render_theme_template(schema.json['theme'],
                                      template_name='thank-you.html',
@@ -334,7 +334,7 @@ def get_view_submission(schema, eq_id, form_type):  # pylint: disable=unused-arg
 
             cookie_message = request.cookies.get('ons_cookie_message_displayed')
             cookie_policy = request.cookies.get('ons_cookie_policy')
-            allow_analytics = cookie_policy and '"usage":true' in cookie_policy
+            allow_analytics = cookie_policy and "'usage':true" in cookie_policy
 
             return render_theme_template(schema.json['theme'],
                                          template_name='view-submission.html',
@@ -590,7 +590,7 @@ def _build_template(current_location, context, template, schema, answer_store, m
     previous_url = previous_location.url(metadata) if previous_location is not None else None
     cookie_message = request.cookies.get('ons_cookie_message_displayed')
     cookie_policy = request.cookies.get('ons_cookie_policy')
-    allow_analytics = cookie_policy and '"usage":true' in cookie_policy
+    allow_analytics = cookie_policy and "'usage':true" in cookie_policy
 
     add_person_url = None
     if routing_path:

--- a/app/views/questionnaire.py
+++ b/app/views/questionnaire.py
@@ -43,6 +43,8 @@ from app.templating.view_context import build_view_context
 from app.utilities.schema import load_schema_from_session_data
 from app.views.errors import check_multiple_survey, MultipleSurveyError
 
+from app.utilities.cookies import analytics_allowed
+
 END_BLOCKS = 'Summary', 'Confirmation'
 
 logger = get_logger()
@@ -250,8 +252,7 @@ def get_thank_you(schema, metadata, eq_id, form_type):
             view_submission_duration = humanize.naturaldelta(timedelta(seconds=schema.json['view_submitted_response']['duration']))
 
         cookie_message = request.cookies.get('ons_cookie_message_displayed')
-        cookie_policy = request.cookies.get('ons_cookie_policy')
-        allow_analytics = cookie_policy and "'usage':true" in cookie_policy
+        allow_analytics = analytics_allowed(request)
 
         return render_theme_template(schema.json['theme'],
                                      template_name='thank-you.html',
@@ -333,8 +334,7 @@ def get_view_submission(schema, eq_id, form_type):  # pylint: disable=unused-arg
             }
 
             cookie_message = request.cookies.get('ons_cookie_message_displayed')
-            cookie_policy = request.cookies.get('ons_cookie_policy')
-            allow_analytics = cookie_policy and "'usage':true" in cookie_policy
+            allow_analytics = analytics_allowed(request)
 
             return render_theme_template(schema.json['theme'],
                                          template_name='view-submission.html',
@@ -589,8 +589,7 @@ def _build_template(current_location, context, template, schema, answer_store, m
     previous_location = path_finder.get_previous_location(current_location)
     previous_url = previous_location.url(metadata) if previous_location is not None else None
     cookie_message = request.cookies.get('ons_cookie_message_displayed')
-    cookie_policy = request.cookies.get('ons_cookie_policy')
-    allow_analytics = cookie_policy and "'usage':true" in cookie_policy
+    allow_analytics = analytics_allowed(request)
 
     add_person_url = None
     if routing_path:

--- a/app/views/session.py
+++ b/app/views/session.py
@@ -133,7 +133,7 @@ def get_sign_out():
 
     cookie_message = request.cookies.get('ons_cookie_message_displayed')
     cookie_policy = request.cookies.get('ons_cookie_policy')
-    allow_analytics = cookie_policy and '"usage":true' in cookie_policy
+    allow_analytics = cookie_policy and "'usage':true" in cookie_policy
 
     return render_theme_template(cookie_session.get('theme', 'default'),
                                  template_name='signed-out.html',

--- a/app/views/session.py
+++ b/app/views/session.py
@@ -18,6 +18,8 @@ from app.templating.template_renderer import TemplateRenderer
 from app.utilities.schema import load_schema_from_metadata
 from app.views.errors import render_template
 
+from app.utilities.cookies import analytics_allowed
+
 logger = get_logger()
 
 
@@ -132,8 +134,7 @@ def get_sign_out():
         return redirect(account_service_log_out_url)
 
     cookie_message = request.cookies.get('ons_cookie_message_displayed')
-    cookie_policy = request.cookies.get('ons_cookie_policy')
-    allow_analytics = cookie_policy and "'usage':true" in cookie_policy
+    allow_analytics = analytics_allowed(request)
 
     return render_theme_template(cookie_session.get('theme', 'default'),
                                  template_name='signed-out.html',

--- a/app/views/static.py
+++ b/app/views/static.py
@@ -23,7 +23,7 @@ def contact():
 
     cookie_message = request.cookies.get('ons_cookie_message_displayed')
     cookie_policy = request.cookies.get('ons_cookie_policy')
-    allow_analytics = cookie_policy and '"usage":true' in cookie_policy
+    allow_analytics = cookie_policy and "'usage':true" in cookie_policy
 
     contact_template = render_theme_template(theme=cookie_session.get('theme', 'default'),
                                              template_name='static/contact-us.html',
@@ -49,7 +49,7 @@ def legal():
 def settings():
     cookie_message = request.cookies.get('ons_cookie_message_displayed')
     cookie_policy = request.cookies.get('ons_cookie_policy')
-    allow_analytics = cookie_policy and '"usage":true' in cookie_policy
+    allow_analytics = cookie_policy and "'usage':true" in cookie_policy
 
     cookie_template = render_theme_template(theme=cookie_session.get('theme', 'default'),
                                             analytics_gtm_id=current_app.config['EQ_GTM_ID'],

--- a/app/views/static.py
+++ b/app/views/static.py
@@ -4,6 +4,7 @@ from structlog import get_logger
 
 from app.globals import get_session_store
 from app.utilities.schema import load_schema_from_session_data
+from app.utilities.cookies import analytics_allowed
 
 logger = get_logger()
 
@@ -22,8 +23,7 @@ def contact():
         survey_id = schema.json['survey_id']
 
     cookie_message = request.cookies.get('ons_cookie_message_displayed')
-    cookie_policy = request.cookies.get('ons_cookie_policy')
-    allow_analytics = cookie_policy and "'usage':true" in cookie_policy
+    allow_analytics = analytics_allowed(request)
 
     contact_template = render_theme_template(theme=cookie_session.get('theme', 'default'),
                                              template_name='static/contact-us.html',
@@ -48,8 +48,7 @@ def legal():
 @contact_blueprint.route('/cookies-settings', methods=['GET'])
 def settings():
     cookie_message = request.cookies.get('ons_cookie_message_displayed')
-    cookie_policy = request.cookies.get('ons_cookie_policy')
-    allow_analytics = cookie_policy and "'usage':true" in cookie_policy
+    allow_analytics = analytics_allowed(request)
 
     cookie_template = render_theme_template(theme=cookie_session.get('theme', 'default'),
                                             analytics_gtm_id=current_app.config['EQ_GTM_ID'],

--- a/tests/app/utilities/analytics_allowed.py
+++ b/tests/app/utilities/analytics_allowed.py
@@ -1,0 +1,24 @@
+import unittest
+
+from app.utilities.cookies import analytics_allowed
+
+
+class MockRequest:
+
+    def __init__(self, value):
+        self.cookies = dict(ons_cookie_policy=value)
+
+
+class TestAnalyticsAllowed(unittest.TestCase):
+
+    def test_with_cookie_usage_false(self):
+        request = MockRequest("{'essential': true, 'usage': false}")
+        self.assertFalse(analytics_allowed(request))
+
+    def test_with_cookie_usage_true(self):
+        request = MockRequest("{'essential': true, 'usage': true}")
+        self.assertTrue(analytics_allowed(request))
+
+    def test_with_cookie_usage_true_double_quotes(self):
+        request = MockRequest('{"essential": true, "usage": true}')
+        self.assertTrue(analytics_allowed(request))

--- a/tests/app/utilities/test_analytics_allowed.py
+++ b/tests/app/utilities/test_analytics_allowed.py
@@ -22,3 +22,7 @@ class TestAnalyticsAllowed(unittest.TestCase):
     def test_with_cookie_usage_true_double_quotes(self):
         request = MockRequest('{"essential": true, "usage": true}')
         self.assertTrue(analytics_allowed(request))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### What is the context of this PR?
### Talk to Andy Pitt before deploying to live so he can test the changes.

Quotes are killing google analytics in live

Live surveys don't have an `ga` working right now because the cookies `HTML` isn't getting pulled in.

We are checking for the presence of double-quotes to pull in `ga` where RAS are using single quotes

This means that in live surveys, if a user accepts cookies in RAS, `ga` isn't getting pulled in. Where as, if cookies are accepted within a survey, `ga` does get pulled in.

We need a solution to take into account both cases.

Sort of a big deal because rolling back breaks GDPR compliance and not doing anything means there is no analytics on any surveys.

#### Tom B edit 26/11, changes:

- Change our JS to emit single quotes in case downstream are expecting single to come back (since they initially set single-quote cookies)
- Refactor the cookie JS and python slightly so the quote-setting logic is just in one function in case we want to change it again
- Change runner so it's happy with either double or single quotes - it now converts to & parses the JSON for the cookie