### PR TITLE
add google tracking for print btn click

### DIFF
--- a/app/templates/thank-you.html
+++ b/app/templates/thank-you.html
@@ -11,12 +11,12 @@
     <div class="panel panel--simple panel--success panel--spacious">
         <p class="u-fs-r">
             {% if metadata.trad_as %}
-                {{ _("Your answers were submitted for <span>%(ru_name)s</span> (%(trading_as_name)s) on %(submitted_date_time)s",
+            {{ _("Your answers were submitted for <span>%(ru_name)s</span> (%(trading_as_name)s) on %(submitted_date_time)s",
                 ru_name = metadata.ru_name,
                 trading_as_name = metadata.trad_as,
                 submitted_date_time=metadata.submitted_time|format_datetime) }}
             {% else %}
-                {{ _("Your answers were submitted for <span>%(ru_name)s</span> on %(submitted_date_time)s",
+            {{ _("Your answers were submitted for <span>%(ru_name)s</span> on %(submitted_date_time)s",
                 ru_name = metadata.ru_name,
                 submitted_date_time=metadata.submitted_time|format_datetime) }}
             {% endif %}
@@ -32,20 +32,25 @@
 
 {% block view_submission %}
 {% if is_view_submitted_response_enabled %}
-    <div class="u-mb-s">
+<div class="u-mb-s">
     {% if view_submission_url %}
-        <p class="u-mb-m@s u-fs-r" data-qa="view-submission"><a href={{view_submission_url}}>{{ _("View and print a copy of your answers") }}</a></p>
-        <p class="u-mb-s u-fs-r">{{ _("Your answers will only be available for <b>%(duration)s</b> to keep them secure.",
-                                                                                        duration=view_submission_duration) }}</p>
+    <p class="u-mb-m@s u-fs-r" data-qa="view-submission"><a href={{view_submission_url}} data-ga="click"
+            data-ga-category="view-submission" data-ga-action="Goto general view-submission page"
+            data-ga-label="Goto general survey view-submission page">{{ _("View and print a copy of your answers") }}</a>
+    </p>
+    <p class="u-mb-s u-fs-r">
+        {{ _("Your answers will only be available for <b>%(duration)s</b> to keep them secure.",
+                                                                                        duration=view_submission_duration) }}
+    </p>
     {% else %}
-        <div class="panel panel--simple panel--info" data-qa="view-submission-expired">
-            <div class="panel__body">
-                <p>{{ _("You are no longer able to view and print your answers") }}.</p>
-                <p>{{ _("The link expires to maintain the security of your information") }}.</p>
-            </div>
+    <div class="panel panel--simple panel--info" data-qa="view-submission-expired">
+        <div class="panel__body">
+            <p>{{ _("You are no longer able to view and print your answers") }}.</p>
+            <p>{{ _("The link expires to maintain the security of your information") }}.</p>
         </div>
-    {% endif %}
     </div>
+    {% endif %}
+</div>
 {% endif %}
 {% endblock %}
 

--- a/app/templates/view-submission.html
+++ b/app/templates/view-submission.html
@@ -6,19 +6,19 @@
 {% block main -%}
 
 <div>
-  <h1 class="u-fs-l">{{ _("Submitted answers") }}</h1>
+    <h1 class="u-fs-l">{{ _("Submitted answers") }}</h1>
 </div>
 
 <div class="u-mb-s">
     <div class="panel panel--simple panel--success panel--spacious">
         <p class="u-fs-r">
             {% if metadata.trad_as %}
-                {{ _("Your answers were submitted for <span>%(ru_name)s</span> (%(trading_as_name)s) on %(submitted_time)s",
+            {{ _("Your answers were submitted for <span>%(ru_name)s</span> (%(trading_as_name)s) on %(submitted_time)s",
                 ru_name = metadata.ru_name,
                 trading_as_name = metadata.trad_as,
                 submitted_time=metadata.submitted_time|format_datetime) }}
             {% else %}
-                {{ _("Your answers were submitted for <span>%(ru_name)s</span> on %(submitted_time)s",
+            {{ _("Your answers were submitted for <span>%(ru_name)s</span> on %(submitted_time)s",
                 ru_name = metadata.ru_name,
                 submitted_time=metadata.submitted_time|format_datetime) }}
             {% endif %}
@@ -27,7 +27,11 @@
     </div>
 </div>
 
-<button type="button" class="btn btn--secondary btn-print icon--print-link u-mt-s u-mb-l print__hidden u-no-js-hide">{{ _("Print this page") }} <span class="btn__icon btn__icon--print-link"></span></button>
+<button type="button"
+    class="btn btn--secondary btn-print icon--print-link u-mt-s u-mb-l print__hidden u-no-js-hide ga-track-print-btn"
+    data-ga="click" data-ga-category="Print Button" data-ga-action="Open Print Dialogue"
+    data-ga-label="Track print button clicks">{{ _("Print this page") }}
+    <span class="btn__icon btn__icon--print-link"></span></button>
 
 {% include theme('partials/summary/summary.html') %}
 

--- a/app/themes/covid/templates/thank-you.html
+++ b/app/themes/covid/templates/thank-you.html
@@ -11,12 +11,12 @@
     <div class="panel panel--simple panel--success panel--spacious">
         <p class="u-fs-r">
             {% if metadata.trad_as %}
-                {{ _("Your answers were submitted for <span>%(ru_name)s</span> (%(trading_as_name)s) on %(submitted_date_time)s",
+            {{ _("Your answers were submitted for <span>%(ru_name)s</span> (%(trading_as_name)s) on %(submitted_date_time)s",
                 ru_name = metadata.ru_name,
                 trading_as_name = metadata.trad_as,
                 submitted_date_time=metadata.submitted_time|format_datetime) }}
             {% else %}
-                {{ _("Your answers were submitted for <span>%(ru_name)s</span> on %(submitted_date_time)s",
+            {{ _("Your answers were submitted for <span>%(ru_name)s</span> on %(submitted_date_time)s",
                 ru_name = metadata.ru_name,
                 submitted_date_time=metadata.submitted_time|format_datetime) }}
             {% endif %}
@@ -27,25 +27,31 @@
 
 <div class="u-mb-s">
     <p>{{ _("Thank you for completing this survey") }}.
-        {{ _("Your response will help inform decision-makers how best to support the UK population and economy at this challenging time") }}.</p>
+        {{ _("Your response will help inform decision-makers how best to support the UK population and economy at this challenging time") }}.
+    </p>
 </div>
 
 {% block view_submission %}
 {% if is_view_submitted_response_enabled %}
-    <div class="u-mb-s">
+<div class="u-mb-s">
     {% if view_submission_url %}
-        <p class="u-mb-m@s u-fs-r" data-qa="view-submission"><a href={{view_submission_url}}>{{ _("View and print a copy of your answers") }}</a></p>
-        <p class="u-mb-s u-fs-r">{{ _("Your answers will only be available for <b>%(duration)s</b> to keep them secure.",
-                                                                                        duration=view_submission_duration) }}</p>
+    <p class="u-mb-m@s u-fs-r" data-qa="view-submission"><a href={{view_submission_url}} data-ga="click"
+            data-ga-category="view-submission Covid" data-ga-action="Goto covid view-submission page"
+            data-ga-label="Goto covid survey view-submission page">{{ _("View and print a copy of your answers") }}</a>
+    </p>
+    <p class="u-mb-s u-fs-r">
+        {{ _("Your answers will only be available for <b>%(duration)s</b> to keep them secure.",
+                                                                                        duration=view_submission_duration) }}
+    </p>
     {% else %}
-        <div class="panel panel--simple panel--info" data-qa="view-submission-expired">
-            <div class="panel__body">
-                <p>{{ _("You are no longer able to view and print your answers") }}.</p>
-                <p>{{ _("The link expires to maintain the security of your information") }}.</p>
-            </div>
+    <div class="panel panel--simple panel--info" data-qa="view-submission-expired">
+        <div class="panel__body">
+            <p>{{ _("You are no longer able to view and print your answers") }}.</p>
+            <p>{{ _("The link expires to maintain the security of your information") }}.</p>
         </div>
-    {% endif %}
     </div>
+    {% endif %}
+</div>
 {% endif %}
 {% endblock %}
 

--- a/app/themes/social/templates/thank-you.html
+++ b/app/themes/social/templates/thank-you.html
@@ -14,20 +14,25 @@
 
 {% block view_submission %}
 {% if is_view_submitted_response_enabled %}
-    <div class="u-mb-s">
+<div class="u-mb-s">
     {% if view_submission_url %}
-        <p class="u-mb-m@s u-fs-r" data-qa="view-submission"><a href={{view_submission_url}}>{{ _("View and print a copy of your answers") }}</a></p>
-        <p class="u-mb-s u-fs-r">{{ _("Your answers will only be available for <b>%(duration)s</b> to keep them secure.",
-                                                                                        duration=view_submission_duration) }}</p>
+    <p class="u-mb-m@s u-fs-r" data-qa="view-submission"><a href={{view_submission_url}} data-ga="click"
+            data-ga-category="view-submission Social" data-ga-action="Goto social view-submission page"
+            data-ga-label="Goto social survey view-submission page">{{ _("View and print a copy of your answers") }}</a>
+    </p>
+    <p class="u-mb-s u-fs-r">
+        {{ _("Your answers will only be available for <b>%(duration)s</b> to keep them secure.",
+                                                                                        duration=view_submission_duration) }}
+    </p>
     {% else %}
-        <div class="panel panel--simple panel--info" data-qa="view-submission-expired">
-            <div class="panel__body">
-                <p>{{ _("You are no longer able to view and print your answers") }}.</p>
-                <p>{{ _("The link expires to maintain the security of your information") }}.</p>
-            </div>
+    <div class="panel panel--simple panel--info" data-qa="view-submission-expired">
+        <div class="panel__body">
+            <p>{{ _("You are no longer able to view and print your answers") }}.</p>
+            <p>{{ _("The link expires to maintain the security of your information") }}.</p>
         </div>
-    {% endif %}
     </div>
+    {% endif %}
+</div>
 {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
### What is the context of this PR?
Add ga- tracking codes for google analytics to track click events on print button at the end of the survey

### How to review 
Run yarn compile
docker-compose up
goto localhost:8000

choose an mbs survey (these are very short) from the dropdown at top of page and start survey
accept all cookies
complete this short survey and submit

open dev tools console
click on: _**View and print a copy of your answers**_
you should see the following in the console:
{hitType: "event", eventCategory: "view-submission", eventAction: "Goto general view-submission page", eventLabel: "Goto general survey view-submission page"}

Hit the **_Print button_** and then cancel
you should see the following in the console:
{hitType: "event", eventCategory: "Print Button", eventAction: "Open Print Dialogue", eventLabel: "Track print button clicks"}
