### PR TITLE
Fix datetime breaking on 0 milliseconds

### DIFF
--- a/app/utilities/format_submitted_time.py
+++ b/app/utilities/format_submitted_time.py
@@ -1,0 +1,9 @@
+from datetime import datetime
+
+
+def format_submitted_time(submitted_time):
+    try:
+        submitted_time = datetime.strptime(submitted_time, '%Y-%m-%dT%H:%M:%S.%f')
+    except ValueError:
+        submitted_time = datetime.strptime(submitted_time, '%Y-%m-%dT%H:%M:%S')
+    return submitted_time

--- a/app/views/questionnaire.py
+++ b/app/views/questionnaire.py
@@ -44,6 +44,7 @@ from app.utilities.schema import load_schema_from_session_data
 from app.views.errors import check_multiple_survey, MultipleSurveyError
 
 from app.utilities.cookies import analytics_allowed
+from app.utilities.format_submitted_time import format_submitted_time
 
 END_BLOCKS = 'Summary', 'Confirmation'
 
@@ -484,8 +485,9 @@ def is_view_submitted_response_enabled(schema):
 
 def _is_submission_viewable(schema, submitted_time):
     if is_view_submitted_response_enabled(schema) and submitted_time:
-        submitted_time = datetime.strptime(submitted_time, '%Y-%m-%dT%H:%M:%S.%f')
-        submission_valid_until = submitted_time + timedelta(seconds=schema['view_submitted_response']['duration'])
+
+        submission_valid_until = format_submitted_time(submitted_time) + timedelta(seconds=schema['view_submitted_response']['duration'])
+
         return submission_valid_until > datetime.utcnow()
 
     return False

--- a/tests/app/utilities/test_submitted_date.py
+++ b/tests/app/utilities/test_submitted_date.py
@@ -1,0 +1,20 @@
+import unittest
+from datetime import datetime
+
+from app.utilities.format_submitted_time import format_submitted_time
+
+
+class TestFormattedSubmitTime(unittest.TestCase):
+
+    def test_with_zero_ms(self):
+        test_date = datetime.today().strftime('%Y-%m-%dT%H:%M:%S')
+        test_date_zero_ms = test_date
+        self.assertTrue(format_submitted_time(test_date_zero_ms) == datetime.strptime(test_date, '%Y-%m-%dT%H:%M:%S'))
+
+    def test_with_ms(self):
+        test_date = datetime.today().strftime('%Y-%m-%dT%H:%M:%S.%f')
+        self.assertTrue(format_submitted_time(test_date) == datetime.strptime(test_date, '%Y-%m-%dT%H:%M:%S.%f'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### What is the context of this PR?
This fixes the thank-you page breaking when the submitted_time has 0 milliseconds.



### How to review 
Test it works by putting the format the other way round so the one with milliseconds is the exception.
