### PR TITLE
fix for section summary

### DIFF
--- a/data/en/1_0005.json
+++ b/data/en/1_0005.json
@@ -311,194 +311,14 @@
             "id": "section1da4e8ee-f4ee-42c4-90ab-485444de2b3e",
             "title": "Weekly pay",
             "groups": [{
-                "id": "group1da4e8ee-f4ee-42c4-90ab-485444de2b3e",
-                "title": "Weekly pay",
-                "blocks": [{
-                        "type": "Interstitial",
-                        "id": "group1da4e8ee-f4ee-42c4-90ab-485444de2b3e-introduction",
-                        "title": "Weekly pay",
-                        "description": "<p>This section covers employees who are paid weekly.</p><p>You will be asked for the:</p><ul><li>number of weekly paid employees</li><li>holiday pay, pay awards and bonuses paid to weekly paid employees</li><li>number of furloughed employees</li><li>number of furloughed employees who received a top-up to their pay in addition to the Coronavirus Job Retention Scheme (CJRS) 80% contributions</li><li>significant changes to the pay or number of weekly paid employees</li></ul>",
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Weekly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block6cef29d1-0d5c-423f-bf1d-e97735f64f3e",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question6cef29d1-0d5c-423f-bf1d-e97735f64f3e",
-                            "title": "What was the <em>number</em> of <em>weekly paid</em> employees paid in the last week of {{ metadata['period_str'] }}?",
-                            "description": "<p>If the last week of the month is affected by holidays please use a more representative week.</p>",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "all employees in Great Britain (England, Scotland and Wales), both full and part-time, who received pay in the relevant period",
-                                            "all trainees or apprentices that were paid through your payroll for the relevant period"
-                                        ]
-                                    },
-                                    {
-                                        "description": "<strong>Exclude:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "trainees or apprentices that were not paid through your payroll for the relevant period",
-                                            "employees working abroad unless paid directly from this business’s GB payroll",
-                                            "employees in Northern Ireland"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "type": "General",
-                            "answers": [{
-                                "id": "answerb13a5707-e248-4c77-bd57-b4090479565f",
-                                "mandatory": true,
-                                "type": "Number",
-                                "label": "Total number of weekly paid employees",
-                                "description": "",
-                                "q_code": "40",
-                                "min_value": {
-                                    "value": 1,
-                                    "exclusive": false
-                                },
-                                "decimal_places": 0
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Weekly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block1d336f8d-5e66-4692-a00d-8b0ad04b091b",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question1d336f8d-5e66-4692-a00d-8b0ad04b091b",
-                            "title": "What was the <em>total gross weekly pay</em> paid to employees in the last week of {{ metadata['period_str'] }}?",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "bonuses or commissions",
-                                            "overtime and shift allowance payments",
-                                            "advanced holiday pay",
-                                            "pay award arrears",
-                                            "voluntary employee contributions to, and annual profit from, profit related pay schemes"
-                                        ]
-                                    },
-                                    {
-                                        "description": "<strong>Exclude:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "any redundancy pay and pay in lieu of notice payments (taxable and non-taxable)",
-                                            "trainees or apprentices that were not paid through your payroll for the relevant period",
-                                            "directors' fees",
-                                            "employer’s NI and contribution to pension schemes",
-                                            "employees working abroad unless paid directly from this business’s GB payroll",
-                                            "signing on fees (sporting professionals)",
-                                            "accrued holiday pay",
-                                            "employees in Northern Ireland",
-                                            "expenses payments for attending meetings or training courses"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "type": "General",
-                            "answers": [{
-                                "id": "answerc50e5990-5933-456a-bdc9-4cc0a02ca02d",
-                                "mandatory": true,
-                                "type": "Currency",
-                                "label": "Total gross weekly pay",
-                                "description": "",
-                                "q_code": "50",
-                                "decimal_places": 2,
-                                "currency": "GBP"
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Weekly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "blockconfirmation-page-for-1d336f8d-5e66-4692-a00d-8b0ad04b091b",
-                        "type": "ConfirmationQuestion",
-                        "questions": [{
-                            "id": "questionconfirmation-page-for-1d336f8d-5e66-4692-a00d-8b0ad04b091b",
-                            "title": "The <em>total gross weekly pay</em> paid to employees in the last week of {{ metadata['period_str'] }} was <em>£0</em>, is this correct?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answerconfirmation-answer-for-1d336f8d-5e66-4692-a00d-8b0ad04b091b",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "options": [{
-                                        "label": "Yes, this is correct",
-                                        "value": "Yes, this is correct"
-                                    },
-                                    {
-                                        "label": "No, I need to change this",
-                                        "value": "No, I need to change this"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "block1d336f8d-5e66-4692-a00d-8b0ad04b091b",
-                                    "when": [{
-                                        "id": "answerconfirmation-answer-for-1d336f8d-5e66-4692-a00d-8b0ad04b091b",
-                                        "condition": "contains any",
-                                        "values": [
-                                            "No, I need to change this"
-                                        ]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block2e4a6b31-bc44-4963-8468-d0d228f2a091",
-                                    "when": [{
-                                        "id": "answerc50e5990-5933-456a-bdc9-4cc0a02ca02d",
-                                        "condition": "equals",
-                                        "value": 0
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block67b07c1a-a4d1-406c-8b06-2217075805a9"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                                "when": [{
-                                    "id": "answerc50e5990-5933-456a-bdc9-4cc0a02ca02d",
-                                    "condition": "greater than",
-                                    "value": 0
-                                }]
-                            },
-                            {
+                    "id": "group1da4e8ee-f4ee-42c4-90ab-485444de2b3e",
+                    "title": "Weekly pay",
+                    "blocks": [{
+                            "type": "Interstitial",
+                            "id": "group1da4e8ee-f4ee-42c4-90ab-485444de2b3e-introduction",
+                            "title": "Weekly pay",
+                            "description": "<p>This section covers employees who are paid weekly.</p><p>You will be asked for the:</p><ul><li>number of weekly paid employees</li><li>holiday pay, pay awards and bonuses paid to weekly paid employees</li><li>number of furloughed employees</li><li>number of furloughed employees who received a top-up to their pay in addition to the Coronavirus Job Retention Scheme (CJRS) 80% contributions</li><li>significant changes to the pay or number of weekly paid employees</li></ul>",
+                            "skip_conditions": [{
                                 "when": [{
                                     "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
                                     "condition": "not contains any",
@@ -506,778 +326,778 @@
                                         "Weekly"
                                     ]
                                 }]
-                            }
-                        ]
-                    },
-                    {
-                        "id": "block67b07c1a-a4d1-406c-8b06-2217075805a9",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question67b07c1a-a4d1-406c-8b06-2217075805a9",
-                            "title": "Of the {{ format_currency(answers['answerc50e5990-5933-456a-bdc9-4cc0a02ca02d'], 'GBP') }} paid to <em>weekly</em> paid employees in the last week of {{ metadata['period_str'] }}, what other amounts were paid?",
-                            "description": "<p>Informed estimates are acceptable.</p>",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "performance pay (for example, productivity bonuses)",
-                                            "long service awards",
-                                            "appearance money (sporting professionals)"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "type": "Calculated",
-                            "answers": [{
-                                    "id": "answer31e50f09-630b-4c18-b547-a527cdc9b4a5",
-                                    "mandatory": true,
-                                    "type": "Currency",
-                                    "label": "Holiday pay, paid in advance",
-                                    "description": "",
-                                    "q_code": "60",
-                                    "max_value": {
-                                        "answer_id": "answerc50e5990-5933-456a-bdc9-4cc0a02ca02d",
-                                        "exclusive": false
-                                    },
-                                    "decimal_places": 2,
-                                    "currency": "GBP"
+                            }]
+                        },
+                        {
+                            "id": "block6cef29d1-0d5c-423f-bf1d-e97735f64f3e",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "question6cef29d1-0d5c-423f-bf1d-e97735f64f3e",
+                                "title": "What was the <em>number</em> of <em>weekly paid</em> employees paid in the last week of {{ metadata['period_str'] }}?",
+                                "description": "<p>If the last week of the month is affected by holidays please use a more representative week.</p>",
+                                "guidance": {
+                                    "content": [{
+                                            "description": "<strong>Include:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "all employees in Great Britain (England, Scotland and Wales), both full and part-time, who received pay in the relevant period",
+                                                "all trainees or apprentices that were paid through your payroll for the relevant period"
+                                            ]
+                                        },
+                                        {
+                                            "description": "<strong>Exclude:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "trainees or apprentices that were not paid through your payroll for the relevant period",
+                                                "employees working abroad unless paid directly from this business’s GB payroll",
+                                                "employees in Northern Ireland"
+                                            ]
+                                        }
+                                    ]
                                 },
-                                {
-                                    "id": "answerc67df32d-4961-49b3-adff-b179310dc34c",
+                                "type": "General",
+                                "answers": [{
+                                    "id": "answerb13a5707-e248-4c77-bd57-b4090479565f",
                                     "mandatory": true,
-                                    "type": "Currency",
-                                    "label": "Arrears of pay owing to pay awards",
-                                    "description": "",
-                                    "q_code": "70",
-                                    "max_value": {
-                                        "answer_id": "answerc50e5990-5933-456a-bdc9-4cc0a02ca02d",
-                                        "exclusive": false
-                                    },
-                                    "decimal_places": 2,
-                                    "currency": "GBP"
-                                },
-                                {
-                                    "id": "answer3dd3d507-f5b6-44a9-863b-f4c47c4ee1fd",
-                                    "mandatory": true,
-                                    "type": "Currency",
-                                    "label": "Bonuses, commissions or annual profit from profit-related pay schemes",
-                                    "description": "",
-                                    "q_code": "80",
-                                    "max_value": {
-                                        "answer_id": "answerc50e5990-5933-456a-bdc9-4cc0a02ca02d",
-                                        "exclusive": false
-                                    },
-                                    "decimal_places": 2,
-                                    "currency": "GBP"
-                                }
-                            ],
-                            "calculations": [{
-                                "calculation_type": "sum",
-                                "answers_to_calculate": [
-                                    "answer31e50f09-630b-4c18-b547-a527cdc9b4a5",
-                                    "answerc67df32d-4961-49b3-adff-b179310dc34c",
-                                    "answer3dd3d507-f5b6-44a9-863b-f4c47c4ee1fd"
-                                ],
-                                "conditions": [
-                                    "less than",
-                                    "equals"
-                                ],
-                                "answer_id": "answerc50e5990-5933-456a-bdc9-4cc0a02ca02d"
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Weekly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block2e4a6b31-bc44-4963-8468-d0d228f2a091",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question2e4a6b31-bc44-4963-8468-d0d228f2a091",
-                            "title": "Were any of {{ metadata['ru_name'] }}'s weekly paid employees <em>furloughed</em> for any of the pay period?",
-                            "description": "<p>Please note that the Coronavirus Job Retention Scheme ended 30 September 2021.</p>",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "employees furloughed for either all, or some, of their normal working hours",
-                                            "employees the business is claiming for via the Coronavirus Job Retention Scheme (CJRS)"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer366325fc-f851-4ce6-b0da-6cfd9e81ddfc",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "400w",
-                                "options": [{
-                                        "label": "Yes",
-                                        "value": "Yes"
-                                    },
-                                    {
-                                        "label": "No",
-                                        "value": "No"
-                                    },
-                                    {
-                                        "label": "Not sure",
-                                        "value": "Not sure"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "block5bf0ea98-d6d2-46cb-9362-50c17fbf55df",
-                                    "when": [{
-                                        "id": "answer366325fc-f851-4ce6-b0da-6cfd9e81ddfc",
-                                        "condition": "contains any",
-                                        "values": [
-                                            "No",
-                                            "Not sure"
-                                        ]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block9bf358f7-91b7-45a2-b98f-3ea939d23a81"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Weekly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block9bf358f7-91b7-45a2-b98f-3ea939d23a81",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question9bf358f7-91b7-45a2-b98f-3ea939d23a81",
-                            "title": "Approximately <em>how many</em> of the weekly paid employees were furloughed for any of the pay period?",
-                            "description": "<p>Please note that the Coronavirus Job Retention Scheme ended 30 September 2021.</p>",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "employees furloughed for either all, or some, of their normal working hours",
-                                            "employees the business is claiming for via the Coronavirus Job Retention Scheme (CJRS)"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "type": "General",
-                            "answers": [{
-                                    "id": "answer9ec81e31-19b3-45b0-a69d-3a15b447a7fb",
-                                    "mandatory": false,
                                     "type": "Number",
-                                    "label": "Number of furloughed employees",
+                                    "label": "Total number of weekly paid employees",
                                     "description": "",
-                                    "q_code": "401w1",
+                                    "q_code": "40",
                                     "min_value": {
                                         "value": 1,
                                         "exclusive": false
                                     },
-                                    "max_value": {
-                                        "answer_id": "answerb13a5707-e248-4c77-bd57-b4090479565f",
-                                        "exclusive": false
-                                    },
                                     "decimal_places": 0
-                                },
-                                {
-                                    "id": "answerd510f333-5f9d-4a49-a67e-e6a4d4494ff1",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "label": "Or select 'Not sure' if the number is not known",
-                                    "description": "",
-                                    "options": [{
-                                        "label": "Not sure",
-                                        "value": "Not sure",
-                                        "q_code": "401w2"
-                                    }]
-                                }
-                            ]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "block5bf0ea98-d6d2-46cb-9362-50c17fbf55df",
-                                    "when": [{
-                                            "id": "answerd510f333-5f9d-4a49-a67e-e6a4d4494ff1",
-                                            "condition": "not set"
+                                }]
+                            }],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Weekly"
+                                    ]
+                                }]
+                            }]
+                        },
+                        {
+                            "id": "block1d336f8d-5e66-4692-a00d-8b0ad04b091b",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "question1d336f8d-5e66-4692-a00d-8b0ad04b091b",
+                                "title": "What was the <em>total gross weekly pay</em> paid to employees in the last week of {{ metadata['period_str'] }}?",
+                                "guidance": {
+                                    "content": [{
+                                            "description": "<strong>Include:</strong>"
                                         },
                                         {
-                                            "id": "answer9ec81e31-19b3-45b0-a69d-3a15b447a7fb",
-                                            "condition": "not set"
+                                            "list": [
+                                                "bonuses or commissions",
+                                                "overtime and shift allowance payments",
+                                                "advanced holiday pay",
+                                                "pay award arrears",
+                                                "voluntary employee contributions to, and annual profit from, profit related pay schemes"
+                                            ]
+                                        },
+                                        {
+                                            "description": "<strong>Exclude:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "any redundancy pay and pay in lieu of notice payments (taxable and non-taxable)",
+                                                "trainees or apprentices that were not paid through your payroll for the relevant period",
+                                                "directors' fees",
+                                                "employer’s NI and contribution to pension schemes",
+                                                "employees working abroad unless paid directly from this business’s GB payroll",
+                                                "signing on fees (sporting professionals)",
+                                                "accrued holiday pay",
+                                                "employees in Northern Ireland",
+                                                "expenses payments for attending meetings or training courses"
+                                            ]
                                         }
                                     ]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block5bf0ea98-d6d2-46cb-9362-50c17fbf55df",
-                                    "when": [{
-                                        "id": "answerd510f333-5f9d-4a49-a67e-e6a4d4494ff1",
-                                        "condition": "contains all",
-                                        "values": [
-                                            "Not sure"
-                                        ]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block02518350-2bab-4832-8ff6-31a2a9e161a7"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Weekly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block02518350-2bab-4832-8ff6-31a2a9e161a7",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question02518350-2bab-4832-8ff6-31a2a9e161a7",
-                            "title": "How many of {{ metadata['ru_name'] }}’s weekly paid furloughed employees received <em>more than the 80%</em>  Coronavirus Job Retention Scheme (CJRS) contribution, for the pay period?",
-                            "description": "<p>Please note that the Coronavirus Job Retention Scheme ended 30 September 2021.</p>",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include: </strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "employees who worked some hours for which they were paid at the normal rate",
-                                            "employees who received a top-up to their pay in addition to the Coronavirus Job Retention Scheme (CJRS) 80% contribution"
-                                        ]
-                                    },
-                                    {
-                                        "description": "<strong>Exclude:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "employer’s NI and contribution to pension schemes"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "type": "General",
-                            "answers": [{
-                                    "id": "answerb5f40be3-7157-4db4-b6ea-e458d058d824",
-                                    "mandatory": false,
-                                    "type": "Number",
-                                    "label": "Number of employees paid more than the 80% CJRS contribution",
+                                },
+                                "type": "General",
+                                "answers": [{
+                                    "id": "answerc50e5990-5933-456a-bdc9-4cc0a02ca02d",
+                                    "mandatory": true,
+                                    "type": "Currency",
+                                    "label": "Total gross weekly pay",
                                     "description": "",
-                                    "q_code": "402w1",
-                                    "max_value": {
-                                        "answer_id": "answer9ec81e31-19b3-45b0-a69d-3a15b447a7fb",
-                                        "exclusive": false
-                                    },
-                                    "decimal_places": 0
+                                    "q_code": "50",
+                                    "decimal_places": 2,
+                                    "currency": "GBP"
+                                }]
+                            }],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Weekly"
+                                    ]
+                                }]
+                            }]
+                        },
+                        {
+                            "id": "blockconfirmation-page-for-1d336f8d-5e66-4692-a00d-8b0ad04b091b",
+                            "type": "ConfirmationQuestion",
+                            "questions": [{
+                                "id": "questionconfirmation-page-for-1d336f8d-5e66-4692-a00d-8b0ad04b091b",
+                                "title": "The <em>total gross weekly pay</em> paid to employees in the last week of {{ metadata['period_str'] }} was <em>£0</em>, is this correct?",
+                                "type": "General",
+                                "answers": [{
+                                    "id": "answerconfirmation-answer-for-1d336f8d-5e66-4692-a00d-8b0ad04b091b",
+                                    "mandatory": true,
+                                    "type": "Radio",
+                                    "options": [{
+                                            "label": "Yes, this is correct",
+                                            "value": "Yes, this is correct"
+                                        },
+                                        {
+                                            "label": "No, I need to change this",
+                                            "value": "No, I need to change this"
+                                        }
+                                    ]
+                                }]
+                            }],
+                            "routing_rules": [{
+                                    "goto": {
+                                        "block": "block1d336f8d-5e66-4692-a00d-8b0ad04b091b",
+                                        "when": [{
+                                            "id": "answerconfirmation-answer-for-1d336f8d-5e66-4692-a00d-8b0ad04b091b",
+                                            "condition": "contains any",
+                                            "values": [
+                                                "No, I need to change this"
+                                            ]
+                                        }]
+                                    }
                                 },
                                 {
-                                    "id": "answerb3eb9d2b-c1a2-4c5e-b03f-4804cb0dd37c",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "label": "Or select 'Not sure' if the number is not known",
-                                    "description": "",
-                                    "options": [{
-                                        "label": "Not sure",
-                                        "value": "Not sure",
-                                        "q_code": "402w2"
+                                    "goto": {
+                                        "block": "block2e4a6b31-bc44-4963-8468-d0d228f2a091",
+                                        "when": [{
+                                            "id": "answerc50e5990-5933-456a-bdc9-4cc0a02ca02d",
+                                            "condition": "equals",
+                                            "value": 0
+                                        }]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "block67b07c1a-a4d1-406c-8b06-2217075805a9"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [{
+                                    "when": [{
+                                        "id": "answerc50e5990-5933-456a-bdc9-4cc0a02ca02d",
+                                        "condition": "greater than",
+                                        "value": 0
+                                    }]
+                                },
+                                {
+                                    "when": [{
+                                        "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                        "condition": "not contains any",
+                                        "values": [
+                                            "Weekly"
+                                        ]
                                     }]
                                 }
                             ]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Weekly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block5bf0ea98-d6d2-46cb-9362-50c17fbf55df",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question5bf0ea98-d6d2-46cb-9362-50c17fbf55df",
-                            "title": "Did any significant changes occur to the <em>total pay or number</em> of <em>weekly</em> paid employees?",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include:</strong>"
+                        },
+                        {
+                            "id": "block67b07c1a-a4d1-406c-8b06-2217075805a9",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "question67b07c1a-a4d1-406c-8b06-2217075805a9",
+                                "title": "Of the {{ format_currency(answers['answerc50e5990-5933-456a-bdc9-4cc0a02ca02d'], 'GBP') }} paid to <em>weekly</em> paid employees in the last week of {{ metadata['period_str'] }}, what other amounts were paid?",
+                                "description": "<p>Informed estimates are acceptable.</p>",
+                                "guidance": {
+                                    "content": [{
+                                            "description": "<strong>Include:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "performance pay (for example, productivity bonuses)",
+                                                "long service awards",
+                                                "appearance money (sporting professionals)"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "type": "Calculated",
+                                "answers": [{
+                                        "id": "answer31e50f09-630b-4c18-b547-a527cdc9b4a5",
+                                        "mandatory": true,
+                                        "type": "Currency",
+                                        "label": "Holiday pay, paid in advance",
+                                        "description": "",
+                                        "q_code": "60",
+                                        "max_value": {
+                                            "answer_id": "answerc50e5990-5933-456a-bdc9-4cc0a02ca02d",
+                                            "exclusive": false
+                                        },
+                                        "decimal_places": 2,
+                                        "currency": "GBP"
                                     },
                                     {
-                                        "list": [
-                                            "redundancies",
-                                            "changes in the number of temporary staff",
-                                            "more or less overtime",
-                                            "new pay rates",
-                                            "industrial action"
-                                        ]
+                                        "id": "answerc67df32d-4961-49b3-adff-b179310dc34c",
+                                        "mandatory": true,
+                                        "type": "Currency",
+                                        "label": "Arrears of pay owing to pay awards",
+                                        "description": "",
+                                        "q_code": "70",
+                                        "max_value": {
+                                            "answer_id": "answerc50e5990-5933-456a-bdc9-4cc0a02ca02d",
+                                            "exclusive": false
+                                        },
+                                        "decimal_places": 2,
+                                        "currency": "GBP"
+                                    },
+                                    {
+                                        "id": "answer3dd3d507-f5b6-44a9-863b-f4c47c4ee1fd",
+                                        "mandatory": true,
+                                        "type": "Currency",
+                                        "label": "Bonuses, commissions or annual profit from profit-related pay schemes",
+                                        "description": "",
+                                        "q_code": "80",
+                                        "max_value": {
+                                            "answer_id": "answerc50e5990-5933-456a-bdc9-4cc0a02ca02d",
+                                            "exclusive": false
+                                        },
+                                        "decimal_places": 2,
+                                        "currency": "GBP"
                                     }
-                                ]
-                            },
-                            "definitions": [{
-                                "title": "What we mean by 'a significant change'",
-                                "content": [{
-                                        "description": "This is dependent on your own interpretation of whether there has been a significant change in the business’s figures compared with the previous month."
+                                ],
+                                "calculations": [{
+                                    "calculation_type": "sum",
+                                    "answers_to_calculate": [
+                                        "answer31e50f09-630b-4c18-b547-a527cdc9b4a5",
+                                        "answerc67df32d-4961-49b3-adff-b179310dc34c",
+                                        "answer3dd3d507-f5b6-44a9-863b-f4c47c4ee1fd"
+                                    ],
+                                    "conditions": [
+                                        "less than",
+                                        "equals"
+                                    ],
+                                    "answer_id": "answerc50e5990-5933-456a-bdc9-4cc0a02ca02d"
+                                }]
+                            }],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Weekly"
+                                    ]
+                                }]
+                            }]
+                        },
+                        {
+                            "id": "block2e4a6b31-bc44-4963-8468-d0d228f2a091",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "question2e4a6b31-bc44-4963-8468-d0d228f2a091",
+                                "title": "Were any of {{ metadata['ru_name'] }}'s weekly paid employees <em>furloughed</em> for any of the pay period?",
+                                "description": "<p>Please note that the Coronavirus Job Retention Scheme ended 30 September 2021.</p>",
+                                "guidance": {
+                                    "content": [{
+                                            "description": "<strong>Include:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "employees furloughed for either all, or some, of their normal working hours",
+                                                "employees the business is claiming for via the Coronavirus Job Retention Scheme (CJRS)"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "type": "General",
+                                "answers": [{
+                                    "id": "answer366325fc-f851-4ce6-b0da-6cfd9e81ddfc",
+                                    "mandatory": true,
+                                    "type": "Radio",
+                                    "label": "",
+                                    "description": "",
+                                    "q_code": "400w",
+                                    "options": [{
+                                            "label": "Yes",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "label": "No",
+                                            "value": "No"
+                                        },
+                                        {
+                                            "label": "Not sure",
+                                            "value": "Not sure"
+                                        }
+                                    ]
+                                }]
+                            }],
+                            "routing_rules": [{
+                                    "goto": {
+                                        "block": "block5bf0ea98-d6d2-46cb-9362-50c17fbf55df",
+                                        "when": [{
+                                            "id": "answer366325fc-f851-4ce6-b0da-6cfd9e81ddfc",
+                                            "condition": "contains any",
+                                            "values": [
+                                                "No",
+                                                "Not sure"
+                                            ]
+                                        }]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "block9bf358f7-91b7-45a2-b98f-3ea939d23a81"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Weekly"
+                                    ]
+                                }]
+                            }]
+                        },
+                        {
+                            "id": "block9bf358f7-91b7-45a2-b98f-3ea939d23a81",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "question9bf358f7-91b7-45a2-b98f-3ea939d23a81",
+                                "title": "Approximately <em>how many</em> of the weekly paid employees were furloughed for any of the pay period?",
+                                "description": "<p>Please note that the Coronavirus Job Retention Scheme ended 30 September 2021.</p>",
+                                "guidance": {
+                                    "content": [{
+                                            "description": "<strong>Include:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "employees furloughed for either all, or some, of their normal working hours",
+                                                "employees the business is claiming for via the Coronavirus Job Retention Scheme (CJRS)"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "type": "General",
+                                "answers": [{
+                                        "id": "answer9ec81e31-19b3-45b0-a69d-3a15b447a7fb",
+                                        "mandatory": false,
+                                        "type": "Number",
+                                        "label": "Number of furloughed employees",
+                                        "description": "",
+                                        "q_code": "401w1",
+                                        "min_value": {
+                                            "value": 1,
+                                            "exclusive": false
+                                        },
+                                        "max_value": {
+                                            "answer_id": "answerb13a5707-e248-4c77-bd57-b4090479565f",
+                                            "exclusive": false
+                                        },
+                                        "decimal_places": 0
                                     },
                                     {
-                                        "description": "Also consider whether there has been a significant change from the same month in the previous year."
+                                        "id": "answerd510f333-5f9d-4a49-a67e-e6a4d4494ff1",
+                                        "mandatory": false,
+                                        "type": "Checkbox",
+                                        "label": "Or select 'Not sure' if the number is not known",
+                                        "description": "",
+                                        "options": [{
+                                            "label": "Not sure",
+                                            "value": "Not sure",
+                                            "q_code": "401w2"
+                                        }]
                                     }
                                 ]
                             }],
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer3b68f565-f13a-4155-b639-124cd0ec82ca",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "90w",
-                                "options": [{
-                                        "label": "Yes",
-                                        "value": "Yes"
-                                    },
-                                    {
-                                        "label": "No",
-                                        "value": "No"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "group": "group-summary-weekly",
-                                    "when": [{
-                                        "id": "answer3b68f565-f13a-4155-b639-124cd0ec82ca",
-                                        "condition": "contains any",
-                                        "values": [
-                                            "No"
+                            "routing_rules": [{
+                                    "goto": {
+                                        "block": "block5bf0ea98-d6d2-46cb-9362-50c17fbf55df",
+                                        "when": [{
+                                                "id": "answerd510f333-5f9d-4a49-a67e-e6a4d4494ff1",
+                                                "condition": "not set"
+                                            },
+                                            {
+                                                "id": "answer9ec81e31-19b3-45b0-a69d-3a15b447a7fb",
+                                                "condition": "not set"
+                                            }
                                         ]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "blockeb152780-ab5b-4df1-b8a0-c8ad4f6a2719"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Weekly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "blockeb152780-ab5b-4df1-b8a0-c8ad4f6a2719",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questioneb152780-ab5b-4df1-b8a0-c8ad4f6a2719",
-                            "title": "What were the reasons for the changes to the <em>total pay or number</em> of <em>weekly</em> paid employees?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answera2630997-28cd-484d-b66a-cc5742622e36",
-                                "mandatory": true,
-                                "type": "Checkbox",
-                                "label": "Select all that apply:",
-                                "description": "",
-                                "options": [{
-                                        "label": "Redundancies",
-                                        "value": "Redundancies",
-                                        "q_code": "91w"
-                                    },
-                                    {
-                                        "label": "More temporary staff",
-                                        "value": "More temporary staff",
-                                        "q_code": "92w1"
-                                    },
-                                    {
-                                        "label": "Fewer temporary staff",
-                                        "value": "Fewer temporary staff",
-                                        "q_code": "92w2"
-                                    },
-                                    {
-                                        "label": "More overtime",
-                                        "value": "More overtime",
-                                        "q_code": "94w1"
-                                    },
-                                    {
-                                        "label": "Less overtime",
-                                        "value": "Less overtime",
-                                        "q_code": "94w2"
-                                    },
-                                    {
-                                        "label": "Pay increase",
-                                        "value": "Pay increase",
-                                        "q_code": "95w"
-                                    },
-                                    {
-                                        "label": "Industrial action",
-                                        "value": "Industrial action",
-                                        "q_code": "96w"
-                                    },
-                                    {
-                                        "label": "Other",
-                                        "value": "Other",
-                                        "q_code": "97w"
                                     }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "block2dc10237-6cca-4f21-8ac8-2904c758dc63",
-                                    "when": [{
-                                        "id": "answera2630997-28cd-484d-b66a-cc5742622e36",
-                                        "condition": "contains all",
-                                        "values": [
-                                            "Pay increase"
-                                        ]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block5af76dd4-4648-4d76-b9b7-7c64f42ede50"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Weekly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block2dc10237-6cca-4f21-8ac8-2904c758dc63",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question2dc10237-6cca-4f21-8ac8-2904c758dc63",
-                            "title": "If your business has new pay rates, what is the percentage increase?",
-                            "type": "General",
-                            "answers": [{
-                                    "id": "answer93318bf0-0228-43e5-8d66-0418e14fa2e7",
-                                    "mandatory": false,
-                                    "type": "Percentage",
-                                    "label": "Percentage increase of new pay rates",
-                                    "description": "",
-                                    "q_code": "100",
-                                    "decimal_places": 2
                                 },
                                 {
-                                    "id": "answerc4899350-1ff4-42f9-8e29-558180452dd3",
-                                    "mandatory": false,
-                                    "type": "Date",
-                                    "label": "If your figures are backdated, which date did they begin?",
-                                    "description": "",
-                                    "q_code": "110"
+                                    "goto": {
+                                        "block": "block5bf0ea98-d6d2-46cb-9362-50c17fbf55df",
+                                        "when": [{
+                                            "id": "answerd510f333-5f9d-4a49-a67e-e6a4d4494ff1",
+                                            "condition": "contains all",
+                                            "values": [
+                                                "Not sure"
+                                            ]
+                                        }]
+                                    }
                                 },
                                 {
-                                    "id": "answerae54accd-007c-4637-a970-891d23d992ed",
-                                    "mandatory": false,
-                                    "type": "Number",
-                                    "label": "What was the number of weekly paid employees who received this new pay rate?",
-                                    "description": "",
-                                    "q_code": "120",
-                                    "max_value": {
-                                        "answer_id": "answerb13a5707-e248-4c77-bd57-b4090479565f",
-                                        "exclusive": false
-                                    },
-                                    "decimal_places": 0
+                                    "goto": {
+                                        "block": "block02518350-2bab-4832-8ff6-31a2a9e161a7"
+                                    }
                                 }
-                            ]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Weekly"
+                            ],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Weekly"
+                                    ]
+                                }]
+                            }]
+                        },
+                        {
+                            "id": "block02518350-2bab-4832-8ff6-31a2a9e161a7",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "question02518350-2bab-4832-8ff6-31a2a9e161a7",
+                                "title": "How many of {{ metadata['ru_name'] }}’s weekly paid furloughed employees received <em>more than the 80%</em>  Coronavirus Job Retention Scheme (CJRS) contribution, for the pay period?",
+                                "description": "<p>Please note that the Coronavirus Job Retention Scheme ended 30 September 2021.</p>",
+                                "guidance": {
+                                    "content": [{
+                                            "description": "<strong>Include: </strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "employees who worked some hours for which they were paid at the normal rate",
+                                                "employees who received a top-up to their pay in addition to the Coronavirus Job Retention Scheme (CJRS) 80% contribution"
+                                            ]
+                                        },
+                                        {
+                                            "description": "<strong>Exclude:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "employer’s NI and contribution to pension schemes"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "type": "General",
+                                "answers": [{
+                                        "id": "answerb5f40be3-7157-4db4-b6ea-e458d058d824",
+                                        "mandatory": false,
+                                        "type": "Number",
+                                        "label": "Number of employees paid more than the 80% CJRS contribution",
+                                        "description": "",
+                                        "q_code": "402w1",
+                                        "max_value": {
+                                            "answer_id": "answer9ec81e31-19b3-45b0-a69d-3a15b447a7fb",
+                                            "exclusive": false
+                                        },
+                                        "decimal_places": 0
+                                    },
+                                    {
+                                        "id": "answerb3eb9d2b-c1a2-4c5e-b03f-4804cb0dd37c",
+                                        "mandatory": false,
+                                        "type": "Checkbox",
+                                        "label": "Or select 'Not sure' if the number is not known",
+                                        "description": "",
+                                        "options": [{
+                                            "label": "Not sure",
+                                            "value": "Not sure",
+                                            "q_code": "402w2"
+                                        }]
+                                    }
                                 ]
+                            }],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Weekly"
+                                    ]
+                                }]
                             }]
-                        }]
-                    },
-                    {
-                        "id": "block5af76dd4-4648-4d76-b9b7-7c64f42ede50",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question5af76dd4-4648-4d76-b9b7-7c64f42ede50",
-                            "title": "What were the changes to the <em>total pay or number</em> of <em>weekly</em> paid employees?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer4ac9c8bb-fb20-45cd-b241-68d37a0b1e51",
-                                "mandatory": true,
-                                "type": "TextArea",
-                                "label": "Comments",
-                                "description": "",
-                                "q_code": "300w",
-                                "max_length": 2000
+                        },
+                        {
+                            "id": "block5bf0ea98-d6d2-46cb-9362-50c17fbf55df",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "question5bf0ea98-d6d2-46cb-9362-50c17fbf55df",
+                                "title": "Did any significant changes occur to the <em>total pay or number</em> of <em>weekly</em> paid employees?",
+                                "guidance": {
+                                    "content": [{
+                                            "description": "<strong>Include:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "redundancies",
+                                                "changes in the number of temporary staff",
+                                                "more or less overtime",
+                                                "new pay rates",
+                                                "industrial action"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "definitions": [{
+                                    "title": "What we mean by 'a significant change'",
+                                    "content": [{
+                                            "description": "This is dependent on your own interpretation of whether there has been a significant change in the business’s figures compared with the previous month."
+                                        },
+                                        {
+                                            "description": "Also consider whether there has been a significant change from the same month in the previous year."
+                                        }
+                                    ]
+                                }],
+                                "type": "General",
+                                "answers": [{
+                                    "id": "answer3b68f565-f13a-4155-b639-124cd0ec82ca",
+                                    "mandatory": true,
+                                    "type": "Radio",
+                                    "label": "",
+                                    "description": "",
+                                    "q_code": "90w",
+                                    "options": [{
+                                            "label": "Yes",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "label": "No",
+                                            "value": "No"
+                                        }
+                                    ]
+                                }]
+                            }],
+                            "routing_rules": [{
+                                    "goto": {
+                                        "group": "group-summary-weekly",
+                                        "when": [{
+                                            "id": "answer3b68f565-f13a-4155-b639-124cd0ec82ca",
+                                            "condition": "contains any",
+                                            "values": [
+                                                "No"
+                                            ]
+                                        }]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "blockeb152780-ab5b-4df1-b8a0-c8ad4f6a2719"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Weekly"
+                                    ]
+                                }]
                             }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Weekly"
+                        },
+                        {
+                            "id": "blockeb152780-ab5b-4df1-b8a0-c8ad4f6a2719",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "questioneb152780-ab5b-4df1-b8a0-c8ad4f6a2719",
+                                "title": "What were the reasons for the changes to the <em>total pay or number</em> of <em>weekly</em> paid employees?",
+                                "type": "General",
+                                "answers": [{
+                                    "id": "answera2630997-28cd-484d-b66a-cc5742622e36",
+                                    "mandatory": true,
+                                    "type": "Checkbox",
+                                    "label": "Select all that apply:",
+                                    "description": "",
+                                    "options": [{
+                                            "label": "Redundancies",
+                                            "value": "Redundancies",
+                                            "q_code": "91w"
+                                        },
+                                        {
+                                            "label": "More temporary staff",
+                                            "value": "More temporary staff",
+                                            "q_code": "92w1"
+                                        },
+                                        {
+                                            "label": "Fewer temporary staff",
+                                            "value": "Fewer temporary staff",
+                                            "q_code": "92w2"
+                                        },
+                                        {
+                                            "label": "More overtime",
+                                            "value": "More overtime",
+                                            "q_code": "94w1"
+                                        },
+                                        {
+                                            "label": "Less overtime",
+                                            "value": "Less overtime",
+                                            "q_code": "94w2"
+                                        },
+                                        {
+                                            "label": "Pay increase",
+                                            "value": "Pay increase",
+                                            "q_code": "95w"
+                                        },
+                                        {
+                                            "label": "Industrial action",
+                                            "value": "Industrial action",
+                                            "q_code": "96w"
+                                        },
+                                        {
+                                            "label": "Other",
+                                            "value": "Other",
+                                            "q_code": "97w"
+                                        }
+                                    ]
+                                }]
+                            }],
+                            "routing_rules": [{
+                                    "goto": {
+                                        "block": "block2dc10237-6cca-4f21-8ac8-2904c758dc63",
+                                        "when": [{
+                                            "id": "answera2630997-28cd-484d-b66a-cc5742622e36",
+                                            "condition": "contains all",
+                                            "values": [
+                                                "Pay increase"
+                                            ]
+                                        }]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "block5af76dd4-4648-4d76-b9b7-7c64f42ede50"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Weekly"
+                                    ]
+                                }]
+                            }]
+                        },
+                        {
+                            "id": "block2dc10237-6cca-4f21-8ac8-2904c758dc63",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "question2dc10237-6cca-4f21-8ac8-2904c758dc63",
+                                "title": "If your business has new pay rates, what is the percentage increase?",
+                                "type": "General",
+                                "answers": [{
+                                        "id": "answer93318bf0-0228-43e5-8d66-0418e14fa2e7",
+                                        "mandatory": false,
+                                        "type": "Percentage",
+                                        "label": "Percentage increase of new pay rates",
+                                        "description": "",
+                                        "q_code": "100",
+                                        "decimal_places": 2
+                                    },
+                                    {
+                                        "id": "answerc4899350-1ff4-42f9-8e29-558180452dd3",
+                                        "mandatory": false,
+                                        "type": "Date",
+                                        "label": "If your figures are backdated, which date did they begin?",
+                                        "description": "",
+                                        "q_code": "110"
+                                    },
+                                    {
+                                        "id": "answerae54accd-007c-4637-a970-891d23d992ed",
+                                        "mandatory": false,
+                                        "type": "Number",
+                                        "label": "What was the number of weekly paid employees who received this new pay rate?",
+                                        "description": "",
+                                        "q_code": "120",
+                                        "max_value": {
+                                            "answer_id": "answerb13a5707-e248-4c77-bd57-b4090479565f",
+                                            "exclusive": false
+                                        },
+                                        "decimal_places": 0
+                                    }
                                 ]
+                            }],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Weekly"
+                                    ]
+                                }]
                             }]
-                        }]
-                    }
-                ]
-            },
-            {
-                "id": "group-summary-weekly",
-                "blocks": [
-                    {
+                        },
+                        {
+                            "id": "block5af76dd4-4648-4d76-b9b7-7c64f42ede50",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "question5af76dd4-4648-4d76-b9b7-7c64f42ede50",
+                                "title": "What were the changes to the <em>total pay or number</em> of <em>weekly</em> paid employees?",
+                                "type": "General",
+                                "answers": [{
+                                    "id": "answer4ac9c8bb-fb20-45cd-b241-68d37a0b1e51",
+                                    "mandatory": true,
+                                    "type": "TextArea",
+                                    "label": "Comments",
+                                    "description": "",
+                                    "q_code": "300w",
+                                    "max_length": 2000
+                                }]
+                            }],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Weekly"
+                                    ]
+                                }]
+                            }]
+                        }
+                    ]
+                },
+                {
+                    "id": "group-summary-weekly",
+                    "title": "section summary weekly",
+                    "blocks": [{
                         "id": "summary-weekly",
                         "type": "SectionSummary",
                         "collapsible": false
-                    }
-                ],
-                "skip_conditions": [{
-                    "when": [{
-                        "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                        "condition": "not contains any",
-                        "values": [
-                            "Weekly"
-                        ]
+                    }],
+                    "skip_conditions": [{
+                        "when": [{
+                            "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                            "condition": "not contains any",
+                            "values": [
+                                "Weekly"
+                            ]
+                        }]
                     }]
-                }]
-            }]
+                }
+            ]
         },
         {
             "id": "sectionb903c023-4354-46af-87bc-708000c86384",
             "title": "Fortnightly pay",
             "groups": [{
-                "id": "groupb903c023-4354-46af-87bc-708000c86384",
-                "title": "Fortnightly pay",
-                "blocks": [{
-                        "type": "Interstitial",
-                        "id": "groupb903c023-4354-46af-87bc-708000c86384-introduction",
-                        "title": "Fortnightly pay",
-                        "description": "<p>This section covers employees who are paid fortnightly.</p><p>You will be asked for the:</p><ul><li>number of fortnightly paid employees</li><li>holiday pay, pay awards and bonuses paid to fortnightly paid employees</li><li>number of furloughed employees</li><li>number of furloughed employees who received a top-up to their pay in addition to the Coronavirus Job Retention Scheme (CJRS) 80% contributions</li><li>significant changes to the pay or number of fortnightly paid employees</li></ul>",
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Fortnightly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block1080314d-73c8-47e8-b189-ba84c20bbbc1",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question1080314d-73c8-47e8-b189-ba84c20bbbc1",
-                            "title": "What was the <em>number</em> of <em>fortnightly paid</em> employees paid in the last week of {{ metadata['period_str'] }}?",
-                            "description": "<p>If the last week of the month is affected by holidays please use a more representative week.</p>",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "all employees in Great Britain (England, Scotland and Wales), both full and part-time, who received pay in the relevant period",
-                                            "all trainees or apprentices that were paid through your payroll for the relevant period"
-                                        ]
-                                    },
-                                    {
-                                        "description": "<strong>Exclude:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "trainees or apprentices that were not paid through your payroll for the relevant period",
-                                            "employees working abroad unless paid directly from this business’s GB payroll",
-                                            "employees in Northern Ireland"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer1d93222d-e3c7-4cd7-8e3c-8ecd0a795409",
-                                "mandatory": true,
-                                "type": "Number",
-                                "label": "Total number of fortnightly paid employees",
-                                "description": "",
-                                "q_code": "40f",
-                                "min_value": {
-                                    "value": 1,
-                                    "exclusive": false
-                                },
-                                "decimal_places": 0
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Fortnightly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block0fe57f5e-f9f9-4988-980c-62edc9af265c",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question0fe57f5e-f9f9-4988-980c-62edc9af265c",
-                            "title": "What was the <em>total gross fortnightly pay</em> paid to employees in the last week of {{ metadata['period_str'] }}?",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "bonuses or commissions",
-                                            "overtime and shift allowance payments",
-                                            "advanced holiday pay",
-                                            "pay award arrears",
-                                            "voluntary employee contributions to, and annual profit from, profit related pay schemes"
-                                        ]
-                                    },
-                                    {
-                                        "description": "<strong>Exclude:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "any redundancy pay and pay in lieu of notice payments (taxable and non-taxable)",
-                                            "trainees or apprentices that were not paid through your payroll for the relevant period",
-                                            "directors' fees",
-                                            "employer’s NI and contribution to pension schemes",
-                                            "employees working abroad unless paid directly from this business’s GB payroll",
-                                            "signing on fees (sporting professionals)",
-                                            "accrued holiday pay",
-                                            "employees in Northern Ireland",
-                                            "expenses payments for attending meetings or training courses"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "type": "General",
-                            "answers": [{
-                                "id": "answere2ace0d3-6f49-4c7e-93f4-802d53395f1f",
-                                "mandatory": true,
-                                "type": "Currency",
-                                "label": "Total gross fortnightly pay",
-                                "description": "",
-                                "q_code": "50f",
-                                "decimal_places": 2,
-                                "currency": "GBP"
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Fortnightly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "blockconfirmation-page-for-0fe57f5e-f9f9-4988-980c-62edc9af265c",
-                        "type": "ConfirmationQuestion",
-                        "questions": [{
-                            "id": "questionconfirmation-page-for-0fe57f5e-f9f9-4988-980c-62edc9af265c",
-                            "title": "The <em>total gross fortnightly pay</em> paid to employees in the last week of {{ metadata['period_str'] }} was <em>£0</em>, is this correct?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answerconfirmation-answer-for-0fe57f5e-f9f9-4988-980c-62edc9af265c",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "options": [{
-                                        "label": "Yes, this is correct",
-                                        "value": "Yes, this is correct"
-                                    },
-                                    {
-                                        "label": "No, I need to change this",
-                                        "value": "No, I need to change this"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "block0fe57f5e-f9f9-4988-980c-62edc9af265c",
-                                    "when": [{
-                                        "id": "answerconfirmation-answer-for-0fe57f5e-f9f9-4988-980c-62edc9af265c",
-                                        "condition": "contains any",
-                                        "values": [
-                                            "No, I need to change this"
-                                        ]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "blockce0d315f-7e22-45df-99bc-251406cc113c",
-                                    "when": [{
-                                        "id": "answere2ace0d3-6f49-4c7e-93f4-802d53395f1f",
-                                        "condition": "equals",
-                                        "value": 0
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block0a92343d-555a-48f7-8614-fd13a6cd1e8e"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                                "when": [{
-                                    "id": "answere2ace0d3-6f49-4c7e-93f4-802d53395f1f",
-                                    "condition": "greater than",
-                                    "value": 0
-                                }]
-                            },
-                            {
+                    "id": "groupb903c023-4354-46af-87bc-708000c86384",
+                    "title": "Fortnightly pay",
+                    "blocks": [{
+                            "type": "Interstitial",
+                            "id": "groupb903c023-4354-46af-87bc-708000c86384-introduction",
+                            "title": "Fortnightly pay",
+                            "description": "<p>This section covers employees who are paid fortnightly.</p><p>You will be asked for the:</p><ul><li>number of fortnightly paid employees</li><li>holiday pay, pay awards and bonuses paid to fortnightly paid employees</li><li>number of furloughed employees</li><li>number of furloughed employees who received a top-up to their pay in addition to the Coronavirus Job Retention Scheme (CJRS) 80% contributions</li><li>significant changes to the pay or number of fortnightly paid employees</li></ul>",
+                            "skip_conditions": [{
                                 "when": [{
                                     "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
                                     "condition": "not contains any",
@@ -1285,776 +1105,778 @@
                                         "Fortnightly"
                                     ]
                                 }]
-                            }
-                        ]
-                    },
-                    {
-                        "id": "block0a92343d-555a-48f7-8614-fd13a6cd1e8e",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question0a92343d-555a-48f7-8614-fd13a6cd1e8e",
-                            "title": "Of the {{ format_currency(answers['answere2ace0d3-6f49-4c7e-93f4-802d53395f1f'], 'GBP') }} paid to <em>fortnightly</em> paid employees in the last week of {{ metadata['period_str'] }}, what other amounts were paid?",
-                            "description": "<p>Informed estimates are acceptable.</p>",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "performance pay (for example, productivity bonuses)",
-                                            "long service awards",
-                                            "appearance money (sporting professionals)"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "type": "Calculated",
-                            "answers": [{
-                                    "id": "answer549cbfad-4ade-4952-bc85-07d0ca3b86f9",
-                                    "mandatory": true,
-                                    "type": "Currency",
-                                    "label": "Holiday pay, paid in advance",
-                                    "description": "",
-                                    "q_code": "60f",
-                                    "max_value": {
-                                        "answer_id": "answere2ace0d3-6f49-4c7e-93f4-802d53395f1f",
-                                        "exclusive": false
-                                    },
-                                    "decimal_places": 2,
-                                    "currency": "GBP"
+                            }]
+                        },
+                        {
+                            "id": "block1080314d-73c8-47e8-b189-ba84c20bbbc1",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "question1080314d-73c8-47e8-b189-ba84c20bbbc1",
+                                "title": "What was the <em>number</em> of <em>fortnightly paid</em> employees paid in the last week of {{ metadata['period_str'] }}?",
+                                "description": "<p>If the last week of the month is affected by holidays please use a more representative week.</p>",
+                                "guidance": {
+                                    "content": [{
+                                            "description": "<strong>Include:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "all employees in Great Britain (England, Scotland and Wales), both full and part-time, who received pay in the relevant period",
+                                                "all trainees or apprentices that were paid through your payroll for the relevant period"
+                                            ]
+                                        },
+                                        {
+                                            "description": "<strong>Exclude:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "trainees or apprentices that were not paid through your payroll for the relevant period",
+                                                "employees working abroad unless paid directly from this business’s GB payroll",
+                                                "employees in Northern Ireland"
+                                            ]
+                                        }
+                                    ]
                                 },
-                                {
-                                    "id": "answerf3f95b24-3224-47a5-9eba-d8f74b73128f",
+                                "type": "General",
+                                "answers": [{
+                                    "id": "answer1d93222d-e3c7-4cd7-8e3c-8ecd0a795409",
                                     "mandatory": true,
-                                    "type": "Currency",
-                                    "label": "Arrears of pay owing to pay awards",
-                                    "description": "",
-                                    "q_code": "70f",
-                                    "max_value": {
-                                        "answer_id": "answere2ace0d3-6f49-4c7e-93f4-802d53395f1f",
-                                        "exclusive": false
-                                    },
-                                    "decimal_places": 2,
-                                    "currency": "GBP"
-                                },
-                                {
-                                    "id": "answer7cc7c90d-e61a-43f9-b5b0-74c27c6e696f",
-                                    "mandatory": true,
-                                    "type": "Currency",
-                                    "label": "Bonuses, commissions or annual profit from profit-related pay schemes",
-                                    "description": "",
-                                    "q_code": "80f",
-                                    "max_value": {
-                                        "answer_id": "answere2ace0d3-6f49-4c7e-93f4-802d53395f1f",
-                                        "exclusive": false
-                                    },
-                                    "decimal_places": 2,
-                                    "currency": "GBP"
-                                }
-                            ],
-                            "calculations": [{
-                                "calculation_type": "sum",
-                                "answers_to_calculate": [
-                                    "answer549cbfad-4ade-4952-bc85-07d0ca3b86f9",
-                                    "answerf3f95b24-3224-47a5-9eba-d8f74b73128f",
-                                    "answer7cc7c90d-e61a-43f9-b5b0-74c27c6e696f"
-                                ],
-                                "conditions": [
-                                    "less than",
-                                    "equals"
-                                ],
-                                "answer_id": "answere2ace0d3-6f49-4c7e-93f4-802d53395f1f"
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Fortnightly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "blockce0d315f-7e22-45df-99bc-251406cc113c",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questionce0d315f-7e22-45df-99bc-251406cc113c",
-                            "title": "Were any of {{ metadata['ru_name'] }}'s fortnightly paid employees <em>furloughed</em> for any of the pay period?",
-                            "description": "<p>Please note that the Coronavirus Job Retention Scheme ended 30 September 2021.</p>",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "employees furloughed for either all, or some, of their normal working hours",
-                                            "employees the business is claiming for via the Coronavirus Job Retention Scheme (CJRS)"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "type": "General",
-                            "answers": [{
-                                "id": "answera68730da-6992-4f45-93f5-36e92b7f8cd5",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "400f",
-                                "options": [{
-                                        "label": "Yes",
-                                        "value": "Yes"
-                                    },
-                                    {
-                                        "label": "No",
-                                        "value": "No"
-                                    },
-                                    {
-                                        "label": "Not sure",
-                                        "value": "Not sure"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "block91744997-daf2-4a5a-9260-21900d7af0c0",
-                                    "when": [{
-                                        "id": "answera68730da-6992-4f45-93f5-36e92b7f8cd5",
-                                        "condition": "contains any",
-                                        "values": [
-                                            "No",
-                                            "Not sure"
-                                        ]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block50f52897-29e8-4f15-91a9-e3cb1d4bd4f0"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Fortnightly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block50f52897-29e8-4f15-91a9-e3cb1d4bd4f0",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question50f52897-29e8-4f15-91a9-e3cb1d4bd4f0",
-                            "title": "Approximately <em>how many</em> of the fortnightly paid employees were furloughed for any of the  pay period?",
-                            "description": "<p>Please note that the Coronavirus Job Retention Scheme ended 30 September 2021.</p>",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "employees furloughed for either all, or some, of their normal working hours",
-                                            "employees the business is claiming for via the Coronavirus Job Retention Scheme (CJRS)"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "type": "General",
-                            "answers": [{
-                                    "id": "answere3dd11d0-c060-437f-a9d6-96c339dc9bfc",
-                                    "mandatory": false,
                                     "type": "Number",
-                                    "label": "Number of furloughed employees",
+                                    "label": "Total number of fortnightly paid employees",
                                     "description": "",
-                                    "q_code": "401f1",
+                                    "q_code": "40f",
                                     "min_value": {
                                         "value": 1,
                                         "exclusive": false
                                     },
-                                    "max_value": {
-                                        "answer_id": "answer1d93222d-e3c7-4cd7-8e3c-8ecd0a795409",
-                                        "exclusive": false
-                                    },
                                     "decimal_places": 0
-                                },
-                                {
-                                    "id": "answer7574a4ce-8d27-4f7d-abc0-f5026ed4fd93",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "label": "Or select 'Not sure' if the number is not known",
-                                    "description": "",
-                                    "options": [{
-                                        "label": "Not sure",
-                                        "value": "Not sure",
-                                        "q_code": "401f2"
-                                    }]
-                                }
-                            ]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "block91744997-daf2-4a5a-9260-21900d7af0c0",
-                                    "when": [{
-                                            "id": "answer7574a4ce-8d27-4f7d-abc0-f5026ed4fd93",
-                                            "condition": "not set"
+                                }]
+                            }],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Fortnightly"
+                                    ]
+                                }]
+                            }]
+                        },
+                        {
+                            "id": "block0fe57f5e-f9f9-4988-980c-62edc9af265c",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "question0fe57f5e-f9f9-4988-980c-62edc9af265c",
+                                "title": "What was the <em>total gross fortnightly pay</em> paid to employees in the last week of {{ metadata['period_str'] }}?",
+                                "guidance": {
+                                    "content": [{
+                                            "description": "<strong>Include:</strong>"
                                         },
                                         {
-                                            "id": "answere3dd11d0-c060-437f-a9d6-96c339dc9bfc",
-                                            "condition": "not set"
+                                            "list": [
+                                                "bonuses or commissions",
+                                                "overtime and shift allowance payments",
+                                                "advanced holiday pay",
+                                                "pay award arrears",
+                                                "voluntary employee contributions to, and annual profit from, profit related pay schemes"
+                                            ]
+                                        },
+                                        {
+                                            "description": "<strong>Exclude:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "any redundancy pay and pay in lieu of notice payments (taxable and non-taxable)",
+                                                "trainees or apprentices that were not paid through your payroll for the relevant period",
+                                                "directors' fees",
+                                                "employer’s NI and contribution to pension schemes",
+                                                "employees working abroad unless paid directly from this business’s GB payroll",
+                                                "signing on fees (sporting professionals)",
+                                                "accrued holiday pay",
+                                                "employees in Northern Ireland",
+                                                "expenses payments for attending meetings or training courses"
+                                            ]
                                         }
                                     ]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block91744997-daf2-4a5a-9260-21900d7af0c0",
-                                    "when": [{
-                                        "id": "answer7574a4ce-8d27-4f7d-abc0-f5026ed4fd93",
-                                        "condition": "contains all",
-                                        "values": [
-                                            "Not sure"
-                                        ]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block5ffbe6f1-afc5-470d-9c4c-c3ece37473a9"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Fortnightly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block5ffbe6f1-afc5-470d-9c4c-c3ece37473a9",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question5ffbe6f1-afc5-470d-9c4c-c3ece37473a9",
-                            "title": "How many of {{ metadata['ru_name'] }}’s fortnightly paid furloughed employees received <em>more than the 80%</em> Coronavirus Job Retention Scheme (CJRS) contribution, for the pay period?",
-                            "description": "<p>Please note that the Coronavirus Job Retention Scheme ended 30 September 2021.</p>",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "employees who worked some hours for which they were paid at the normal rate",
-                                            "employees who received a top-up to their pay in addition to the Coronavirus Job Retention Scheme (CJRS) 80% contribution"
-                                        ]
-                                    },
-                                    {
-                                        "description": "<strong>Exclude:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "employer’s NI and contribution to pension schemes"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "type": "General",
-                            "answers": [{
-                                    "id": "answer9a026048-5126-4dec-b650-377dd21faa1f",
-                                    "mandatory": false,
-                                    "type": "Number",
-                                    "label": "Number of employees paid more than the 80% CJRS contribution",
+                                },
+                                "type": "General",
+                                "answers": [{
+                                    "id": "answere2ace0d3-6f49-4c7e-93f4-802d53395f1f",
+                                    "mandatory": true,
+                                    "type": "Currency",
+                                    "label": "Total gross fortnightly pay",
                                     "description": "",
-                                    "q_code": "402f1",
-                                    "max_value": {
-                                        "answer_id": "answere3dd11d0-c060-437f-a9d6-96c339dc9bfc",
-                                        "exclusive": false
-                                    },
-                                    "decimal_places": 0
+                                    "q_code": "50f",
+                                    "decimal_places": 2,
+                                    "currency": "GBP"
+                                }]
+                            }],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Fortnightly"
+                                    ]
+                                }]
+                            }]
+                        },
+                        {
+                            "id": "blockconfirmation-page-for-0fe57f5e-f9f9-4988-980c-62edc9af265c",
+                            "type": "ConfirmationQuestion",
+                            "questions": [{
+                                "id": "questionconfirmation-page-for-0fe57f5e-f9f9-4988-980c-62edc9af265c",
+                                "title": "The <em>total gross fortnightly pay</em> paid to employees in the last week of {{ metadata['period_str'] }} was <em>£0</em>, is this correct?",
+                                "type": "General",
+                                "answers": [{
+                                    "id": "answerconfirmation-answer-for-0fe57f5e-f9f9-4988-980c-62edc9af265c",
+                                    "mandatory": true,
+                                    "type": "Radio",
+                                    "options": [{
+                                            "label": "Yes, this is correct",
+                                            "value": "Yes, this is correct"
+                                        },
+                                        {
+                                            "label": "No, I need to change this",
+                                            "value": "No, I need to change this"
+                                        }
+                                    ]
+                                }]
+                            }],
+                            "routing_rules": [{
+                                    "goto": {
+                                        "block": "block0fe57f5e-f9f9-4988-980c-62edc9af265c",
+                                        "when": [{
+                                            "id": "answerconfirmation-answer-for-0fe57f5e-f9f9-4988-980c-62edc9af265c",
+                                            "condition": "contains any",
+                                            "values": [
+                                                "No, I need to change this"
+                                            ]
+                                        }]
+                                    }
                                 },
                                 {
-                                    "id": "answer2f3be02c-9e51-425e-b912-b7f786dfcbcb",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "label": "Or select 'Not sure' if the number is not known",
-                                    "description": "",
-                                    "options": [{
-                                        "label": "Not sure",
-                                        "value": "Not sure",
-                                        "q_code": "402f2"
+                                    "goto": {
+                                        "block": "blockce0d315f-7e22-45df-99bc-251406cc113c",
+                                        "when": [{
+                                            "id": "answere2ace0d3-6f49-4c7e-93f4-802d53395f1f",
+                                            "condition": "equals",
+                                            "value": 0
+                                        }]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "block0a92343d-555a-48f7-8614-fd13a6cd1e8e"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [{
+                                    "when": [{
+                                        "id": "answere2ace0d3-6f49-4c7e-93f4-802d53395f1f",
+                                        "condition": "greater than",
+                                        "value": 0
+                                    }]
+                                },
+                                {
+                                    "when": [{
+                                        "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                        "condition": "not contains any",
+                                        "values": [
+                                            "Fortnightly"
+                                        ]
                                     }]
                                 }
                             ]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Fortnightly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block91744997-daf2-4a5a-9260-21900d7af0c0",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question91744997-daf2-4a5a-9260-21900d7af0c0",
-                            "title": "Did any significant changes occur to the <em>total pay or number</em> of <em>fortnightly</em> paid employees?",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include:</strong>"
+                        },
+                        {
+                            "id": "block0a92343d-555a-48f7-8614-fd13a6cd1e8e",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "question0a92343d-555a-48f7-8614-fd13a6cd1e8e",
+                                "title": "Of the {{ format_currency(answers['answere2ace0d3-6f49-4c7e-93f4-802d53395f1f'], 'GBP') }} paid to <em>fortnightly</em> paid employees in the last week of {{ metadata['period_str'] }}, what other amounts were paid?",
+                                "description": "<p>Informed estimates are acceptable.</p>",
+                                "guidance": {
+                                    "content": [{
+                                            "description": "<strong>Include:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "performance pay (for example, productivity bonuses)",
+                                                "long service awards",
+                                                "appearance money (sporting professionals)"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "type": "Calculated",
+                                "answers": [{
+                                        "id": "answer549cbfad-4ade-4952-bc85-07d0ca3b86f9",
+                                        "mandatory": true,
+                                        "type": "Currency",
+                                        "label": "Holiday pay, paid in advance",
+                                        "description": "",
+                                        "q_code": "60f",
+                                        "max_value": {
+                                            "answer_id": "answere2ace0d3-6f49-4c7e-93f4-802d53395f1f",
+                                            "exclusive": false
+                                        },
+                                        "decimal_places": 2,
+                                        "currency": "GBP"
                                     },
                                     {
-                                        "list": [
-                                            "redundancies",
-                                            "changes in the number of temporary staff",
-                                            "more or less overtime",
-                                            "new pay rates",
-                                            "industrial action"
-                                        ]
+                                        "id": "answerf3f95b24-3224-47a5-9eba-d8f74b73128f",
+                                        "mandatory": true,
+                                        "type": "Currency",
+                                        "label": "Arrears of pay owing to pay awards",
+                                        "description": "",
+                                        "q_code": "70f",
+                                        "max_value": {
+                                            "answer_id": "answere2ace0d3-6f49-4c7e-93f4-802d53395f1f",
+                                            "exclusive": false
+                                        },
+                                        "decimal_places": 2,
+                                        "currency": "GBP"
+                                    },
+                                    {
+                                        "id": "answer7cc7c90d-e61a-43f9-b5b0-74c27c6e696f",
+                                        "mandatory": true,
+                                        "type": "Currency",
+                                        "label": "Bonuses, commissions or annual profit from profit-related pay schemes",
+                                        "description": "",
+                                        "q_code": "80f",
+                                        "max_value": {
+                                            "answer_id": "answere2ace0d3-6f49-4c7e-93f4-802d53395f1f",
+                                            "exclusive": false
+                                        },
+                                        "decimal_places": 2,
+                                        "currency": "GBP"
                                     }
-                                ]
-                            },
-                            "definitions": [{
-                                "title": "What we mean by 'a significant change'",
-                                "content": [{
-                                        "description": "This is dependent on your own interpretation of whether there has been a significant change in the business’s figures compared with the previous month."
+                                ],
+                                "calculations": [{
+                                    "calculation_type": "sum",
+                                    "answers_to_calculate": [
+                                        "answer549cbfad-4ade-4952-bc85-07d0ca3b86f9",
+                                        "answerf3f95b24-3224-47a5-9eba-d8f74b73128f",
+                                        "answer7cc7c90d-e61a-43f9-b5b0-74c27c6e696f"
+                                    ],
+                                    "conditions": [
+                                        "less than",
+                                        "equals"
+                                    ],
+                                    "answer_id": "answere2ace0d3-6f49-4c7e-93f4-802d53395f1f"
+                                }]
+                            }],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Fortnightly"
+                                    ]
+                                }]
+                            }]
+                        },
+                        {
+                            "id": "blockce0d315f-7e22-45df-99bc-251406cc113c",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "questionce0d315f-7e22-45df-99bc-251406cc113c",
+                                "title": "Were any of {{ metadata['ru_name'] }}'s fortnightly paid employees <em>furloughed</em> for any of the pay period?",
+                                "description": "<p>Please note that the Coronavirus Job Retention Scheme ended 30 September 2021.</p>",
+                                "guidance": {
+                                    "content": [{
+                                            "description": "<strong>Include:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "employees furloughed for either all, or some, of their normal working hours",
+                                                "employees the business is claiming for via the Coronavirus Job Retention Scheme (CJRS)"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "type": "General",
+                                "answers": [{
+                                    "id": "answera68730da-6992-4f45-93f5-36e92b7f8cd5",
+                                    "mandatory": true,
+                                    "type": "Radio",
+                                    "label": "",
+                                    "description": "",
+                                    "q_code": "400f",
+                                    "options": [{
+                                            "label": "Yes",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "label": "No",
+                                            "value": "No"
+                                        },
+                                        {
+                                            "label": "Not sure",
+                                            "value": "Not sure"
+                                        }
+                                    ]
+                                }]
+                            }],
+                            "routing_rules": [{
+                                    "goto": {
+                                        "block": "block91744997-daf2-4a5a-9260-21900d7af0c0",
+                                        "when": [{
+                                            "id": "answera68730da-6992-4f45-93f5-36e92b7f8cd5",
+                                            "condition": "contains any",
+                                            "values": [
+                                                "No",
+                                                "Not sure"
+                                            ]
+                                        }]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "block50f52897-29e8-4f15-91a9-e3cb1d4bd4f0"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Fortnightly"
+                                    ]
+                                }]
+                            }]
+                        },
+                        {
+                            "id": "block50f52897-29e8-4f15-91a9-e3cb1d4bd4f0",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "question50f52897-29e8-4f15-91a9-e3cb1d4bd4f0",
+                                "title": "Approximately <em>how many</em> of the fortnightly paid employees were furloughed for any of the  pay period?",
+                                "description": "<p>Please note that the Coronavirus Job Retention Scheme ended 30 September 2021.</p>",
+                                "guidance": {
+                                    "content": [{
+                                            "description": "<strong>Include:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "employees furloughed for either all, or some, of their normal working hours",
+                                                "employees the business is claiming for via the Coronavirus Job Retention Scheme (CJRS)"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "type": "General",
+                                "answers": [{
+                                        "id": "answere3dd11d0-c060-437f-a9d6-96c339dc9bfc",
+                                        "mandatory": false,
+                                        "type": "Number",
+                                        "label": "Number of furloughed employees",
+                                        "description": "",
+                                        "q_code": "401f1",
+                                        "min_value": {
+                                            "value": 1,
+                                            "exclusive": false
+                                        },
+                                        "max_value": {
+                                            "answer_id": "answer1d93222d-e3c7-4cd7-8e3c-8ecd0a795409",
+                                            "exclusive": false
+                                        },
+                                        "decimal_places": 0
                                     },
                                     {
-                                        "description": "Also consider whether there has been a significant change from the same month in the previous year."
+                                        "id": "answer7574a4ce-8d27-4f7d-abc0-f5026ed4fd93",
+                                        "mandatory": false,
+                                        "type": "Checkbox",
+                                        "label": "Or select 'Not sure' if the number is not known",
+                                        "description": "",
+                                        "options": [{
+                                            "label": "Not sure",
+                                            "value": "Not sure",
+                                            "q_code": "401f2"
+                                        }]
                                     }
                                 ]
                             }],
-                            "type": "General",
-                            "answers": [{
-                                "id": "answerf4882ee4-ec46-4c98-840a-7171597d1285",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "90f",
-                                "options": [{
-                                        "label": "Yes",
-                                        "value": "Yes"
-                                    },
-                                    {
-                                        "label": "No",
-                                        "value": "No"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "group": "group-summary-fortnightly",
-                                    "when": [{
-                                        "id": "answerf4882ee4-ec46-4c98-840a-7171597d1285",
-                                        "condition": "contains any",
-                                        "values": [
-                                            "No"
+                            "routing_rules": [{
+                                    "goto": {
+                                        "block": "block91744997-daf2-4a5a-9260-21900d7af0c0",
+                                        "when": [{
+                                                "id": "answer7574a4ce-8d27-4f7d-abc0-f5026ed4fd93",
+                                                "condition": "not set"
+                                            },
+                                            {
+                                                "id": "answere3dd11d0-c060-437f-a9d6-96c339dc9bfc",
+                                                "condition": "not set"
+                                            }
                                         ]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block9e9823b1-d24d-4305-8c33-597c32dc63c5"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Fortnightly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block9e9823b1-d24d-4305-8c33-597c32dc63c5",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question9e9823b1-d24d-4305-8c33-597c32dc63c5",
-                            "title": "What were the reasons for the changes to the <em>total pay or number</em> of <em>fortnightly</em> paid employees?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer8f69ff4d-24d1-4c70-990b-894315fed5c0",
-                                "mandatory": true,
-                                "type": "Checkbox",
-                                "label": "Select all that apply:",
-                                "description": "",
-                                "options": [{
-                                        "label": "Redundancies",
-                                        "value": "Redundancies",
-                                        "q_code": "91f"
-                                    },
-                                    {
-                                        "label": "More temporary staff",
-                                        "value": "More temporary staff",
-                                        "q_code": "92f1"
-                                    },
-                                    {
-                                        "label": "Fewer temporary staff",
-                                        "value": "Fewer temporary staff",
-                                        "q_code": "92f2"
-                                    },
-                                    {
-                                        "label": "More overtime",
-                                        "value": "More overtime",
-                                        "q_code": "94f1"
-                                    },
-                                    {
-                                        "label": "Less overtime",
-                                        "value": "Less overtime",
-                                        "q_code": "94f2"
-                                    },
-                                    {
-                                        "label": "Pay increase",
-                                        "value": "Pay increase",
-                                        "q_code": "95f"
-                                    },
-                                    {
-                                        "label": "Industrial action",
-                                        "value": "Industrial action",
-                                        "q_code": "96f"
-                                    },
-                                    {
-                                        "label": "Other",
-                                        "value": "Other",
-                                        "q_code": "97f"
                                     }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "blockd468f012-b7d6-4e2a-9953-7d5fb59fac92",
-                                    "when": [{
-                                        "id": "answer8f69ff4d-24d1-4c70-990b-894315fed5c0",
-                                        "condition": "contains all",
-                                        "values": [
-                                            "Pay increase"
-                                        ]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block10619c27-01e0-4663-aab3-b154efa37ae8"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Fortnightly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "blockd468f012-b7d6-4e2a-9953-7d5fb59fac92",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questiond468f012-b7d6-4e2a-9953-7d5fb59fac92",
-                            "title": "If your business has new pay rates, what is the percentage increase?",
-                            "type": "General",
-                            "answers": [{
-                                    "id": "answerc957206d-aeab-4067-9364-d8b488a4ffac",
-                                    "mandatory": false,
-                                    "type": "Percentage",
-                                    "label": "Percentage increase of new pay rates",
-                                    "description": "",
-                                    "q_code": "100f",
-                                    "decimal_places": 2
                                 },
                                 {
-                                    "id": "answerad334329-6dd2-4fbf-ab69-a07284996c86",
-                                    "mandatory": false,
-                                    "type": "Date",
-                                    "label": "If your figures are backdated, which date did they begin?",
-                                    "description": "",
-                                    "q_code": "110f"
+                                    "goto": {
+                                        "block": "block91744997-daf2-4a5a-9260-21900d7af0c0",
+                                        "when": [{
+                                            "id": "answer7574a4ce-8d27-4f7d-abc0-f5026ed4fd93",
+                                            "condition": "contains all",
+                                            "values": [
+                                                "Not sure"
+                                            ]
+                                        }]
+                                    }
                                 },
                                 {
-                                    "id": "answer14d09350-1737-4ebb-adda-3189901e2788",
-                                    "mandatory": false,
-                                    "type": "Number",
-                                    "label": "What was the number of fortnightly paid employees who received this new pay rate?",
-                                    "description": "",
-                                    "q_code": "120f",
-                                    "max_value": {
-                                        "answer_id": "answer1d93222d-e3c7-4cd7-8e3c-8ecd0a795409",
-                                        "exclusive": false
-                                    },
-                                    "decimal_places": 0
+                                    "goto": {
+                                        "block": "block5ffbe6f1-afc5-470d-9c4c-c3ece37473a9"
+                                    }
                                 }
-                            ]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Fortnightly"
+                            ],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Fortnightly"
+                                    ]
+                                }]
+                            }]
+                        },
+                        {
+                            "id": "block5ffbe6f1-afc5-470d-9c4c-c3ece37473a9",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "question5ffbe6f1-afc5-470d-9c4c-c3ece37473a9",
+                                "title": "How many of {{ metadata['ru_name'] }}’s fortnightly paid furloughed employees received <em>more than the 80%</em> Coronavirus Job Retention Scheme (CJRS) contribution, for the pay period?",
+                                "description": "<p>Please note that the Coronavirus Job Retention Scheme ended 30 September 2021.</p>",
+                                "guidance": {
+                                    "content": [{
+                                            "description": "<strong>Include:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "employees who worked some hours for which they were paid at the normal rate",
+                                                "employees who received a top-up to their pay in addition to the Coronavirus Job Retention Scheme (CJRS) 80% contribution"
+                                            ]
+                                        },
+                                        {
+                                            "description": "<strong>Exclude:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "employer’s NI and contribution to pension schemes"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "type": "General",
+                                "answers": [{
+                                        "id": "answer9a026048-5126-4dec-b650-377dd21faa1f",
+                                        "mandatory": false,
+                                        "type": "Number",
+                                        "label": "Number of employees paid more than the 80% CJRS contribution",
+                                        "description": "",
+                                        "q_code": "402f1",
+                                        "max_value": {
+                                            "answer_id": "answere3dd11d0-c060-437f-a9d6-96c339dc9bfc",
+                                            "exclusive": false
+                                        },
+                                        "decimal_places": 0
+                                    },
+                                    {
+                                        "id": "answer2f3be02c-9e51-425e-b912-b7f786dfcbcb",
+                                        "mandatory": false,
+                                        "type": "Checkbox",
+                                        "label": "Or select 'Not sure' if the number is not known",
+                                        "description": "",
+                                        "options": [{
+                                            "label": "Not sure",
+                                            "value": "Not sure",
+                                            "q_code": "402f2"
+                                        }]
+                                    }
                                 ]
+                            }],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Fortnightly"
+                                    ]
+                                }]
                             }]
-                        }]
-                    },
-                    {
-                        "id": "block10619c27-01e0-4663-aab3-b154efa37ae8",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question10619c27-01e0-4663-aab3-b154efa37ae8",
-                            "title": "What were the changes to the <em>total pay or number</em> of <em>fortnightly</em> paid employees?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answerefedc87b-0008-4f47-b2a0-059943749b8d",
-                                "mandatory": true,
-                                "type": "TextArea",
-                                "label": "Comments",
-                                "description": "",
-                                "q_code": "300f",
-                                "max_length": 2000
+                        },
+                        {
+                            "id": "block91744997-daf2-4a5a-9260-21900d7af0c0",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "question91744997-daf2-4a5a-9260-21900d7af0c0",
+                                "title": "Did any significant changes occur to the <em>total pay or number</em> of <em>fortnightly</em> paid employees?",
+                                "guidance": {
+                                    "content": [{
+                                            "description": "<strong>Include:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "redundancies",
+                                                "changes in the number of temporary staff",
+                                                "more or less overtime",
+                                                "new pay rates",
+                                                "industrial action"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "definitions": [{
+                                    "title": "What we mean by 'a significant change'",
+                                    "content": [{
+                                            "description": "This is dependent on your own interpretation of whether there has been a significant change in the business’s figures compared with the previous month."
+                                        },
+                                        {
+                                            "description": "Also consider whether there has been a significant change from the same month in the previous year."
+                                        }
+                                    ]
+                                }],
+                                "type": "General",
+                                "answers": [{
+                                    "id": "answerf4882ee4-ec46-4c98-840a-7171597d1285",
+                                    "mandatory": true,
+                                    "type": "Radio",
+                                    "label": "",
+                                    "description": "",
+                                    "q_code": "90f",
+                                    "options": [{
+                                            "label": "Yes",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "label": "No",
+                                            "value": "No"
+                                        }
+                                    ]
+                                }]
+                            }],
+                            "routing_rules": [{
+                                    "goto": {
+                                        "group": "group-summary-fortnightly",
+                                        "when": [{
+                                            "id": "answerf4882ee4-ec46-4c98-840a-7171597d1285",
+                                            "condition": "contains any",
+                                            "values": [
+                                                "No"
+                                            ]
+                                        }]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "block9e9823b1-d24d-4305-8c33-597c32dc63c5"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Fortnightly"
+                                    ]
+                                }]
                             }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Fortnightly"
+                        },
+                        {
+                            "id": "block9e9823b1-d24d-4305-8c33-597c32dc63c5",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "question9e9823b1-d24d-4305-8c33-597c32dc63c5",
+                                "title": "What were the reasons for the changes to the <em>total pay or number</em> of <em>fortnightly</em> paid employees?",
+                                "type": "General",
+                                "answers": [{
+                                    "id": "answer8f69ff4d-24d1-4c70-990b-894315fed5c0",
+                                    "mandatory": true,
+                                    "type": "Checkbox",
+                                    "label": "Select all that apply:",
+                                    "description": "",
+                                    "options": [{
+                                            "label": "Redundancies",
+                                            "value": "Redundancies",
+                                            "q_code": "91f"
+                                        },
+                                        {
+                                            "label": "More temporary staff",
+                                            "value": "More temporary staff",
+                                            "q_code": "92f1"
+                                        },
+                                        {
+                                            "label": "Fewer temporary staff",
+                                            "value": "Fewer temporary staff",
+                                            "q_code": "92f2"
+                                        },
+                                        {
+                                            "label": "More overtime",
+                                            "value": "More overtime",
+                                            "q_code": "94f1"
+                                        },
+                                        {
+                                            "label": "Less overtime",
+                                            "value": "Less overtime",
+                                            "q_code": "94f2"
+                                        },
+                                        {
+                                            "label": "Pay increase",
+                                            "value": "Pay increase",
+                                            "q_code": "95f"
+                                        },
+                                        {
+                                            "label": "Industrial action",
+                                            "value": "Industrial action",
+                                            "q_code": "96f"
+                                        },
+                                        {
+                                            "label": "Other",
+                                            "value": "Other",
+                                            "q_code": "97f"
+                                        }
+                                    ]
+                                }]
+                            }],
+                            "routing_rules": [{
+                                    "goto": {
+                                        "block": "blockd468f012-b7d6-4e2a-9953-7d5fb59fac92",
+                                        "when": [{
+                                            "id": "answer8f69ff4d-24d1-4c70-990b-894315fed5c0",
+                                            "condition": "contains all",
+                                            "values": [
+                                                "Pay increase"
+                                            ]
+                                        }]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "block10619c27-01e0-4663-aab3-b154efa37ae8"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Fortnightly"
+                                    ]
+                                }]
+                            }]
+                        },
+                        {
+                            "id": "blockd468f012-b7d6-4e2a-9953-7d5fb59fac92",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "questiond468f012-b7d6-4e2a-9953-7d5fb59fac92",
+                                "title": "If your business has new pay rates, what is the percentage increase?",
+                                "type": "General",
+                                "answers": [{
+                                        "id": "answerc957206d-aeab-4067-9364-d8b488a4ffac",
+                                        "mandatory": false,
+                                        "type": "Percentage",
+                                        "label": "Percentage increase of new pay rates",
+                                        "description": "",
+                                        "q_code": "100f",
+                                        "decimal_places": 2
+                                    },
+                                    {
+                                        "id": "answerad334329-6dd2-4fbf-ab69-a07284996c86",
+                                        "mandatory": false,
+                                        "type": "Date",
+                                        "label": "If your figures are backdated, which date did they begin?",
+                                        "description": "",
+                                        "q_code": "110f"
+                                    },
+                                    {
+                                        "id": "answer14d09350-1737-4ebb-adda-3189901e2788",
+                                        "mandatory": false,
+                                        "type": "Number",
+                                        "label": "What was the number of fortnightly paid employees who received this new pay rate?",
+                                        "description": "",
+                                        "q_code": "120f",
+                                        "max_value": {
+                                            "answer_id": "answer1d93222d-e3c7-4cd7-8e3c-8ecd0a795409",
+                                            "exclusive": false
+                                        },
+                                        "decimal_places": 0
+                                    }
                                 ]
+                            }],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Fortnightly"
+                                    ]
+                                }]
                             }]
-                        }]
-                    }
-                ]
-            },
-            {
-                "id": "group-summary-fortnightly",
-                "blocks": [
-                    {
+                        },
+                        {
+                            "id": "block10619c27-01e0-4663-aab3-b154efa37ae8",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "question10619c27-01e0-4663-aab3-b154efa37ae8",
+                                "title": "What were the changes to the <em>total pay or number</em> of <em>fortnightly</em> paid employees?",
+                                "type": "General",
+                                "answers": [{
+                                    "id": "answerefedc87b-0008-4f47-b2a0-059943749b8d",
+                                    "mandatory": true,
+                                    "type": "TextArea",
+                                    "label": "Comments",
+                                    "description": "",
+                                    "q_code": "300f",
+                                    "max_length": 2000
+                                }]
+                            }],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Fortnightly"
+                                    ]
+                                }]
+                            }]
+                        }
+                    ]
+                },
+                {
+                    "id": "group-summary-fortnightly",
+                    "title": "section summary fortnightly",
+                    "blocks": [{
                         "id": "summary-fortnightly",
                         "type": "SectionSummary",
                         "collapsible": false
-                    }
-                ],
-                "skip_conditions": [{
-                    "when": [{
-                        "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                        "condition": "not contains any",
-                        "values": [
-                            "Fortnightly"
-                        ]
+                    }],
+                    "skip_conditions": [{
+                        "when": [{
+                            "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                            "condition": "not contains any",
+                            "values": [
+                                "Fortnightly"
+                            ]
+                        }]
                     }]
-                }]
-            }]
+                }
+            ]
         },
         {
             "id": "section9832eee5-f77a-4d30-87e7-80220310090c",
             "title": "Calendar monthly pay",
             "groups": [{
-                "id": "group9832eee5-f77a-4d30-87e7-80220310090c",
-                "title": "Calendar monthly pay",
-                "blocks": [{
-                        "type": "Interstitial",
-                        "id": "group9832eee5-f77a-4d30-87e7-80220310090c-introduction",
-                        "title": "Calendar monthly pay",
-                        "description": "<p>This section covers employees who are paid calendar monthly.</p><p>You will be asked for the:</p><ul><li>number of calendar monthly paid employees</li><li>pay awards and bonuses paid to calendar monthly paid employees</li><li>number of furloughed employees</li><li>number of furloughed employees who received a top-up to their pay in addition to the Coronavirus Job Retention Scheme (CJRS) 80% contributions</li><li>significant changes to the pay or number of calendar monthly paid employees</li></ul>",
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Calendar monthly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "blockbb7d7348-bfbd-4f60-a720-220fa4e6de82",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questionbb7d7348-bfbd-4f60-a720-220fa4e6de82",
-                            "title": "What was the <em>number</em> of <em>calendar monthly</em> paid employees paid in {{ metadata['period_str'] }}?",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "all employees in Great Britain (England, Scotland and Wales), both full and part-time, who received pay in the relevant period",
-                                            "all trainees or apprentices that were paid through your payroll for the relevant period"
-                                        ]
-                                    },
-                                    {
-                                        "description": "<strong>Exclude:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "trainees or apprentices that were not paid through your payroll for the relevant period",
-                                            "employees working abroad unless paid directly from this business’s GB payroll",
-                                            "employees in Northern Ireland"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer50a8167d-581f-4548-8759-cfbf2e0af696",
-                                "mandatory": true,
-                                "type": "Number",
-                                "label": "Total number of calendar monthly paid employees",
-                                "description": "",
-                                "q_code": "140m",
-                                "min_value": {
-                                    "value": 1,
-                                    "exclusive": false
-                                },
-                                "decimal_places": 0
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Calendar monthly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block37657691-0f39-459a-b509-50611659acef",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question37657691-0f39-459a-b509-50611659acef",
-                            "title": "What was the <em>total gross calendar monthly pay</em> paid to employees in {{ metadata['period_str'] }}?",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "bonuses or commissions",
-                                            "overtime and shift allowance payments",
-                                            "pay award arrears",
-                                            "voluntary employee contributions to, and annual profit from, profit related pay schemes"
-                                        ]
-                                    },
-                                    {
-                                        "description": "<strong>Exclude:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "any redundancy pay and pay in lieu of notice payments (taxable and non-taxable)",
-                                            "trainees or apprentices that were not paid through your payroll for the relevant period",
-                                            "directors' fees",
-                                            "employer’s NI and contribution to pension schemes",
-                                            "employees working abroad unless paid directly from this business’s GB payroll",
-                                            "signing on fees (sporting professionals)",
-                                            "accrued holiday pay",
-                                            "employees in Northern Ireland",
-                                            "expenses payments for attending meetings or training courses"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "type": "General",
-                            "answers": [{
-                                "id": "answerd77a1a42-5fb5-4097-9e10-dee45c9b2ef7",
-                                "mandatory": true,
-                                "type": "Currency",
-                                "label": "Total gross calendar monthly pay",
-                                "description": "",
-                                "q_code": "151",
-                                "decimal_places": 2,
-                                "currency": "GBP"
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Calendar monthly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "blockconfirmation-page-for-37657691-0f39-459a-b509-50611659acef",
-                        "type": "ConfirmationQuestion",
-                        "questions": [{
-                            "id": "questionconfirmation-page-for-37657691-0f39-459a-b509-50611659acef",
-                            "title": "The <em>total gross calendar monthly pay</em> paid to employees in {{ metadata['period_str'] }} was <em>£0</em>, is this correct?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answerconfirmation-answer-for-37657691-0f39-459a-b509-50611659acef",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "options": [{
-                                        "label": "Yes, this is correct",
-                                        "value": "Yes, this is correct"
-                                    },
-                                    {
-                                        "label": "No, I need to change this",
-                                        "value": "No, I need to change this"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "block37657691-0f39-459a-b509-50611659acef",
-                                    "when": [{
-                                        "id": "answerconfirmation-answer-for-37657691-0f39-459a-b509-50611659acef",
-                                        "condition": "contains any",
-                                        "values": [
-                                            "No, I need to change this"
-                                        ]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "blockcbe68969-dd3f-43b8-b39c-11de0d060b53",
-                                    "when": [{
-                                        "id": "answerd77a1a42-5fb5-4097-9e10-dee45c9b2ef7",
-                                        "condition": "equals",
-                                        "value": 0
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block1fb595fa-05f7-4cc7-95b4-c4671e6abddf"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                                "when": [{
-                                    "id": "answerd77a1a42-5fb5-4097-9e10-dee45c9b2ef7",
-                                    "condition": "greater than",
-                                    "value": 0
-                                }]
-                            },
-                            {
+                    "id": "group9832eee5-f77a-4d30-87e7-80220310090c",
+                    "title": "Calendar monthly pay",
+                    "blocks": [{
+                            "type": "Interstitial",
+                            "id": "group9832eee5-f77a-4d30-87e7-80220310090c-introduction",
+                            "title": "Calendar monthly pay",
+                            "description": "<p>This section covers employees who are paid calendar monthly.</p><p>You will be asked for the:</p><ul><li>number of calendar monthly paid employees</li><li>pay awards and bonuses paid to calendar monthly paid employees</li><li>number of furloughed employees</li><li>number of furloughed employees who received a top-up to their pay in addition to the Coronavirus Job Retention Scheme (CJRS) 80% contributions</li><li>significant changes to the pay or number of calendar monthly paid employees</li></ul>",
+                            "skip_conditions": [{
                                 "when": [{
                                     "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
                                     "condition": "not contains any",
@@ -2062,761 +1884,761 @@
                                         "Calendar monthly"
                                     ]
                                 }]
-                            }
-                        ]
-                    },
-                    {
-                        "id": "block1fb595fa-05f7-4cc7-95b4-c4671e6abddf",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question1fb595fa-05f7-4cc7-95b4-c4671e6abddf",
-                            "title": "Of the {{ format_currency(answers['answerd77a1a42-5fb5-4097-9e10-dee45c9b2ef7'], 'GBP') }} paid to <em>calendar monthly</em> paid employees in  {{ metadata['period_str'] }}, what other amounts were paid?",
-                            "description": "<p>Informed estimates are acceptable.</p>",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "performance pay (for example, productivity bonuses)",
-                                            "long service awards",
-                                            "appearance money (sporting professionals)"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "type": "Calculated",
-                            "answers": [{
-                                    "id": "answere32b77cb-10b7-4368-8c7c-aeee21e8fca2",
-                                    "mandatory": true,
-                                    "type": "Currency",
-                                    "label": "Arrears of pay owing to pay awards",
-                                    "description": "",
-                                    "q_code": "171",
-                                    "max_value": {
-                                        "answer_id": "answerd77a1a42-5fb5-4097-9e10-dee45c9b2ef7",
-                                        "exclusive": false
-                                    },
-                                    "decimal_places": 2,
-                                    "currency": "GBP"
+                            }]
+                        },
+                        {
+                            "id": "blockbb7d7348-bfbd-4f60-a720-220fa4e6de82",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "questionbb7d7348-bfbd-4f60-a720-220fa4e6de82",
+                                "title": "What was the <em>number</em> of <em>calendar monthly</em> paid employees paid in {{ metadata['period_str'] }}?",
+                                "guidance": {
+                                    "content": [{
+                                            "description": "<strong>Include:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "all employees in Great Britain (England, Scotland and Wales), both full and part-time, who received pay in the relevant period",
+                                                "all trainees or apprentices that were paid through your payroll for the relevant period"
+                                            ]
+                                        },
+                                        {
+                                            "description": "<strong>Exclude:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "trainees or apprentices that were not paid through your payroll for the relevant period",
+                                                "employees working abroad unless paid directly from this business’s GB payroll",
+                                                "employees in Northern Ireland"
+                                            ]
+                                        }
+                                    ]
                                 },
-                                {
-                                    "id": "answer984778ad-9a9f-49cc-80f8-45aa785c6690",
+                                "type": "General",
+                                "answers": [{
+                                    "id": "answer50a8167d-581f-4548-8759-cfbf2e0af696",
                                     "mandatory": true,
-                                    "type": "Currency",
-                                    "label": "Bonuses, commissions or annual profit from profit-related pay schemes",
-                                    "description": "",
-                                    "q_code": "181",
-                                    "max_value": {
-                                        "answer_id": "answerd77a1a42-5fb5-4097-9e10-dee45c9b2ef7",
-                                        "exclusive": false
-                                    },
-                                    "decimal_places": 2,
-                                    "currency": "GBP"
-                                }
-                            ],
-                            "calculations": [{
-                                "calculation_type": "sum",
-                                "answers_to_calculate": [
-                                    "answere32b77cb-10b7-4368-8c7c-aeee21e8fca2",
-                                    "answer984778ad-9a9f-49cc-80f8-45aa785c6690"
-                                ],
-                                "conditions": [
-                                    "less than",
-                                    "equals"
-                                ],
-                                "answer_id": "answerd77a1a42-5fb5-4097-9e10-dee45c9b2ef7"
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Calendar monthly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "blockcbe68969-dd3f-43b8-b39c-11de0d060b53",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questioncbe68969-dd3f-43b8-b39c-11de0d060b53",
-                            "title": "Were any of {{ metadata['ru_name'] }}'s calendar monthly paid employees <em>furloughed</em> for any of the pay period?",
-                            "description": "<p>Please note that the Coronavirus Job Retention Scheme ended 30 September 2021.</p>",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "employees furloughed for either all, or some, of their normal working hours",
-                                            "employees the business is claiming for via the Coronavirus Job Retention Scheme (CJRS)"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer2d30c4b8-c3da-48d6-9df9-db31b48377fb",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "400m",
-                                "options": [{
-                                        "label": "Yes",
-                                        "value": "Yes"
-                                    },
-                                    {
-                                        "label": "No",
-                                        "value": "No"
-                                    },
-                                    {
-                                        "label": "Not sure",
-                                        "value": "Not sure"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "block5f882a69-50f1-4a71-ac4b-f594a5be29fe",
-                                    "when": [{
-                                        "id": "answer2d30c4b8-c3da-48d6-9df9-db31b48377fb",
-                                        "condition": "contains any",
-                                        "values": [
-                                            "No",
-                                            "Not sure"
-                                        ]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block76e20301-7179-4373-8821-c6c28ae771bc"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Calendar monthly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block76e20301-7179-4373-8821-c6c28ae771bc",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question76e20301-7179-4373-8821-c6c28ae771bc",
-                            "title": "Approximately <em>how many</em> of the calendar monthly paid employees were furloughed for any of the pay period?",
-                            "description": "<p>Please note that the Coronavirus Job Retention Scheme ended 30 September 2021.</p>",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "employees furloughed for either all, or some, of their normal working hours",
-                                            "employees the business is claiming for via the Coronavirus Job Retention Scheme (CJRS)"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "type": "General",
-                            "answers": [{
-                                    "id": "answer3f28264e-880b-4ae6-a6e5-9eba9d855bb5",
-                                    "mandatory": false,
                                     "type": "Number",
-                                    "label": "Number of furloughed employees",
+                                    "label": "Total number of calendar monthly paid employees",
                                     "description": "",
-                                    "q_code": "401m1",
+                                    "q_code": "140m",
                                     "min_value": {
                                         "value": 1,
                                         "exclusive": false
                                     },
-                                    "max_value": {
-                                        "answer_id": "answer50a8167d-581f-4548-8759-cfbf2e0af696",
-                                        "exclusive": false
-                                    },
                                     "decimal_places": 0
-                                },
-                                {
-                                    "id": "answerd4b7c476-90e2-4217-a0eb-b33dc8574220",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "label": "Or select 'Not sure' if the number is not known",
-                                    "description": "",
-                                    "options": [{
-                                        "label": "Not sure",
-                                        "value": "Not sure",
-                                        "q_code": "401m2"
-                                    }]
-                                }
-                            ]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "block5f882a69-50f1-4a71-ac4b-f594a5be29fe",
-                                    "when": [{
-                                            "id": "answerd4b7c476-90e2-4217-a0eb-b33dc8574220",
-                                            "condition": "not set"
+                                }]
+                            }],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Calendar monthly"
+                                    ]
+                                }]
+                            }]
+                        },
+                        {
+                            "id": "block37657691-0f39-459a-b509-50611659acef",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "question37657691-0f39-459a-b509-50611659acef",
+                                "title": "What was the <em>total gross calendar monthly pay</em> paid to employees in {{ metadata['period_str'] }}?",
+                                "guidance": {
+                                    "content": [{
+                                            "description": "<strong>Include:</strong>"
                                         },
                                         {
-                                            "id": "answer3f28264e-880b-4ae6-a6e5-9eba9d855bb5",
-                                            "condition": "not set"
+                                            "list": [
+                                                "bonuses or commissions",
+                                                "overtime and shift allowance payments",
+                                                "pay award arrears",
+                                                "voluntary employee contributions to, and annual profit from, profit related pay schemes"
+                                            ]
+                                        },
+                                        {
+                                            "description": "<strong>Exclude:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "any redundancy pay and pay in lieu of notice payments (taxable and non-taxable)",
+                                                "trainees or apprentices that were not paid through your payroll for the relevant period",
+                                                "directors' fees",
+                                                "employer’s NI and contribution to pension schemes",
+                                                "employees working abroad unless paid directly from this business’s GB payroll",
+                                                "signing on fees (sporting professionals)",
+                                                "accrued holiday pay",
+                                                "employees in Northern Ireland",
+                                                "expenses payments for attending meetings or training courses"
+                                            ]
                                         }
                                     ]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block5f882a69-50f1-4a71-ac4b-f594a5be29fe",
-                                    "when": [{
-                                        "id": "answerd4b7c476-90e2-4217-a0eb-b33dc8574220",
-                                        "condition": "contains all",
-                                        "values": [
-                                            "Not sure"
-                                        ]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block6ea7a041-d06b-4543-a539-8254b6121c6a"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Calendar monthly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block6ea7a041-d06b-4543-a539-8254b6121c6a",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question6ea7a041-d06b-4543-a539-8254b6121c6a",
-                            "title": "How many of {{ metadata['ru_name'] }}’s calendar monthly paid furloughed employees received <em>more than the 80%</em> Coronavirus Job Retention Scheme (CJRS) contribution, for the pay period?",
-                            "description": "<p>Please note that the Coronavirus Job Retention Scheme ended 30 September 2021.</p>",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "employees who worked some hours for which they were paid at the normal rate",
-                                            "employees who received a top-up to their pay in addition to the Coronavirus Job Retention Scheme (CJRS) 80% contribution"
-                                        ]
-                                    },
-                                    {
-                                        "description": "<strong>Exclude:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "employer’s NI and contribution to pension schemes"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "type": "General",
-                            "answers": [{
-                                    "id": "answera1385c58-f1e3-4b4c-a5f6-53cc06779cf1",
-                                    "mandatory": false,
-                                    "type": "Number",
-                                    "label": "Number of employees paid more than the 80% CJRS contribution",
+                                },
+                                "type": "General",
+                                "answers": [{
+                                    "id": "answerd77a1a42-5fb5-4097-9e10-dee45c9b2ef7",
+                                    "mandatory": true,
+                                    "type": "Currency",
+                                    "label": "Total gross calendar monthly pay",
                                     "description": "",
-                                    "q_code": "402m1",
-                                    "max_value": {
-                                        "answer_id": "answer3f28264e-880b-4ae6-a6e5-9eba9d855bb5",
-                                        "exclusive": false
-                                    },
-                                    "decimal_places": 0
+                                    "q_code": "151",
+                                    "decimal_places": 2,
+                                    "currency": "GBP"
+                                }]
+                            }],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Calendar monthly"
+                                    ]
+                                }]
+                            }]
+                        },
+                        {
+                            "id": "blockconfirmation-page-for-37657691-0f39-459a-b509-50611659acef",
+                            "type": "ConfirmationQuestion",
+                            "questions": [{
+                                "id": "questionconfirmation-page-for-37657691-0f39-459a-b509-50611659acef",
+                                "title": "The <em>total gross calendar monthly pay</em> paid to employees in {{ metadata['period_str'] }} was <em>£0</em>, is this correct?",
+                                "type": "General",
+                                "answers": [{
+                                    "id": "answerconfirmation-answer-for-37657691-0f39-459a-b509-50611659acef",
+                                    "mandatory": true,
+                                    "type": "Radio",
+                                    "options": [{
+                                            "label": "Yes, this is correct",
+                                            "value": "Yes, this is correct"
+                                        },
+                                        {
+                                            "label": "No, I need to change this",
+                                            "value": "No, I need to change this"
+                                        }
+                                    ]
+                                }]
+                            }],
+                            "routing_rules": [{
+                                    "goto": {
+                                        "block": "block37657691-0f39-459a-b509-50611659acef",
+                                        "when": [{
+                                            "id": "answerconfirmation-answer-for-37657691-0f39-459a-b509-50611659acef",
+                                            "condition": "contains any",
+                                            "values": [
+                                                "No, I need to change this"
+                                            ]
+                                        }]
+                                    }
                                 },
                                 {
-                                    "id": "answer7f3a747d-d030-4e4d-a3ec-d88f07534d22",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "label": "Or select 'Not sure' if the number is not known",
-                                    "description": "",
-                                    "options": [{
-                                        "label": "Not sure",
-                                        "value": "Not sure",
-                                        "q_code": "402m2"
+                                    "goto": {
+                                        "block": "blockcbe68969-dd3f-43b8-b39c-11de0d060b53",
+                                        "when": [{
+                                            "id": "answerd77a1a42-5fb5-4097-9e10-dee45c9b2ef7",
+                                            "condition": "equals",
+                                            "value": 0
+                                        }]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "block1fb595fa-05f7-4cc7-95b4-c4671e6abddf"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [{
+                                    "when": [{
+                                        "id": "answerd77a1a42-5fb5-4097-9e10-dee45c9b2ef7",
+                                        "condition": "greater than",
+                                        "value": 0
+                                    }]
+                                },
+                                {
+                                    "when": [{
+                                        "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                        "condition": "not contains any",
+                                        "values": [
+                                            "Calendar monthly"
+                                        ]
                                     }]
                                 }
                             ]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Calendar monthly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block5f882a69-50f1-4a71-ac4b-f594a5be29fe",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question5f882a69-50f1-4a71-ac4b-f594a5be29fe",
-                            "title": "Did any significant changes occur to the <em>total pay or number</em> of <em>calendar monthly</em> paid employees?",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include:</strong>"
+                        },
+                        {
+                            "id": "block1fb595fa-05f7-4cc7-95b4-c4671e6abddf",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "question1fb595fa-05f7-4cc7-95b4-c4671e6abddf",
+                                "title": "Of the {{ format_currency(answers['answerd77a1a42-5fb5-4097-9e10-dee45c9b2ef7'], 'GBP') }} paid to <em>calendar monthly</em> paid employees in  {{ metadata['period_str'] }}, what other amounts were paid?",
+                                "description": "<p>Informed estimates are acceptable.</p>",
+                                "guidance": {
+                                    "content": [{
+                                            "description": "<strong>Include:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "performance pay (for example, productivity bonuses)",
+                                                "long service awards",
+                                                "appearance money (sporting professionals)"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "type": "Calculated",
+                                "answers": [{
+                                        "id": "answere32b77cb-10b7-4368-8c7c-aeee21e8fca2",
+                                        "mandatory": true,
+                                        "type": "Currency",
+                                        "label": "Arrears of pay owing to pay awards",
+                                        "description": "",
+                                        "q_code": "171",
+                                        "max_value": {
+                                            "answer_id": "answerd77a1a42-5fb5-4097-9e10-dee45c9b2ef7",
+                                            "exclusive": false
+                                        },
+                                        "decimal_places": 2,
+                                        "currency": "GBP"
                                     },
                                     {
-                                        "list": [
-                                            "redundancies",
-                                            "changes in the number of temporary staff",
-                                            "more or less overtime",
-                                            "new pay rates",
-                                            "industrial action"
-                                        ]
+                                        "id": "answer984778ad-9a9f-49cc-80f8-45aa785c6690",
+                                        "mandatory": true,
+                                        "type": "Currency",
+                                        "label": "Bonuses, commissions or annual profit from profit-related pay schemes",
+                                        "description": "",
+                                        "q_code": "181",
+                                        "max_value": {
+                                            "answer_id": "answerd77a1a42-5fb5-4097-9e10-dee45c9b2ef7",
+                                            "exclusive": false
+                                        },
+                                        "decimal_places": 2,
+                                        "currency": "GBP"
                                     }
-                                ]
-                            },
-                            "definitions": [{
-                                "title": "What we mean by 'a significant change'",
-                                "content": [{
-                                        "description": "This is dependent on your own interpretation of whether there has been a significant change in the business’s figures compared with the previous month."
+                                ],
+                                "calculations": [{
+                                    "calculation_type": "sum",
+                                    "answers_to_calculate": [
+                                        "answere32b77cb-10b7-4368-8c7c-aeee21e8fca2",
+                                        "answer984778ad-9a9f-49cc-80f8-45aa785c6690"
+                                    ],
+                                    "conditions": [
+                                        "less than",
+                                        "equals"
+                                    ],
+                                    "answer_id": "answerd77a1a42-5fb5-4097-9e10-dee45c9b2ef7"
+                                }]
+                            }],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Calendar monthly"
+                                    ]
+                                }]
+                            }]
+                        },
+                        {
+                            "id": "blockcbe68969-dd3f-43b8-b39c-11de0d060b53",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "questioncbe68969-dd3f-43b8-b39c-11de0d060b53",
+                                "title": "Were any of {{ metadata['ru_name'] }}'s calendar monthly paid employees <em>furloughed</em> for any of the pay period?",
+                                "description": "<p>Please note that the Coronavirus Job Retention Scheme ended 30 September 2021.</p>",
+                                "guidance": {
+                                    "content": [{
+                                            "description": "<strong>Include:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "employees furloughed for either all, or some, of their normal working hours",
+                                                "employees the business is claiming for via the Coronavirus Job Retention Scheme (CJRS)"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "type": "General",
+                                "answers": [{
+                                    "id": "answer2d30c4b8-c3da-48d6-9df9-db31b48377fb",
+                                    "mandatory": true,
+                                    "type": "Radio",
+                                    "label": "",
+                                    "description": "",
+                                    "q_code": "400m",
+                                    "options": [{
+                                            "label": "Yes",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "label": "No",
+                                            "value": "No"
+                                        },
+                                        {
+                                            "label": "Not sure",
+                                            "value": "Not sure"
+                                        }
+                                    ]
+                                }]
+                            }],
+                            "routing_rules": [{
+                                    "goto": {
+                                        "block": "block5f882a69-50f1-4a71-ac4b-f594a5be29fe",
+                                        "when": [{
+                                            "id": "answer2d30c4b8-c3da-48d6-9df9-db31b48377fb",
+                                            "condition": "contains any",
+                                            "values": [
+                                                "No",
+                                                "Not sure"
+                                            ]
+                                        }]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "block76e20301-7179-4373-8821-c6c28ae771bc"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Calendar monthly"
+                                    ]
+                                }]
+                            }]
+                        },
+                        {
+                            "id": "block76e20301-7179-4373-8821-c6c28ae771bc",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "question76e20301-7179-4373-8821-c6c28ae771bc",
+                                "title": "Approximately <em>how many</em> of the calendar monthly paid employees were furloughed for any of the pay period?",
+                                "description": "<p>Please note that the Coronavirus Job Retention Scheme ended 30 September 2021.</p>",
+                                "guidance": {
+                                    "content": [{
+                                            "description": "<strong>Include:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "employees furloughed for either all, or some, of their normal working hours",
+                                                "employees the business is claiming for via the Coronavirus Job Retention Scheme (CJRS)"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "type": "General",
+                                "answers": [{
+                                        "id": "answer3f28264e-880b-4ae6-a6e5-9eba9d855bb5",
+                                        "mandatory": false,
+                                        "type": "Number",
+                                        "label": "Number of furloughed employees",
+                                        "description": "",
+                                        "q_code": "401m1",
+                                        "min_value": {
+                                            "value": 1,
+                                            "exclusive": false
+                                        },
+                                        "max_value": {
+                                            "answer_id": "answer50a8167d-581f-4548-8759-cfbf2e0af696",
+                                            "exclusive": false
+                                        },
+                                        "decimal_places": 0
                                     },
                                     {
-                                        "description": "Also consider whether there has been a significant change from the same month in the previous year."
+                                        "id": "answerd4b7c476-90e2-4217-a0eb-b33dc8574220",
+                                        "mandatory": false,
+                                        "type": "Checkbox",
+                                        "label": "Or select 'Not sure' if the number is not known",
+                                        "description": "",
+                                        "options": [{
+                                            "label": "Not sure",
+                                            "value": "Not sure",
+                                            "q_code": "401m2"
+                                        }]
                                     }
                                 ]
                             }],
-                            "type": "General",
-                            "answers": [{
-                                "id": "answerd6064ed2-4172-462a-9b7f-af57f1bc7b9a",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "190m",
-                                "options": [{
-                                        "label": "Yes",
-                                        "value": "Yes"
-                                    },
-                                    {
-                                        "label": "No",
-                                        "value": "No"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "group": "group-summary-monthly",
-                                    "when": [{
-                                        "id": "answerd6064ed2-4172-462a-9b7f-af57f1bc7b9a",
-                                        "condition": "contains any",
-                                        "values": [
-                                            "No"
+                            "routing_rules": [{
+                                    "goto": {
+                                        "block": "block5f882a69-50f1-4a71-ac4b-f594a5be29fe",
+                                        "when": [{
+                                                "id": "answerd4b7c476-90e2-4217-a0eb-b33dc8574220",
+                                                "condition": "not set"
+                                            },
+                                            {
+                                                "id": "answer3f28264e-880b-4ae6-a6e5-9eba9d855bb5",
+                                                "condition": "not set"
+                                            }
                                         ]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "blocke00d504c-fd63-4082-a4d6-410bc3691338"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Calendar monthly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "blocke00d504c-fd63-4082-a4d6-410bc3691338",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questione00d504c-fd63-4082-a4d6-410bc3691338",
-                            "title": "What were the reasons for the changes to the <em>total pay or number</em> of <em>calendar monthly</em> paid employees?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer930cde2f-3ef6-4579-be3e-915a9dc607c9",
-                                "mandatory": true,
-                                "type": "Checkbox",
-                                "label": "Select all that apply:",
-                                "description": "",
-                                "options": [{
-                                        "label": "Redundancies",
-                                        "value": "Redundancies",
-                                        "q_code": "191m"
-                                    },
-                                    {
-                                        "label": "More temporary staff",
-                                        "value": "More temporary staff",
-                                        "q_code": "192m1"
-                                    },
-                                    {
-                                        "label": "Fewer temporary staff",
-                                        "value": "Fewer temporary staff",
-                                        "q_code": "192m2"
-                                    },
-                                    {
-                                        "label": "More overtime",
-                                        "value": "More overtime",
-                                        "q_code": "194m1"
-                                    },
-                                    {
-                                        "label": "Less overtime",
-                                        "value": "Less overtime",
-                                        "q_code": "194m2"
-                                    },
-                                    {
-                                        "label": "Pay increase",
-                                        "value": "Pay increase",
-                                        "q_code": "195m"
-                                    },
-                                    {
-                                        "label": "Industrial action",
-                                        "value": "Industrial action",
-                                        "q_code": "196m"
-                                    },
-                                    {
-                                        "label": "Other",
-                                        "value": "Other",
-                                        "q_code": "197m"
                                     }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "block601111a3-05ca-4dcc-ab3f-4d4d483e39a2",
-                                    "when": [{
-                                        "id": "answer930cde2f-3ef6-4579-be3e-915a9dc607c9",
-                                        "condition": "contains all",
-                                        "values": [
-                                            "Pay increase"
-                                        ]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "blockd9b1acdc-6d2f-41bb-b913-f6ab3402389b"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Calendar monthly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block601111a3-05ca-4dcc-ab3f-4d4d483e39a2",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question601111a3-05ca-4dcc-ab3f-4d4d483e39a2",
-                            "title": "If your business has new pay rates, what is the percentage increase?",
-                            "type": "General",
-                            "answers": [{
-                                    "id": "answer931d7403-3fc8-4dd3-9ceb-507f12fa2561",
-                                    "mandatory": false,
-                                    "type": "Percentage",
-                                    "label": "Percentage increase of new pay rates",
-                                    "description": "",
-                                    "q_code": "200",
-                                    "decimal_places": 2
                                 },
                                 {
-                                    "id": "answer33940067-f517-4db9-9fa3-cb749f03b43b",
-                                    "mandatory": false,
-                                    "type": "Date",
-                                    "label": "If your figures are backdated, which date did they begin?",
-                                    "description": "",
-                                    "q_code": "210"
+                                    "goto": {
+                                        "block": "block5f882a69-50f1-4a71-ac4b-f594a5be29fe",
+                                        "when": [{
+                                            "id": "answerd4b7c476-90e2-4217-a0eb-b33dc8574220",
+                                            "condition": "contains all",
+                                            "values": [
+                                                "Not sure"
+                                            ]
+                                        }]
+                                    }
                                 },
                                 {
-                                    "id": "answer9026c765-8a66-4128-926c-1f752539058c",
-                                    "mandatory": false,
-                                    "type": "Number",
-                                    "label": "What was the number of calendar monthly paid employees who received this new pay rate?",
-                                    "description": "",
-                                    "q_code": "220",
-                                    "max_value": {
-                                        "answer_id": "answer50a8167d-581f-4548-8759-cfbf2e0af696",
-                                        "exclusive": false
-                                    },
-                                    "decimal_places": 0
+                                    "goto": {
+                                        "block": "block6ea7a041-d06b-4543-a539-8254b6121c6a"
+                                    }
                                 }
-                            ]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Calendar monthly"
+                            ],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Calendar monthly"
+                                    ]
+                                }]
+                            }]
+                        },
+                        {
+                            "id": "block6ea7a041-d06b-4543-a539-8254b6121c6a",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "question6ea7a041-d06b-4543-a539-8254b6121c6a",
+                                "title": "How many of {{ metadata['ru_name'] }}’s calendar monthly paid furloughed employees received <em>more than the 80%</em> Coronavirus Job Retention Scheme (CJRS) contribution, for the pay period?",
+                                "description": "<p>Please note that the Coronavirus Job Retention Scheme ended 30 September 2021.</p>",
+                                "guidance": {
+                                    "content": [{
+                                            "description": "<strong>Include:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "employees who worked some hours for which they were paid at the normal rate",
+                                                "employees who received a top-up to their pay in addition to the Coronavirus Job Retention Scheme (CJRS) 80% contribution"
+                                            ]
+                                        },
+                                        {
+                                            "description": "<strong>Exclude:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "employer’s NI and contribution to pension schemes"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "type": "General",
+                                "answers": [{
+                                        "id": "answera1385c58-f1e3-4b4c-a5f6-53cc06779cf1",
+                                        "mandatory": false,
+                                        "type": "Number",
+                                        "label": "Number of employees paid more than the 80% CJRS contribution",
+                                        "description": "",
+                                        "q_code": "402m1",
+                                        "max_value": {
+                                            "answer_id": "answer3f28264e-880b-4ae6-a6e5-9eba9d855bb5",
+                                            "exclusive": false
+                                        },
+                                        "decimal_places": 0
+                                    },
+                                    {
+                                        "id": "answer7f3a747d-d030-4e4d-a3ec-d88f07534d22",
+                                        "mandatory": false,
+                                        "type": "Checkbox",
+                                        "label": "Or select 'Not sure' if the number is not known",
+                                        "description": "",
+                                        "options": [{
+                                            "label": "Not sure",
+                                            "value": "Not sure",
+                                            "q_code": "402m2"
+                                        }]
+                                    }
                                 ]
+                            }],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Calendar monthly"
+                                    ]
+                                }]
                             }]
-                        }]
-                    },
-                    {
-                        "id": "blockd9b1acdc-6d2f-41bb-b913-f6ab3402389b",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questiond9b1acdc-6d2f-41bb-b913-f6ab3402389b",
-                            "title": "What were the changes to the <em>total pay or number</em> of <em>calendar monthly</em> paid employees?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer30a279d5-8562-4f11-942f-a9cd8199ad9a",
-                                "mandatory": true,
-                                "type": "TextArea",
-                                "label": "Comments",
-                                "description": "",
-                                "q_code": "300m",
-                                "max_length": 2000
+                        },
+                        {
+                            "id": "block5f882a69-50f1-4a71-ac4b-f594a5be29fe",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "question5f882a69-50f1-4a71-ac4b-f594a5be29fe",
+                                "title": "Did any significant changes occur to the <em>total pay or number</em> of <em>calendar monthly</em> paid employees?",
+                                "guidance": {
+                                    "content": [{
+                                            "description": "<strong>Include:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "redundancies",
+                                                "changes in the number of temporary staff",
+                                                "more or less overtime",
+                                                "new pay rates",
+                                                "industrial action"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "definitions": [{
+                                    "title": "What we mean by 'a significant change'",
+                                    "content": [{
+                                            "description": "This is dependent on your own interpretation of whether there has been a significant change in the business’s figures compared with the previous month."
+                                        },
+                                        {
+                                            "description": "Also consider whether there has been a significant change from the same month in the previous year."
+                                        }
+                                    ]
+                                }],
+                                "type": "General",
+                                "answers": [{
+                                    "id": "answerd6064ed2-4172-462a-9b7f-af57f1bc7b9a",
+                                    "mandatory": true,
+                                    "type": "Radio",
+                                    "label": "",
+                                    "description": "",
+                                    "q_code": "190m",
+                                    "options": [{
+                                            "label": "Yes",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "label": "No",
+                                            "value": "No"
+                                        }
+                                    ]
+                                }]
+                            }],
+                            "routing_rules": [{
+                                    "goto": {
+                                        "group": "group-summary-monthly",
+                                        "when": [{
+                                            "id": "answerd6064ed2-4172-462a-9b7f-af57f1bc7b9a",
+                                            "condition": "contains any",
+                                            "values": [
+                                                "No"
+                                            ]
+                                        }]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "blocke00d504c-fd63-4082-a4d6-410bc3691338"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Calendar monthly"
+                                    ]
+                                }]
                             }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Calendar monthly"
+                        },
+                        {
+                            "id": "blocke00d504c-fd63-4082-a4d6-410bc3691338",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "questione00d504c-fd63-4082-a4d6-410bc3691338",
+                                "title": "What were the reasons for the changes to the <em>total pay or number</em> of <em>calendar monthly</em> paid employees?",
+                                "type": "General",
+                                "answers": [{
+                                    "id": "answer930cde2f-3ef6-4579-be3e-915a9dc607c9",
+                                    "mandatory": true,
+                                    "type": "Checkbox",
+                                    "label": "Select all that apply:",
+                                    "description": "",
+                                    "options": [{
+                                            "label": "Redundancies",
+                                            "value": "Redundancies",
+                                            "q_code": "191m"
+                                        },
+                                        {
+                                            "label": "More temporary staff",
+                                            "value": "More temporary staff",
+                                            "q_code": "192m1"
+                                        },
+                                        {
+                                            "label": "Fewer temporary staff",
+                                            "value": "Fewer temporary staff",
+                                            "q_code": "192m2"
+                                        },
+                                        {
+                                            "label": "More overtime",
+                                            "value": "More overtime",
+                                            "q_code": "194m1"
+                                        },
+                                        {
+                                            "label": "Less overtime",
+                                            "value": "Less overtime",
+                                            "q_code": "194m2"
+                                        },
+                                        {
+                                            "label": "Pay increase",
+                                            "value": "Pay increase",
+                                            "q_code": "195m"
+                                        },
+                                        {
+                                            "label": "Industrial action",
+                                            "value": "Industrial action",
+                                            "q_code": "196m"
+                                        },
+                                        {
+                                            "label": "Other",
+                                            "value": "Other",
+                                            "q_code": "197m"
+                                        }
+                                    ]
+                                }]
+                            }],
+                            "routing_rules": [{
+                                    "goto": {
+                                        "block": "block601111a3-05ca-4dcc-ab3f-4d4d483e39a2",
+                                        "when": [{
+                                            "id": "answer930cde2f-3ef6-4579-be3e-915a9dc607c9",
+                                            "condition": "contains all",
+                                            "values": [
+                                                "Pay increase"
+                                            ]
+                                        }]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "blockd9b1acdc-6d2f-41bb-b913-f6ab3402389b"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Calendar monthly"
+                                    ]
+                                }]
+                            }]
+                        },
+                        {
+                            "id": "block601111a3-05ca-4dcc-ab3f-4d4d483e39a2",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "question601111a3-05ca-4dcc-ab3f-4d4d483e39a2",
+                                "title": "If your business has new pay rates, what is the percentage increase?",
+                                "type": "General",
+                                "answers": [{
+                                        "id": "answer931d7403-3fc8-4dd3-9ceb-507f12fa2561",
+                                        "mandatory": false,
+                                        "type": "Percentage",
+                                        "label": "Percentage increase of new pay rates",
+                                        "description": "",
+                                        "q_code": "200",
+                                        "decimal_places": 2
+                                    },
+                                    {
+                                        "id": "answer33940067-f517-4db9-9fa3-cb749f03b43b",
+                                        "mandatory": false,
+                                        "type": "Date",
+                                        "label": "If your figures are backdated, which date did they begin?",
+                                        "description": "",
+                                        "q_code": "210"
+                                    },
+                                    {
+                                        "id": "answer9026c765-8a66-4128-926c-1f752539058c",
+                                        "mandatory": false,
+                                        "type": "Number",
+                                        "label": "What was the number of calendar monthly paid employees who received this new pay rate?",
+                                        "description": "",
+                                        "q_code": "220",
+                                        "max_value": {
+                                            "answer_id": "answer50a8167d-581f-4548-8759-cfbf2e0af696",
+                                            "exclusive": false
+                                        },
+                                        "decimal_places": 0
+                                    }
                                 ]
+                            }],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Calendar monthly"
+                                    ]
+                                }]
                             }]
-                        }]
-                    }
-                ]
-            },
-            {
-                "id": "group-summary-monthly",
-                "blocks": [
-                    {
+                        },
+                        {
+                            "id": "blockd9b1acdc-6d2f-41bb-b913-f6ab3402389b",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "questiond9b1acdc-6d2f-41bb-b913-f6ab3402389b",
+                                "title": "What were the changes to the <em>total pay or number</em> of <em>calendar monthly</em> paid employees?",
+                                "type": "General",
+                                "answers": [{
+                                    "id": "answer30a279d5-8562-4f11-942f-a9cd8199ad9a",
+                                    "mandatory": true,
+                                    "type": "TextArea",
+                                    "label": "Comments",
+                                    "description": "",
+                                    "q_code": "300m",
+                                    "max_length": 2000
+                                }]
+                            }],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Calendar monthly"
+                                    ]
+                                }]
+                            }]
+                        }
+                    ]
+                },
+                {
+                    "id": "group-summary-monthly",
+                    "title": "section summary monthly",
+                    "blocks": [{
                         "id": "summary-monthly",
                         "type": "SectionSummary",
                         "collapsible": false
-                    }
-                ],
-                "skip_conditions": [{
-                    "when": [{
-                        "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                        "condition": "not contains any",
-                        "values": [
-                            "Calendar monthly"
-                        ]
+                    }],
+                    "skip_conditions": [{
+                        "when": [{
+                            "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                            "condition": "not contains any",
+                            "values": [
+                                "Calendar monthly"
+                            ]
+                        }]
                     }]
-                }]
-            }]
+                }
+            ]
         },
         {
             "id": "section9442599d-4b92-4c58-81f2-693ae40b7100",
             "title": "Four weekly pay",
             "groups": [{
-                "id": "group9442599d-4b92-4c58-81f2-693ae40b7100",
-                "title": "Four weekly pay",
-                "blocks": [{
-                        "type": "Interstitial",
-                        "id": "group9442599d-4b92-4c58-81f2-693ae40b7100-introduction",
-                        "title": "Four weekly pay",
-                        "description": "<p>This section covers employees who are paid four weekly.</p><p>You will be asked for the:</p><ul><li>number of four weekly paid employees</li><li>pay awards and bonuses paid to four weekly paid employees</li><li>number of furloughed employees</li><li>number of furloughed employees who received a top-up to their pay in addition to the Coronavirus Job Retention Scheme (CJRS) 80% contributions</li><li>significant changes to the pay or number of four weekly paid employees</li></ul>",
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Four weekly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block239f5378-d772-46ea-ae35-0b12d3c887ce",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question239f5378-d772-46ea-ae35-0b12d3c887ce",
-                            "title": "What was the <em>number</em> of <em>four weekly</em> paid employees paid in {{ metadata['period_str'] }}?",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "all employees in Great Britain (England, Scotland and Wales), both full and part-time, who received pay in the relevant period",
-                                            "all trainees or apprentices that were paid through your payroll for the relevant period"
-                                        ]
-                                    },
-                                    {
-                                        "description": "<strong>Exclude:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "trainees or apprentices that were not paid through your payroll for the relevant period",
-                                            "employees working abroad unless paid directly from this business’s GB payroll",
-                                            "employees in Northern Ireland"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer82db87fd-dc48-4385-8eee-e49d1fc37c65",
-                                "mandatory": true,
-                                "type": "Number",
-                                "label": "Total number of four weekly paid employees",
-                                "description": "",
-                                "q_code": "140w4",
-                                "min_value": {
-                                    "value": 1,
-                                    "exclusive": false
-                                },
-                                "decimal_places": 0
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Four weekly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block205ec5ba-6004-4c87-b7a1-116964667f24",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question205ec5ba-6004-4c87-b7a1-116964667f24",
-                            "title": "What was the <em>total gross four weekly pay</em> paid to employees in {{ metadata['period_str'] }}?",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "bonuses or commissions",
-                                            "overtime and shift allowance payments",
-                                            "pay award arrears",
-                                            "voluntary employee contributions to, and annual profit from, profit related pay schemes"
-                                        ]
-                                    },
-                                    {
-                                        "description": "<strong>Exclude:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "any redundancy pay and pay in lieu of notice payments (taxable and non-taxable)",
-                                            "trainees or apprentices that were not paid through your payroll for the relevant period",
-                                            "directors' fees",
-                                            "employer’s NI and contribution to pension schemes",
-                                            "employees working abroad unless paid directly from this business’s GB payroll",
-                                            "signing on fees (sporting professionals)",
-                                            "accrued holiday pay",
-                                            "employees in Northern Ireland",
-                                            "expenses payments for attending meetings or training courses"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "type": "General",
-                            "answers": [{
-                                "id": "answerab7b97dc-541f-4b59-83f0-ca4867bdfcad",
-                                "mandatory": true,
-                                "type": "Currency",
-                                "label": "Total gross four weekly pay",
-                                "description": "",
-                                "q_code": "152",
-                                "decimal_places": 2,
-                                "currency": "GBP"
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Four weekly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "blockconfirmation-page-for-205ec5ba-6004-4c87-b7a1-116964667f24",
-                        "type": "ConfirmationQuestion",
-                        "questions": [{
-                            "id": "questionconfirmation-page-for-205ec5ba-6004-4c87-b7a1-116964667f24",
-                            "title": "The <em>total gross four weekly pay</em> paid to employees in {{ metadata['period_str'] }} was <em>£0</em>, is this correct?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answerconfirmation-answer-for-205ec5ba-6004-4c87-b7a1-116964667f24",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "options": [{
-                                        "label": "Yes, this is correct",
-                                        "value": "Yes, this is correct"
-                                    },
-                                    {
-                                        "label": "No, I need to change this",
-                                        "value": "No, I need to change this"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "block205ec5ba-6004-4c87-b7a1-116964667f24",
-                                    "when": [{
-                                        "id": "answerconfirmation-answer-for-205ec5ba-6004-4c87-b7a1-116964667f24",
-                                        "condition": "contains any",
-                                        "values": [
-                                            "No, I need to change this"
-                                        ]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block28de8e8c-139d-4ab2-8d1f-344dd26cd150",
-                                    "when": [{
-                                        "id": "answerab7b97dc-541f-4b59-83f0-ca4867bdfcad",
-                                        "condition": "equals",
-                                        "value": 0
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "blockc35e2043-b393-47f6-983f-ebee763a2145"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                                "when": [{
-                                    "id": "answerab7b97dc-541f-4b59-83f0-ca4867bdfcad",
-                                    "condition": "greater than",
-                                    "value": 0
-                                }]
-                            },
-                            {
+                    "id": "group9442599d-4b92-4c58-81f2-693ae40b7100",
+                    "title": "Four weekly pay",
+                    "blocks": [{
+                            "type": "Interstitial",
+                            "id": "group9442599d-4b92-4c58-81f2-693ae40b7100-introduction",
+                            "title": "Four weekly pay",
+                            "description": "<p>This section covers employees who are paid four weekly.</p><p>You will be asked for the:</p><ul><li>number of four weekly paid employees</li><li>pay awards and bonuses paid to four weekly paid employees</li><li>number of furloughed employees</li><li>number of furloughed employees who received a top-up to their pay in addition to the Coronavirus Job Retention Scheme (CJRS) 80% contributions</li><li>significant changes to the pay or number of four weekly paid employees</li></ul>",
+                            "skip_conditions": [{
                                 "when": [{
                                     "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
                                     "condition": "not contains any",
@@ -2824,761 +2646,761 @@
                                         "Four weekly"
                                     ]
                                 }]
-                            }
-                        ]
-                    },
-                    {
-                        "id": "blockc35e2043-b393-47f6-983f-ebee763a2145",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questionc35e2043-b393-47f6-983f-ebee763a2145",
-                            "title": "Of the {{ format_currency(answers['answerab7b97dc-541f-4b59-83f0-ca4867bdfcad'], 'GBP') }} paid to <em>four weekly</em> paid employees in  {{ metadata['period_str'] }}, what other amounts were paid?",
-                            "description": "<p>Informed estimates are acceptable.</p>",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "performance pay (for example, productivity bonuses)",
-                                            "long service awards",
-                                            "appearance money (sporting professionals)"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "type": "Calculated",
-                            "answers": [{
-                                    "id": "answer7eea963c-2fe1-4f97-a1f6-4a40c0376167",
-                                    "mandatory": true,
-                                    "type": "Currency",
-                                    "label": "Arrears of pay owing to pay awards",
-                                    "description": "",
-                                    "q_code": "172",
-                                    "max_value": {
-                                        "answer_id": "answerab7b97dc-541f-4b59-83f0-ca4867bdfcad",
-                                        "exclusive": false
-                                    },
-                                    "decimal_places": 2,
-                                    "currency": "GBP"
+                            }]
+                        },
+                        {
+                            "id": "block239f5378-d772-46ea-ae35-0b12d3c887ce",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "question239f5378-d772-46ea-ae35-0b12d3c887ce",
+                                "title": "What was the <em>number</em> of <em>four weekly</em> paid employees paid in {{ metadata['period_str'] }}?",
+                                "guidance": {
+                                    "content": [{
+                                            "description": "<strong>Include:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "all employees in Great Britain (England, Scotland and Wales), both full and part-time, who received pay in the relevant period",
+                                                "all trainees or apprentices that were paid through your payroll for the relevant period"
+                                            ]
+                                        },
+                                        {
+                                            "description": "<strong>Exclude:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "trainees or apprentices that were not paid through your payroll for the relevant period",
+                                                "employees working abroad unless paid directly from this business’s GB payroll",
+                                                "employees in Northern Ireland"
+                                            ]
+                                        }
+                                    ]
                                 },
-                                {
-                                    "id": "answer2e4a2094-e6f1-417b-ba3a-aee9a9689018",
+                                "type": "General",
+                                "answers": [{
+                                    "id": "answer82db87fd-dc48-4385-8eee-e49d1fc37c65",
                                     "mandatory": true,
-                                    "type": "Currency",
-                                    "label": "Bonuses, commissions or annual profit from profit-related pay schemes",
-                                    "description": "",
-                                    "q_code": "182",
-                                    "max_value": {
-                                        "answer_id": "answerab7b97dc-541f-4b59-83f0-ca4867bdfcad",
-                                        "exclusive": false
-                                    },
-                                    "decimal_places": 2,
-                                    "currency": "GBP"
-                                }
-                            ],
-                            "calculations": [{
-                                "calculation_type": "sum",
-                                "answers_to_calculate": [
-                                    "answer7eea963c-2fe1-4f97-a1f6-4a40c0376167",
-                                    "answer2e4a2094-e6f1-417b-ba3a-aee9a9689018"
-                                ],
-                                "conditions": [
-                                    "less than",
-                                    "equals"
-                                ],
-                                "answer_id": "answerab7b97dc-541f-4b59-83f0-ca4867bdfcad"
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Four weekly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block28de8e8c-139d-4ab2-8d1f-344dd26cd150",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question28de8e8c-139d-4ab2-8d1f-344dd26cd150",
-                            "title": "Were any of {{ metadata['ru_name'] }}'s four weekly paid employees <em>furloughed</em> for any of the pay period?",
-                            "description": "<p>Please note that the Coronavirus Job Retention Scheme ended 30 September 2021.</p>",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "employees furloughed for either all, or some, of their normal working hours",
-                                            "employees the business is claiming for via the Coronavirus Job Retention Scheme (CJRS)"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "type": "General",
-                            "answers": [{
-                                "id": "answere5646097-3273-4474-a9e1-cfed9e2187f6",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "400w4",
-                                "options": [{
-                                        "label": "Yes",
-                                        "value": "Yes"
-                                    },
-                                    {
-                                        "label": "No",
-                                        "value": "No"
-                                    },
-                                    {
-                                        "label": "Not sure",
-                                        "value": "Not sure"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "blockeec63409-b030-4ea0-a894-34e50549397d",
-                                    "when": [{
-                                        "id": "answere5646097-3273-4474-a9e1-cfed9e2187f6",
-                                        "condition": "contains any",
-                                        "values": [
-                                            "No",
-                                            "Not sure"
-                                        ]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block4c0442b6-32ba-40cd-a7c9-a9bf00367375"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Four weekly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block4c0442b6-32ba-40cd-a7c9-a9bf00367375",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question4c0442b6-32ba-40cd-a7c9-a9bf00367375",
-                            "title": "Approximately <em>how many</em> of the four weekly paid employees were furloughed for any of the pay period?",
-                            "description": "<p>Please note that the Coronavirus Job Retention Scheme ended 30 September 2021.</p>",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "employees furloughed for either all, or some, of their normal working hours",
-                                            "employees the business is claiming for via the Coronavirus Job Retention Scheme (CJRS)"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "type": "General",
-                            "answers": [{
-                                    "id": "answerdba707ab-4564-49e4-9875-6c55f94fb4ff",
-                                    "mandatory": false,
                                     "type": "Number",
-                                    "label": "Number of furloughed employees",
+                                    "label": "Total number of four weekly paid employees",
                                     "description": "",
-                                    "q_code": "401w41",
+                                    "q_code": "140w4",
                                     "min_value": {
                                         "value": 1,
                                         "exclusive": false
                                     },
-                                    "max_value": {
-                                        "answer_id": "answer82db87fd-dc48-4385-8eee-e49d1fc37c65",
-                                        "exclusive": false
-                                    },
                                     "decimal_places": 0
-                                },
-                                {
-                                    "id": "answer2aa4be5a-ce19-44be-a2c5-4ef8278e057e",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "label": "Or select 'Not sure' if the number is not known",
-                                    "description": "",
-                                    "options": [{
-                                        "label": "Not sure",
-                                        "value": "Not sure",
-                                        "q_code": "401w42"
-                                    }]
-                                }
-                            ]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "blockeec63409-b030-4ea0-a894-34e50549397d",
-                                    "when": [{
-                                            "id": "answer2aa4be5a-ce19-44be-a2c5-4ef8278e057e",
-                                            "condition": "not set"
+                                }]
+                            }],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Four weekly"
+                                    ]
+                                }]
+                            }]
+                        },
+                        {
+                            "id": "block205ec5ba-6004-4c87-b7a1-116964667f24",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "question205ec5ba-6004-4c87-b7a1-116964667f24",
+                                "title": "What was the <em>total gross four weekly pay</em> paid to employees in {{ metadata['period_str'] }}?",
+                                "guidance": {
+                                    "content": [{
+                                            "description": "<strong>Include:</strong>"
                                         },
                                         {
-                                            "id": "answerdba707ab-4564-49e4-9875-6c55f94fb4ff",
-                                            "condition": "not set"
+                                            "list": [
+                                                "bonuses or commissions",
+                                                "overtime and shift allowance payments",
+                                                "pay award arrears",
+                                                "voluntary employee contributions to, and annual profit from, profit related pay schemes"
+                                            ]
+                                        },
+                                        {
+                                            "description": "<strong>Exclude:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "any redundancy pay and pay in lieu of notice payments (taxable and non-taxable)",
+                                                "trainees or apprentices that were not paid through your payroll for the relevant period",
+                                                "directors' fees",
+                                                "employer’s NI and contribution to pension schemes",
+                                                "employees working abroad unless paid directly from this business’s GB payroll",
+                                                "signing on fees (sporting professionals)",
+                                                "accrued holiday pay",
+                                                "employees in Northern Ireland",
+                                                "expenses payments for attending meetings or training courses"
+                                            ]
                                         }
                                     ]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "blockeec63409-b030-4ea0-a894-34e50549397d",
-                                    "when": [{
-                                        "id": "answer2aa4be5a-ce19-44be-a2c5-4ef8278e057e",
-                                        "condition": "contains all",
-                                        "values": [
-                                            "Not sure"
-                                        ]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block4f8871b9-3af5-4672-b002-e3ab49e8d376"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Four weekly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block4f8871b9-3af5-4672-b002-e3ab49e8d376",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question4f8871b9-3af5-4672-b002-e3ab49e8d376",
-                            "title": "How many of {{ metadata['ru_name'] }}’s four weekly paid furloughed employees received <em>more than the 80%</em> Coronavirus Job Retention Scheme (CJRS) contribution, for the pay period?",
-                            "description": "<p>Please note that the Coronavirus Job Retention Scheme ended 30 September 2021.</p>",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "employees who worked some hours for which they were paid at the normal rate",
-                                            "employees who received a top-up to their pay in addition to the Coronavirus Job Retention Scheme (CJRS) 80% contribution"
-                                        ]
-                                    },
-                                    {
-                                        "description": "<strong>Exclude:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "employer’s NI and contribution to pension schemes"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "type": "General",
-                            "answers": [{
-                                    "id": "answerf7c7e549-6873-4bcb-8451-2b72633ed916",
-                                    "mandatory": false,
-                                    "type": "Number",
-                                    "label": "Number of employees paid more than the 80% CJRS contribution",
+                                },
+                                "type": "General",
+                                "answers": [{
+                                    "id": "answerab7b97dc-541f-4b59-83f0-ca4867bdfcad",
+                                    "mandatory": true,
+                                    "type": "Currency",
+                                    "label": "Total gross four weekly pay",
                                     "description": "",
-                                    "q_code": "402w41",
-                                    "max_value": {
-                                        "answer_id": "answerdba707ab-4564-49e4-9875-6c55f94fb4ff",
-                                        "exclusive": false
-                                    },
-                                    "decimal_places": 0
+                                    "q_code": "152",
+                                    "decimal_places": 2,
+                                    "currency": "GBP"
+                                }]
+                            }],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Four weekly"
+                                    ]
+                                }]
+                            }]
+                        },
+                        {
+                            "id": "blockconfirmation-page-for-205ec5ba-6004-4c87-b7a1-116964667f24",
+                            "type": "ConfirmationQuestion",
+                            "questions": [{
+                                "id": "questionconfirmation-page-for-205ec5ba-6004-4c87-b7a1-116964667f24",
+                                "title": "The <em>total gross four weekly pay</em> paid to employees in {{ metadata['period_str'] }} was <em>£0</em>, is this correct?",
+                                "type": "General",
+                                "answers": [{
+                                    "id": "answerconfirmation-answer-for-205ec5ba-6004-4c87-b7a1-116964667f24",
+                                    "mandatory": true,
+                                    "type": "Radio",
+                                    "options": [{
+                                            "label": "Yes, this is correct",
+                                            "value": "Yes, this is correct"
+                                        },
+                                        {
+                                            "label": "No, I need to change this",
+                                            "value": "No, I need to change this"
+                                        }
+                                    ]
+                                }]
+                            }],
+                            "routing_rules": [{
+                                    "goto": {
+                                        "block": "block205ec5ba-6004-4c87-b7a1-116964667f24",
+                                        "when": [{
+                                            "id": "answerconfirmation-answer-for-205ec5ba-6004-4c87-b7a1-116964667f24",
+                                            "condition": "contains any",
+                                            "values": [
+                                                "No, I need to change this"
+                                            ]
+                                        }]
+                                    }
                                 },
                                 {
-                                    "id": "answer99b1fdfe-9939-49a2-990c-aca02499998a",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "label": "Or select 'Not sure' if the number is not known",
-                                    "description": "",
-                                    "options": [{
-                                        "label": "Not sure",
-                                        "value": "Not sure",
-                                        "q_code": "402w42"
+                                    "goto": {
+                                        "block": "block28de8e8c-139d-4ab2-8d1f-344dd26cd150",
+                                        "when": [{
+                                            "id": "answerab7b97dc-541f-4b59-83f0-ca4867bdfcad",
+                                            "condition": "equals",
+                                            "value": 0
+                                        }]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "blockc35e2043-b393-47f6-983f-ebee763a2145"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [{
+                                    "when": [{
+                                        "id": "answerab7b97dc-541f-4b59-83f0-ca4867bdfcad",
+                                        "condition": "greater than",
+                                        "value": 0
+                                    }]
+                                },
+                                {
+                                    "when": [{
+                                        "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                        "condition": "not contains any",
+                                        "values": [
+                                            "Four weekly"
+                                        ]
                                     }]
                                 }
                             ]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Four weekly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "blockeec63409-b030-4ea0-a894-34e50549397d",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questioneec63409-b030-4ea0-a894-34e50549397d",
-                            "title": "Did any significant changes occur to the total pay or number of four weekly paid employees?",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include:</strong>"
+                        },
+                        {
+                            "id": "blockc35e2043-b393-47f6-983f-ebee763a2145",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "questionc35e2043-b393-47f6-983f-ebee763a2145",
+                                "title": "Of the {{ format_currency(answers['answerab7b97dc-541f-4b59-83f0-ca4867bdfcad'], 'GBP') }} paid to <em>four weekly</em> paid employees in  {{ metadata['period_str'] }}, what other amounts were paid?",
+                                "description": "<p>Informed estimates are acceptable.</p>",
+                                "guidance": {
+                                    "content": [{
+                                            "description": "<strong>Include:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "performance pay (for example, productivity bonuses)",
+                                                "long service awards",
+                                                "appearance money (sporting professionals)"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "type": "Calculated",
+                                "answers": [{
+                                        "id": "answer7eea963c-2fe1-4f97-a1f6-4a40c0376167",
+                                        "mandatory": true,
+                                        "type": "Currency",
+                                        "label": "Arrears of pay owing to pay awards",
+                                        "description": "",
+                                        "q_code": "172",
+                                        "max_value": {
+                                            "answer_id": "answerab7b97dc-541f-4b59-83f0-ca4867bdfcad",
+                                            "exclusive": false
+                                        },
+                                        "decimal_places": 2,
+                                        "currency": "GBP"
                                     },
                                     {
-                                        "list": [
-                                            "redundancies",
-                                            "changes in the number of temporary staff",
-                                            "more or less overtime",
-                                            "new pay rates",
-                                            "industrial action"
-                                        ]
+                                        "id": "answer2e4a2094-e6f1-417b-ba3a-aee9a9689018",
+                                        "mandatory": true,
+                                        "type": "Currency",
+                                        "label": "Bonuses, commissions or annual profit from profit-related pay schemes",
+                                        "description": "",
+                                        "q_code": "182",
+                                        "max_value": {
+                                            "answer_id": "answerab7b97dc-541f-4b59-83f0-ca4867bdfcad",
+                                            "exclusive": false
+                                        },
+                                        "decimal_places": 2,
+                                        "currency": "GBP"
                                     }
-                                ]
-                            },
-                            "definitions": [{
-                                "title": "What we mean by 'a significant change'",
-                                "content": [{
-                                        "description": "This is dependent on your own interpretation of whether there has been a significant change in the business’s figures compared with the previous month."
+                                ],
+                                "calculations": [{
+                                    "calculation_type": "sum",
+                                    "answers_to_calculate": [
+                                        "answer7eea963c-2fe1-4f97-a1f6-4a40c0376167",
+                                        "answer2e4a2094-e6f1-417b-ba3a-aee9a9689018"
+                                    ],
+                                    "conditions": [
+                                        "less than",
+                                        "equals"
+                                    ],
+                                    "answer_id": "answerab7b97dc-541f-4b59-83f0-ca4867bdfcad"
+                                }]
+                            }],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Four weekly"
+                                    ]
+                                }]
+                            }]
+                        },
+                        {
+                            "id": "block28de8e8c-139d-4ab2-8d1f-344dd26cd150",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "question28de8e8c-139d-4ab2-8d1f-344dd26cd150",
+                                "title": "Were any of {{ metadata['ru_name'] }}'s four weekly paid employees <em>furloughed</em> for any of the pay period?",
+                                "description": "<p>Please note that the Coronavirus Job Retention Scheme ended 30 September 2021.</p>",
+                                "guidance": {
+                                    "content": [{
+                                            "description": "<strong>Include:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "employees furloughed for either all, or some, of their normal working hours",
+                                                "employees the business is claiming for via the Coronavirus Job Retention Scheme (CJRS)"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "type": "General",
+                                "answers": [{
+                                    "id": "answere5646097-3273-4474-a9e1-cfed9e2187f6",
+                                    "mandatory": true,
+                                    "type": "Radio",
+                                    "label": "",
+                                    "description": "",
+                                    "q_code": "400w4",
+                                    "options": [{
+                                            "label": "Yes",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "label": "No",
+                                            "value": "No"
+                                        },
+                                        {
+                                            "label": "Not sure",
+                                            "value": "Not sure"
+                                        }
+                                    ]
+                                }]
+                            }],
+                            "routing_rules": [{
+                                    "goto": {
+                                        "block": "blockeec63409-b030-4ea0-a894-34e50549397d",
+                                        "when": [{
+                                            "id": "answere5646097-3273-4474-a9e1-cfed9e2187f6",
+                                            "condition": "contains any",
+                                            "values": [
+                                                "No",
+                                                "Not sure"
+                                            ]
+                                        }]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "block4c0442b6-32ba-40cd-a7c9-a9bf00367375"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Four weekly"
+                                    ]
+                                }]
+                            }]
+                        },
+                        {
+                            "id": "block4c0442b6-32ba-40cd-a7c9-a9bf00367375",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "question4c0442b6-32ba-40cd-a7c9-a9bf00367375",
+                                "title": "Approximately <em>how many</em> of the four weekly paid employees were furloughed for any of the pay period?",
+                                "description": "<p>Please note that the Coronavirus Job Retention Scheme ended 30 September 2021.</p>",
+                                "guidance": {
+                                    "content": [{
+                                            "description": "<strong>Include:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "employees furloughed for either all, or some, of their normal working hours",
+                                                "employees the business is claiming for via the Coronavirus Job Retention Scheme (CJRS)"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "type": "General",
+                                "answers": [{
+                                        "id": "answerdba707ab-4564-49e4-9875-6c55f94fb4ff",
+                                        "mandatory": false,
+                                        "type": "Number",
+                                        "label": "Number of furloughed employees",
+                                        "description": "",
+                                        "q_code": "401w41",
+                                        "min_value": {
+                                            "value": 1,
+                                            "exclusive": false
+                                        },
+                                        "max_value": {
+                                            "answer_id": "answer82db87fd-dc48-4385-8eee-e49d1fc37c65",
+                                            "exclusive": false
+                                        },
+                                        "decimal_places": 0
                                     },
                                     {
-                                        "description": "Also consider whether there has been a significant change from the same month in the previous year."
+                                        "id": "answer2aa4be5a-ce19-44be-a2c5-4ef8278e057e",
+                                        "mandatory": false,
+                                        "type": "Checkbox",
+                                        "label": "Or select 'Not sure' if the number is not known",
+                                        "description": "",
+                                        "options": [{
+                                            "label": "Not sure",
+                                            "value": "Not sure",
+                                            "q_code": "401w42"
+                                        }]
                                     }
                                 ]
                             }],
-                            "type": "General",
-                            "answers": [{
-                                "id": "answerfefeb3ed-f1fe-4359-aebd-16739cf8ac6e",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "190w4",
-                                "options": [{
-                                        "label": "Yes",
-                                        "value": "Yes"
-                                    },
-                                    {
-                                        "label": "No",
-                                        "value": "No"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "group": "group-summary-fourweekly",
-                                    "when": [{
-                                        "id": "answerfefeb3ed-f1fe-4359-aebd-16739cf8ac6e",
-                                        "condition": "contains any",
-                                        "values": [
-                                            "No"
+                            "routing_rules": [{
+                                    "goto": {
+                                        "block": "blockeec63409-b030-4ea0-a894-34e50549397d",
+                                        "when": [{
+                                                "id": "answer2aa4be5a-ce19-44be-a2c5-4ef8278e057e",
+                                                "condition": "not set"
+                                            },
+                                            {
+                                                "id": "answerdba707ab-4564-49e4-9875-6c55f94fb4ff",
+                                                "condition": "not set"
+                                            }
                                         ]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block0122b4d1-eff3-40f6-870f-751657f02059"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Four weekly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block0122b4d1-eff3-40f6-870f-751657f02059",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question0122b4d1-eff3-40f6-870f-751657f02059",
-                            "title": "What were the reasons for the changes to the <em>total pay or number</em> of <em>four weekly</em> paid employees?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer0b89e980-809d-42c7-b82e-bfc05adbdbd5",
-                                "mandatory": true,
-                                "type": "Checkbox",
-                                "label": "Select all that apply:",
-                                "description": "",
-                                "options": [{
-                                        "label": "Redundancies",
-                                        "value": "Redundancies",
-                                        "q_code": "191w4"
-                                    },
-                                    {
-                                        "label": "More temporary staff",
-                                        "value": "More temporary staff",
-                                        "q_code": "192w41"
-                                    },
-                                    {
-                                        "label": "Fewer temporary staff",
-                                        "value": "Fewer temporary staff",
-                                        "q_code": "192w42"
-                                    },
-                                    {
-                                        "label": "More overtime",
-                                        "value": "More overtime",
-                                        "q_code": "194w41"
-                                    },
-                                    {
-                                        "label": "Less overtime",
-                                        "value": "Less overtime",
-                                        "q_code": "194w42"
-                                    },
-                                    {
-                                        "label": "Pay increase",
-                                        "value": "Pay increase",
-                                        "q_code": "195w4"
-                                    },
-                                    {
-                                        "label": "Industrial action",
-                                        "value": "Industrial action",
-                                        "q_code": "196w4"
-                                    },
-                                    {
-                                        "label": "Other",
-                                        "value": "Other",
-                                        "q_code": "197w4"
                                     }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "blockc553342f-bbb1-4ae2-8b09-afe46ac2ae97",
-                                    "when": [{
-                                        "id": "answer0b89e980-809d-42c7-b82e-bfc05adbdbd5",
-                                        "condition": "contains all",
-                                        "values": [
-                                            "Pay increase"
-                                        ]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "blockf7c4fb33-79b0-4613-a30e-6abe10351ae6"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Four weekly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "blockc553342f-bbb1-4ae2-8b09-afe46ac2ae97",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questionc553342f-bbb1-4ae2-8b09-afe46ac2ae97",
-                            "title": "If your business has new pay rates, what is the percentage increase?",
-                            "type": "General",
-                            "answers": [{
-                                    "id": "answera95a7f65-8303-4ffb-8201-092bd9ceffca",
-                                    "mandatory": false,
-                                    "type": "Percentage",
-                                    "label": "Percentage increase of new pay rates",
-                                    "description": "",
-                                    "q_code": "200w4",
-                                    "decimal_places": 2
                                 },
                                 {
-                                    "id": "answer2a0c01cd-ae5f-47e5-9914-734d9a610616",
-                                    "mandatory": false,
-                                    "type": "Date",
-                                    "label": "If your figures are backdated, which date did they begin?",
-                                    "description": "",
-                                    "q_code": "210w4"
+                                    "goto": {
+                                        "block": "blockeec63409-b030-4ea0-a894-34e50549397d",
+                                        "when": [{
+                                            "id": "answer2aa4be5a-ce19-44be-a2c5-4ef8278e057e",
+                                            "condition": "contains all",
+                                            "values": [
+                                                "Not sure"
+                                            ]
+                                        }]
+                                    }
                                 },
                                 {
-                                    "id": "answer607c19b8-1c87-4d85-aa79-efdadebf8a42",
-                                    "mandatory": false,
-                                    "type": "Number",
-                                    "label": "What was the number of four weekly paid employees who received this new pay rate?",
-                                    "description": "",
-                                    "q_code": "220w4",
-                                    "max_value": {
-                                        "answer_id": "answer82db87fd-dc48-4385-8eee-e49d1fc37c65",
-                                        "exclusive": false
-                                    },
-                                    "decimal_places": 0
+                                    "goto": {
+                                        "block": "block4f8871b9-3af5-4672-b002-e3ab49e8d376"
+                                    }
                                 }
-                            ]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Four weekly"
+                            ],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Four weekly"
+                                    ]
+                                }]
+                            }]
+                        },
+                        {
+                            "id": "block4f8871b9-3af5-4672-b002-e3ab49e8d376",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "question4f8871b9-3af5-4672-b002-e3ab49e8d376",
+                                "title": "How many of {{ metadata['ru_name'] }}’s four weekly paid furloughed employees received <em>more than the 80%</em> Coronavirus Job Retention Scheme (CJRS) contribution, for the pay period?",
+                                "description": "<p>Please note that the Coronavirus Job Retention Scheme ended 30 September 2021.</p>",
+                                "guidance": {
+                                    "content": [{
+                                            "description": "<strong>Include:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "employees who worked some hours for which they were paid at the normal rate",
+                                                "employees who received a top-up to their pay in addition to the Coronavirus Job Retention Scheme (CJRS) 80% contribution"
+                                            ]
+                                        },
+                                        {
+                                            "description": "<strong>Exclude:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "employer’s NI and contribution to pension schemes"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "type": "General",
+                                "answers": [{
+                                        "id": "answerf7c7e549-6873-4bcb-8451-2b72633ed916",
+                                        "mandatory": false,
+                                        "type": "Number",
+                                        "label": "Number of employees paid more than the 80% CJRS contribution",
+                                        "description": "",
+                                        "q_code": "402w41",
+                                        "max_value": {
+                                            "answer_id": "answerdba707ab-4564-49e4-9875-6c55f94fb4ff",
+                                            "exclusive": false
+                                        },
+                                        "decimal_places": 0
+                                    },
+                                    {
+                                        "id": "answer99b1fdfe-9939-49a2-990c-aca02499998a",
+                                        "mandatory": false,
+                                        "type": "Checkbox",
+                                        "label": "Or select 'Not sure' if the number is not known",
+                                        "description": "",
+                                        "options": [{
+                                            "label": "Not sure",
+                                            "value": "Not sure",
+                                            "q_code": "402w42"
+                                        }]
+                                    }
                                 ]
+                            }],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Four weekly"
+                                    ]
+                                }]
                             }]
-                        }]
-                    },
-                    {
-                        "id": "blockf7c4fb33-79b0-4613-a30e-6abe10351ae6",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questionf7c4fb33-79b0-4613-a30e-6abe10351ae6",
-                            "title": "What were the changes to the <em>total pay or number</em> of <em>four weekly</em> paid employees?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer0bec4dde-9124-4eb5-9fa0-7c022d73ae1e",
-                                "mandatory": true,
-                                "type": "TextArea",
-                                "label": "Comments",
-                                "description": "",
-                                "q_code": "300w4",
-                                "max_length": 2000
+                        },
+                        {
+                            "id": "blockeec63409-b030-4ea0-a894-34e50549397d",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "questioneec63409-b030-4ea0-a894-34e50549397d",
+                                "title": "Did any significant changes occur to the total pay or number of four weekly paid employees?",
+                                "guidance": {
+                                    "content": [{
+                                            "description": "<strong>Include:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "redundancies",
+                                                "changes in the number of temporary staff",
+                                                "more or less overtime",
+                                                "new pay rates",
+                                                "industrial action"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "definitions": [{
+                                    "title": "What we mean by 'a significant change'",
+                                    "content": [{
+                                            "description": "This is dependent on your own interpretation of whether there has been a significant change in the business’s figures compared with the previous month."
+                                        },
+                                        {
+                                            "description": "Also consider whether there has been a significant change from the same month in the previous year."
+                                        }
+                                    ]
+                                }],
+                                "type": "General",
+                                "answers": [{
+                                    "id": "answerfefeb3ed-f1fe-4359-aebd-16739cf8ac6e",
+                                    "mandatory": true,
+                                    "type": "Radio",
+                                    "label": "",
+                                    "description": "",
+                                    "q_code": "190w4",
+                                    "options": [{
+                                            "label": "Yes",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "label": "No",
+                                            "value": "No"
+                                        }
+                                    ]
+                                }]
+                            }],
+                            "routing_rules": [{
+                                    "goto": {
+                                        "group": "group-summary-fourweekly",
+                                        "when": [{
+                                            "id": "answerfefeb3ed-f1fe-4359-aebd-16739cf8ac6e",
+                                            "condition": "contains any",
+                                            "values": [
+                                                "No"
+                                            ]
+                                        }]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "block0122b4d1-eff3-40f6-870f-751657f02059"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Four weekly"
+                                    ]
+                                }]
                             }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Four weekly"
+                        },
+                        {
+                            "id": "block0122b4d1-eff3-40f6-870f-751657f02059",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "question0122b4d1-eff3-40f6-870f-751657f02059",
+                                "title": "What were the reasons for the changes to the <em>total pay or number</em> of <em>four weekly</em> paid employees?",
+                                "type": "General",
+                                "answers": [{
+                                    "id": "answer0b89e980-809d-42c7-b82e-bfc05adbdbd5",
+                                    "mandatory": true,
+                                    "type": "Checkbox",
+                                    "label": "Select all that apply:",
+                                    "description": "",
+                                    "options": [{
+                                            "label": "Redundancies",
+                                            "value": "Redundancies",
+                                            "q_code": "191w4"
+                                        },
+                                        {
+                                            "label": "More temporary staff",
+                                            "value": "More temporary staff",
+                                            "q_code": "192w41"
+                                        },
+                                        {
+                                            "label": "Fewer temporary staff",
+                                            "value": "Fewer temporary staff",
+                                            "q_code": "192w42"
+                                        },
+                                        {
+                                            "label": "More overtime",
+                                            "value": "More overtime",
+                                            "q_code": "194w41"
+                                        },
+                                        {
+                                            "label": "Less overtime",
+                                            "value": "Less overtime",
+                                            "q_code": "194w42"
+                                        },
+                                        {
+                                            "label": "Pay increase",
+                                            "value": "Pay increase",
+                                            "q_code": "195w4"
+                                        },
+                                        {
+                                            "label": "Industrial action",
+                                            "value": "Industrial action",
+                                            "q_code": "196w4"
+                                        },
+                                        {
+                                            "label": "Other",
+                                            "value": "Other",
+                                            "q_code": "197w4"
+                                        }
+                                    ]
+                                }]
+                            }],
+                            "routing_rules": [{
+                                    "goto": {
+                                        "block": "blockc553342f-bbb1-4ae2-8b09-afe46ac2ae97",
+                                        "when": [{
+                                            "id": "answer0b89e980-809d-42c7-b82e-bfc05adbdbd5",
+                                            "condition": "contains all",
+                                            "values": [
+                                                "Pay increase"
+                                            ]
+                                        }]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "blockf7c4fb33-79b0-4613-a30e-6abe10351ae6"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Four weekly"
+                                    ]
+                                }]
+                            }]
+                        },
+                        {
+                            "id": "blockc553342f-bbb1-4ae2-8b09-afe46ac2ae97",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "questionc553342f-bbb1-4ae2-8b09-afe46ac2ae97",
+                                "title": "If your business has new pay rates, what is the percentage increase?",
+                                "type": "General",
+                                "answers": [{
+                                        "id": "answera95a7f65-8303-4ffb-8201-092bd9ceffca",
+                                        "mandatory": false,
+                                        "type": "Percentage",
+                                        "label": "Percentage increase of new pay rates",
+                                        "description": "",
+                                        "q_code": "200w4",
+                                        "decimal_places": 2
+                                    },
+                                    {
+                                        "id": "answer2a0c01cd-ae5f-47e5-9914-734d9a610616",
+                                        "mandatory": false,
+                                        "type": "Date",
+                                        "label": "If your figures are backdated, which date did they begin?",
+                                        "description": "",
+                                        "q_code": "210w4"
+                                    },
+                                    {
+                                        "id": "answer607c19b8-1c87-4d85-aa79-efdadebf8a42",
+                                        "mandatory": false,
+                                        "type": "Number",
+                                        "label": "What was the number of four weekly paid employees who received this new pay rate?",
+                                        "description": "",
+                                        "q_code": "220w4",
+                                        "max_value": {
+                                            "answer_id": "answer82db87fd-dc48-4385-8eee-e49d1fc37c65",
+                                            "exclusive": false
+                                        },
+                                        "decimal_places": 0
+                                    }
                                 ]
+                            }],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Four weekly"
+                                    ]
+                                }]
                             }]
-                        }]
-                    }
-                ]
-            },
-            {
-                "id": "group-summary-fourweekly",
-                "blocks": [
-                    {
+                        },
+                        {
+                            "id": "blockf7c4fb33-79b0-4613-a30e-6abe10351ae6",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "questionf7c4fb33-79b0-4613-a30e-6abe10351ae6",
+                                "title": "What were the changes to the <em>total pay or number</em> of <em>four weekly</em> paid employees?",
+                                "type": "General",
+                                "answers": [{
+                                    "id": "answer0bec4dde-9124-4eb5-9fa0-7c022d73ae1e",
+                                    "mandatory": true,
+                                    "type": "TextArea",
+                                    "label": "Comments",
+                                    "description": "",
+                                    "q_code": "300w4",
+                                    "max_length": 2000
+                                }]
+                            }],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Four weekly"
+                                    ]
+                                }]
+                            }]
+                        }
+                    ]
+                },
+                {
+                    "id": "group-summary-fourweekly",
+                    "title": "section summary fourweekly",
+                    "blocks": [{
                         "id": "summary-fourweekly",
                         "type": "SectionSummary",
                         "collapsible": false
-                    }
-                ],
-                "skip_conditions": [{
-                    "when": [{
-                        "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                        "condition": "not contains any",
-                        "values": [
-                            "Four weekly"
-                        ]
+                    }],
+                    "skip_conditions": [{
+                        "when": [{
+                            "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                            "condition": "not contains any",
+                            "values": [
+                                "Four weekly"
+                            ]
+                        }]
                     }]
-                }]
-            }]
+                }
+            ]
         },
         {
             "id": "section9747ed13-704c-46f6-8d17-3655314314ca",
             "title": "Five weekly pay",
             "groups": [{
-                "id": "group9747ed13-704c-46f6-8d17-3655314314ca",
-                "title": "Five weekly pay",
-                "blocks": [{
-                        "type": "Interstitial",
-                        "id": "group9747ed13-704c-46f6-8d17-3655314314ca-introduction",
-                        "title": "Five weekly pay",
-                        "description": "<p>This section covers employees who are paid five weekly.</p><p>You will be asked for the:</p><ul><li>number of five weekly paid employees</li><li>pay awards and bonuses paid to five weekly paid employees</li><li>number of furloughed employees</li><li>number of furloughed employees who received a top-up to their pay in addition to the Coronavirus Job Retention Scheme (CJRS) 80% contributions</li><li>significant changes to the pay or number of five weekly paid employees</li></ul>",
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Five weekly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "blockf87befb8-fc95-4ad7-b041-310100116dd4",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questionf87befb8-fc95-4ad7-b041-310100116dd4",
-                            "title": "What was the <em>number</em> of <em>five weekly</em> paid employees paid in {{ metadata['period_str'] }}?",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "all employees in Great Britain (England, Scotland and Wales), both full and part-time, who received pay in the relevant period",
-                                            "all trainees or apprentices that were paid through your payroll for the relevant period"
-                                        ]
-                                    },
-                                    {
-                                        "description": "<strong>Exclude:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "trainees or apprentices that were not paid through your payroll for the relevant period",
-                                            "employees working abroad unless paid directly from this business’s GB payroll",
-                                            "employees in Northern Ireland"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "type": "General",
-                            "answers": [{
-                                "id": "answerd4b1c6ce-17f6-4ea9-8b98-c21f36d44efa",
-                                "mandatory": true,
-                                "type": "Number",
-                                "label": "Total number of five weekly paid employees",
-                                "description": "",
-                                "q_code": "140w5",
-                                "min_value": {
-                                    "value": 1,
-                                    "exclusive": false
-                                },
-                                "decimal_places": 0
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Five weekly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block4c1c59b1-2a3a-43f7-859b-c95f67312fa4",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question4c1c59b1-2a3a-43f7-859b-c95f67312fa4",
-                            "title": "What was the <em>total gross five weekly pay</em> paid to employees in {{ metadata['period_str'] }}?",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "bonuses or commissions",
-                                            "overtime and shift allowance payments",
-                                            "pay award arrears",
-                                            "voluntary employee contributions to, and annual profit from, profit related pay schemes"
-                                        ]
-                                    },
-                                    {
-                                        "description": "<strong>Exclude:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "any redundancy pay and pay in lieu of notice payments (taxable and non-taxable)",
-                                            "trainees or apprentices that were not paid through your payroll for the relevant period",
-                                            "directors' fees",
-                                            "employer’s NI and contribution to pension schemes",
-                                            "employees working abroad unless paid directly from this business’s GB payroll",
-                                            "signing on fees (sporting professionals)",
-                                            "accrued holiday pay",
-                                            "employees in Northern Ireland",
-                                            "expenses payments for attending meetings or training courses"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer7f095ddc-e4bd-403d-9cc0-50788063e778",
-                                "mandatory": true,
-                                "type": "Currency",
-                                "label": "Total gross five weekly pay",
-                                "description": "",
-                                "q_code": "153",
-                                "decimal_places": 2,
-                                "currency": "GBP"
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Five weekly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "blockconfirmation-page-for-4c1c59b1-2a3a-43f7-859b-c95f67312fa4",
-                        "type": "ConfirmationQuestion",
-                        "questions": [{
-                            "id": "questionconfirmation-page-for-4c1c59b1-2a3a-43f7-859b-c95f67312fa4",
-                            "title": "The <em>total gross five weekly pay</em> paid to employees in {{ metadata['period_str'] }} was <em>£0</em>, is this correct?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answerconfirmation-answer-for-4c1c59b1-2a3a-43f7-859b-c95f67312fa4",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "options": [{
-                                        "label": "Yes, this is correct",
-                                        "value": "Yes, this is correct"
-                                    },
-                                    {
-                                        "label": "No, I need to change this",
-                                        "value": "No, I need to change this"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "block4c1c59b1-2a3a-43f7-859b-c95f67312fa4",
-                                    "when": [{
-                                        "id": "answerconfirmation-answer-for-4c1c59b1-2a3a-43f7-859b-c95f67312fa4",
-                                        "condition": "contains any",
-                                        "values": [
-                                            "No, I need to change this"
-                                        ]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "blockc7193cb8-4f8b-4398-ae65-f69e9e976c32",
-                                    "when": [{
-                                        "id": "answer7f095ddc-e4bd-403d-9cc0-50788063e778",
-                                        "condition": "equals",
-                                        "value": 0
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block53c7d7a0-099b-4f42-8efb-b4fc4fd2cdf0"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                                "when": [{
-                                    "id": "answer7f095ddc-e4bd-403d-9cc0-50788063e778",
-                                    "condition": "greater than",
-                                    "value": 0
-                                }]
-                            },
-                            {
+                    "id": "group9747ed13-704c-46f6-8d17-3655314314ca",
+                    "title": "Five weekly pay",
+                    "blocks": [{
+                            "type": "Interstitial",
+                            "id": "group9747ed13-704c-46f6-8d17-3655314314ca-introduction",
+                            "title": "Five weekly pay",
+                            "description": "<p>This section covers employees who are paid five weekly.</p><p>You will be asked for the:</p><ul><li>number of five weekly paid employees</li><li>pay awards and bonuses paid to five weekly paid employees</li><li>number of furloughed employees</li><li>number of furloughed employees who received a top-up to their pay in addition to the Coronavirus Job Retention Scheme (CJRS) 80% contributions</li><li>significant changes to the pay or number of five weekly paid employees</li></ul>",
+                            "skip_conditions": [{
                                 "when": [{
                                     "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
                                     "condition": "not contains any",
@@ -3586,570 +3408,748 @@
                                         "Five weekly"
                                     ]
                                 }]
-                            }
-                        ]
-                    },
-                    {
-                        "id": "block53c7d7a0-099b-4f42-8efb-b4fc4fd2cdf0",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question53c7d7a0-099b-4f42-8efb-b4fc4fd2cdf0",
-                            "title": "Of the {{ format_currency(answers['answer7f095ddc-e4bd-403d-9cc0-50788063e778'], 'GBP') }} paid to <em>five weekly paid employees</em> in  {{ metadata['period_str'] }}, what other amounts were paid?",
-                            "description": "<p>Informed estimates are acceptable.</p>",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "performance pay (for example, productivity bonuses)",
-                                            "long service awards",
-                                            "appearance money (sporting professionals)"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "type": "Calculated",
-                            "answers": [{
-                                    "id": "answerdb354001-bde7-45e3-8c2a-0a78b737d876",
-                                    "mandatory": true,
-                                    "type": "Currency",
-                                    "label": "Arrears of pay owing to pay awards",
-                                    "description": "",
-                                    "q_code": "173",
-                                    "max_value": {
-                                        "answer_id": "answer7f095ddc-e4bd-403d-9cc0-50788063e778",
-                                        "exclusive": false
-                                    },
-                                    "decimal_places": 2,
-                                    "currency": "GBP"
+                            }]
+                        },
+                        {
+                            "id": "blockf87befb8-fc95-4ad7-b041-310100116dd4",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "questionf87befb8-fc95-4ad7-b041-310100116dd4",
+                                "title": "What was the <em>number</em> of <em>five weekly</em> paid employees paid in {{ metadata['period_str'] }}?",
+                                "guidance": {
+                                    "content": [{
+                                            "description": "<strong>Include:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "all employees in Great Britain (England, Scotland and Wales), both full and part-time, who received pay in the relevant period",
+                                                "all trainees or apprentices that were paid through your payroll for the relevant period"
+                                            ]
+                                        },
+                                        {
+                                            "description": "<strong>Exclude:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "trainees or apprentices that were not paid through your payroll for the relevant period",
+                                                "employees working abroad unless paid directly from this business’s GB payroll",
+                                                "employees in Northern Ireland"
+                                            ]
+                                        }
+                                    ]
                                 },
-                                {
-                                    "id": "answer89c5abc9-7da4-4ba4-84bb-e88350bed8e4",
+                                "type": "General",
+                                "answers": [{
+                                    "id": "answerd4b1c6ce-17f6-4ea9-8b98-c21f36d44efa",
                                     "mandatory": true,
-                                    "type": "Currency",
-                                    "label": "Bonuses, commissions or annual profit from profit-related pay schemes",
-                                    "description": "",
-                                    "q_code": "183",
-                                    "max_value": {
-                                        "answer_id": "answer7f095ddc-e4bd-403d-9cc0-50788063e778",
-                                        "exclusive": false
-                                    },
-                                    "decimal_places": 2,
-                                    "currency": "GBP"
-                                }
-                            ],
-                            "calculations": [{
-                                "calculation_type": "sum",
-                                "answers_to_calculate": [
-                                    "answerdb354001-bde7-45e3-8c2a-0a78b737d876",
-                                    "answer89c5abc9-7da4-4ba4-84bb-e88350bed8e4"
-                                ],
-                                "conditions": [
-                                    "less than",
-                                    "equals"
-                                ],
-                                "answer_id": "answer7f095ddc-e4bd-403d-9cc0-50788063e778"
-                            }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Five weekly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "blockc7193cb8-4f8b-4398-ae65-f69e9e976c32",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questionc7193cb8-4f8b-4398-ae65-f69e9e976c32",
-                            "title": "Were any of {{ metadata['ru_name'] }}'s five weekly paid employees <em>furloughed</em> for any of the pay period?",
-                            "description": "<p>Please note that the Coronavirus Job Retention Scheme ended 30 September 2021.</p>",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "employees furloughed for either all, or some, of their normal working hours",
-                                            "employees the business is claiming for via the Coronavirus Job Retention Scheme (CJRS)"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer0d9e46cb-61b1-41d0-9c0d-cdc4c8ba69e6",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "400w5",
-                                "options": [{
-                                        "label": "Yes",
-                                        "value": "Yes"
-                                    },
-                                    {
-                                        "label": "No",
-                                        "value": "No"
-                                    },
-                                    {
-                                        "label": "Not sure",
-                                        "value": "Not sure"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "block67abd7a8-49e0-4c7a-95fc-6f57d8f16540",
-                                    "when": [{
-                                        "id": "answer0d9e46cb-61b1-41d0-9c0d-cdc4c8ba69e6",
-                                        "condition": "contains any",
-                                        "values": [
-                                            "No",
-                                            "Not sure"
-                                        ]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "blockbc80d0f0-b3ba-431d-89aa-6237a16efd96"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Five weekly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "blockbc80d0f0-b3ba-431d-89aa-6237a16efd96",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questionbc80d0f0-b3ba-431d-89aa-6237a16efd96",
-                            "title": "Approximately <em>how many</em> of the five weekly paid employees were furloughed for any of the pay period?",
-                            "description": "<p>Please note that the Coronavirus Job Retention Scheme ended 30 September 2021.</p>",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "employees furloughed for either all, or some, of their normal working hours",
-                                            "employees the business is claiming for via the Coronavirus Job Retention Scheme (CJRS)"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "type": "General",
-                            "answers": [{
-                                    "id": "answer4e449013-ec55-4df2-9ddb-e88fb79f7272",
-                                    "mandatory": false,
                                     "type": "Number",
-                                    "label": "Number of furloughed employees",
+                                    "label": "Total number of five weekly paid employees",
                                     "description": "",
-                                    "q_code": "401w51",
+                                    "q_code": "140w5",
                                     "min_value": {
                                         "value": 1,
                                         "exclusive": false
                                     },
-                                    "max_value": {
-                                        "answer_id": "answerd4b1c6ce-17f6-4ea9-8b98-c21f36d44efa",
-                                        "exclusive": false
-                                    },
                                     "decimal_places": 0
-                                },
-                                {
-                                    "id": "answer608ca49e-cc84-415e-8c80-260d052e4970",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "label": "Or select 'Not sure' if the answer is not known",
-                                    "description": "",
-                                    "options": [{
-                                        "label": "Not sure",
-                                        "value": "Not sure",
-                                        "q_code": "401w52"
-                                    }]
-                                }
-                            ]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "block67abd7a8-49e0-4c7a-95fc-6f57d8f16540",
-                                    "when": [{
-                                            "id": "answer4e449013-ec55-4df2-9ddb-e88fb79f7272",
-                                            "condition": "not set"
+                                }]
+                            }],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Five weekly"
+                                    ]
+                                }]
+                            }]
+                        },
+                        {
+                            "id": "block4c1c59b1-2a3a-43f7-859b-c95f67312fa4",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "question4c1c59b1-2a3a-43f7-859b-c95f67312fa4",
+                                "title": "What was the <em>total gross five weekly pay</em> paid to employees in {{ metadata['period_str'] }}?",
+                                "guidance": {
+                                    "content": [{
+                                            "description": "<strong>Include:</strong>"
                                         },
                                         {
-                                            "id": "answer608ca49e-cc84-415e-8c80-260d052e4970",
-                                            "condition": "not set"
+                                            "list": [
+                                                "bonuses or commissions",
+                                                "overtime and shift allowance payments",
+                                                "pay award arrears",
+                                                "voluntary employee contributions to, and annual profit from, profit related pay schemes"
+                                            ]
+                                        },
+                                        {
+                                            "description": "<strong>Exclude:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "any redundancy pay and pay in lieu of notice payments (taxable and non-taxable)",
+                                                "trainees or apprentices that were not paid through your payroll for the relevant period",
+                                                "directors' fees",
+                                                "employer’s NI and contribution to pension schemes",
+                                                "employees working abroad unless paid directly from this business’s GB payroll",
+                                                "signing on fees (sporting professionals)",
+                                                "accrued holiday pay",
+                                                "employees in Northern Ireland",
+                                                "expenses payments for attending meetings or training courses"
+                                            ]
                                         }
                                     ]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block67abd7a8-49e0-4c7a-95fc-6f57d8f16540",
-                                    "when": [{
-                                        "id": "answer608ca49e-cc84-415e-8c80-260d052e4970",
-                                        "condition": "contains all",
-                                        "values": [
-                                            "Not sure"
-                                        ]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block3ac047f9-2cbc-4bf9-9376-a001f14ec09b"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Five weekly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block3ac047f9-2cbc-4bf9-9376-a001f14ec09b",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question3ac047f9-2cbc-4bf9-9376-a001f14ec09b",
-                            "title": "How many of {{ metadata['ru_name'] }}’s five weekly paid furloughed employees received <em>more than the 80%</em> Coronavirus Job Retention Scheme (CJRS) contribution, for the pay period?",
-                            "description": "<p>Please note that the Coronavirus Job Retention Scheme ended 30 September 2021.</p>",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "employees who worked some hours for which they were paid at the normal rate",
-                                            "employees who received a top-up to their pay in addition to the Coronavirus Job Retention Scheme (CJRS) 80% contribution"
-                                        ]
-                                    },
-                                    {
-                                        "description": "<strong>Exclude:</strong>"
-                                    },
-                                    {
-                                        "list": [
-                                            "employer’s NI and contribution to pension schemes"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "type": "General",
-                            "answers": [{
-                                    "id": "answer42056da6-e398-4211-a548-0c9602758a35",
-                                    "mandatory": false,
-                                    "type": "Number",
-                                    "label": "Number of employees paid more than the 80% CJRS contribution",
+                                },
+                                "type": "General",
+                                "answers": [{
+                                    "id": "answer7f095ddc-e4bd-403d-9cc0-50788063e778",
+                                    "mandatory": true,
+                                    "type": "Currency",
+                                    "label": "Total gross five weekly pay",
                                     "description": "",
-                                    "q_code": "402w51",
-                                    "max_value": {
-                                        "answer_id": "answer4e449013-ec55-4df2-9ddb-e88fb79f7272",
-                                        "exclusive": false
-                                    },
-                                    "decimal_places": 0
+                                    "q_code": "153",
+                                    "decimal_places": 2,
+                                    "currency": "GBP"
+                                }]
+                            }],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Five weekly"
+                                    ]
+                                }]
+                            }]
+                        },
+                        {
+                            "id": "blockconfirmation-page-for-4c1c59b1-2a3a-43f7-859b-c95f67312fa4",
+                            "type": "ConfirmationQuestion",
+                            "questions": [{
+                                "id": "questionconfirmation-page-for-4c1c59b1-2a3a-43f7-859b-c95f67312fa4",
+                                "title": "The <em>total gross five weekly pay</em> paid to employees in {{ metadata['period_str'] }} was <em>£0</em>, is this correct?",
+                                "type": "General",
+                                "answers": [{
+                                    "id": "answerconfirmation-answer-for-4c1c59b1-2a3a-43f7-859b-c95f67312fa4",
+                                    "mandatory": true,
+                                    "type": "Radio",
+                                    "options": [{
+                                            "label": "Yes, this is correct",
+                                            "value": "Yes, this is correct"
+                                        },
+                                        {
+                                            "label": "No, I need to change this",
+                                            "value": "No, I need to change this"
+                                        }
+                                    ]
+                                }]
+                            }],
+                            "routing_rules": [{
+                                    "goto": {
+                                        "block": "block4c1c59b1-2a3a-43f7-859b-c95f67312fa4",
+                                        "when": [{
+                                            "id": "answerconfirmation-answer-for-4c1c59b1-2a3a-43f7-859b-c95f67312fa4",
+                                            "condition": "contains any",
+                                            "values": [
+                                                "No, I need to change this"
+                                            ]
+                                        }]
+                                    }
                                 },
                                 {
-                                    "id": "answer39bfd735-7058-4976-a6d3-fcedb2cfe51f",
-                                    "mandatory": false,
-                                    "type": "Checkbox",
-                                    "label": "Or select 'Not sure' if the number is not known",
-                                    "description": "",
-                                    "options": [{
-                                        "label": "Not sure",
-                                        "value": "Not sure",
-                                        "q_code": "402w52"
+                                    "goto": {
+                                        "block": "blockc7193cb8-4f8b-4398-ae65-f69e9e976c32",
+                                        "when": [{
+                                            "id": "answer7f095ddc-e4bd-403d-9cc0-50788063e778",
+                                            "condition": "equals",
+                                            "value": 0
+                                        }]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "block53c7d7a0-099b-4f42-8efb-b4fc4fd2cdf0"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [{
+                                    "when": [{
+                                        "id": "answer7f095ddc-e4bd-403d-9cc0-50788063e778",
+                                        "condition": "greater than",
+                                        "value": 0
+                                    }]
+                                },
+                                {
+                                    "when": [{
+                                        "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                        "condition": "not contains any",
+                                        "values": [
+                                            "Five weekly"
+                                        ]
                                     }]
                                 }
                             ]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Five weekly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block67abd7a8-49e0-4c7a-95fc-6f57d8f16540",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question67abd7a8-49e0-4c7a-95fc-6f57d8f16540",
-                            "title": "Did any significant changes occur to the <em>total pay or number</em> of <em>five weekly</em> paid employees?",
-                            "guidance": {
-                                "content": [{
-                                        "description": "<strong>Include:</strong>"
+                        },
+                        {
+                            "id": "block53c7d7a0-099b-4f42-8efb-b4fc4fd2cdf0",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "question53c7d7a0-099b-4f42-8efb-b4fc4fd2cdf0",
+                                "title": "Of the {{ format_currency(answers['answer7f095ddc-e4bd-403d-9cc0-50788063e778'], 'GBP') }} paid to <em>five weekly paid employees</em> in  {{ metadata['period_str'] }}, what other amounts were paid?",
+                                "description": "<p>Informed estimates are acceptable.</p>",
+                                "guidance": {
+                                    "content": [{
+                                            "description": "<strong>Include:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "performance pay (for example, productivity bonuses)",
+                                                "long service awards",
+                                                "appearance money (sporting professionals)"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "type": "Calculated",
+                                "answers": [{
+                                        "id": "answerdb354001-bde7-45e3-8c2a-0a78b737d876",
+                                        "mandatory": true,
+                                        "type": "Currency",
+                                        "label": "Arrears of pay owing to pay awards",
+                                        "description": "",
+                                        "q_code": "173",
+                                        "max_value": {
+                                            "answer_id": "answer7f095ddc-e4bd-403d-9cc0-50788063e778",
+                                            "exclusive": false
+                                        },
+                                        "decimal_places": 2,
+                                        "currency": "GBP"
                                     },
                                     {
-                                        "list": [
-                                            "redundancies",
-                                            "changes in the number of temporary staff",
-                                            "more or less overtime",
-                                            "new pay rates",
-                                            "industrial action"
-                                        ]
+                                        "id": "answer89c5abc9-7da4-4ba4-84bb-e88350bed8e4",
+                                        "mandatory": true,
+                                        "type": "Currency",
+                                        "label": "Bonuses, commissions or annual profit from profit-related pay schemes",
+                                        "description": "",
+                                        "q_code": "183",
+                                        "max_value": {
+                                            "answer_id": "answer7f095ddc-e4bd-403d-9cc0-50788063e778",
+                                            "exclusive": false
+                                        },
+                                        "decimal_places": 2,
+                                        "currency": "GBP"
                                     }
-                                ]
-                            },
-                            "definitions": [{
-                                "title": "What we mean by 'a significant change'",
-                                "content": [{
-                                        "description": "This is dependent on your own interpretation of whether there has been a significant change in the business’s figures compared with the previous month."
+                                ],
+                                "calculations": [{
+                                    "calculation_type": "sum",
+                                    "answers_to_calculate": [
+                                        "answerdb354001-bde7-45e3-8c2a-0a78b737d876",
+                                        "answer89c5abc9-7da4-4ba4-84bb-e88350bed8e4"
+                                    ],
+                                    "conditions": [
+                                        "less than",
+                                        "equals"
+                                    ],
+                                    "answer_id": "answer7f095ddc-e4bd-403d-9cc0-50788063e778"
+                                }]
+                            }],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Five weekly"
+                                    ]
+                                }]
+                            }]
+                        },
+                        {
+                            "id": "blockc7193cb8-4f8b-4398-ae65-f69e9e976c32",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "questionc7193cb8-4f8b-4398-ae65-f69e9e976c32",
+                                "title": "Were any of {{ metadata['ru_name'] }}'s five weekly paid employees <em>furloughed</em> for any of the pay period?",
+                                "description": "<p>Please note that the Coronavirus Job Retention Scheme ended 30 September 2021.</p>",
+                                "guidance": {
+                                    "content": [{
+                                            "description": "<strong>Include:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "employees furloughed for either all, or some, of their normal working hours",
+                                                "employees the business is claiming for via the Coronavirus Job Retention Scheme (CJRS)"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "type": "General",
+                                "answers": [{
+                                    "id": "answer0d9e46cb-61b1-41d0-9c0d-cdc4c8ba69e6",
+                                    "mandatory": true,
+                                    "type": "Radio",
+                                    "label": "",
+                                    "description": "",
+                                    "q_code": "400w5",
+                                    "options": [{
+                                            "label": "Yes",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "label": "No",
+                                            "value": "No"
+                                        },
+                                        {
+                                            "label": "Not sure",
+                                            "value": "Not sure"
+                                        }
+                                    ]
+                                }]
+                            }],
+                            "routing_rules": [{
+                                    "goto": {
+                                        "block": "block67abd7a8-49e0-4c7a-95fc-6f57d8f16540",
+                                        "when": [{
+                                            "id": "answer0d9e46cb-61b1-41d0-9c0d-cdc4c8ba69e6",
+                                            "condition": "contains any",
+                                            "values": [
+                                                "No",
+                                                "Not sure"
+                                            ]
+                                        }]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "blockbc80d0f0-b3ba-431d-89aa-6237a16efd96"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Five weekly"
+                                    ]
+                                }]
+                            }]
+                        },
+                        {
+                            "id": "blockbc80d0f0-b3ba-431d-89aa-6237a16efd96",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "questionbc80d0f0-b3ba-431d-89aa-6237a16efd96",
+                                "title": "Approximately <em>how many</em> of the five weekly paid employees were furloughed for any of the pay period?",
+                                "description": "<p>Please note that the Coronavirus Job Retention Scheme ended 30 September 2021.</p>",
+                                "guidance": {
+                                    "content": [{
+                                            "description": "<strong>Include:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "employees furloughed for either all, or some, of their normal working hours",
+                                                "employees the business is claiming for via the Coronavirus Job Retention Scheme (CJRS)"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "type": "General",
+                                "answers": [{
+                                        "id": "answer4e449013-ec55-4df2-9ddb-e88fb79f7272",
+                                        "mandatory": false,
+                                        "type": "Number",
+                                        "label": "Number of furloughed employees",
+                                        "description": "",
+                                        "q_code": "401w51",
+                                        "min_value": {
+                                            "value": 1,
+                                            "exclusive": false
+                                        },
+                                        "max_value": {
+                                            "answer_id": "answerd4b1c6ce-17f6-4ea9-8b98-c21f36d44efa",
+                                            "exclusive": false
+                                        },
+                                        "decimal_places": 0
                                     },
                                     {
-                                        "description": "Also consider whether there has been a significant change from the same month in the previous year."
+                                        "id": "answer608ca49e-cc84-415e-8c80-260d052e4970",
+                                        "mandatory": false,
+                                        "type": "Checkbox",
+                                        "label": "Or select 'Not sure' if the answer is not known",
+                                        "description": "",
+                                        "options": [{
+                                            "label": "Not sure",
+                                            "value": "Not sure",
+                                            "q_code": "401w52"
+                                        }]
                                     }
                                 ]
                             }],
-                            "type": "General",
-                            "answers": [{
-                                "id": "answerb567e1f5-c395-4db3-98b6-03dad97e420c",
-                                "mandatory": true,
-                                "type": "Radio",
-                                "label": "",
-                                "description": "",
-                                "q_code": "190w5",
-                                "options": [{
-                                        "label": "Yes",
-                                        "value": "Yes"
-                                    },
-                                    {
-                                        "label": "No",
-                                        "value": "No"
-                                    }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "group": "group-summary-fiveweekly",
-                                    "when": [{
-                                        "id": "answerb567e1f5-c395-4db3-98b6-03dad97e420c",
-                                        "condition": "contains any",
-                                        "values": [
-                                            "No"
+                            "routing_rules": [{
+                                    "goto": {
+                                        "block": "block67abd7a8-49e0-4c7a-95fc-6f57d8f16540",
+                                        "when": [{
+                                                "id": "answer4e449013-ec55-4df2-9ddb-e88fb79f7272",
+                                                "condition": "not set"
+                                            },
+                                            {
+                                                "id": "answer608ca49e-cc84-415e-8c80-260d052e4970",
+                                                "condition": "not set"
+                                            }
                                         ]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "block16aa95d8-c5dd-42bb-b4a9-5b0e442ea380"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Five weekly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block16aa95d8-c5dd-42bb-b4a9-5b0e442ea380",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question16aa95d8-c5dd-42bb-b4a9-5b0e442ea380",
-                            "title": "What were the reasons for the changes to the <em>total pay or number</em> of <em>five weekly</em> paid employees?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answer4801c23e-323b-4162-ab1a-47d1379bb66f",
-                                "mandatory": true,
-                                "type": "Checkbox",
-                                "label": "Select all that apply:",
-                                "description": "",
-                                "options": [{
-                                        "label": "Redundancies",
-                                        "value": "Redundancies",
-                                        "q_code": "191w5"
-                                    },
-                                    {
-                                        "label": "More temporary staff",
-                                        "value": "More temporary staff",
-                                        "q_code": "192w51"
-                                    },
-                                    {
-                                        "label": "Fewer temporary staff",
-                                        "value": "Fewer temporary staff",
-                                        "q_code": "192w52"
-                                    },
-                                    {
-                                        "label": "More overtime",
-                                        "value": "More overtime",
-                                        "q_code": "194w51"
-                                    },
-                                    {
-                                        "label": "Less overtime",
-                                        "value": "Less overtime",
-                                        "q_code": "194w52"
-                                    },
-                                    {
-                                        "label": "Pay increase",
-                                        "value": "Pay increase",
-                                        "q_code": "195w5"
-                                    },
-                                    {
-                                        "label": "Industrial action",
-                                        "value": "Industrial action",
-                                        "q_code": "196w5"
-                                    },
-                                    {
-                                        "label": "Other",
-                                        "value": "Other",
-                                        "q_code": "197w5"
                                     }
-                                ]
-                            }]
-                        }],
-                        "routing_rules": [{
-                                "goto": {
-                                    "block": "block0b24b72c-b7ae-4dd3-a450-c6c1b6d2cbf1",
-                                    "when": [{
-                                        "id": "answer4801c23e-323b-4162-ab1a-47d1379bb66f",
-                                        "condition": "contains all",
-                                        "values": [
-                                            "Pay increase"
-                                        ]
-                                    }]
-                                }
-                            },
-                            {
-                                "goto": {
-                                    "block": "blockd2c57075-9594-4a5c-8fca-bc5973491f35"
-                                }
-                            }
-                        ],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Five weekly"
-                                ]
-                            }]
-                        }]
-                    },
-                    {
-                        "id": "block0b24b72c-b7ae-4dd3-a450-c6c1b6d2cbf1",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "question0b24b72c-b7ae-4dd3-a450-c6c1b6d2cbf1",
-                            "title": "If your business has new pay rates, what is the percentage increase?",
-                            "type": "General",
-                            "answers": [{
-                                    "id": "answer75500c5f-eefc-434c-b398-1bf784a1700d",
-                                    "mandatory": false,
-                                    "type": "Percentage",
-                                    "label": "Percentage increase of new pay rates",
-                                    "description": "",
-                                    "q_code": "200w5",
-                                    "decimal_places": 2
                                 },
                                 {
-                                    "id": "answer73e7f01f-4944-4014-ac47-988640c748d1",
-                                    "mandatory": false,
-                                    "type": "Date",
-                                    "label": "If your figures are backdated, which date did they begin?",
-                                    "description": "",
-                                    "q_code": "210w5"
+                                    "goto": {
+                                        "block": "block67abd7a8-49e0-4c7a-95fc-6f57d8f16540",
+                                        "when": [{
+                                            "id": "answer608ca49e-cc84-415e-8c80-260d052e4970",
+                                            "condition": "contains all",
+                                            "values": [
+                                                "Not sure"
+                                            ]
+                                        }]
+                                    }
                                 },
                                 {
-                                    "id": "answera75be9c8-0b06-4ed3-8fd0-41fbd0dfe967",
-                                    "mandatory": false,
-                                    "type": "Number",
-                                    "label": "What was the number of five weekly paid employees who received this new pay rate?",
-                                    "description": "",
-                                    "q_code": "220w5",
-                                    "max_value": {
-                                        "answer_id": "answerd4b1c6ce-17f6-4ea9-8b98-c21f36d44efa",
-                                        "exclusive": false
-                                    },
-                                    "decimal_places": 0
+                                    "goto": {
+                                        "block": "block3ac047f9-2cbc-4bf9-9376-a001f14ec09b"
+                                    }
                                 }
-                            ]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Five weekly"
+                            ],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Five weekly"
+                                    ]
+                                }]
+                            }]
+                        },
+                        {
+                            "id": "block3ac047f9-2cbc-4bf9-9376-a001f14ec09b",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "question3ac047f9-2cbc-4bf9-9376-a001f14ec09b",
+                                "title": "How many of {{ metadata['ru_name'] }}’s five weekly paid furloughed employees received <em>more than the 80%</em> Coronavirus Job Retention Scheme (CJRS) contribution, for the pay period?",
+                                "description": "<p>Please note that the Coronavirus Job Retention Scheme ended 30 September 2021.</p>",
+                                "guidance": {
+                                    "content": [{
+                                            "description": "<strong>Include:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "employees who worked some hours for which they were paid at the normal rate",
+                                                "employees who received a top-up to their pay in addition to the Coronavirus Job Retention Scheme (CJRS) 80% contribution"
+                                            ]
+                                        },
+                                        {
+                                            "description": "<strong>Exclude:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "employer’s NI and contribution to pension schemes"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "type": "General",
+                                "answers": [{
+                                        "id": "answer42056da6-e398-4211-a548-0c9602758a35",
+                                        "mandatory": false,
+                                        "type": "Number",
+                                        "label": "Number of employees paid more than the 80% CJRS contribution",
+                                        "description": "",
+                                        "q_code": "402w51",
+                                        "max_value": {
+                                            "answer_id": "answer4e449013-ec55-4df2-9ddb-e88fb79f7272",
+                                            "exclusive": false
+                                        },
+                                        "decimal_places": 0
+                                    },
+                                    {
+                                        "id": "answer39bfd735-7058-4976-a6d3-fcedb2cfe51f",
+                                        "mandatory": false,
+                                        "type": "Checkbox",
+                                        "label": "Or select 'Not sure' if the number is not known",
+                                        "description": "",
+                                        "options": [{
+                                            "label": "Not sure",
+                                            "value": "Not sure",
+                                            "q_code": "402w52"
+                                        }]
+                                    }
                                 ]
+                            }],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Five weekly"
+                                    ]
+                                }]
                             }]
-                        }]
-                    },
-                    {
-                        "id": "blockd2c57075-9594-4a5c-8fca-bc5973491f35",
-                        "type": "Question",
-                        "questions": [{
-                            "id": "questiond2c57075-9594-4a5c-8fca-bc5973491f35",
-                            "title": "What were the changes to the <em>total pay or number</em> of <em>five weekly</em> paid employees?",
-                            "type": "General",
-                            "answers": [{
-                                "id": "answercadb3f15-e20f-4e8d-90d4-6e36af237df2",
-                                "mandatory": true,
-                                "type": "TextArea",
-                                "label": "Comments",
-                                "description": "",
-                                "q_code": "300w5",
-                                "max_length": 2000
+                        },
+                        {
+                            "id": "block67abd7a8-49e0-4c7a-95fc-6f57d8f16540",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "question67abd7a8-49e0-4c7a-95fc-6f57d8f16540",
+                                "title": "Did any significant changes occur to the <em>total pay or number</em> of <em>five weekly</em> paid employees?",
+                                "guidance": {
+                                    "content": [{
+                                            "description": "<strong>Include:</strong>"
+                                        },
+                                        {
+                                            "list": [
+                                                "redundancies",
+                                                "changes in the number of temporary staff",
+                                                "more or less overtime",
+                                                "new pay rates",
+                                                "industrial action"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "definitions": [{
+                                    "title": "What we mean by 'a significant change'",
+                                    "content": [{
+                                            "description": "This is dependent on your own interpretation of whether there has been a significant change in the business’s figures compared with the previous month."
+                                        },
+                                        {
+                                            "description": "Also consider whether there has been a significant change from the same month in the previous year."
+                                        }
+                                    ]
+                                }],
+                                "type": "General",
+                                "answers": [{
+                                    "id": "answerb567e1f5-c395-4db3-98b6-03dad97e420c",
+                                    "mandatory": true,
+                                    "type": "Radio",
+                                    "label": "",
+                                    "description": "",
+                                    "q_code": "190w5",
+                                    "options": [{
+                                            "label": "Yes",
+                                            "value": "Yes"
+                                        },
+                                        {
+                                            "label": "No",
+                                            "value": "No"
+                                        }
+                                    ]
+                                }]
+                            }],
+                            "routing_rules": [{
+                                    "goto": {
+                                        "group": "group-summary-fiveweekly",
+                                        "when": [{
+                                            "id": "answerb567e1f5-c395-4db3-98b6-03dad97e420c",
+                                            "condition": "contains any",
+                                            "values": [
+                                                "No"
+                                            ]
+                                        }]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "block16aa95d8-c5dd-42bb-b4a9-5b0e442ea380"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Five weekly"
+                                    ]
+                                }]
                             }]
-                        }],
-                        "skip_conditions": [{
-                            "when": [{
-                                "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                                "condition": "not contains any",
-                                "values": [
-                                    "Five weekly"
+                        },
+                        {
+                            "id": "block16aa95d8-c5dd-42bb-b4a9-5b0e442ea380",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "question16aa95d8-c5dd-42bb-b4a9-5b0e442ea380",
+                                "title": "What were the reasons for the changes to the <em>total pay or number</em> of <em>five weekly</em> paid employees?",
+                                "type": "General",
+                                "answers": [{
+                                    "id": "answer4801c23e-323b-4162-ab1a-47d1379bb66f",
+                                    "mandatory": true,
+                                    "type": "Checkbox",
+                                    "label": "Select all that apply:",
+                                    "description": "",
+                                    "options": [{
+                                            "label": "Redundancies",
+                                            "value": "Redundancies",
+                                            "q_code": "191w5"
+                                        },
+                                        {
+                                            "label": "More temporary staff",
+                                            "value": "More temporary staff",
+                                            "q_code": "192w51"
+                                        },
+                                        {
+                                            "label": "Fewer temporary staff",
+                                            "value": "Fewer temporary staff",
+                                            "q_code": "192w52"
+                                        },
+                                        {
+                                            "label": "More overtime",
+                                            "value": "More overtime",
+                                            "q_code": "194w51"
+                                        },
+                                        {
+                                            "label": "Less overtime",
+                                            "value": "Less overtime",
+                                            "q_code": "194w52"
+                                        },
+                                        {
+                                            "label": "Pay increase",
+                                            "value": "Pay increase",
+                                            "q_code": "195w5"
+                                        },
+                                        {
+                                            "label": "Industrial action",
+                                            "value": "Industrial action",
+                                            "q_code": "196w5"
+                                        },
+                                        {
+                                            "label": "Other",
+                                            "value": "Other",
+                                            "q_code": "197w5"
+                                        }
+                                    ]
+                                }]
+                            }],
+                            "routing_rules": [{
+                                    "goto": {
+                                        "block": "block0b24b72c-b7ae-4dd3-a450-c6c1b6d2cbf1",
+                                        "when": [{
+                                            "id": "answer4801c23e-323b-4162-ab1a-47d1379bb66f",
+                                            "condition": "contains all",
+                                            "values": [
+                                                "Pay increase"
+                                            ]
+                                        }]
+                                    }
+                                },
+                                {
+                                    "goto": {
+                                        "block": "blockd2c57075-9594-4a5c-8fca-bc5973491f35"
+                                    }
+                                }
+                            ],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Five weekly"
+                                    ]
+                                }]
+                            }]
+                        },
+                        {
+                            "id": "block0b24b72c-b7ae-4dd3-a450-c6c1b6d2cbf1",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "question0b24b72c-b7ae-4dd3-a450-c6c1b6d2cbf1",
+                                "title": "If your business has new pay rates, what is the percentage increase?",
+                                "type": "General",
+                                "answers": [{
+                                        "id": "answer75500c5f-eefc-434c-b398-1bf784a1700d",
+                                        "mandatory": false,
+                                        "type": "Percentage",
+                                        "label": "Percentage increase of new pay rates",
+                                        "description": "",
+                                        "q_code": "200w5",
+                                        "decimal_places": 2
+                                    },
+                                    {
+                                        "id": "answer73e7f01f-4944-4014-ac47-988640c748d1",
+                                        "mandatory": false,
+                                        "type": "Date",
+                                        "label": "If your figures are backdated, which date did they begin?",
+                                        "description": "",
+                                        "q_code": "210w5"
+                                    },
+                                    {
+                                        "id": "answera75be9c8-0b06-4ed3-8fd0-41fbd0dfe967",
+                                        "mandatory": false,
+                                        "type": "Number",
+                                        "label": "What was the number of five weekly paid employees who received this new pay rate?",
+                                        "description": "",
+                                        "q_code": "220w5",
+                                        "max_value": {
+                                            "answer_id": "answerd4b1c6ce-17f6-4ea9-8b98-c21f36d44efa",
+                                            "exclusive": false
+                                        },
+                                        "decimal_places": 0
+                                    }
                                 ]
+                            }],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Five weekly"
+                                    ]
+                                }]
                             }]
-                        }]
-                    }
-                ]
-            },
-            {
-                "id": "group-summary-fiveweekly",
-                "blocks": [
-                    {
+                        },
+                        {
+                            "id": "blockd2c57075-9594-4a5c-8fca-bc5973491f35",
+                            "type": "Question",
+                            "questions": [{
+                                "id": "questiond2c57075-9594-4a5c-8fca-bc5973491f35",
+                                "title": "What were the changes to the <em>total pay or number</em> of <em>five weekly</em> paid employees?",
+                                "type": "General",
+                                "answers": [{
+                                    "id": "answercadb3f15-e20f-4e8d-90d4-6e36af237df2",
+                                    "mandatory": true,
+                                    "type": "TextArea",
+                                    "label": "Comments",
+                                    "description": "",
+                                    "q_code": "300w5",
+                                    "max_length": 2000
+                                }]
+                            }],
+                            "skip_conditions": [{
+                                "when": [{
+                                    "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                                    "condition": "not contains any",
+                                    "values": [
+                                        "Five weekly"
+                                    ]
+                                }]
+                            }]
+                        }
+                    ]
+                },
+                {
+                    "id": "group-summary-fiveweekly",
+                    "title": "section summary fiveweekly",
+                    "blocks": [{
                         "id": "summary-fiveweekly",
                         "type": "SectionSummary",
                         "collapsible": false
-                    }
-                ],
-                "skip_conditions": [{
-                    "when": [{
-                        "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
-                        "condition": "not contains any",
-                        "values": [
-                            "Five weekly"
-                        ]
+                    }],
+                    "skip_conditions": [{
+                        "when": [{
+                            "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                            "condition": "not contains any",
+                            "values": [
+                                "Five weekly"
+                            ]
+                        }]
                     }]
-                }]
-            }]
+                }
+            ]
         },
         {
             "id": "sectione30dd07c-2f93-4605-bd45-eb821be27e9e",

--- a/data/en/1_0005.json
+++ b/data/en/1_0005.json
@@ -878,7 +878,7 @@
                         }],
                         "routing_rules": [{
                                 "goto": {
-                                    "group": "groupb903c023-4354-46af-87bc-708000c86384",
+                                    "group": "group-summary-weekly",
                                     "when": [{
                                         "id": "answer3b68f565-f13a-4155-b639-124cd0ec82ca",
                                         "condition": "contains any",
@@ -1063,13 +1063,27 @@
                                 ]
                             }]
                         }]
-                    },
+                    }
+                ]
+            },
+            {
+                "id": "group-summary-weekly",
+                "blocks": [
                     {
-                        "id": "summary1da4e8ee-f4ee-42c4-90ab-485444de2b3e",
+                        "id": "summary-weekly",
                         "type": "SectionSummary",
                         "collapsible": false
                     }
-                ]
+                ],
+                "skip_conditions": [{
+                    "when": [{
+                        "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                        "condition": "not contains any",
+                        "values": [
+                            "Weekly"
+                        ]
+                    }]
+                }]
             }]
         },
         {
@@ -1643,7 +1657,7 @@
                         }],
                         "routing_rules": [{
                                 "goto": {
-                                    "group": "group9832eee5-f77a-4d30-87e7-80220310090c",
+                                    "group": "group-summary-fortnightly",
                                     "when": [{
                                         "id": "answerf4882ee4-ec46-4c98-840a-7171597d1285",
                                         "condition": "contains any",
@@ -1828,13 +1842,27 @@
                                 ]
                             }]
                         }]
-                    },
+                    }
+                ]
+            },
+            {
+                "id": "group-summary-fortnightly",
+                "blocks": [
                     {
-                        "id": "summaryb903c023-4354-46af-87bc-708000c86384",
+                        "id": "summary-fortnightly",
                         "type": "SectionSummary",
                         "collapsible": false
                     }
-                ]
+                ],
+                "skip_conditions": [{
+                    "when": [{
+                        "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                        "condition": "not contains any",
+                        "values": [
+                            "Fortnightly"
+                        ]
+                    }]
+                }]
             }]
         },
         {
@@ -2391,7 +2419,7 @@
                         }],
                         "routing_rules": [{
                                 "goto": {
-                                    "group": "group9442599d-4b92-4c58-81f2-693ae40b7100",
+                                    "group": "group-summary-monthly",
                                     "when": [{
                                         "id": "answerd6064ed2-4172-462a-9b7f-af57f1bc7b9a",
                                         "condition": "contains any",
@@ -2576,13 +2604,27 @@
                                 ]
                             }]
                         }]
-                    },
+                    }
+                ]
+            },
+            {
+                "id": "group-summary-monthly",
+                "blocks": [
                     {
-                        "id": "summary9832eee5-f77a-4d30-87e7-80220310090c",
+                        "id": "summary-monthly",
                         "type": "SectionSummary",
                         "collapsible": false
                     }
-                ]
+                ],
+                "skip_conditions": [{
+                    "when": [{
+                        "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                        "condition": "not contains any",
+                        "values": [
+                            "Calendar monthly"
+                        ]
+                    }]
+                }]
             }]
         },
         {
@@ -3139,7 +3181,7 @@
                         }],
                         "routing_rules": [{
                                 "goto": {
-                                    "group": "group9747ed13-704c-46f6-8d17-3655314314ca",
+                                    "group": "group-summary-fourweekly",
                                     "when": [{
                                         "id": "answerfefeb3ed-f1fe-4359-aebd-16739cf8ac6e",
                                         "condition": "contains any",
@@ -3324,13 +3366,27 @@
                                 ]
                             }]
                         }]
-                    },
+                    }
+                ]
+            },
+            {
+                "id": "group-summary-fourweekly",
+                "blocks": [
                     {
-                        "id": "summary9442599d-4b92-4c58-81f2-693ae40b7100",
+                        "id": "summary-fourweekly",
                         "type": "SectionSummary",
                         "collapsible": false
                     }
-                ]
+                ],
+                "skip_conditions": [{
+                    "when": [{
+                        "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                        "condition": "not contains any",
+                        "values": [
+                            "Four weekly"
+                        ]
+                    }]
+                }]
             }]
         },
         {
@@ -3887,7 +3943,7 @@
                         }],
                         "routing_rules": [{
                                 "goto": {
-                                    "group": "groupe30dd07c-2f93-4605-bd45-eb821be27e9e",
+                                    "group": "group-summary-fiveweekly",
                                     "when": [{
                                         "id": "answerb567e1f5-c395-4db3-98b6-03dad97e420c",
                                         "condition": "contains any",
@@ -4072,13 +4128,27 @@
                                 ]
                             }]
                         }]
-                    },
+                    }
+                ]
+            },
+            {
+                "id": "group-summary-fiveweekly",
+                "blocks": [
                     {
-                        "id": "summary9747ed13-704c-46f6-8d17-3655314314ca",
+                        "id": "summary-fiveweekly",
                         "type": "SectionSummary",
                         "collapsible": false
                     }
-                ]
+                ],
+                "skip_conditions": [{
+                    "when": [{
+                        "id": "answer9c73f380-4074-4680-853a-8e6a24d00b33",
+                        "condition": "not contains any",
+                        "values": [
+                            "Five weekly"
+                        ]
+                    }]
+                }]
             }]
         },
         {
@@ -4110,11 +4180,6 @@
                                     "max_length": 2000
                                 }]
                             }]
-                        },
-                        {
-                            "id": "summarye30dd07c-2f93-4605-bd45-eb821be27e9e",
-                            "type": "SectionSummary",
-                            "collapsible": false
                         }
                     ]
                 },


### PR DESCRIPTION
This is a manual fix for when section summaries are turned on. 
Skip conditions are not being applied to the summary.

The summary has now been pulled into its own group, so a skip can be applied.