### PR TITLE
EAR 1136 Add privacy and data protection to footers

### DIFF
--- a/app/templates/partials/footer-transactional.html
+++ b/app/templates/partials/footer-transactional.html
@@ -8,7 +8,10 @@
                         <a href="/contact-us" class="footer__link footer__link--inline" target="_blank">{{ _("Contact us") }}</a>
                     </li>
                     <li>
-                        <a href="/cookies-settings" class="footer__link">{{ _("Cookie settings") }}</a>
+                        <a href="/cookies-settings" class="footer__link footer__link--inline">{{ _("Cookie settings") }}</a>
+                    </li>
+                    <li>
+                        <a rel='noopener noreferrer' target='_blank' href="https://surveys.ons.gov.uk/privacy-and-data-protection" class="footer__link">{{ _("Privacy and data protection") }}</a>
                     </li>
                 </ul>
             </div>

--- a/app/templates/partials/footer.html
+++ b/app/templates/partials/footer.html
@@ -8,6 +8,9 @@
                     <li>
                         <a href="/cookies-settings" class="footer__link">{{ _("Cookie settings") }}</a>
                     </li>
+                    <li>
+                        <a rel='noopener noreferrer' target='_blank' href="https://surveys.ons.gov.uk/privacy-and-data-protection" class="footer__link">{{ _("Privacy and data protection") }}</a>
+                    </li>
                 </ul>
             </div>
             <div class="grid__col col-4@m">

--- a/app/themes/census/templates/partials/footer-transactional.html
+++ b/app/themes/census/templates/partials/footer-transactional.html
@@ -14,9 +14,6 @@
                     <li>
                         <a href="/cookies-settings" class="footer__link">{{ _("Cookie settings") }}</a>
                     </li>
-                    <li>
-                        <a rel='noopener noreferrer' target='_blank' href="https://surveys.ons.gov.uk/privacy-and-data-protection" class="footer__link">{{ _("Privacy and data protection") }}</a>
-                    </li>
                 </ul>
             </div>
             <div class="grid__col col-12@m">

--- a/app/themes/census/templates/partials/footer-transactional.html
+++ b/app/themes/census/templates/partials/footer-transactional.html
@@ -14,6 +14,9 @@
                     <li>
                         <a href="/cookies-settings" class="footer__link">{{ _("Cookie settings") }}</a>
                     </li>
+                    <li>
+                        <a rel='noopener noreferrer' target='_blank' href="https://surveys.ons.gov.uk/privacy-and-data-protection" class="footer__link">{{ _("Privacy and data protection") }}</a>
+                    </li>
                 </ul>
             </div>
             <div class="grid__col col-12@m">

--- a/app/themes/epenorthernireland/templates/partials/footer-transactional.html
+++ b/app/themes/epenorthernireland/templates/partials/footer-transactional.html
@@ -12,7 +12,10 @@
                         <a href="/contact-us" class="footer__link footer__link--inline" target="_blank">{{ _("Contact us") }}</a>
                     </li>
                     <li>
-                        <a href="/cookies-settings" class="footer__link">{{ _("Cookie settings") }}</a>
+                        <a href="/cookies-settings" class="footer__link footer__link--inline">{{ _("Cookie settings") }}</a>
+                    </li>
+                    <li>
+                        <a rel='noopener noreferrer' target='_blank' href="https://surveys.ons.gov.uk/privacy-and-data-protection" class="footer__link">{{ _("Privacy and data protection") }}</a>
                     </li>
                 </ul>
             </div>

--- a/app/themes/epenorthernireland/templates/partials/footer.html
+++ b/app/themes/epenorthernireland/templates/partials/footer.html
@@ -12,6 +12,9 @@
                     <li>
                         <a href="/cookies-settings" class="footer__link">{{ _("Cookie settings") }}</a>
                     </li>
+                    <li>
+                        <a rel='noopener noreferrer' target='_blank' href="https://surveys.ons.gov.uk/privacy-and-data-protection" class="footer__link">{{ _("Privacy and data protection") }}</a>
+                    </li>
                 </ul>
             </div>
             <div class="grid__col col-4@m">

--- a/app/themes/northernireland/templates/partials/footer-transactional.html
+++ b/app/themes/northernireland/templates/partials/footer-transactional.html
@@ -12,7 +12,10 @@
                         <a href="/contact-us" class="footer__link footer__link--inline" target="_blank">{{ _("Contact us") }}</a>
                     </li>
                     <li>
-                        <a href="/cookies-settings" class="footer__link">{{ _("Cookie settings") }}</a>
+                        <a href="/cookies-settings" class="footer__link footer__link--inline">{{ _("Cookie settings") }}</a>
+                    </li>
+                    <li>
+                        <a rel='noopener noreferrer' target='_blank' href="https://surveys.ons.gov.uk/privacy-and-data-protection" class="footer__link">{{ _("Privacy and data protection") }}</a>
                     </li>
                 </ul>
             </div>

--- a/app/themes/northernireland/templates/partials/footer.html
+++ b/app/themes/northernireland/templates/partials/footer.html
@@ -12,6 +12,9 @@
                     <li>
                         <a href="/cookies-settings" class="footer__link">{{ _("Cookie settings") }}</a>
                     </li>
+                    <li>
+                        <a rel='noopener noreferrer' target='_blank' href="https://surveys.ons.gov.uk/privacy-and-data-protection" class="footer__link">{{ _("Privacy and data protection") }}</a>
+                    </li>
                 </ul>
             </div>
             <div class="grid__col col-4@m">

--- a/app/themes/ukis/templates/partials/footer-transactional.html
+++ b/app/themes/ukis/templates/partials/footer-transactional.html
@@ -13,7 +13,10 @@
                         <a href="/contact-us" class="footer__link footer__link--inline" target="_blank">{{ _("Contact us") }}</a>
                     </li>
                     <li>
-                        <a href="/cookies-settings" class="footer__link">{{ _("Cookie settings") }}</a>
+                        <a href="/cookies-settings" class="footer__link footer__link--inline">{{ _("Cookie settings") }}</a>
+                    </li>
+                    <li>
+                        <a rel='noopener noreferrer' target='_blank' href="https://surveys.ons.gov.uk/privacy-and-data-protection" class="footer__link">{{ _("Privacy and data protection") }}</a>
                     </li>
                 </ul>
             </div>

--- a/app/themes/ukis/templates/partials/footer.html
+++ b/app/themes/ukis/templates/partials/footer.html
@@ -13,6 +13,9 @@
                     <li>
                         <a href="/cookies-settings" class="footer__link">{{ _("Cookie settings") }}</a>
                     </li>
+                    <li>
+                        <a rel='noopener noreferrer' target='_blank' href="https://surveys.ons.gov.uk/privacy-and-data-protection" class="footer__link">{{ _("Privacy and data protection") }}</a>
+                    </li>
                 </ul>
             </div>
             <div class="grid__col col-4@m">

--- a/app/themes/ukis_ni/templates/partials/footer-transactional.html
+++ b/app/themes/ukis_ni/templates/partials/footer-transactional.html
@@ -13,7 +13,10 @@
                         <a href="/contact-us" class="footer__link footer__link--inline" target="_blank">{{ _("Contact us") }}</a>
                     </li>
                     <li>
-                        <a href="/cookies-settings" class="footer__link">{{ _("Cookie settings") }}</a>
+                        <a href="/cookies-settings" class="footer__link footer__link--inline">{{ _("Cookie settings") }}</a>
+                    </li>
+                    <li>
+                        <a rel='noopener noreferrer' target='_blank' href="https://surveys.ons.gov.uk/privacy-and-data-protection" class="footer__link">{{ _("Privacy and data protection") }}</a>
                     </li>
                 </ul>
             </div>

--- a/app/themes/ukis_ni/templates/partials/footer.html
+++ b/app/themes/ukis_ni/templates/partials/footer.html
@@ -13,6 +13,9 @@
                     <li>
                         <a href="/cookies-settings" class="footer__link">{{ _("Cookie settings") }}</a>
                     </li>
+                    <li>
+                        <a rel='noopener noreferrer' target='_blank' href="https://surveys.ons.gov.uk/privacy-and-data-protection" class="footer__link">{{ _("Privacy and data protection") }}</a>
+                    </li>
                 </ul>
             </div>
             <div class="grid__col col-4@m">


### PR DESCRIPTION
[Ticket](https://collaborate2.ons.gov.uk/jira/browse/EAR-1136)
### What is the context of this PR?
Adding a privacy and data protection link to footers

### How to review 
Check that all ten of the footers include a working link to the correct privacy and data protection page
The page should open in a new tab
The surveys that should be used for testing are found in the EAR 1136 ticket