### PR TITLE
🛠 EAR 1259 - Allow calc sum across groups

### DIFF
--- a/app/templates/partials/summary/summary.html
+++ b/app/templates/partials/summary/summary.html
@@ -23,10 +23,10 @@
 
                     {%- endfor -%}
                 {%- endfor -%}
+            {%- if loop.last or loop.nextitem.title -%}
                 {%- if content.summary.summary_type == 'CalculatedSummary' -%}
                     {%- include theme(['partials/summary/calculated-summary-answer.html']) -%}
                 {%- endif -%}
-            {%- if loop.last or loop.nextitem.title -%}
                 </div>
             {%- endif -%}
         {%- endfor -%}

--- a/app/templating/view_context.py
+++ b/app/templating/view_context.py
@@ -249,11 +249,11 @@ def _build_calculated_summary_section_list(schema, rendered_block):
         if blocks:
             groups.append({
                 'id': group['id'],
-                'blocks': blocks
+                'blocks': blocks,
             })
 
     section = {
-        'groups': groups
+        'groups': groups,
     }
 
     return [section]


### PR DESCRIPTION
### What is the context of this PR?

[Ticket](https://collaborate2.ons.gov.uk/jira/browse/EAR-1259)

Allow calculated summaries to utilise answers drawn from multiple groups within a section.
Allows users of eQ Author to use calculated summaries which reference answers in different folders.

### How to review 
- Create a questionnaire in eQ Author
- Create a calculated summary page which references answers in different folders (within the same section)
- View survey running with this branch of eQ Runner running via docker-compose
- Shouldn't break when you get to the calculated summary page
- All answers shown should match the ones you selected in Author
- No other answers should be shown

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
